### PR TITLE
fix(test): stop feature-permissions mock.module leak breaking main unit-tests

### DIFF
--- a/apps/dashboard/src/lib/ai/agent/tools/query-tools.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/query-tools.ts
@@ -212,9 +212,7 @@ export function createQueryTools(hostId: number) {
       }),
       execute: async (input: unknown) => {
         const { getTableQuery } = await import('@/lib/api/table-registry')
-        const { executeTableConfig } = await import(
-          '@/lib/api/query-executor'
-        )
+        const { executeTableConfig } = await import('@/lib/api/query-executor')
         const {
           limit = 10,
           lastHours = 24,

--- a/apps/dashboard/src/routes/api/v1/charts/__tests__/cloud-demo-host-guard.test.ts
+++ b/apps/dashboard/src/routes/api/v1/charts/__tests__/cloud-demo-host-guard.test.ts
@@ -21,7 +21,15 @@ mock.module('cloudflare:workers', () => ({
   },
 }))
 
+import * as realFeaturePermissions from '@/lib/feature-permissions/server'
+
+// Spread the real module so other test files' named imports (e.g.
+// `isAnonymousPublicReadRequest`, used by name-edge-cache.test.ts) keep
+// resolving when this mock.module call is still active in the same test
+// worker — Bun's mock.module replaces the module registry entry globally,
+// not per-file, even under `--isolate`.
 mock.module('@/lib/feature-permissions/server', () => ({
+  ...realFeaturePermissions,
   authorizeFeatureRequest: async () => null,
 }))
 


### PR DESCRIPTION
## Problem

Main's \`unit-tests\` job started failing after #2302 (#2172) merged: `SyntaxError: Export named 'isAnonymousPublicReadRequest' not found in module '.../lib/feature-permissions/server.ts'`.

Root cause: \`charts/__tests__/cloud-demo-host-guard.test.ts\` (added by #2172) fully replaced \`@/lib/feature-permissions/server\` via \`mock.module\` with only \`{ authorizeFeatureRequest }\`, dropping every other real export. Bun's \`mock.module\` patches the module registry globally for the whole test worker, not per-file — even under \`--isolate\` — so when \`charts/__tests__/name-edge-cache.test.ts\` (added by #2181, merged separately) ran in the same worker and tried to use the real \`isAnonymousPublicReadRequest\` export, it was gone.

Both PRs were individually correct and passed CI in isolation; the interaction only appears once both are on \`main\` together.

## Fix

Spread the real module before overriding, matching the pattern this same test file already uses for \`@/lib/auth/provider\` and \`@/lib/api/chart-registry\`:
\`\`\`ts
mock.module('@/lib/feature-permissions/server', () => ({
  ...realFeaturePermissions,
  authorizeFeatureRequest: async () => null,
}))
\`\`\`

Also fixed a pre-existing, unrelated Biome formatting violation in \`query-tools.ts\` (from #2263) that was failing \`bun run check\` repo-wide and blocking this push.

## Verification
- \`bun test src/ --isolate\` (apps/dashboard): 5828 pass / 0 fail (was 1 fail / 1 unhandled error before the fix)
- \`bun run lint\`: clean
- Full pre-push hook (biome check + test:unit + test:packages): passed