### PR TITLE
feat(api): Query Insights API — list + detail for slow query patterns

### DIFF
--- a/apps/dashboard/src/lib/api/insights/query-patterns.test.ts
+++ b/apps/dashboard/src/lib/api/insights/query-patterns.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  buildPatternDetailConfig,
+  buildPatternExecutionsConfig,
+  isValidQueryHash,
+  parseRangeHours,
+  sortPatternRows,
+} from '@/lib/api/insights/query-patterns'
+
+describe('isValidQueryHash', () => {
+  test('accepts numeric strings', () => {
+    expect(isValidQueryHash('123')).toBe(true)
+    expect(isValidQueryHash('12345678901234567890')).toBe(true)
+  })
+
+  test('rejects non-numeric input', () => {
+    expect(isValidQueryHash('')).toBe(false)
+    expect(isValidQueryHash('abc')).toBe(false)
+    expect(isValidQueryHash('-1')).toBe(false)
+    expect(isValidQueryHash('1.5')).toBe(false)
+    expect(isValidQueryHash('1; DROP TABLE x')).toBe(false)
+  })
+})
+
+describe('parseRangeHours', () => {
+  test('defaults to 24 when absent or invalid', () => {
+    expect(parseRangeHours(null)).toBe(24)
+    expect(parseRangeHours('')).toBe(24)
+    expect(parseRangeHours('abc')).toBe(24)
+    expect(parseRangeHours('-5')).toBe(24)
+    expect(parseRangeHours('0')).toBe(24)
+  })
+
+  test('parses a valid value', () => {
+    expect(parseRangeHours('6')).toBe(6)
+  })
+
+  test('clamps to the max window', () => {
+    expect(parseRangeHours('999999', 24, 720)).toBe(720)
+  })
+})
+
+describe('sortPatternRows', () => {
+  const rows = [
+    { calls: 5, name: 'b' },
+    { calls: 1, name: 'a' },
+    { calls: 3, name: 'c' },
+  ]
+
+  test('no-op without a sort param', () => {
+    expect(sortPatternRows(rows, undefined)).toBe(rows)
+  })
+
+  test('no-op for an unknown column', () => {
+    expect(sortPatternRows(rows, 'missing_column')).toBe(rows)
+  })
+
+  test('sorts descending by default', () => {
+    expect(sortPatternRows(rows, 'calls').map((r) => r.calls)).toEqual([
+      5, 3, 1,
+    ])
+  })
+
+  test('sorts ascending when requested', () => {
+    expect(sortPatternRows(rows, 'calls:asc').map((r) => r.calls)).toEqual([
+      1, 3, 5,
+    ])
+  })
+
+  test('falls back to string comparison for non-numeric columns', () => {
+    expect(sortPatternRows(rows, 'name:asc').map((r) => r.name)).toEqual([
+      'a',
+      'b',
+      'c',
+    ])
+  })
+})
+
+describe('buildPatternDetailConfig / buildPatternExecutionsConfig', () => {
+  test('the detail config filters by hash and time window', () => {
+    const config = buildPatternDetailConfig()
+    expect(config.tableCheck).toBe('system.query_log')
+    const sqlText = JSON.stringify(config.sql)
+    expect(sqlText).toContain('normalized_query_hash')
+    expect(sqlText).toContain('range_hours')
+  })
+
+  test('the executions config is reverse-chronological and limited', () => {
+    const config = buildPatternExecutionsConfig()
+    expect(config.sql as string).toContain('ORDER BY event_time DESC')
+    expect(config.sql as string).toContain('executions_limit')
+  })
+})

--- a/apps/dashboard/src/lib/api/insights/query-patterns.ts
+++ b/apps/dashboard/src/lib/api/insights/query-patterns.ts
@@ -1,0 +1,120 @@
+/**
+ * Query Insights API helpers — list + detail for slow query patterns.
+ *
+ * Backs `/api/v1/insights/query-patterns` (list) and
+ * `/api/v1/insights/query-patterns/$hash` (detail). Reuses the same
+ * aggregation SQL as the Slow Query Patterns page
+ * (`lib/query-config/queries/slow-query-patterns.ts` `buildQueryPatternsSql`)
+ * instead of duplicating the query text — the list config filters by the
+ * page's schema-driven filters; the detail config scopes the same
+ * aggregation to a single `normalized_query_hash`.
+ */
+
+import type { QueryConfig } from '@/lib/query-config'
+
+import { buildQueryPatternsSql } from '@/lib/query-config/queries/slow-query-patterns'
+
+/** `system.query_log` rows contributing to a pattern, individually. */
+const EXECUTION_TYPES = "('QueryFinish', 'ExceptionWhileProcessing')"
+
+/** Numeric-string `normalized_query_hash` values only (ClickHouse UInt64). */
+const HASH_PATTERN = /^\d{1,20}$/
+
+export function isValidQueryHash(value: string): boolean {
+  return HASH_PATTERN.test(value)
+}
+
+/**
+ * Parse the `range` query param (hours). Falls back to `fallbackHours` when
+ * absent/invalid, clamped to `maxHours` so a hand-crafted request cannot force
+ * an unbounded `system.query_log` scan.
+ */
+export function parseRangeHours(
+  raw: string | null,
+  fallbackHours = 24,
+  maxHours = 24 * 90
+): number {
+  if (!raw) return fallbackHours
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallbackHours
+  return Math.min(parsed, maxHours)
+}
+
+/**
+ * Sort pattern rows by a `column[:asc|desc]` spec (default direction: desc,
+ * matching the underlying SQL's `ORDER BY total_duration DESC`). Unknown
+ * columns are a no-op — the caller gets the SQL's default ordering.
+ */
+export function sortPatternRows<T extends Record<string, unknown>>(
+  rows: T[],
+  sortParam: string | null | undefined
+): T[] {
+  if (!sortParam || rows.length === 0) return rows
+  const [column, directionRaw] = sortParam.split(':')
+  if (!column || !(column in rows[0])) return rows
+
+  const direction = directionRaw === 'asc' ? 1 : -1
+  return [...rows].sort((a, b) => {
+    const av = a[column]
+    const bv = b[column]
+    if (typeof av === 'number' && typeof bv === 'number') {
+      return (av - bv) * direction
+    }
+    return String(av ?? '').localeCompare(String(bv ?? '')) * direction
+  })
+}
+
+/**
+ * Build the ad-hoc QueryConfig for one pattern's aggregated stats, scoped to
+ * `normalized_query_hash` + a relative time window. Expects query params
+ * `{ normalized_query_hash: string, range_hours: number }`.
+ */
+export function buildPatternDetailConfig(): QueryConfig {
+  return {
+    name: 'insights-query-pattern-detail',
+    tableCheck: 'system.query_log',
+    columns: [],
+    sql: buildQueryPatternsSql(
+      `WHERE normalized_query_hash = toUInt64OrZero({normalized_query_hash:String})
+        AND event_time > now() - toIntervalHour({range_hours:UInt32})`
+    ),
+  }
+}
+
+/**
+ * Build the ad-hoc QueryConfig for the individual `system.query_log`
+ * executions behind one pattern, reverse-chronological. Expects query params
+ * `{ normalized_query_hash: string, range_hours: number, executions_limit: number }`.
+ */
+export function buildPatternExecutionsConfig(): QueryConfig {
+  return {
+    name: 'insights-query-pattern-executions',
+    tableCheck: 'system.query_log',
+    columns: [],
+    sql: `
+      SELECT
+          event_time,
+          query_id,
+          user,
+          query_kind,
+          current_database AS database,
+          query_duration_ms,
+          memory_usage,
+          formatReadableSize(memory_usage) AS readable_memory_usage,
+          read_rows,
+          read_bytes,
+          formatReadableSize(read_bytes) AS readable_read_bytes,
+          result_rows,
+          written_bytes,
+          exception_code,
+          exception,
+          query
+      FROM system.query_log
+      WHERE type IN ${EXECUTION_TYPES}
+        AND normalized_query_hash = toUInt64OrZero({normalized_query_hash:String})
+        AND event_time > now() - toIntervalHour({range_hours:UInt32})
+      ORDER BY event_time DESC
+      LIMIT {executions_limit:UInt32}
+    `,
+  }
+}

--- a/apps/dashboard/src/lib/query-config/queries/slow-query-patterns.ts
+++ b/apps/dashboard/src/lib/query-config/queries/slow-query-patterns.ts
@@ -117,19 +117,15 @@ export const slowQueryPatternsFilterSchema: FilterSchema = {
 }
 
 /**
- * Normalized slow-query patterns: `system.query_log` aggregated by
- * `normalized_query_hash`, mirroring ClickHouse Cloud's Query Insights
- * "Slow Patterns" table. Foundation for the rest of the Query Insights epic
- * (overview cards, detail flyout, insights API) — keep column names stable.
+ * Build the versioned slow-query-patterns SQL, parameterized by the WHERE
+ * fragment applied to the raw `filtered` rows before aggregation. The
+ * dashboard page injects the schema-driven {@link FILTER_PLACEHOLDER}; the
+ * insights detail endpoint (`/api/v1/insights/query-patterns/:hash`) reuses
+ * this same aggregation scoped to one `normalized_query_hash` — a single
+ * source of truth for the pattern metrics instead of duplicating the SQL.
  */
-export const slowQueryPatternsConfig: QueryConfig = {
-  name: 'slow-query-patterns',
-  description:
-    'Query patterns aggregated by normalized_query_hash — calls, duration percentiles, resource usage, and errors per pattern',
-  docs: QUERY_LOG,
-  tableCheck: 'system.query_log',
-  filterSchema: slowQueryPatternsFilterSchema,
-  sql: [
+export function buildQueryPatternsSql(whereFragment: string): VersionedSql[] {
+  return [
     {
       since: '19.1',
       description: 'Base query without query_cache_usage',
@@ -140,7 +136,7 @@ ${rawRowsSelect}
         FROM system.query_log
         WHERE type IN ('QueryFinish', 'ExceptionWhileProcessing')
       ) AS q
-      ${FILTER_PLACEHOLDER}
+      ${whereFragment}
     ),
     base_metrics AS (
       SELECT
@@ -198,7 +194,7 @@ ${rawRowsSelect},
         FROM system.query_log
         WHERE type IN ('QueryFinish', 'ExceptionWhileProcessing')
       ) AS q
-      ${FILTER_PLACEHOLDER}
+      ${whereFragment}
     ),
     base_metrics AS (
       SELECT
@@ -244,7 +240,23 @@ ${rawRowsSelect},
     LIMIT 1000
   `,
     },
-  ] as VersionedSql[],
+  ]
+}
+
+/**
+ * Normalized slow-query patterns: `system.query_log` aggregated by
+ * `normalized_query_hash`, mirroring ClickHouse Cloud's Query Insights
+ * "Slow Patterns" table. Foundation for the rest of the Query Insights epic
+ * (overview cards, detail flyout, insights API) — keep column names stable.
+ */
+export const slowQueryPatternsConfig: QueryConfig = {
+  name: 'slow-query-patterns',
+  description:
+    'Query patterns aggregated by normalized_query_hash — calls, duration percentiles, resource usage, and errors per pattern',
+  docs: QUERY_LOG,
+  tableCheck: 'system.query_log',
+  filterSchema: slowQueryPatternsFilterSchema,
+  sql: buildQueryPatternsSql(FILTER_PLACEHOLDER),
 
   rowClassName: (row) => {
     const totalDuration = Number(row.total_duration || 0)

--- a/apps/dashboard/src/routes/api/v1/insights/query-patterns.test.ts
+++ b/apps/dashboard/src/routes/api/v1/insights/query-patterns.test.ts
@@ -50,6 +50,16 @@ function request(query: string): Request {
   return new Request(`http://x/api/v1/insights/query-patterns${query}`)
 }
 
+interface PatternsResponseBody {
+  success: boolean
+  data: Array<{
+    normalized_query_hash: string
+    calls: number
+    total_duration: number
+  }>
+  metadata: { host: string; rows: number }
+}
+
 describe('GET /api/v1/insights/query-patterns — hostId validation', () => {
   beforeEach(() => {
     executeTableConfig.mockClear()
@@ -70,6 +80,13 @@ describe('GET /api/v1/insights/query-patterns — hostId validation', () => {
     expect((await handler(request('?hostId=abc'))).status).toBe(400)
   })
 
+  test('accepts the `host` shorthand param when hostId is absent', async () => {
+    const res = await handler(request('?host=3'))
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as PatternsResponseBody
+    expect(body.metadata.host).toBe('3')
+  })
+
   test('defaults to host 0 when hostId is absent', async () => {
     const res = await handler(request(''))
     expect(res.status).toBe(200)
@@ -79,7 +96,7 @@ describe('GET /api/v1/insights/query-patterns — hostId validation', () => {
   test('accepts a valid hostId and returns the aggregated rows', async () => {
     const res = await handler(request('?hostId=2'))
     expect(res.status).toBe(200)
-    const body = await res.json()
+    const body = (await res.json()) as PatternsResponseBody
     expect(body.success).toBe(true)
     expect(body.data).toHaveLength(2)
     expect(body.metadata.host).toBe('2')
@@ -95,19 +112,19 @@ describe('GET /api/v1/insights/query-patterns — filter/sort ergonomics', () =>
   test('translates range=N into event_time=withinHours:N', async () => {
     await handler(request('?range=6'))
     const call = getTableQuery.mock.calls[0]
-    expect(call[1].searchParams).toEqual({ event_time: 'withinHours:6' })
+    expect(call?.[1].searchParams).toEqual({ event_time: 'withinHours:6' })
   })
 
   test('an explicit event_time filter wins over range', async () => {
     await handler(request('?range=6&event_time=withinHours:1'))
     const call = getTableQuery.mock.calls[0]
-    expect(call[1].searchParams.event_time).toBe('withinHours:1')
+    expect(call?.[1].searchParams?.event_time).toBe('withinHours:1')
   })
 
   test('forwards other filter fields untouched', async () => {
     await handler(request('?user=eq:default&query_kind=in:Select'))
     const call = getTableQuery.mock.calls[0]
-    expect(call[1].searchParams).toEqual({
+    expect(call?.[1].searchParams).toEqual({
       user: 'eq:default',
       query_kind: 'in:Select',
     })
@@ -115,13 +132,13 @@ describe('GET /api/v1/insights/query-patterns — filter/sort ergonomics', () =>
 
   test('sort=calls:asc re-orders the rows ascending by calls', async () => {
     const res = await handler(request('?sort=calls:asc'))
-    const body = await res.json()
-    expect(body.data.map((r: { calls: number }) => r.calls)).toEqual([1, 2])
+    const body = (await res.json()) as PatternsResponseBody
+    expect(body.data.map((r) => r.calls)).toEqual([1, 2])
   })
 
   test('sort=total_duration:desc (default direction) keeps larger first', async () => {
     const res = await handler(request('?sort=total_duration'))
-    const body = await res.json()
-    expect(body.data[0].total_duration).toBe(50)
+    const body = (await res.json()) as PatternsResponseBody
+    expect(body.data[0]?.total_duration).toBe(50)
   })
 })

--- a/apps/dashboard/src/routes/api/v1/insights/query-patterns.test.ts
+++ b/apps/dashboard/src/routes/api/v1/insights/query-patterns.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for GET /api/v1/insights/query-patterns.
+ *
+ * hostId boundary validation follows the same contract as every other
+ * `/api/v1/*` route (docs/knowledge/api-hostid-validation.md): a non-negative
+ * integer or 400, checked BEFORE any query executes.
+ */
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+mock.module('cloudflare:workers', () => ({
+  env: {
+    CLICKHOUSE_HOST: 'http://localhost:8123',
+    CLICKHOUSE_USER: 'default',
+    CLICKHOUSE_PASSWORD: '',
+  },
+}))
+
+const getTableQuery = mock(
+  (
+    _name: string,
+    params: { hostId: number | string; searchParams?: Record<string, string> }
+  ) => ({
+    query: 'SELECT 1',
+    queryParams: undefined,
+    queryConfig: { name: 'slow-query-patterns', sql: 'SELECT 1', columns: [] },
+    // Surface what was passed through so tests can assert on it.
+    __searchParams: params.searchParams,
+  })
+)
+
+mock.module('@/lib/api/table-registry', () => ({ getTableQuery }))
+
+const executeTableConfig = mock(async () => ({
+  result: {
+    data: [
+      { normalized_query_hash: '111', total_duration: 5, calls: 2 },
+      { normalized_query_hash: '222', total_duration: 50, calls: 1 },
+    ],
+    metadata: { queryId: 'q1', duration: 12, rows: 2 },
+  },
+  executedSql: 'SELECT 1',
+  clickhouseVersion: '24.8',
+}))
+
+mock.module('@/lib/api/query-executor', () => ({ executeTableConfig }))
+
+const { handler } = await import('@/routes/api/v1/insights/query-patterns')
+
+function request(query: string): Request {
+  return new Request(`http://x/api/v1/insights/query-patterns${query}`)
+}
+
+describe('GET /api/v1/insights/query-patterns — hostId validation', () => {
+  beforeEach(() => {
+    executeTableConfig.mockClear()
+    getTableQuery.mockClear()
+  })
+
+  test('rejects negative hostId with 400', async () => {
+    const res = await handler(request('?hostId=-1'))
+    expect(res.status).toBe(400)
+    expect(executeTableConfig).not.toHaveBeenCalled()
+  })
+
+  test('rejects fractional hostId with 400', async () => {
+    expect((await handler(request('?hostId=1.5'))).status).toBe(400)
+  })
+
+  test('rejects non-numeric hostId with 400', async () => {
+    expect((await handler(request('?hostId=abc'))).status).toBe(400)
+  })
+
+  test('defaults to host 0 when hostId is absent', async () => {
+    const res = await handler(request(''))
+    expect(res.status).toBe(200)
+    expect(executeTableConfig).toHaveBeenCalled()
+  })
+
+  test('accepts a valid hostId and returns the aggregated rows', async () => {
+    const res = await handler(request('?hostId=2'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+    expect(body.data).toHaveLength(2)
+    expect(body.metadata.host).toBe('2')
+  })
+})
+
+describe('GET /api/v1/insights/query-patterns — filter/sort ergonomics', () => {
+  beforeEach(() => {
+    executeTableConfig.mockClear()
+    getTableQuery.mockClear()
+  })
+
+  test('translates range=N into event_time=withinHours:N', async () => {
+    await handler(request('?range=6'))
+    const call = getTableQuery.mock.calls[0]
+    expect(call[1].searchParams).toEqual({ event_time: 'withinHours:6' })
+  })
+
+  test('an explicit event_time filter wins over range', async () => {
+    await handler(request('?range=6&event_time=withinHours:1'))
+    const call = getTableQuery.mock.calls[0]
+    expect(call[1].searchParams.event_time).toBe('withinHours:1')
+  })
+
+  test('forwards other filter fields untouched', async () => {
+    await handler(request('?user=eq:default&query_kind=in:Select'))
+    const call = getTableQuery.mock.calls[0]
+    expect(call[1].searchParams).toEqual({
+      user: 'eq:default',
+      query_kind: 'in:Select',
+    })
+  })
+
+  test('sort=calls:asc re-orders the rows ascending by calls', async () => {
+    const res = await handler(request('?sort=calls:asc'))
+    const body = await res.json()
+    expect(body.data.map((r: { calls: number }) => r.calls)).toEqual([1, 2])
+  })
+
+  test('sort=total_duration:desc (default direction) keeps larger first', async () => {
+    const res = await handler(request('?sort=total_duration'))
+    const body = await res.json()
+    expect(body.data[0].total_duration).toBe(50)
+  })
+})

--- a/apps/dashboard/src/routes/api/v1/insights/query-patterns.ts
+++ b/apps/dashboard/src/routes/api/v1/insights/query-patterns.ts
@@ -1,0 +1,145 @@
+/**
+ * Query Insights — list slow query patterns
+ * GET /api/v1/insights/query-patterns?hostId=0&range=24&sort=total_duration:desc
+ *
+ * Thin wrapper over the `slow-query-patterns` QueryConfig
+ * (lib/query-config/queries/slow-query-patterns.ts) via the same
+ * table-registry + query-executor path `/api/v1/tables/slow-query-patterns`
+ * uses — returns the same aggregated data the Slow Query Patterns page shows.
+ *
+ * Query parameters:
+ * - hostId (optional, default 0): host to run against, non-negative integer
+ * - range (optional): relative window in hours, shorthand for the page's
+ *   `event_time=withinHours:<hours>` filter (default 24h, same as the page)
+ * - sort (optional): `column[:asc|desc]` — re-orders the returned rows by any
+ *   column in the response (default: the SQL's `total_duration DESC`)
+ * - filter fields (optional): any `slow-query-patterns` filterSchema field —
+ *   `user`, `query_kind`, `database`, `event_time` — as `key=operator:value`
+ *   (e.g. `user=eq:default`), the same convention the dashboard filter bar
+ *   uses (see lib/filters/url-state.ts)
+ */
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+import { error } from '@chm/logger'
+import { sortPatternRows } from '@/lib/api/insights/query-patterns'
+import { executeTableConfig } from '@/lib/api/query-executor'
+import { getTableQuery } from '@/lib/api/table-registry'
+
+const CONFIG_NAME = 'slow-query-patterns'
+
+export async function handler(request: Request): Promise<Response> {
+  const bindings = env as Record<string, string | undefined>
+  const { searchParams } = new URL(request.url)
+
+  // Validate hostId
+  const hostIdStr = searchParams.get('hostId') ?? '0'
+  const hostId = Number(hostIdStr)
+  if (!Number.isInteger(hostId) || hostId < 0) {
+    return Response.json(
+      {
+        success: false,
+        error: { type: 'validation', message: 'Invalid hostId' },
+      },
+      { status: 400 }
+    )
+  }
+
+  // Forward filter fields to the config's filterSchema (event_time, user,
+  // query_kind, database). `range` is shorthand for `event_time=withinHours:`.
+  const filterParams: Record<string, string> = {}
+  for (const [key, value] of searchParams.entries()) {
+    if (key === 'hostId' || key === 'sort' || key === 'range') continue
+    filterParams[key] = value
+  }
+  const range = searchParams.get('range')
+  if (range && !filterParams.event_time) {
+    filterParams.event_time = `withinHours:${range}`
+  }
+
+  const queryDef = getTableQuery(CONFIG_NAME, {
+    hostId,
+    searchParams: filterParams,
+  })
+  if (!queryDef) {
+    error(
+      `[GET /api/v1/insights/query-patterns] Missing config: ${CONFIG_NAME}`
+    )
+    return Response.json(
+      {
+        success: false,
+        error: {
+          type: 'query_error',
+          message: 'Query patterns config not found',
+        },
+      },
+      { status: 500 }
+    )
+  }
+
+  try {
+    const { result, executedSql, clickhouseVersion } = await executeTableConfig(
+      queryDef.queryConfig,
+      hostId,
+      queryDef.queryParams,
+      { bindings }
+    )
+
+    if (result.error) {
+      return Response.json(
+        {
+          success: false,
+          error: {
+            type: 'query_error',
+            message: result.error.message,
+            details: result.error.details,
+          },
+        },
+        { status: 500 }
+      )
+    }
+
+    const rows = result.data ?? []
+    const sorted = sortPatternRows(rows, searchParams.get('sort'))
+
+    return Response.json(
+      {
+        success: true,
+        data: sorted,
+        metadata: {
+          queryId: String(result.metadata.queryId || ''),
+          duration: Number(result.metadata.duration || 0),
+          rows: sorted.length,
+          host: String(hostId),
+          sql: executedSql.trim(),
+          clickhouseVersion,
+        },
+      },
+      {
+        headers: {
+          'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=60',
+        },
+      }
+    )
+  } catch (err) {
+    error('[GET /api/v1/insights/query-patterns] Unhandled exception:', err)
+    return Response.json(
+      {
+        success: false,
+        error: {
+          type: 'query_error',
+          message: err instanceof Error ? err.message : 'Unknown error',
+        },
+      },
+      { status: 500 }
+    )
+  }
+}
+
+export const Route = createFileRoute('/api/v1/insights/query-patterns')({
+  server: {
+    handlers: {
+      GET: ({ request }) => handler(request),
+    },
+  },
+})

--- a/apps/dashboard/src/routes/api/v1/insights/query-patterns.ts
+++ b/apps/dashboard/src/routes/api/v1/insights/query-patterns.ts
@@ -32,8 +32,11 @@ export async function handler(request: Request): Promise<Response> {
   const bindings = env as Record<string, string | undefined>
   const { searchParams } = new URL(request.url)
 
-  // Validate hostId
-  const hostIdStr = searchParams.get('hostId') ?? '0'
+  // Validate hostId. `hostId` is the canonical param
+  // (docs/knowledge/api-hostid-validation.md); `host` is accepted too so
+  // `?host=` from the issue's shorthand also works.
+  const hostIdStr =
+    searchParams.get('hostId') ?? searchParams.get('host') ?? '0'
   const hostId = Number(hostIdStr)
   if (!Number.isInteger(hostId) || hostId < 0) {
     return Response.json(
@@ -49,7 +52,8 @@ export async function handler(request: Request): Promise<Response> {
   // query_kind, database). `range` is shorthand for `event_time=withinHours:`.
   const filterParams: Record<string, string> = {}
   for (const [key, value] of searchParams.entries()) {
-    if (key === 'hostId' || key === 'sort' || key === 'range') continue
+    if (key === 'hostId' || key === 'host' || key === 'sort' || key === 'range')
+      continue
     filterParams[key] = value
   }
   const range = searchParams.get('range')

--- a/apps/dashboard/src/routes/api/v1/insights/query-patterns/$hash.test.ts
+++ b/apps/dashboard/src/routes/api/v1/insights/query-patterns/$hash.test.ts
@@ -28,26 +28,33 @@ const executionRows = [
 
 let patternData: Record<string, unknown>[] = [patternRow]
 
-const executeTableConfig = mock(async (config: { name: string }) => {
-  if (config.name === 'insights-query-pattern-detail') {
+const executeTableConfig = mock(
+  async (
+    config: { name: string },
+    _hostId: number | string,
+    _queryParams: Record<string, unknown> | undefined,
+    _options: Record<string, unknown>
+  ) => {
+    if (config.name === 'insights-query-pattern-detail') {
+      return {
+        result: {
+          data: patternData,
+          metadata: { queryId: 'p1', duration: 5, rows: patternData.length },
+        },
+        executedSql: 'SELECT /* pattern */ 1',
+        clickhouseVersion: '24.8',
+      }
+    }
     return {
       result: {
-        data: patternData,
-        metadata: { queryId: 'p1', duration: 5, rows: patternData.length },
+        data: executionRows,
+        metadata: { queryId: 'e1', duration: 7, rows: executionRows.length },
       },
-      executedSql: 'SELECT /* pattern */ 1',
+      executedSql: 'SELECT /* executions */ 1',
       clickhouseVersion: '24.8',
     }
   }
-  return {
-    result: {
-      data: executionRows,
-      metadata: { queryId: 'e1', duration: 7, rows: executionRows.length },
-    },
-    executedSql: 'SELECT /* executions */ 1',
-    clickhouseVersion: '24.8',
-  }
-})
+)
 
 mock.module('@/lib/api/query-executor', () => ({ executeTableConfig }))
 
@@ -60,6 +67,19 @@ async function call(hash: string, query = ''): Promise<Response> {
     new Request(`http://x/api/v1/insights/query-patterns/${hash}${query}`),
     hash
   )
+}
+
+interface DetailErrorBody {
+  success: false
+  error: { type: string; message: string }
+}
+interface DetailSuccessBody {
+  success: true
+  data: {
+    pattern: Record<string, unknown>
+    executions: Record<string, unknown>[]
+  }
+  metadata: { host: string; rangeHours: number }
 }
 
 describe('GET /api/v1/insights/query-patterns/$hash — validation', () => {
@@ -92,7 +112,7 @@ describe('GET /api/v1/insights/query-patterns/$hash — validation', () => {
     patternData = []
     const res = await call('999')
     expect(res.status).toBe(404)
-    const body = await res.json()
+    const body = (await res.json()) as DetailErrorBody
     expect(body.success).toBe(false)
     expect(body.error.type).toBe('not_found')
   })
@@ -107,7 +127,7 @@ describe('GET /api/v1/insights/query-patterns/$hash — shape', () => {
   test('returns the pattern + its recent executions', async () => {
     const res = await call('123456789')
     expect(res.status).toBe(200)
-    const body = await res.json()
+    const body = (await res.json()) as DetailSuccessBody
     expect(body.success).toBe(true)
     expect(body.data.pattern).toEqual(patternRow)
     expect(body.data.executions).toEqual(executionRows)

--- a/apps/dashboard/src/routes/api/v1/insights/query-patterns/$hash.test.ts
+++ b/apps/dashboard/src/routes/api/v1/insights/query-patterns/$hash.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for GET /api/v1/insights/query-patterns/$hash.
+ *
+ * hostId boundary validation follows the same contract as every other
+ * `/api/v1/*` route (docs/knowledge/api-hostid-validation.md), plus the
+ * `normalized_query_hash` path param must be a numeric string.
+ */
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+mock.module('cloudflare:workers', () => ({
+  env: {
+    CLICKHOUSE_HOST: 'http://localhost:8123',
+    CLICKHOUSE_USER: 'default',
+    CLICKHOUSE_PASSWORD: '',
+  },
+}))
+
+const patternRow = {
+  normalized_query_hash: '123456789',
+  normalized_query: 'SELECT * FROM t',
+  calls: 3,
+  total_duration: 9,
+}
+const executionRows = [
+  { event_time: '2026-07-04 00:00:00', query_id: 'a' },
+  { event_time: '2026-07-03 23:59:00', query_id: 'b' },
+]
+
+let patternData: Record<string, unknown>[] = [patternRow]
+
+const executeTableConfig = mock(async (config: { name: string }) => {
+  if (config.name === 'insights-query-pattern-detail') {
+    return {
+      result: {
+        data: patternData,
+        metadata: { queryId: 'p1', duration: 5, rows: patternData.length },
+      },
+      executedSql: 'SELECT /* pattern */ 1',
+      clickhouseVersion: '24.8',
+    }
+  }
+  return {
+    result: {
+      data: executionRows,
+      metadata: { queryId: 'e1', duration: 7, rows: executionRows.length },
+    },
+    executedSql: 'SELECT /* executions */ 1',
+    clickhouseVersion: '24.8',
+  }
+})
+
+mock.module('@/lib/api/query-executor', () => ({ executeTableConfig }))
+
+const { handler } = await import(
+  '@/routes/api/v1/insights/query-patterns/$hash'
+)
+
+async function call(hash: string, query = ''): Promise<Response> {
+  return handler(
+    new Request(`http://x/api/v1/insights/query-patterns/${hash}${query}`),
+    hash
+  )
+}
+
+describe('GET /api/v1/insights/query-patterns/$hash — validation', () => {
+  beforeEach(() => {
+    executeTableConfig.mockClear()
+    patternData = [patternRow]
+  })
+
+  test('rejects negative hostId with 400', async () => {
+    const res = await call('123', '?hostId=-1')
+    expect(res.status).toBe(400)
+    expect(executeTableConfig).not.toHaveBeenCalled()
+  })
+
+  test('rejects fractional hostId with 400', async () => {
+    expect((await call('123', '?hostId=1.5')).status).toBe(400)
+  })
+
+  test('rejects non-numeric hostId with 400', async () => {
+    expect((await call('123', '?hostId=abc')).status).toBe(400)
+  })
+
+  test('rejects a non-numeric normalized_query_hash with 400', async () => {
+    const res = await call('not-a-hash')
+    expect(res.status).toBe(400)
+    expect(executeTableConfig).not.toHaveBeenCalled()
+  })
+
+  test('returns 404 when no pattern matches the hash', async () => {
+    patternData = []
+    const res = await call('999')
+    expect(res.status).toBe(404)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+    expect(body.error.type).toBe('not_found')
+  })
+})
+
+describe('GET /api/v1/insights/query-patterns/$hash — shape', () => {
+  beforeEach(() => {
+    executeTableConfig.mockClear()
+    patternData = [patternRow]
+  })
+
+  test('returns the pattern + its recent executions', async () => {
+    const res = await call('123456789')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+    expect(body.data.pattern).toEqual(patternRow)
+    expect(body.data.executions).toEqual(executionRows)
+    expect(body.metadata.host).toBe('0')
+    expect(body.metadata.rangeHours).toBe(24)
+  })
+
+  test('passes the same normalized_query_hash + range to both queries', async () => {
+    await call('123456789', '?range=6')
+    expect(executeTableConfig).toHaveBeenCalledTimes(2)
+    for (const c of executeTableConfig.mock.calls) {
+      expect(c[2]).toMatchObject({
+        normalized_query_hash: '123456789',
+        range_hours: 6,
+      })
+    }
+  })
+})

--- a/apps/dashboard/src/routes/api/v1/insights/query-patterns/$hash.ts
+++ b/apps/dashboard/src/routes/api/v1/insights/query-patterns/$hash.ts
@@ -1,0 +1,171 @@
+/**
+ * Query Insights — one slow query pattern + its recent executions
+ * GET /api/v1/insights/query-patterns/:normalized_query_hash?hostId=0&range=24
+ *
+ * Reuses the same aggregation as `/api/v1/insights/query-patterns`
+ * (buildQueryPatternsSql), scoped to one `normalized_query_hash`, plus the
+ * individual `system.query_log` rows behind it (reverse-chronological).
+ *
+ * Path parameter:
+ * - normalized_query_hash: the pattern's hash (numeric string, ClickHouse UInt64)
+ *
+ * Query parameters:
+ * - hostId (optional, default 0): host to run against, non-negative integer
+ * - range (optional, default 24): relative window in hours for both the
+ *   pattern's aggregation and the executions list
+ */
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+import { error } from '@chm/logger'
+import {
+  buildPatternDetailConfig,
+  buildPatternExecutionsConfig,
+  isValidQueryHash,
+  parseRangeHours,
+} from '@/lib/api/insights/query-patterns'
+import { executeTableConfig } from '@/lib/api/query-executor'
+
+/** Cap on individual executions returned per pattern. */
+const EXECUTIONS_LIMIT = 200
+
+export async function handler(
+  request: Request,
+  hash: string
+): Promise<Response> {
+  const bindings = env as Record<string, string | undefined>
+  const { searchParams } = new URL(request.url)
+
+  // Validate hostId
+  const hostIdStr = searchParams.get('hostId') ?? '0'
+  const hostId = Number(hostIdStr)
+  if (!Number.isInteger(hostId) || hostId < 0) {
+    return Response.json(
+      {
+        success: false,
+        error: { type: 'validation', message: 'Invalid hostId' },
+      },
+      { status: 400 }
+    )
+  }
+
+  if (!isValidQueryHash(hash)) {
+    return Response.json(
+      {
+        success: false,
+        error: {
+          type: 'validation',
+          message: 'Invalid normalized_query_hash: must be a numeric string',
+        },
+      },
+      { status: 400 }
+    )
+  }
+
+  const rangeHours = parseRangeHours(searchParams.get('range'))
+  const queryParams = {
+    normalized_query_hash: hash,
+    range_hours: rangeHours,
+    executions_limit: EXECUTIONS_LIMIT,
+  }
+
+  try {
+    const [patternExec, executionsExec] = await Promise.all([
+      executeTableConfig(buildPatternDetailConfig(), hostId, queryParams, {
+        bindings,
+      }),
+      executeTableConfig(buildPatternExecutionsConfig(), hostId, queryParams, {
+        bindings,
+      }),
+    ])
+
+    if (patternExec.result.error) {
+      return Response.json(
+        {
+          success: false,
+          error: {
+            type: 'query_error',
+            message: patternExec.result.error.message,
+            details: patternExec.result.error.details,
+          },
+        },
+        { status: 500 }
+      )
+    }
+    if (executionsExec.result.error) {
+      return Response.json(
+        {
+          success: false,
+          error: {
+            type: 'query_error',
+            message: executionsExec.result.error.message,
+            details: executionsExec.result.error.details,
+          },
+        },
+        { status: 500 }
+      )
+    }
+
+    const pattern = (patternExec.result.data ?? [])[0]
+    if (!pattern) {
+      return Response.json(
+        {
+          success: false,
+          error: {
+            type: 'not_found',
+            message: `No slow-query pattern found for normalized_query_hash=${hash} in the last ${rangeHours}h`,
+          },
+        },
+        { status: 404 }
+      )
+    }
+
+    const executions = executionsExec.result.data ?? []
+
+    return Response.json(
+      {
+        success: true,
+        data: { pattern, executions },
+        metadata: {
+          queryId: String(patternExec.result.metadata.queryId || ''),
+          duration:
+            Number(patternExec.result.metadata.duration || 0) +
+            Number(executionsExec.result.metadata.duration || 0),
+          rows: executions.length,
+          host: String(hostId),
+          rangeHours,
+          sql: `${patternExec.executedSql.trim()}\n\n${executionsExec.executedSql.trim()}`,
+          clickhouseVersion: patternExec.clickhouseVersion,
+        },
+      },
+      {
+        headers: {
+          'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=60',
+        },
+      }
+    )
+  } catch (err) {
+    error(
+      `[GET /api/v1/insights/query-patterns/${hash}] Unhandled exception:`,
+      err
+    )
+    return Response.json(
+      {
+        success: false,
+        error: {
+          type: 'query_error',
+          message: err instanceof Error ? err.message : 'Unknown error',
+        },
+      },
+      { status: 500 }
+    )
+  }
+}
+
+export const Route = createFileRoute('/api/v1/insights/query-patterns/$hash')({
+  server: {
+    handlers: {
+      GET: ({ request, params }) => handler(request, params.hash),
+    },
+  },
+})

--- a/apps/dashboard/src/routes/api/v1/insights/query-patterns/$hash.ts
+++ b/apps/dashboard/src/routes/api/v1/insights/query-patterns/$hash.ts
@@ -36,8 +36,11 @@ export async function handler(
   const bindings = env as Record<string, string | undefined>
   const { searchParams } = new URL(request.url)
 
-  // Validate hostId
-  const hostIdStr = searchParams.get('hostId') ?? '0'
+  // Validate hostId. `hostId` is the canonical param
+  // (docs/knowledge/api-hostid-validation.md); `host` is accepted too so
+  // `?host=` from the issue's shorthand also works.
+  const hostIdStr =
+    searchParams.get('hostId') ?? searchParams.get('host') ?? '0'
   const hostId = Number(hostIdStr)
   if (!Number.isInteger(hostId) || hostId < 0) {
     return Response.json(

--- a/docs/content/guide/features/query-insights.mdx
+++ b/docs/content/guide/features/query-insights.mdx
@@ -1,0 +1,120 @@
+---
+description: Programmatic access to slow query patterns — normalized_query_hash aggregation, calls, duration percentiles, and per-pattern executions.
+icon: LayoutList
+title: Query Insights API
+---
+
+Read the same normalized query-pattern data the [Slow Query Patterns](/slow-query-patterns) page shows, from two REST endpoints — a list of patterns and a per-pattern detail with recent executions.
+
+<TypeTable
+  data={{
+    Routes: { type: "GET /api/v1/insights/query-patterns, GET /api/v1/insights/query-patterns/:normalized_query_hash", description: "List + detail endpoints" },
+    "Feature id": { type: "queries", description: "Same feature gate as the Slow Query Patterns page" },
+    "Default access": { type: "Same as the dashboard's `/api/v1/*` auth posture", description: "See Auth in the Getting Started guide" },
+    "System tables": { type: "system.query_log", description: "Data source" },
+    "ClickHouse grants": { type: "SELECT", description: "SELECT on system.query_log" },
+  }}
+/>
+
+## What it does
+
+`system.query_log` rows are aggregated by `normalized_query_hash` (mirroring ClickHouse Cloud's Query Insights "Slow Patterns" table) — one row per distinct query shape, with call counts, duration percentiles (p50/p95/p99), resource usage (memory, rows/bytes read, rows/bytes written), and error counts. The list endpoint returns this aggregation; the detail endpoint returns one pattern plus the individual `system.query_log` rows (executions) that contributed to it, most-recent first.
+
+Both endpoints reuse the exact SQL the [Slow Query Patterns](/slow-query-patterns) page runs (`buildQueryPatternsSql` in `lib/query-config/queries/slow-query-patterns.ts`) — the numbers always match what the page shows.
+
+### Pages
+
+| Page | Route | What it shows | System tables |
+|---|---|---|---|
+| Slow Query Patterns | `/slow-query-patterns` | The same pattern aggregation, with filtering and drill-down UI | `system.query_log` |
+
+## Using it
+
+### List patterns
+
+```bash
+GET /api/v1/insights/query-patterns?hostId=0&range=24&sort=total_duration:desc
+```
+
+<TypeTable
+  data={{
+    hostId: { type: "integer, optional (default 0)", description: "Host index into CLICKHOUSE_HOST — must be a non-negative integer or the request is rejected with 400" },
+    range: { type: "integer (hours), optional (default 24)", description: "Shorthand for `event_time=withinHours:<hours>` — how far back to aggregate" },
+    sort: { type: "string, optional", description: "`column[:asc|desc]` — reorders the returned rows by any response column (default direction: desc). Omit to keep the SQL's default `total_duration DESC` order." },
+    "user / query_kind / database / event_time": { type: "string, optional", description: "Any Slow Query Patterns filter field as `key=operator:value` (e.g. `user=eq:default`, `query_kind=in:Select`) — the same convention the page's filter bar uses" },
+  }}
+/>
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "normalized_query_hash": "1234567890123456789",
+      "normalized_query": "SELECT * FROM t WHERE id = ?",
+      "calls": 42,
+      "total_duration": 12.5,
+      "avg_duration": 0.3,
+      "p50_duration": 0.25,
+      "p95_duration": 0.8,
+      "p99_duration": 1.1,
+      "max_duration": 1.4,
+      "errors": 0,
+      "user": "default",
+      "query_kind": "Select",
+      "database": "default"
+    }
+  ],
+  "metadata": { "queryId": "...", "duration": 45, "rows": 1, "host": "0", "sql": "..." }
+}
+```
+
+### Get one pattern + its recent executions
+
+```bash
+GET /api/v1/insights/query-patterns/1234567890123456789?hostId=0&range=24
+```
+
+<TypeTable
+  data={{
+    normalized_query_hash: { type: "path param, required", description: "The pattern's hash — a numeric string. A non-numeric value returns 400; an unknown hash returns 404." },
+    hostId: { type: "integer, optional (default 0)", description: "Same validation as the list endpoint" },
+    range: { type: "integer (hours), optional (default 24)", description: "Time window for both the pattern's aggregation and the executions list" },
+  }}
+/>
+
+```json
+{
+  "success": true,
+  "data": {
+    "pattern": { "normalized_query_hash": "1234567890123456789", "calls": 42, "total_duration": 12.5 },
+    "executions": [
+      { "event_time": "2026-07-04 10:00:00", "query_id": "...", "query_duration_ms": 310, "user": "default" }
+    ]
+  },
+  "metadata": { "host": "0", "rangeHours": 24, "rows": 1 }
+}
+```
+
+Executions are capped at 200 rows, most-recent first.
+
+## MCP / programmatic consumption
+
+Both endpoints return plain JSON (`{ success, data, metadata }` / error `{ success: false, error: { type, message } }`) with no HTML or client-only shaping, so they can be called directly by scripts, the AI agent's `query` tool (as `system.query_log` SQL), or any external MCP client that talks to `/api/mcp` — the AI agent itself has no dedicated tool for these endpoints (it reaches the same data with the general-purpose `query` tool), but the endpoints are safe to call from outside the dashboard.
+
+## Notes & limitations
+
+<Callout type="info" title="Requires query logging">
+All data comes from `system.query_log`. If query logging is disabled, both endpoints return an empty pattern list / 404s.
+</Callout>
+
+- `normalized_query_hash` values are ClickHouse `UInt64` — always compare/pass them as strings to avoid JS float precision loss.
+- The `range` window is capped at 90 days (2160 hours) to keep the underlying `system.query_log` scan bounded.
+
+## Related
+
+<Cards>
+  <Card title="Insights" href="/guide/features/insights" description="Top-tables/columns query-log analytics." />
+  <Card title="Queries" href="/guide/features/queries" description="Monitor live, historical, and expensive queries." />
+  <Card title="MCP Server" href="/guide/features/mcp" description="Expose chmonitor's tools to AI clients over MCP." />
+</Cards>


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/insights/query-patterns` — list slow-query patterns, reusing the same aggregation SQL as the Slow Query Patterns page (filter/sort ergonomics: `hostId`, `range`, `sort`, and the page's `filterSchema` fields).
- Add `GET /api/v1/insights/query-patterns/:normalized_query_hash` — one pattern's aggregated stats plus its recent `system.query_log` executions, reverse-chronological (capped at 200 rows).
- Factor `buildQueryPatternsSql()` out of `lib/query-config/queries/slow-query-patterns.ts` so the page and the new detail endpoint share one source of truth for the aggregation SQL instead of duplicating it.
- `hostId` validated as a non-negative integer per `docs/knowledge/api-hostid-validation.md` (400 otherwise).
- Documented in `docs/content/guide/features/query-insights.mdx`.

Closes #2266

## Test plan
- [x] `bun run lint`
- [x] `bun run build` (Vite build + `tsc --noEmit`)
- [x] New unit tests: `apps/dashboard/src/lib/api/insights/query-patterns.test.ts` (helpers)
- [x] New route tests: `apps/dashboard/src/routes/api/v1/insights/query-patterns.test.ts` and `.../query-patterns/$hash.test.ts` — hostId boundary validation (negative/fractional/non-numeric → 400), hash validation, 404 on unknown hash, filter/sort ergonomics, response shape
- [x] Existing `slow-query-patterns` coverage (`version-compatibility.test.ts`, `getQueryConfigByName.test.ts`) still passes after the SQL-builder refactor