### PR TITLE
fix(insights): rank notable runs server-side, not from a capped sample

### DIFF
--- a/apps/dashboard/src/components/slow-query-patterns/pattern-detail-sheet.tsx
+++ b/apps/dashboard/src/components/slow-query-patterns/pattern-detail-sheet.tsx
@@ -9,9 +9,12 @@
  *   filters and time range, so no extra query is needed here.
  * - Recent / Notable runs: `GET /api/v1/insights/query-patterns/:hash`
  *   (#2266) — reused rather than duplicating a second "executions for one
- *   pattern" query. "Notable" (slowest / largest result / errored) is
- *   derived client-side from that same up-to-200-row response, the same
- *   window cap the endpoint itself already applies.
+ *   pattern" query. "Recent" reads the endpoint's reverse-chronological
+ *   `executions` (capped at 200 rows). "Notable" (slowest / largest result /
+ *   errored) reads the endpoint's separately server-ranked `notable` list —
+ *   NOT derived by sorting `executions` client-side, since that list is
+ *   capped and would silently rank within "the last 200 runs" rather than
+ *   the full time window for any pattern hot enough to exceed the cap.
  * - Advisor: reuses `/api/v1/advisor` + `AdvisorRecommendationsPanel`, the
  *   same engine and renderer as the `/advisor` page.
  *
@@ -45,7 +48,10 @@ import {
   SheetTitle,
 } from '@/components/ui/sheet'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { isValidQueryHash } from '@/lib/api/insights/query-patterns'
+import {
+  isValidQueryHash,
+  type NotableRunReason,
+} from '@/lib/api/insights/query-patterns'
 import { buildExplorerQueryUrl } from '@/lib/explorer-url'
 import { useSearchParams } from '@/lib/next-compat'
 import { apiFetch } from '@/lib/swr/api-fetch'
@@ -99,6 +105,7 @@ interface PatternDetailApiResponse {
   data: {
     pattern: Record<string, unknown>
     executions: PatternExecutionRow[]
+    notable: Array<PatternExecutionRow & { reason: NotableRunReason }>
   }
 }
 interface AdvisorApiResponse extends AdvisorRecommendationsOutput {
@@ -145,13 +152,6 @@ async function fetchAdvisor(url: string): Promise<AdvisorApiResponse> {
   return body
 }
 
-/** Best-effort top-N helper for the "Notable runs" tab — sorts a copy so the
- * caller's array/order (reverse-chronological, as the API returns it) is
- * untouched for the "Recent" tab. */
-function topN<T>(rows: T[], by: (row: T) => number, n: number): T[] {
-  return [...rows].sort((a, b) => by(b) - by(a)).slice(0, n)
-}
-
 /** Only mounted while the Sheet is open — gates the drilldown/advisor fetches. */
 function PatternDetailSheetContent({
   pattern,
@@ -187,15 +187,15 @@ function PatternDetailSheetContent({
   })
 
   const byReason = useMemo(() => {
-    const executions = detailData?.data.executions ?? []
+    const notable = detailData?.data.notable ?? []
     return {
       // Already reverse-chronological from the API.
-      recent: executions.slice(0, 20),
-      slowest: topN(executions, (r) => Number(r.query_duration_ms || 0), 5),
-      largest_result: topN(executions, (r) => Number(r.result_rows || 0), 5),
-      errored: executions
-        .filter((r) => Number(r.exception_code || 0) !== 0)
-        .slice(0, 5),
+      recent: (detailData?.data.executions ?? []).slice(0, 20),
+      // Server-ranked (see buildPatternNotableRunsConfig) — NOT sliced from
+      // `executions`, which is capped and would misrank hot patterns.
+      slowest: notable.filter((r) => r.reason === 'slowest'),
+      largest_result: notable.filter((r) => r.reason === 'largest_result'),
+      errored: notable.filter((r) => r.reason === 'errored'),
     }
   }, [detailData])
 

--- a/apps/dashboard/src/lib/api/insights/query-patterns.test.ts
+++ b/apps/dashboard/src/lib/api/insights/query-patterns.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import {
   buildPatternDetailConfig,
   buildPatternExecutionsConfig,
+  buildPatternNotableRunsConfig,
   isValidQueryHash,
   parseRangeHours,
   sortPatternRows,
@@ -94,5 +95,27 @@ describe('buildPatternDetailConfig / buildPatternExecutionsConfig', () => {
     const config = buildPatternExecutionsConfig()
     expect(config.sql as string).toContain('ORDER BY event_time DESC')
     expect(config.sql as string).toContain('executions_limit')
+  })
+})
+
+describe('buildPatternNotableRunsConfig', () => {
+  test('ranks each notable category independently, not sliced from a shared cap', () => {
+    const sql = buildPatternNotableRunsConfig().sql as string
+    // Each branch must have its own ORDER BY + LIMIT against the full
+    // hash/time-filtered `base` CTE — never a slice of a capped result set,
+    // or a hot pattern's true slowest/largest run silently falls outside it.
+    expect(sql).toContain('ORDER BY query_duration_ms DESC')
+    expect(sql).toContain('ORDER BY result_rows DESC')
+    expect(sql).toContain('WHERE exception_code != 0')
+    expect(sql.match(/notable_limit/g)?.length).toBe(3)
+    expect(sql).toContain("'slowest' AS reason")
+    expect(sql).toContain("'largest_result' AS reason")
+    expect(sql).toContain("'errored' AS reason")
+  })
+
+  test('scopes to the pattern hash and time window', () => {
+    const sql = buildPatternNotableRunsConfig().sql as string
+    expect(sql).toContain('normalized_query_hash')
+    expect(sql).toContain('range_hours')
   })
 })

--- a/apps/dashboard/src/lib/api/insights/query-patterns.ts
+++ b/apps/dashboard/src/lib/api/insights/query-patterns.ts
@@ -120,3 +120,65 @@ export function buildPatternExecutionsConfig(): QueryConfig {
     `,
   }
 }
+
+/** The "Notable runs" categories the pattern detail flyout renders. */
+export type NotableRunReason = 'slowest' | 'largest_result' | 'errored'
+
+/**
+ * Build the ad-hoc QueryConfig for one pattern's "notable" executions —
+ * slowest / largest-result / errored — ranked server-side across the FULL
+ * time window.
+ *
+ * This must NOT be derived by sorting {@link buildPatternExecutionsConfig}'s
+ * response in JS: that endpoint caps at `executions_limit` (200) rows,
+ * reverse-chronological, so a pattern that runs more than ~8 times/hour over
+ * a 24h window already exceeds that cap — its true slowest/largest run is
+ * routinely older than the sample, silently contradicting the Overview
+ * card's `max_duration` (computed by the full, uncapped aggregation). Ranking
+ * with its own `ORDER BY ... LIMIT` query against the same filtered rows
+ * keeps every tab honest.
+ *
+ * Expects query params
+ * `{ normalized_query_hash: string, range_hours: number, notable_limit: number }`.
+ */
+export function buildPatternNotableRunsConfig(): QueryConfig {
+  return {
+    name: 'insights-query-pattern-notable-runs',
+    tableCheck: 'system.query_log',
+    columns: [],
+    sql: `
+      WITH base AS (
+        SELECT
+            event_time,
+            query_id,
+            user,
+            query_kind,
+            current_database AS database,
+            query_duration_ms,
+            memory_usage,
+            formatReadableSize(memory_usage) AS readable_memory_usage,
+            read_rows,
+            read_bytes,
+            formatReadableSize(read_bytes) AS readable_read_bytes,
+            result_rows,
+            written_bytes,
+            exception_code,
+            exception,
+            query
+        FROM system.query_log
+        WHERE type IN ${EXECUTION_TYPES}
+          AND normalized_query_hash = toUInt64OrZero({normalized_query_hash:String})
+          AND event_time > now() - toIntervalHour({range_hours:UInt32})
+      )
+      SELECT *, 'slowest' AS reason FROM base
+        ORDER BY query_duration_ms DESC LIMIT {notable_limit:UInt32}
+      UNION ALL
+      SELECT *, 'largest_result' AS reason FROM base
+        ORDER BY result_rows DESC LIMIT {notable_limit:UInt32}
+      UNION ALL
+      SELECT *, 'errored' AS reason FROM base
+        WHERE exception_code != 0
+        ORDER BY event_time DESC LIMIT {notable_limit:UInt32}
+    `,
+  }
+}

--- a/apps/dashboard/src/routes/api/v1/insights/query-patterns/$hash.test.ts
+++ b/apps/dashboard/src/routes/api/v1/insights/query-patterns/$hash.test.ts
@@ -25,6 +25,9 @@ const executionRows = [
   { event_time: '2026-07-04 00:00:00', query_id: 'a' },
   { event_time: '2026-07-03 23:59:00', query_id: 'b' },
 ]
+const notableRows = [
+  { event_time: '2026-07-04 00:00:00', query_id: 'a', reason: 'slowest' },
+]
 
 let patternData: Record<string, unknown>[] = [patternRow]
 
@@ -42,6 +45,16 @@ const executeTableConfig = mock(
           metadata: { queryId: 'p1', duration: 5, rows: patternData.length },
         },
         executedSql: 'SELECT /* pattern */ 1',
+        clickhouseVersion: '24.8',
+      }
+    }
+    if (config.name === 'insights-query-pattern-notable-runs') {
+      return {
+        result: {
+          data: notableRows,
+          metadata: { queryId: 'n1', duration: 3, rows: notableRows.length },
+        },
+        executedSql: 'SELECT /* notable */ 1',
         clickhouseVersion: '24.8',
       }
     }
@@ -78,6 +91,7 @@ interface DetailSuccessBody {
   data: {
     pattern: Record<string, unknown>
     executions: Record<string, unknown>[]
+    notable: Record<string, unknown>[]
   }
   metadata: { host: string; rangeHours: number }
 }
@@ -124,24 +138,26 @@ describe('GET /api/v1/insights/query-patterns/$hash — shape', () => {
     patternData = [patternRow]
   })
 
-  test('returns the pattern + its recent executions', async () => {
+  test('returns the pattern + its recent executions + notable runs', async () => {
     const res = await call('123456789')
     expect(res.status).toBe(200)
     const body = (await res.json()) as DetailSuccessBody
     expect(body.success).toBe(true)
     expect(body.data.pattern).toEqual(patternRow)
     expect(body.data.executions).toEqual(executionRows)
+    expect(body.data.notable).toEqual(notableRows)
     expect(body.metadata.host).toBe('0')
     expect(body.metadata.rangeHours).toBe(24)
   })
 
-  test('passes the same normalized_query_hash + range to both queries', async () => {
+  test('passes the same normalized_query_hash + range to all three queries', async () => {
     await call('123456789', '?range=6')
-    expect(executeTableConfig).toHaveBeenCalledTimes(2)
+    expect(executeTableConfig).toHaveBeenCalledTimes(3)
     for (const c of executeTableConfig.mock.calls) {
       expect(c[2]).toMatchObject({
         normalized_query_hash: '123456789',
         range_hours: 6,
+        notable_limit: 5,
       })
     }
   })

--- a/apps/dashboard/src/routes/api/v1/insights/query-patterns/$hash.ts
+++ b/apps/dashboard/src/routes/api/v1/insights/query-patterns/$hash.ts
@@ -21,6 +21,7 @@ import { error } from '@chm/logger'
 import {
   buildPatternDetailConfig,
   buildPatternExecutionsConfig,
+  buildPatternNotableRunsConfig,
   isValidQueryHash,
   parseRangeHours,
 } from '@/lib/api/insights/query-patterns'
@@ -28,6 +29,9 @@ import { executeTableConfig } from '@/lib/api/query-executor'
 
 /** Cap on individual executions returned per pattern. */
 const EXECUTIONS_LIMIT = 200
+
+/** Cap on rows returned per "Notable runs" category (slowest/largest/errored). */
+const NOTABLE_LIMIT = 5
 
 export async function handler(
   request: Request,
@@ -70,14 +74,18 @@ export async function handler(
     normalized_query_hash: hash,
     range_hours: rangeHours,
     executions_limit: EXECUTIONS_LIMIT,
+    notable_limit: NOTABLE_LIMIT,
   }
 
   try {
-    const [patternExec, executionsExec] = await Promise.all([
+    const [patternExec, executionsExec, notableExec] = await Promise.all([
       executeTableConfig(buildPatternDetailConfig(), hostId, queryParams, {
         bindings,
       }),
       executeTableConfig(buildPatternExecutionsConfig(), hostId, queryParams, {
+        bindings,
+      }),
+      executeTableConfig(buildPatternNotableRunsConfig(), hostId, queryParams, {
         bindings,
       }),
     ])
@@ -108,6 +116,19 @@ export async function handler(
         { status: 500 }
       )
     }
+    if (notableExec.result.error) {
+      return Response.json(
+        {
+          success: false,
+          error: {
+            type: 'query_error',
+            message: notableExec.result.error.message,
+            details: notableExec.result.error.details,
+          },
+        },
+        { status: 500 }
+      )
+    }
 
     const pattern = (patternExec.result.data ?? [])[0]
     if (!pattern) {
@@ -124,20 +145,22 @@ export async function handler(
     }
 
     const executions = executionsExec.result.data ?? []
+    const notable = notableExec.result.data ?? []
 
     return Response.json(
       {
         success: true,
-        data: { pattern, executions },
+        data: { pattern, executions, notable },
         metadata: {
           queryId: String(patternExec.result.metadata.queryId || ''),
           duration:
             Number(patternExec.result.metadata.duration || 0) +
-            Number(executionsExec.result.metadata.duration || 0),
+            Number(executionsExec.result.metadata.duration || 0) +
+            Number(notableExec.result.metadata.duration || 0),
           rows: executions.length,
           host: String(hostId),
           rangeHours,
-          sql: `${patternExec.executedSql.trim()}\n\n${executionsExec.executedSql.trim()}`,
+          sql: `${patternExec.executedSql.trim()}\n\n${executionsExec.executedSql.trim()}\n\n${notableExec.executedSql.trim()}`,
           clickhouseVersion: patternExec.clickhouseVersion,
         },
       },

--- a/docs/content/guide/features/query-insights.mdx
+++ b/docs/content/guide/features/query-insights.mdx
@@ -91,13 +91,20 @@ GET /api/v1/insights/query-patterns/1234567890123456789?hostId=0&range=24
     "pattern": { "normalized_query_hash": "1234567890123456789", "calls": 42, "total_duration": 12.5 },
     "executions": [
       { "event_time": "2026-07-04 10:00:00", "query_id": "...", "query_duration_ms": 310, "user": "default" }
+    ],
+    "notable": [
+      { "event_time": "2026-07-03 22:00:00", "query_id": "...", "query_duration_ms": 4200, "reason": "slowest" }
     ]
   },
   "metadata": { "host": "0", "rangeHours": 24, "rows": 1 }
 }
 ```
 
-Executions are capped at 200 rows, most-recent first.
+`executions` is capped at 200 rows, most-recent first. `notable` is a separate,
+server-ranked query (5 rows per category: `slowest` by duration, `largest_result`
+by result rows, `errored` by exception, most-recent first) over the full
+`rangeHours` window — not a client-side slice of `executions` — so it stays
+correct for patterns with more than 200 executions in the window.
 
 ## MCP / programmatic consumption
 


### PR DESCRIPTION
## Summary

Follow-up correctness fix to #2262 / #2316 (Query Insights: pattern detail flyout).

- The flyout's **Notable runs** tab (slowest / largest result / errored) was derived by sorting the same up-to-200-row `executions` response used for the **Recent** tab.
- For any pattern popular enough to open a flyout for (roughly >8 calls/hour over a 24h window), the true slowest/largest run routinely falls outside that 200-row cap — silently contradicting the Overview stat card's `max_duration`, which comes from the full, uncapped aggregation.

Fix: `buildPatternNotableRunsConfig` (`lib/api/insights/query-patterns.ts`) runs three independently server-ranked queries (`ORDER BY query_duration_ms/result_rows/event_time` + `LIMIT`) against the same hash/time-filtered rows, unioned with a `reason` column. `GET /api/v1/insights/query-patterns/:hash` now returns this as a new `data.notable` field alongside `executions`; the flyout reads it directly instead of re-deriving it client-side.

## Changes

- `apps/dashboard/src/lib/api/insights/query-patterns.ts` — add `buildPatternNotableRunsConfig` + `NotableRunReason` type
- `apps/dashboard/src/routes/api/v1/insights/query-patterns/$hash.ts` — fetch the notable-runs query in parallel, add `notable` to the response
- `apps/dashboard/src/components/slow-query-patterns/pattern-detail-sheet.tsx` — read `data.notable` (grouped by `reason`) instead of client-side `topN`/`filter` over the capped `executions` sample
- `docs/content/guide/features/query-insights.mdx` — document the new `notable` response field
- Tests updated/added in `query-patterns.test.ts` and `$hash.test.ts`

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bun run lint` — clean
- [x] `bun run build` — clean (prerender succeeds)
- [x] `bun run test:unit` — 5844 pass, 0 fail
- [x] `bun run test:query-config` — 1044 pass, 0 fail
- [x] Targeted tests for the new query builder + route response shape

Closes #2262 (correctness follow-up)