### PR TITLE
fix(api): floor fractional range hours before binding to UInt32

### DIFF
--- a/apps/dashboard/src/lib/ai/agent/tools/query-tools.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/query-tools.ts
@@ -212,9 +212,7 @@ export function createQueryTools(hostId: number) {
       }),
       execute: async (input: unknown) => {
         const { getTableQuery } = await import('@/lib/api/table-registry')
-        const { executeTableConfig } = await import(
-          '@/lib/api/query-executor'
-        )
+        const { executeTableConfig } = await import('@/lib/api/query-executor')
         const {
           limit = 10,
           lastHours = 24,

--- a/apps/dashboard/src/lib/api/insights/query-patterns.test.ts
+++ b/apps/dashboard/src/lib/api/insights/query-patterns.test.ts
@@ -35,6 +35,11 @@ describe('parseRangeHours', () => {
     expect(parseRangeHours('6')).toBe(6)
   })
 
+  test('floors a fractional value (feeds a ClickHouse UInt32 param)', () => {
+    expect(parseRangeHours('1.5')).toBe(1)
+    expect(Number.isInteger(parseRangeHours('1.5'))).toBe(true)
+  })
+
   test('clamps to the max window', () => {
     expect(parseRangeHours('999999', 24, 720)).toBe(720)
   })

--- a/apps/dashboard/src/lib/api/insights/query-patterns.ts
+++ b/apps/dashboard/src/lib/api/insights/query-patterns.ts
@@ -37,7 +37,9 @@ export function parseRangeHours(
   if (!raw) return fallbackHours
   const parsed = Number(raw)
   if (!Number.isFinite(parsed) || parsed <= 0) return fallbackHours
-  return Math.min(parsed, maxHours)
+  // Floor to an integer — this feeds a ClickHouse UInt32 query param, which
+  // rejects fractional values (e.g. `?range=1.5` would 500 the query).
+  return Math.min(Math.floor(parsed), maxHours)
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fast-follow to #2266/#2310 (Query Insights API). `parseRangeHours` only checked finite/positive, so `?range=1.5` on the pattern-detail endpoint slipped through and bound a fractional value to a ClickHouse `UInt32` query param, turning malformed input into a 500 instead of a handled/validated case. Floor to an integer, in line with the non-negative-integer boundary contract other params already follow.
- Incidental: fixed an unrelated pre-existing Biome formatting violation in `query-tools.ts` that was blocking the pre-push hook for this branch.

## Test plan
- [x] `bun run lint`
- [x] `bun run build`
- [x] `apps/dashboard/src/lib/api/insights/query-patterns.test.ts` — new case: `parseRangeHours('1.5')` floors to `1`