### PR TITLE
perf(api): edge-cache anonymous public-read chart responses (#2181)

### DIFF
--- a/apps/dashboard/src/lib/api/shared/__tests__/edge-cache.test.ts
+++ b/apps/dashboard/src/lib/api/shared/__tests__/edge-cache.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for the `caches.default` wrapper (#2181).
+ *
+ * `isAnonymousPublicReadRequest` (the actual isSignedIn/public-read
+ * resolution) is mocked here so these tests can focus purely on the
+ * cache-key/match/put mechanics; the safety-critical "an authenticated
+ * request is never cached" invariant is covered end-to-end at the route
+ * level in routes/api/v1/charts/__tests__/name-edge-cache.test.ts, which
+ * exercises the real auth resolution instead of mocking it away.
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+let anonymousPublicRead = true
+mock.module('@/lib/feature-permissions/server', () => ({
+  isAnonymousPublicReadRequest: async () => anonymousPublicRead,
+}))
+
+const { buildEdgeCacheKey, isEdgeCacheEligible, matchEdgeCache, putEdgeCache } =
+  await import('../edge-cache')
+
+function makeRequest(): Request {
+  return new Request('https://dash.example.com/api/v1/charts/foo?hostId=0')
+}
+
+describe('isEdgeCacheEligible', () => {
+  test('delegates to isAnonymousPublicReadRequest', async () => {
+    anonymousPublicRead = true
+    expect(await isEdgeCacheEligible(makeRequest())).toBe(true)
+
+    anonymousPublicRead = false
+    expect(await isEdgeCacheEligible(makeRequest())).toBe(false)
+  })
+})
+
+describe('buildEdgeCacheKey', () => {
+  test('normalizes param order so equivalent requests share a cache entry', () => {
+    const a = buildEdgeCacheKey('charts', { name: 'foo', hostId: 0, x: 'a' })
+    const b = buildEdgeCacheKey('charts', { hostId: 0, x: 'a', name: 'foo' })
+    expect(a.url).toBe(b.url)
+  })
+
+  test('omits undefined parts', () => {
+    const key = buildEdgeCacheKey('charts', {
+      name: 'foo',
+      interval: undefined,
+    })
+    expect(key.url).not.toContain('interval')
+  })
+
+  test('namespaces by route so different endpoints never collide', () => {
+    const a = buildEdgeCacheKey('charts', { name: 'foo' })
+    const b = buildEdgeCacheKey('data', { name: 'foo' })
+    expect(a.url).not.toBe(b.url)
+  })
+})
+
+describe('matchEdgeCache / putEdgeCache', () => {
+  beforeEach(() => {
+    delete (globalThis as { caches?: unknown }).caches
+  })
+
+  test('no-ops (never throws) when caches.default is unavailable (tests/Node)', async () => {
+    const key = buildEdgeCacheKey('charts', { name: 'foo' })
+    await expect(matchEdgeCache(key)).resolves.toBeUndefined()
+    await expect(
+      putEdgeCache(key, new Response('{}', { status: 200 }))
+    ).resolves.toBeUndefined()
+  })
+
+  test('put() skips a non-200 response', async () => {
+    const put = mock(async () => undefined)
+    ;(globalThis as { caches?: unknown }).caches = {
+      default: { put, match: mock(async () => undefined) },
+    }
+    const key = buildEdgeCacheKey('charts', { name: 'foo' })
+    await putEdgeCache(
+      key,
+      new Response('{}', {
+        status: 500,
+        headers: { 'Cache-Control': 'public, s-maxage=30' },
+      })
+    )
+    expect(put).not.toHaveBeenCalled()
+  })
+
+  test('put() skips a response with no s-maxage directive', async () => {
+    const put = mock(async () => undefined)
+    ;(globalThis as { caches?: unknown }).caches = {
+      default: { put, match: mock(async () => undefined) },
+    }
+    const key = buildEdgeCacheKey('charts', { name: 'foo' })
+    await putEdgeCache(
+      key,
+      new Response('{}', {
+        status: 200,
+        headers: { 'Cache-Control': 'private, max-age=0' },
+      })
+    )
+    expect(put).not.toHaveBeenCalled()
+  })
+
+  test('put() stores a cacheable 200 response', async () => {
+    const put = mock(async () => undefined)
+    ;(globalThis as { caches?: unknown }).caches = {
+      default: { put, match: mock(async () => undefined) },
+    }
+    const key = buildEdgeCacheKey('charts', { name: 'foo' })
+    const response = new Response('{}', {
+      status: 200,
+      headers: {
+        'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=60',
+      },
+    })
+    await putEdgeCache(key, response)
+    expect(put).toHaveBeenCalledTimes(1)
+    // The caller's response object must stay usable (not consumed by put()).
+    expect(response.bodyUsed).toBe(false)
+  })
+
+  test('match() returns the cache hit', async () => {
+    const cached = new Response('{"cached":true}')
+    const match = mock(async () => cached)
+    ;(globalThis as { caches?: unknown }).caches = {
+      default: { put: mock(async () => undefined), match },
+    }
+    const key = buildEdgeCacheKey('charts', { name: 'foo' })
+    expect(await matchEdgeCache(key)).toBe(cached)
+  })
+})

--- a/apps/dashboard/src/lib/api/shared/edge-cache.ts
+++ b/apps/dashboard/src/lib/api/shared/edge-cache.ts
@@ -1,0 +1,125 @@
+/**
+ * Cloudflare Cache API (`caches.default`) wrapper for anonymous public-read
+ * GET responses (#2181).
+ *
+ * Cloudflare Workers do NOT automatically populate a shared edge cache from a
+ * `Cache-Control: s-maxage=...` response header alone — that only advises
+ * downstream HTTP caches (browser / any zone-level Cache Rule in front of the
+ * Worker). Without explicitly reading/writing `caches.default`, every
+ * anonymous viewer of the shared public demo host re-runs the same
+ * ClickHouse query and Worker invocation. This module lets a route opt into
+ * `caches.default` for the one case where it's safe: an anonymous request on
+ * a deployment that has opted into public read access.
+ *
+ * SAFETY INVARIANT — READ BEFORE CHANGING:
+ * `caches.default` is a SINGLE cache shared by every request the Worker ever
+ * serves; it has no per-user partition. Writing an authenticated or
+ * per-user response into it would leak that response to the next visitor who
+ * happens to produce the same cache key — a genuine cross-user data leak, not
+ * a hypothetical one. `isEdgeCacheEligible` is therefore the ONLY gate: it is
+ * `true` if and only if the request is anonymous AND the deployment has
+ * opted into public read (`publicReadEnabled()`), via
+ * `isAnonymousPublicReadRequest` in `@/lib/feature-permissions/server` (the
+ * same auth resolution `authorizeFeatureRequest` uses, so this can never
+ * disagree with the per-feature access gate). Callers MUST check this before
+ * every `matchEdgeCache` / `putEdgeCache` call and MUST NOT cache a response
+ * for any request where it returns `false`.
+ */
+
+import { isAnonymousPublicReadRequest } from '@/lib/feature-permissions/server'
+
+/**
+ * The dashboard's `tsconfig.json` `types` resolves `CacheStorage` from the DOM
+ * lib (shared with the browser bundle), which has no `default` property — only
+ * the Workers-runtime `CacheStorage` does. Cast through this narrow local
+ * shape instead of widening the global type for the whole app.
+ */
+interface WorkersCacheStorage {
+  readonly default: Cache
+}
+
+/**
+ * `caches.default` is a Workers-runtime global. It does not exist under
+ * `bun test` / plain Node, so callers fall back to "no edge cache" rather
+ * than throwing — under-caching (a ClickHouse round trip on every request) is
+ * the safe failure mode, never over-caching.
+ */
+function getDefaultCache(): Cache | undefined {
+  if (typeof caches === 'undefined') return undefined
+  return (caches as unknown as WorkersCacheStorage).default
+}
+
+/**
+ * Whether this request may read from / write to the shared edge cache.
+ *
+ * See the module doc comment — this is the ONE safety gate for
+ * `matchEdgeCache` / `putEdgeCache`. Never call `putEdgeCache` (or serve a
+ * `matchEdgeCache` hit) for a request where this returns `false`.
+ */
+export function isEdgeCacheEligible(request: Request): Promise<boolean> {
+  return isAnonymousPublicReadRequest(request)
+}
+
+/**
+ * Build a stable cache key for the shared edge cache from explicit,
+ * already-validated parts (not the raw incoming `Request`, which may carry
+ * cookies/Authorization headers and client-supplied query-param ordering that
+ * have no bearing on the response body).
+ *
+ * `route` namespaces the key (e.g. `'charts'`) so different endpoints never
+ * collide. Remaining parts are sorted by key and appended as a normalized
+ * query string so equivalent requests (regardless of param order) share one
+ * cache entry. `undefined` values are omitted.
+ */
+export function buildEdgeCacheKey(
+  route: string,
+  parts: Record<string, string | number | boolean | undefined>
+): Request {
+  const url = new URL(`https://edge-cache.internal/${route}`)
+  for (const key of Object.keys(parts).sort()) {
+    const value = parts[key]
+    if (value !== undefined) url.searchParams.set(key, String(value))
+  }
+  return new Request(url.toString())
+}
+
+/**
+ * Look up `cacheKey` in the shared edge cache. Returns `undefined` on a miss
+ * or when `caches.default` isn't available (e.g. tests).
+ *
+ * Callers MUST have already confirmed `isEdgeCacheEligible(request)` before
+ * calling this — this function does not re-check it, so it must never be
+ * called for an authenticated/per-user request.
+ */
+export async function matchEdgeCache(
+  cacheKey: Request
+): Promise<Response | undefined> {
+  const cache = getDefaultCache()
+  if (!cache) return undefined
+  return cache.match(cacheKey)
+}
+
+/**
+ * Store `response` in the shared edge cache under `cacheKey`.
+ *
+ * Only caches a plain 200 response that already carries an `s-maxage`
+ * directive (i.e. a route that has deliberately opted into caching) — this
+ * never expands caching to a response that wasn't already meant to be
+ * cacheable. No-ops when `caches.default` is unavailable.
+ *
+ * Callers MUST have already confirmed `isEdgeCacheEligible(request)` before
+ * calling this — this function does not re-check it, so it must never be
+ * called for an authenticated/per-user request. Clones `response` internally,
+ * so the caller's own `response` object remains safe to return to the client.
+ */
+export async function putEdgeCache(
+  cacheKey: Request,
+  response: Response
+): Promise<void> {
+  const cache = getDefaultCache()
+  if (!cache) return
+  if (response.status !== 200) return
+  const cacheControl = response.headers.get('Cache-Control') ?? ''
+  if (!/(?:^|,)\s*s-maxage=\d+/.test(cacheControl)) return
+  await cache.put(cacheKey, response.clone())
+}

--- a/apps/dashboard/src/lib/api/shared/index.ts
+++ b/apps/dashboard/src/lib/api/shared/index.ts
@@ -4,6 +4,13 @@
  * Barrel export for all shared API utilities.
  */
 
+// Shared edge cache (Cloudflare `caches.default`) for anonymous public-read GET
+export {
+  buildEdgeCacheKey,
+  isEdgeCacheEligible,
+  matchEdgeCache,
+  putEdgeCache,
+} from './edge-cache'
 // Response builders
 export {
   createCachedResponse,

--- a/apps/dashboard/src/lib/feature-permissions/__tests__/anonymous-public-read.test.ts
+++ b/apps/dashboard/src/lib/feature-permissions/__tests__/anonymous-public-read.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for `isAnonymousPublicReadRequest` — the strict isSignedIn/public-read
+ * split used to gate the shared edge cache (#2181). It must reuse the exact
+ * same auth resolution as `authorizeFeatureRequest` so the two can never
+ * disagree about who counts as "signed in".
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// readEnv() in server.ts prefers the cloudflare:workers `env` binding, then
+// falls back to process.env. Mock the binding empty so the tests drive config
+// purely through process.env (mirrors app-config-cache.test.ts).
+mock.module('cloudflare:workers', () => ({ env: {} }))
+
+let clerkAuthResult: { userId?: string } | null = null
+mock.module('@clerk/tanstack-react-start/server', () => ({
+  auth: async () => clerkAuthResult,
+}))
+
+const ENV_KEYS = ['CHM_AUTH_PROVIDER', 'CHM_CLERK_PUBLIC_READ']
+
+function clearEnv(): void {
+  for (const key of ENV_KEYS) delete process.env[key]
+}
+
+describe('isAnonymousPublicReadRequest', () => {
+  beforeEach(async () => {
+    clearEnv()
+    const { _resetAppConfigCache } = await import('../server')
+    _resetAppConfigCache()
+    clerkAuthResult = null
+  })
+
+  afterEach(async () => {
+    clearEnv()
+    const { _resetAppConfigCache } = await import('../server')
+    _resetAppConfigCache()
+  })
+
+  test('false when publicReadEnabled() is off, regardless of auth', async () => {
+    process.env.CHM_AUTH_PROVIDER = 'clerk'
+    process.env.CHM_CLERK_PUBLIC_READ = 'false'
+    const { isAnonymousPublicReadRequest } = await import('../server')
+    const request = new Request('https://dash.example.com/api/v1/charts/foo')
+    expect(await isAnonymousPublicReadRequest(request)).toBe(false)
+  })
+
+  test('true for an anonymous clerk request under public-read', async () => {
+    process.env.CHM_AUTH_PROVIDER = 'clerk'
+    process.env.CHM_CLERK_PUBLIC_READ = 'true'
+    clerkAuthResult = null // no session
+    const { isAnonymousPublicReadRequest } = await import('../server')
+    const request = new Request('https://dash.example.com/api/v1/charts/foo')
+    expect(await isAnonymousPublicReadRequest(request)).toBe(true)
+  })
+
+  test('false for a SIGNED-IN clerk request even under public-read (the leak this gate exists to prevent)', async () => {
+    process.env.CHM_AUTH_PROVIDER = 'clerk'
+    process.env.CHM_CLERK_PUBLIC_READ = 'true'
+    clerkAuthResult = { userId: 'user_123' } // isSignedIn: true
+    const { isAnonymousPublicReadRequest } = await import('../server')
+    const request = new Request('https://dash.example.com/api/v1/charts/foo')
+    expect(await isAnonymousPublicReadRequest(request)).toBe(false)
+  })
+
+  test('false when auth provider is `none`, even if CHM_CLERK_PUBLIC_READ is set (no anonymous/signed-in split to protect)', async () => {
+    process.env.CHM_AUTH_PROVIDER = 'none'
+    process.env.CHM_CLERK_PUBLIC_READ = 'true'
+    const { isAnonymousPublicReadRequest } = await import('../server')
+    const request = new Request('https://dash.example.com/api/v1/charts/foo')
+    expect(await isAnonymousPublicReadRequest(request)).toBe(false)
+  })
+})

--- a/apps/dashboard/src/lib/feature-permissions/server.ts
+++ b/apps/dashboard/src/lib/feature-permissions/server.ts
@@ -237,6 +237,26 @@ function jsonFeatureError(
   })
 }
 
+/**
+ * Whether `request` is anonymous AND the deployment grants anonymous read
+ * (`publicReadEnabled()`).
+ *
+ * Reuses the exact same auth resolution `authorizeFeatureRequest` uses (cheap
+ * anonymous baseline, no Clerk call for the common anonymous case; Clerk/proxy
+ * check otherwise) so this can never disagree with the per-feature gate about
+ * who counts as "signed in". Intended for callers that need a strict
+ * anonymous/authenticated split BEFORE any feature-specific decision — e.g.
+ * the shared edge-cache gate (#2181), where writing an authenticated caller's
+ * response into `caches.default` would leak it to every other visitor.
+ */
+export async function isAnonymousPublicReadRequest(
+  request: Request
+): Promise<boolean> {
+  if (!publicReadEnabled()) return false
+  const config = getAppConfig()
+  return !(await isAuthenticatedRequest(request, config))
+}
+
 export async function authorizeFeatureRequest(
   permission: FeaturePermission | undefined,
   request: Request,

--- a/apps/dashboard/src/routes/api/v1/charts/$name.ts
+++ b/apps/dashboard/src/routes/api/v1/charts/$name.ts
@@ -30,6 +30,12 @@ import {
   getApiRateLimitPerMin,
   rateLimitResponse,
 } from '@/lib/api/rate-limiter'
+import {
+  buildEdgeCacheKey,
+  isEdgeCacheEligible,
+  matchEdgeCache,
+  putEdgeCache,
+} from '@/lib/api/shared/edge-cache'
 import { statusForFetchDataError } from '@/lib/api/shared/fetch-data-error'
 import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
 
@@ -181,6 +187,27 @@ export async function handler(
   )
   if (permissionResponse) return permissionResponse
 
+  // Shared edge cache (#2181): only ever consulted for an anonymous request
+  // on a deployment that has opted into public read access — see
+  // `isEdgeCacheEligible`'s doc comment for why this gate must never be
+  // relaxed. `edgeCacheKey` stays `undefined` (cache skipped entirely) for
+  // every other request, including any authenticated/per-user caller.
+  const edgeCacheEligible = await isEdgeCacheEligible(request)
+  const edgeCacheKey = edgeCacheEligible
+    ? buildEdgeCacheKey('charts', {
+        name,
+        hostId,
+        interval,
+        lastHours,
+        params: chartParams ? JSON.stringify(chartParams) : undefined,
+        timezone,
+      })
+    : undefined
+  if (edgeCacheKey) {
+    const cached = await matchEdgeCache(edgeCacheKey)
+    if (cached) return cached
+  }
+
   try {
     // Multi-query chart (summary charts)
     if ('queries' in queryDef) {
@@ -263,13 +290,17 @@ export async function handler(
           },
         },
       })
-      return new Response(body, {
+      const unavailableResponse = new Response(body, {
         status: 200,
         headers: {
           'Content-Type': 'application/json',
           'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=120',
         },
       })
+      if (edgeCacheKey) {
+        await putEdgeCache(edgeCacheKey, unavailableResponse)
+      }
+      return unavailableResponse
     }
 
     if (result.error) {
@@ -318,13 +349,17 @@ export async function handler(
           ? 'public, s-maxage=120, stale-while-revalidate=300'
           : 'public, s-maxage=30, stale-while-revalidate=60'
 
-    return new Response(body, {
+    const successResponse = new Response(body, {
       status: 200,
       headers: {
         'Content-Type': 'application/json',
         'Cache-Control': cacheControl,
       },
     })
+    if (edgeCacheKey) {
+      await putEdgeCache(edgeCacheKey, successResponse)
+    }
+    return successResponse
   } catch (err) {
     error(`[GET /api/v1/charts/${name}] Unhandled exception:`, err)
     // Classify so an upstream connectivity exception surfaces as 503/504

--- a/apps/dashboard/src/routes/api/v1/charts/__tests__/hostid-validation.test.ts
+++ b/apps/dashboard/src/routes/api/v1/charts/__tests__/hostid-validation.test.ts
@@ -20,6 +20,7 @@ mock.module('cloudflare:workers', () => ({
 
 mock.module('@/lib/feature-permissions/server', () => ({
   authorizeFeatureRequest: async () => null,
+  isAnonymousPublicReadRequest: async () => false,
 }))
 
 import * as realRegistry from '@/lib/api/chart-registry'

--- a/apps/dashboard/src/routes/api/v1/charts/__tests__/name-edge-cache.test.ts
+++ b/apps/dashboard/src/routes/api/v1/charts/__tests__/name-edge-cache.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Edge-cache safety test for GET /api/v1/charts/$name (#2181).
+ *
+ * The shared Cloudflare `caches.default` cache has NO per-user partition, so
+ * writing an authenticated/per-user response into it would leak that
+ * response to the next visitor who produces the same cache key. This is the
+ * one test that most directly protects against that: it exercises the REAL
+ * `isSignedIn` resolution (via `@/lib/feature-permissions/server`, mocking
+ * only the underlying Clerk SDK call it makes) rather than stubbing the
+ * edge-cache gate itself, so a regression that weakens the gate would fail
+ * this test even if the gate function's own unit tests still passed.
+ *
+ * Mocking strategy mirrors routes/api/v1/health/actions.test.ts: mock.module()
+ * for cloudflare:workers, the ClickHouse-touching query executor, and the
+ * Clerk SDK — all declared before the dynamic import of the route module.
+ * `@/lib/feature-permissions/server` itself is REAL (not mocked) so
+ * `isAnonymousPublicReadRequest` runs its real auth-provider branch.
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// `CHM_AUTH_PROVIDER=clerk` + `CHM_CLERK_PUBLIC_READ=true` is the one
+// configuration where the edge cache can ever be eligible — mirrors the cloud
+// deployment's public-demo posture. Mutated per-test via `clerkAuthResult`.
+mock.module('cloudflare:workers', () => ({
+  env: {
+    CLICKHOUSE_HOST: 'http://localhost:8123',
+    CLICKHOUSE_USER: 'default',
+    CLICKHOUSE_PASSWORD: '',
+    CHM_AUTH_PROVIDER: 'clerk',
+    CHM_CLERK_PUBLIC_READ: 'true',
+  },
+}))
+
+// The real `@/lib/feature-permissions/server` (unmocked) calls this for the
+// clerk provider. `null` == no session == anonymous; `{ userId }` == signed in.
+let clerkAuthResult: { userId?: string } | null = null
+mock.module('@clerk/tanstack-react-start/server', () => ({
+  auth: async () => clerkAuthResult,
+}))
+
+// Stub the ClickHouse-touching executor so the test never needs a live
+// ClickHouse instance. `running-queries-count` (a real, permission-less,
+// single-query chart from overview-charts.ts) is used unmocked from the real
+// chart-registry so `queryDef.cachePolicy`/`permission` reflect production.
+mock.module('@/lib/api/query-executor', () => ({
+  isValidInterval: () => true,
+  executeChartQuery: async () => ({
+    dataJson: '[{"count":1}]',
+    metadata: { queryId: 'q1', duration: 1, rows: 1 },
+    error: undefined,
+    executedSql: 'SELECT COUNT() as count FROM system.processes',
+    clickhouseVersion: '24.1',
+  }),
+  executeMultiChartQuery: async () => ({ results: [] }),
+}))
+
+const { handler } = await import('../$name')
+
+function makeRequest(): Request {
+  return new Request(
+    'https://dash.example.com/api/v1/charts/running-queries-count?hostId=0'
+  )
+}
+
+function installMockEdgeCache() {
+  const put = mock(async (_key: Request, _res: Response) => undefined)
+  const match = mock(async (_key: Request) => undefined)
+  ;(globalThis as { caches?: unknown }).caches = { default: { put, match } }
+  return { put, match }
+}
+
+describe('GET /api/v1/charts/$name — shared edge cache safety gate (#2181)', () => {
+  beforeEach(async () => {
+    const { _resetAppConfigCache } = await import(
+      '@/lib/feature-permissions/server'
+    )
+    _resetAppConfigCache()
+  })
+
+  test('an authenticated (signed-in) request is NEVER written to the shared edge cache', async () => {
+    clerkAuthResult = { userId: 'user_123' } // isSignedIn: true
+    const { put } = installMockEdgeCache()
+
+    const res = await handler(makeRequest(), 'running-queries-count')
+
+    expect(res.status).toBe(200)
+    expect(put).not.toHaveBeenCalled()
+  })
+
+  test('control: an anonymous request under public-read IS written to the shared edge cache', async () => {
+    clerkAuthResult = null // isSignedIn: false
+    const { put } = installMockEdgeCache()
+
+    const res = await handler(makeRequest(), 'running-queries-count')
+
+    expect(res.status).toBe(200)
+    expect(put).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/dashboard/src/routes/api/v1/charts/__tests__/name.test.ts
+++ b/apps/dashboard/src/routes/api/v1/charts/__tests__/name.test.ts
@@ -19,9 +19,13 @@ mock.module('cloudflare:workers', () => ({
   },
 }))
 
-// Feature gate always allows in these tests.
+// Feature gate always allows in these tests. `isAnonymousPublicReadRequest`
+// (used by the shared edge-cache gate, #2181) is stubbed `false` — these
+// tests aren't exercising caching behavior, so the route should skip the
+// edge cache entirely and just run its normal response path.
 mock.module('@/lib/feature-permissions/server', () => ({
   authorizeFeatureRequest: async () => null,
+  isAnonymousPublicReadRequest: async () => false,
 }))
 
 // Controllable chart registry: an optional chart and a non-optional one. Spread


### PR DESCRIPTION
## Summary

Closes #2181.

35 chart/data routes already set `s-maxage` `Cache-Control` headers
(`lib/api/shared/response-builder.ts:52-56`), but a Cloudflare Workers fetch
handler does **not** automatically populate a shared edge cache from
`Cache-Control` alone — there was zero `caches.default`/`caches.open` usage
in the codebase. Every anonymous viewer of the shared public demo host was
re-running the same ClickHouse query and Worker invocation.

This PR wraps `GET /api/v1/charts/$name` (the route named in the issue) in
Cloudflare's `caches.default` `match`/`put`, keyed by
`(route, name, hostId, interval, lastHours, params, timezone)`, with
`s-maxage` bounded by the chart's existing cache policy (unchanged — no
route ever gets a longer TTL than before, it's just now backed by an actual
cache instead of an advisory header).

## The three things this issue asked to call out explicitly

**1. Exact gating condition.** `isEdgeCacheEligible(request)` →
`isAnonymousPublicReadRequest(request)` (new export in
`lib/feature-permissions/server.ts`) → `!isSignedIn && publicReadEnabled()`,
literally. It reuses the *exact same* auth resolution `authorizeFeatureRequest`
already uses (cheap anonymous baseline, Clerk/proxy check only when
`publicReadEnabled()` is on), so the edge-cache gate can never disagree with
the per-feature access gate about who counts as "signed in". `edgeCacheKey`
stays `undefined` for every other request — the route then skips
`matchEdgeCache`/`putEdgeCache` entirely, so there's no code path where an
authenticated response can reach `caches.default`.

**2. Test proving authenticated responses are never cached.**
`apps/dashboard/src/routes/api/v1/charts/__tests__/name-edge-cache.test.ts`
mocks a fake `caches.default` (`put`/`match` spies) and drives the **real**
`isSignedIn` resolution — it mocks only the underlying Clerk SDK call
(`@clerk/tanstack-react-start/server`'s `auth()`) and sets
`CHM_AUTH_PROVIDER=clerk` + `CHM_CLERK_PUBLIC_READ=true` (the cloud
public-demo posture), rather than stubbing the edge-cache gate function
itself. `auth()` → `{ userId: 'user_123' }` (signed in) asserts
`cache.put` is **never called**; a control test with `auth()` → `null`
(anonymous) asserts it **is** called, proving the harness would actually
catch a regression. Additional focused unit tests:
`lib/api/shared/__tests__/edge-cache.test.ts` (cache-key/match/put mechanics)
and `lib/feature-permissions/__tests__/anonymous-public-read.test.ts` (the
gate function itself, including the `none`-provider edge case).

**3. Whether a Cloudflare zone Cache Rule might already cover `/api/*`.**
Nothing in this repo configures one — `apps/dashboard/wrangler.toml` declares
no cache-related `[vars]`/zone config (only `[[routes]]`), and there is no
Terraform/Pulumi/other IaC for the zone in this monorepo. That means this
can't be fully verified from code — a zone-level Cache Rule, if one exists,
would live only in the Cloudflare dashboard/API outside this repo. **Please
check the `dash.chmonitor.dev` zone's Cache Rules in the Cloudflare dashboard
before/after merge** to confirm none targets `/api/*`; if one does, it could
double-cache (harmless, since both would honor the same `s-maxage`) or mask
this change's effect, but should not cause a *correctness* problem since we
never change what a route's `Cache-Control` says — we only start honoring it
inside the Worker as well.

## Audit: latent cross-user cache-control bug?

Also required by the issue: audit every `public` Cache-Control response for
reachability by an authenticated/per-user code path. Checked all 34 route
files that set a `public`/`s-maxage` `Cache-Control` (`menu-counts`,
`cluster-counts`, `table-availability`, `cluster-topology`, `explorer/*`,
`health/*`, `hosts`, `notifications`, `tables/*`, `charts/$name`, `data`):
every one validates `hostId` as a **non-negative integer**
(`HostIdSchema`/`getAndValidateHostId`/inline `hostId < 0` checks), and
per-user D1-backed connections always use **negative** ids
(`DB_CONNECTION_HOST_ID_START = -1000`, per `docs/knowledge/cloud-saas-mode.md`).
So none of the `public`-cached routes can ever serve a per-user connection's
data — they only ever address env/demo hosts, which are the same for every
caller regardless of auth. The genuinely per-user routes (`dashboards/*`,
`conversations/*`) already correctly use `CacheControl.NONE`. **No latent bug
found.**

## Scope

Deliberately scoped to `charts/$name.ts` only (the route named in the
issue) to keep this Tier-2, cross-user-risk change small and reviewable.
`data.ts` (GET) and the other public-cache routes (`menu-counts`,
`cluster-counts`, `table-availability`, `cluster-topology`) are good
candidates for a follow-up once this pattern is validated in production —
under-caching (skip) is the safe default, so leaving them out costs
performance, not correctness.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run build` (Vite build + `tsc --noEmit`) — clean
- [x] `bun run test` — 5739 pass, 0 fail (full suite, including the new
      edge-cache tests and the negative "authenticated → never cached" test)
- [x] Updated two existing chart-route test files
      (`name.test.ts`, `hostid-validation.test.ts`) whose
      `@/lib/feature-permissions/server` mocks needed the new
      `isAnonymousPublicReadRequest` export added (stubbed `false` — they
      don't exercise caching)