### PR TITLE
perf(clickhouse): KV-backed L2 cache for version + table-existence checks

### DIFF
--- a/apps/dashboard/src/lib/table-existence-kv-cache.test.ts
+++ b/apps/dashboard/src/lib/table-existence-kv-cache.test.ts
@@ -6,8 +6,7 @@ import { beforeEach, describe, expect, it } from 'bun:test'
 
 function createFakeKv() {
   const store = new Map<string, { value: string; expirationTtl?: number }>()
-  return {
-    store,
+  const kv = {
     get: async (key: string, _options?: { type?: string }) => {
       const entry = store.get(key)
       return entry ? JSON.parse(entry.value) : null
@@ -20,6 +19,7 @@ function createFakeKv() {
       store.set(key, { value, expirationTtl: options?.expirationTtl })
     },
   } as unknown as KVNamespace
+  return { kv, store }
 }
 
 describe('getTableExistenceCache — Node/self-hosted degradation (issue #2183)', () => {
@@ -35,7 +35,7 @@ describe('getTableExistenceCache — Node/self-hosted degradation (issue #2183)'
   })
 
   it('gets and sets through the injected KV binding', async () => {
-    const kv = createFakeKv()
+    const { kv } = createFakeKv()
     const cache = getTableExistenceCache(kv)
 
     expect(await cache.get('0:system.backup_log')).toBeNull()
@@ -44,10 +44,10 @@ describe('getTableExistenceCache — Node/self-hosted degradation (issue #2183)'
   })
 
   it('writes with the given TTL under a namespaced key', async () => {
-    const kv = createFakeKv()
+    const { kv, store } = createFakeKv()
     const cache = getTableExistenceCache(kv)
     await cache.set('0:system.backup_log', false, 300)
-    expect(kv.store.get('ch-table-exists:0:system.backup_log')).toEqual({
+    expect(store.get('ch-table-exists:0:system.backup_log')).toEqual({
       value: 'false',
       expirationTtl: 300,
     })
@@ -55,7 +55,7 @@ describe('getTableExistenceCache — Node/self-hosted degradation (issue #2183)'
 
   it('memoizes the instance across calls', () => {
     const first = getTableExistenceCache(null)
-    const second = getTableExistenceCache(createFakeKv())
+    const second = getTableExistenceCache(createFakeKv().kv)
     expect(second).toBe(first)
   })
 })

--- a/apps/dashboard/src/lib/table-existence-kv-cache.test.ts
+++ b/apps/dashboard/src/lib/table-existence-kv-cache.test.ts
@@ -1,0 +1,61 @@
+import {
+  getTableExistenceCache,
+  resetTableExistenceCacheInstance,
+} from './table-existence-kv-cache'
+import { beforeEach, describe, expect, it } from 'bun:test'
+
+function createFakeKv() {
+  const store = new Map<string, { value: string; expirationTtl?: number }>()
+  return {
+    store,
+    get: async (key: string, _options?: { type?: string }) => {
+      const entry = store.get(key)
+      return entry ? JSON.parse(entry.value) : null
+    },
+    put: async (
+      key: string,
+      value: string,
+      options?: { expirationTtl?: number }
+    ) => {
+      store.set(key, { value, expirationTtl: options?.expirationTtl })
+    },
+  } as unknown as KVNamespace
+}
+
+describe('getTableExistenceCache — Node/self-hosted degradation (issue #2183)', () => {
+  beforeEach(() => {
+    resetTableExistenceCacheInstance()
+  })
+
+  it('degrades to a no-op when no KV binding is passed (Node/self-hosted path)', async () => {
+    const cache = getTableExistenceCache(null)
+    expect(await cache.get('0:system.backup_log')).toBeNull()
+    await cache.set('0:system.backup_log', true, 300) // should not throw
+    expect(await cache.get('0:system.backup_log')).toBeNull()
+  })
+
+  it('gets and sets through the injected KV binding', async () => {
+    const kv = createFakeKv()
+    const cache = getTableExistenceCache(kv)
+
+    expect(await cache.get('0:system.backup_log')).toBeNull()
+    await cache.set('0:system.backup_log', true, 300)
+    expect(await cache.get('0:system.backup_log')).toBe(true)
+  })
+
+  it('writes with the given TTL under a namespaced key', async () => {
+    const kv = createFakeKv()
+    const cache = getTableExistenceCache(kv)
+    await cache.set('0:system.backup_log', false, 300)
+    expect(kv.store.get('ch-table-exists:0:system.backup_log')).toEqual({
+      value: 'false',
+      expirationTtl: 300,
+    })
+  })
+
+  it('memoizes the instance across calls', () => {
+    const first = getTableExistenceCache(null)
+    const second = getTableExistenceCache(createFakeKv())
+    expect(second).toBe(first)
+  })
+})

--- a/apps/dashboard/src/lib/table-existence-kv-cache.ts
+++ b/apps/dashboard/src/lib/table-existence-kv-cache.ts
@@ -1,0 +1,81 @@
+/**
+ * L2 cache adapter for the table-existence check (issue #2183).
+ *
+ * `@chm/clickhouse-client/table-existence-cache` keeps a per-isolate LRU (5min
+ * TTL) guarding optional system tables (`system.backup_log`,
+ * `system.zookeeper`, …). On Cloudflare that cache is wiped on every Worker
+ * isolate churn, forcing a fresh `SELECT count() FROM system.tables` per cold
+ * start. This adapter backs it with the same `VERSION_CACHE_KV` namespace
+ * used by `version-cache.ts` (different key prefix, same binding — a table's
+ * existence rarely changes, so one small KV namespace covers both caches),
+ * and is registered as that package's L2 provider from `src/start.ts`.
+ *
+ * Degrades to a no-op (`get` → null, `set` → no-op) when the binding is
+ * unbound — self-hosted Docker/K8s, Node build, or Cloudflare before
+ * `[[kv_namespaces]]` is provisioned — so the in-memory LRU keeps working
+ * standalone everywhere this adapter can't reach KV.
+ */
+
+import { debug, warn } from '@chm/logger'
+
+export interface TableExistenceCacheAdapter {
+  get(key: string): Promise<boolean | null>
+  set(key: string, exists: boolean, ttlSeconds: number): Promise<void>
+}
+
+function kvKey(key: string): string {
+  return `ch-table-exists:${key}`
+}
+
+class KVTableExistenceCache implements TableExistenceCacheAdapter {
+  constructor(private readonly kv: KVNamespace | null) {}
+
+  async get(key: string): Promise<boolean | null> {
+    if (!this.kv) return null
+
+    try {
+      const value = await this.kv.get(kvKey(key), { type: 'json' })
+      if (typeof value !== 'boolean') return null
+      debug(`[table-existence-kv-cache] KV cache hit for ${key}`)
+      return value
+    } catch (err) {
+      warn('[table-existence-kv-cache] KV get error:', err)
+      return null
+    }
+  }
+
+  async set(key: string, exists: boolean, ttlSeconds: number): Promise<void> {
+    if (!this.kv) return
+
+    try {
+      await this.kv.put(kvKey(key), JSON.stringify(exists), {
+        expirationTtl: ttlSeconds,
+      })
+    } catch (err) {
+      warn('[table-existence-kv-cache] KV set error:', err)
+    }
+  }
+}
+
+let cacheInstance: TableExistenceCacheAdapter | null = null
+
+/**
+ * Get the table-existence L2 cache adapter. Safe to call unconditionally —
+ * every method degrades to a no-op when the caller passes a null/undefined
+ * `kv` (Node/self-hosted, or Cloudflare before `[[kv_namespaces]]` is
+ * provisioned). Resolving the binding is the caller's job (`start.ts`) — this
+ * module must not import `cloudflare:workers` itself (#2183).
+ */
+export function getTableExistenceCache(
+  kv?: KVNamespace | null
+): TableExistenceCacheAdapter {
+  if (!cacheInstance) {
+    cacheInstance = new KVTableExistenceCache(kv ?? null)
+  }
+  return cacheInstance
+}
+
+/** Reset the cache instance (tests only). */
+export function resetTableExistenceCacheInstance(): void {
+  cacheInstance = null
+}

--- a/apps/dashboard/src/lib/version-cache.test.ts
+++ b/apps/dashboard/src/lib/version-cache.test.ts
@@ -15,8 +15,7 @@ const version1 = {
 
 function createFakeKv() {
   const store = new Map<string, { value: string; expirationTtl?: number }>()
-  return {
-    store,
+  const kv = {
     get: async (key: string, _options?: { type?: string }) => {
       const entry = store.get(key)
       return entry ? JSON.parse(entry.value) : null
@@ -29,6 +28,7 @@ function createFakeKv() {
       store.set(key, { value, expirationTtl: options?.expirationTtl })
     },
   } as unknown as KVNamespace
+  return { kv, store }
 }
 
 describe('InMemoryCache', () => {
@@ -52,7 +52,7 @@ describe('InMemoryCache', () => {
 
 describe('CloudflareKVCache', () => {
   it('gets and sets through the injected KV binding', async () => {
-    const kv = createFakeKv()
+    const { kv } = createFakeKv()
     const cache = new CloudflareKVCache(kv)
 
     expect(await cache.get(0)).toBeNull()
@@ -61,10 +61,10 @@ describe('CloudflareKVCache', () => {
   })
 
   it('writes with the given TTL', async () => {
-    const kv = createFakeKv()
+    const { kv, store } = createFakeKv()
     const cache = new CloudflareKVCache(kv)
     await cache.set(1, version1, 86400)
-    expect(kv.store.get('ch-version:1')?.expirationTtl).toBe(86400)
+    expect(store.get('ch-version:1')?.expirationTtl).toBe(86400)
   })
 })
 
@@ -82,14 +82,14 @@ describe('getVersionCache — Node/self-hosted degradation (issue #2183)', () =>
   })
 
   it('uses the KV adapter when a binding is passed (Cloudflare path)', async () => {
-    const kv = createFakeKv()
+    const { kv } = createFakeKv()
     const cache = getVersionCache(kv)
     expect(cache).toBeInstanceOf(CloudflareKVCache)
   })
 
   it('memoizes the instance across calls', () => {
     const first = getVersionCache(null)
-    const second = getVersionCache(createFakeKv())
+    const second = getVersionCache(createFakeKv().kv)
     expect(second).toBe(first)
   })
 })

--- a/apps/dashboard/src/lib/version-cache.test.ts
+++ b/apps/dashboard/src/lib/version-cache.test.ts
@@ -1,0 +1,95 @@
+import {
+  CloudflareKVCache,
+  getVersionCache,
+  InMemoryCache,
+  resetCacheInstance,
+} from './version-cache'
+import { beforeEach, describe, expect, it } from 'bun:test'
+
+const version1 = {
+  major: 24,
+  minor: 3,
+  patch: 1,
+  raw: '24.3.1',
+}
+
+function createFakeKv() {
+  const store = new Map<string, { value: string; expirationTtl?: number }>()
+  return {
+    store,
+    get: async (key: string, _options?: { type?: string }) => {
+      const entry = store.get(key)
+      return entry ? JSON.parse(entry.value) : null
+    },
+    put: async (
+      key: string,
+      value: string,
+      options?: { expirationTtl?: number }
+    ) => {
+      store.set(key, { value, expirationTtl: options?.expirationTtl })
+    },
+  } as unknown as KVNamespace
+}
+
+describe('InMemoryCache', () => {
+  it('returns null for a miss', async () => {
+    const cache = new InMemoryCache()
+    expect(await cache.get(0)).toBeNull()
+  })
+
+  it('stores and retrieves a version within the TTL', async () => {
+    const cache = new InMemoryCache()
+    await cache.set(0, version1, 3600)
+    expect(await cache.get(0)).toEqual(version1)
+  })
+
+  it('expires an entry past its TTL', async () => {
+    const cache = new InMemoryCache()
+    await cache.set(0, version1, -1) // already expired
+    expect(await cache.get(0)).toBeNull()
+  })
+})
+
+describe('CloudflareKVCache', () => {
+  it('gets and sets through the injected KV binding', async () => {
+    const kv = createFakeKv()
+    const cache = new CloudflareKVCache(kv)
+
+    expect(await cache.get(0)).toBeNull()
+    await cache.set(0, version1, 86400)
+    expect(await cache.get(0)).toEqual(version1)
+  })
+
+  it('writes with the given TTL', async () => {
+    const kv = createFakeKv()
+    const cache = new CloudflareKVCache(kv)
+    await cache.set(1, version1, 86400)
+    expect(kv.store.get('ch-version:1')?.expirationTtl).toBe(86400)
+  })
+})
+
+describe('getVersionCache — Node/self-hosted degradation (issue #2183)', () => {
+  beforeEach(() => {
+    resetCacheInstance()
+  })
+
+  it('degrades to memory-only when no KV binding is passed (Node/self-hosted path)', async () => {
+    const cache = getVersionCache(null)
+    expect(cache).toBeInstanceOf(InMemoryCache)
+
+    await cache.set(0, version1, 3600)
+    expect(await cache.get(0)).toEqual(version1)
+  })
+
+  it('uses the KV adapter when a binding is passed (Cloudflare path)', async () => {
+    const kv = createFakeKv()
+    const cache = getVersionCache(kv)
+    expect(cache).toBeInstanceOf(CloudflareKVCache)
+  })
+
+  it('memoizes the instance across calls', () => {
+    const first = getVersionCache(null)
+    const second = getVersionCache(createFakeKv())
+    expect(second).toBe(first)
+  })
+})

--- a/apps/dashboard/src/lib/version-cache.ts
+++ b/apps/dashboard/src/lib/version-cache.ts
@@ -4,8 +4,13 @@
  * Zero-config cache layer for ClickHouse version caching.
  * Auto-detects environment and uses appropriate caching strategy:
  * 1. Cloudflare Workers KV (if VERSION_CACHE_KV binding exists)
- * 2. Redis (if REDIS_URL is set)
- * 3. In-memory fallback (always works)
+ * 2. In-memory fallback (always works — self-hosted Node/Docker, or
+ *    Cloudflare before the KV namespace is provisioned)
+ *
+ * Registered as the L2 provider for
+ * `@chm/clickhouse-client/clickhouse-version`'s per-isolate L1 cache from
+ * `src/start.ts` (issue #2183) — that package can't import this file directly
+ * (dependency-cruiser forbids `packages/` → `apps/`).
  *
  * Usage:
  * ```typescript
@@ -21,20 +26,8 @@ import type { ClickHouseVersion } from '@chm/clickhouse-client/clickhouse-versio
 
 import { debug, warn } from '@chm/logger'
 
-/**
- * Cloudflare KV Namespace type (for Workers environments)
- */
-interface KVNamespace {
-  get(
-    key: string,
-    options?: { type?: 'text' | 'json' | 'arrayBuffer' | 'stream' }
-  ): Promise<unknown>
-  put(
-    key: string,
-    value: string,
-    options?: { expirationTtl?: number }
-  ): Promise<void>
-}
+/** The wrangler.toml binding name this module reads (see issue #2183). */
+export const VERSION_CACHE_KV_BINDING = 'VERSION_CACHE_KV'
 
 /**
  * Cache adapter interface
@@ -84,21 +77,8 @@ export class InMemoryCache implements VersionCacheAdapter {
 export class CloudflareKVCache implements VersionCacheAdapter {
   private kv: KVNamespace
 
-  constructor(binding?: KVNamespace) {
-    // Try to get KV binding from globalThis or provided binding
-    if (binding) {
-      this.kv = binding
-    } else if (
-      typeof globalThis !== 'undefined' &&
-      'VERSION_CACHE_KV' in globalThis
-    ) {
-      // Cast through unknown to satisfy TypeScript
-      this.kv = (
-        globalThis as unknown as { VERSION_CACHE_KV: KVNamespace }
-      ).VERSION_CACHE_KV
-    } else {
-      throw new Error('VERSION_CACHE_KV binding not found')
-    }
+  constructor(binding: KVNamespace) {
+    this.kv = binding
     debug('[version-cache] Using Cloudflare KV cache')
   }
 
@@ -138,118 +118,6 @@ export class CloudflareKVCache implements VersionCacheAdapter {
 }
 
 /**
- * Redis cache implementation
- */
-export class RedisCache implements VersionCacheAdapter {
-  private redis: {
-    get: (key: string) => Promise<string | null>
-    setex: (key: string, ttl: number, value: string) => Promise<void>
-    disconnect: () => Promise<void>
-  } | null = null
-
-  private initPromise: Promise<void> | null = null
-
-  constructor(redisUrl?: string) {
-    const url = redisUrl || process.env.REDIS_URL
-    if (!url) {
-      throw new Error('REDIS_URL not set')
-    }
-
-    // Initialize Redis asynchronously
-    this.initPromise = this.init(url)
-  }
-
-  private async init(url: string): Promise<void> {
-    try {
-      // Dynamic import to avoid bundling if not used
-      // @ts-expect-error - ioredis is optional peer dependency
-      const ioredisModule = await import('ioredis').catch(() => null)
-      if (!ioredisModule) {
-        warn('[version-cache] ioredis not installed, Redis cache unavailable')
-        this.redis = null
-        return
-      }
-
-      const Redis = ioredisModule.default
-      const client = new Redis(url, {
-        lazyConnect: true,
-        retryStrategy: (times: number) => {
-          if (times > 3) {
-            warn('[version-cache] Redis max retries reached')
-            return null // Stop retrying
-          }
-          return Math.min(times * 100, 2000)
-        },
-      })
-
-      await client.connect()
-      this.redis = client as {
-        get: (key: string) => Promise<string | null>
-        setex: (key: string, ttl: number, value: string) => Promise<void>
-        disconnect: () => Promise<void>
-      }
-
-      debug('[version-cache] Using Redis cache')
-    } catch (err) {
-      warn('[version-cache] Redis initialization error:', err)
-      this.redis = null
-    }
-  }
-
-  private async waitForInit(): Promise<boolean> {
-    if (this.initPromise) {
-      await this.initPromise
-      this.initPromise = null
-    }
-    return this.redis !== null
-  }
-
-  private getKey(hostId: number): string {
-    return `ch-version:${hostId}`
-  }
-
-  async get(hostId: number): Promise<ClickHouseVersion | null> {
-    try {
-      const ready = await this.waitForInit()
-      if (!ready || !this.redis) return null
-
-      const key = this.getKey(hostId)
-      const value = await this.redis.get(key)
-      if (!value) return null
-
-      debug(`[version-cache] Redis cache hit for host ${hostId}`)
-      return JSON.parse(value) as ClickHouseVersion
-    } catch (err) {
-      warn('[version-cache] Redis get error:', err)
-      return null
-    }
-  }
-
-  async set(
-    hostId: number,
-    version: ClickHouseVersion,
-    ttlSeconds: number
-  ): Promise<void> {
-    try {
-      const ready = await this.waitForInit()
-      if (!ready || !this.redis) return
-
-      const key = this.getKey(hostId)
-      await this.redis.setex(key, ttlSeconds, JSON.stringify(version))
-      debug(`[version-cache] Redis cached version for host ${hostId}`)
-    } catch (err) {
-      warn('[version-cache] Redis set error:', err)
-    }
-  }
-
-  async disconnect(): Promise<void> {
-    if (this.redis) {
-      await this.redis.disconnect()
-    }
-  }
-}
-
-/**
  * Singleton cache instance
  */
 let cacheInstance: VersionCacheAdapter | null = null
@@ -259,35 +127,30 @@ let cacheInstance: VersionCacheAdapter | null = null
  *
  * Priority order:
  * 1. Cloudflare Workers KV (if VERSION_CACHE_KV binding exists)
- * 2. Redis (if REDIS_URL is set)
- * 3. In-memory fallback
+ * 2. In-memory fallback
  *
  * @returns Cache adapter instance
  */
-export function getVersionCache(): VersionCacheAdapter {
+export function getVersionCache(kv?: KVNamespace | null): VersionCacheAdapter {
   if (cacheInstance) return cacheInstance
 
-  // 1. Check Cloudflare KV
-  if (typeof globalThis !== 'undefined' && 'VERSION_CACHE_KV' in globalThis) {
+  // 1. Use the Cloudflare KV binding when the caller resolved one (null on
+  // Node/self-hosted, or on Cloudflare before `[[kv_namespaces]]` is
+  // provisioned). Resolving the binding is the caller's job (`start.ts`,
+  // inside a `.server()` middleware body) — this module must not import
+  // `cloudflare:workers` itself. TanStack Start splits code outside
+  // `.server()` callbacks into an isomorphic chunk without that virtual
+  // module, so importing it here breaks the build (#2183).
+  if (kv) {
     try {
-      cacheInstance = new CloudflareKVCache()
+      cacheInstance = new CloudflareKVCache(kv)
       return cacheInstance
     } catch (err) {
       warn('[version-cache] Failed to initialize KV cache:', err)
     }
   }
 
-  // 2. Check Redis
-  if (process.env.REDIS_URL) {
-    try {
-      cacheInstance = new RedisCache()
-      return cacheInstance
-    } catch (err) {
-      warn('[version-cache] Failed to initialize Redis cache:', err)
-    }
-  }
-
-  // 3. Fallback to in-memory
+  // 2. Fallback to in-memory
   debug('[version-cache] Using in-memory cache (fallback)')
   cacheInstance = new InMemoryCache()
   return cacheInstance

--- a/apps/dashboard/src/start.ts
+++ b/apps/dashboard/src/start.ts
@@ -16,6 +16,8 @@
 import { createMiddleware, createStart } from '@tanstack/react-start'
 
 import { env } from 'cloudflare:workers'
+import { setVersionCacheL2Provider } from '@chm/clickhouse-client/clickhouse-version'
+import { setTableExistenceL2Provider } from '@chm/clickhouse-client/table-existence-cache'
 import { clerkMiddleware } from '@clerk/tanstack-react-start/server'
 import { wrapRequestHandler } from '@sentry/cloudflare'
 import {
@@ -28,12 +30,42 @@ import { resolveServerSentryOptions } from '@/lib/observability/sentry.server'
 import { forceFlushOtel, getOtelTracer } from '@/lib/otel/exporter'
 import { withSpan } from '@/lib/otel/with-span'
 import { withSecurityHeaders } from '@/lib/security-headers'
+import { getTableExistenceCache } from '@/lib/table-existence-kv-cache'
+import { getVersionCache, VERSION_CACHE_KV_BINDING } from '@/lib/version-cache'
 
 // Returning a Response from a request middleware short-circuits the chain and
 // sends that Response without running the route handler (same mechanism the
 // built-in CSRF middleware uses). Calling `next()` proceeds normally.
+let kvCacheWired = false
+
+/**
+ * Wire the version + table-existence KV L2 caches (issue #2183) the first
+ * time a request middleware actually runs. This MUST stay inside a
+ * `.server()` callback body, not module top-level scope: TanStack Start
+ * splits everything outside `.server()` callbacks into an isomorphic chunk
+ * that does not carry the `cloudflare:workers` virtual module, so reading
+ * `env` at top level here breaks the build (top-level `env` reads elsewhere
+ * in this file are fine ONLY because the pre-existing ones already lived
+ * inside `.server()` bodies).
+ */
+function wireVersionCacheKvOnce(): void {
+  if (kvCacheWired) return
+  kvCacheWired = true
+
+  const binding = (env as Record<string, unknown> | undefined)?.[
+    VERSION_CACHE_KV_BINDING
+  ]
+  const kv =
+    binding && typeof binding === 'object' ? (binding as KVNamespace) : null
+
+  setVersionCacheL2Provider(() => getVersionCache(kv))
+  setTableExistenceL2Provider(() => getTableExistenceCache(kv))
+}
+
 const apiAuthMiddleware = createMiddleware().server(
   async ({ next, request }) => {
+    wireVersionCacheKvOnce()
+
     // Bridge the Worker env secret onto process.env so apiKeyAuthEnabled() /
     // verifyApiKey() (which read process.env.CHM_API_KEY_SECRET) can see it.
     bridgeApiKeyEnv(env as Record<string, string | undefined>)

--- a/apps/dashboard/wrangler.toml
+++ b/apps/dashboard/wrangler.toml
@@ -51,6 +51,30 @@ pattern = "dash.chmonitor.dev"
 custom_domain = true
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Version + table-existence L2 cache (Cloudflare KV) — EXAMPLE, NOT ACTIVE.
+# See issue #2183. `lib/version-cache.ts` / `lib/table-existence-kv-cache.ts`
+# back the per-isolate ClickHouse-version and table-existence caches
+# (`@chm/clickhouse-client/clickhouse-version` /
+# `@chm/clickhouse-client/table-existence-cache`) with a KV L2 so they survive
+# Worker isolate churn instead of re-querying `SELECT version()` /
+# `system.tables` on every cold start. This binding is intentionally left
+# commented out: `wrangler deploy` fails hard if a `[[kv_namespaces]]` block
+# references a namespace that doesn't exist yet, which would break the next CI
+# deploy. Self-host has no KV binding by design, so both caches always fall
+# back to their in-memory-only (L1) behavior — identical to today — until an
+# operator completes this setup:
+#
+#   1. wrangler kv namespace create VERSION_CACHE_KV
+#   2. Uncomment the block below with the real `id` from step 1 (mirror into
+#      [env.preview] with its own namespace, or reuse the same one).
+#   3. Redeploy.
+#
+# [[kv_namespaces]]
+# binding = "VERSION_CACHE_KV"
+# id = "<namespace id from `wrangler kv namespace create`>"
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Inbound event bus (Cloudflare Queues) — EXAMPLE, NOT ACTIVE.
 # See plans/36-inbound-event-bus-queues.md. POST /api/events/ingest and the
 # consumer (lib/events/queue-consumer.ts processEventBatch) are implemented

--- a/packages/clickhouse-client/src/__tests__/clickhouse-version.test.ts
+++ b/packages/clickhouse-client/src/__tests__/clickhouse-version.test.ts
@@ -31,6 +31,9 @@ const {
   getTableInfoMessage,
   SYSTEM_TABLE_INFO,
   checkTableExists,
+  getClickHouseVersion,
+  setVersionCacheL2Provider,
+  clearVersionCache,
 } = await import(
   new URL('../clickhouse-version.ts?test=version', import.meta.url).href
 )
@@ -495,5 +498,91 @@ describe('checkTableExists', () => {
 
     const result = await checkTableExists(0, 'system', 'query_log')
     expect(result).toBe(false)
+  })
+})
+
+describe('getClickHouseVersion — L2 (KV) cache wiring (issue #2183)', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    process.env.CLICKHOUSE_HOST = 'http://localhost:8123'
+    process.env.CLICKHOUSE_USER = 'default'
+    process.env.CLICKHOUSE_PASSWORD = ''
+    resetEnvCache()
+    clientPool.clear()
+    clearVersionCache()
+    setVersionCacheL2Provider(null)
+    mockCreateClient.mockReset()
+    mockClientQuery.mockReset()
+    mockCreateClient.mockReturnValue(mockClient)
+    mockClientQuery.mockResolvedValue({
+      json: () => Promise.resolve([{ version: '24.3.1.1' }]),
+    })
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+    setVersionCacheL2Provider(null)
+  })
+
+  it('returns the L2 cache hit without querying ClickHouse', async () => {
+    const cached = parseVersion('23.8.0')
+    setVersionCacheL2Provider(() => ({
+      get: async () => cached,
+      set: async () => {},
+    }))
+
+    const result = await getClickHouseVersion(0)
+
+    expect(result).toEqual(cached)
+    expect(mockClientQuery).not.toHaveBeenCalled()
+  })
+
+  it('queries ClickHouse and populates the L2 cache on an L2 miss', async () => {
+    const setSpy = mock(async () => {})
+    setVersionCacheL2Provider(() => ({
+      get: async () => null,
+      set: setSpy,
+    }))
+
+    const result = await getClickHouseVersion(0)
+
+    expect(result).toEqual(parseVersion('24.3.1.1'))
+    expect(mockClientQuery).toHaveBeenCalledTimes(1)
+    expect(setSpy).toHaveBeenCalledTimes(1)
+    const [hostId, version, ttlSeconds] = setSpy.mock.calls[0]
+    expect(hostId).toBe(0)
+    expect(version).toEqual(parseVersion('24.3.1.1'))
+    expect(ttlSeconds).toBe(24 * 60 * 60) // 24h, matching the L1 TTL
+  })
+
+  it('degrades to L1-memory-only when no L2 provider is registered (Node/self-hosted path)', async () => {
+    // No `setVersionCacheL2Provider` call — mirrors the Node/self-hosted
+    // build, where `src/start.ts` never wires a provider because
+    // `target().kv(...)` (or the resolved binding) is null.
+    const first = await getClickHouseVersion(0)
+    expect(first).toEqual(parseVersion('24.3.1.1'))
+    expect(mockClientQuery).toHaveBeenCalledTimes(1)
+
+    // Second call within the TTL window hits the L1 map, not ClickHouse again.
+    const second = await getClickHouseVersion(0)
+    expect(second).toEqual(parseVersion('24.3.1.1'))
+    expect(mockClientQuery).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not throw when the L2 provider rejects', async () => {
+    setVersionCacheL2Provider(() => ({
+      get: async () => {
+        throw new Error('KV unavailable')
+      },
+      set: async () => {
+        throw new Error('KV unavailable')
+      },
+    }))
+
+    const result = await getClickHouseVersion(0)
+    expect(result).toEqual(parseVersion('24.3.1.1'))
+    expect(mockClientQuery).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/clickhouse-client/src/__tests__/table-existence-cache.test.ts
+++ b/packages/clickhouse-client/src/__tests__/table-existence-cache.test.ts
@@ -3,7 +3,7 @@
 // ... })) can't make these helpers undefined at import time when the full
 // suite runs together.
 import * as cache from '../table-existence-cache'
-import { beforeEach, describe, expect, it } from 'bun:test'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
 
 // These tests only touch the public side-effect-free shims around the LRU
 // cache (size / invalidate / clear / metrics). The async checkTableExists
@@ -45,5 +45,85 @@ describe('tableExistenceCache shims', () => {
   // Bun session, leaving the other shim methods undefined.
   it('checkTableExists is exposed through the legacy namespace', () => {
     expect(typeof cache.tableExistenceCache.checkTableExists).toBe('function')
+  })
+})
+
+describe('checkTableExists — L2 (KV) cache wiring (issue #2183)', () => {
+  // Mocked/isolated the same way as clickhouse-version.test.ts: a fresh
+  // module instance (via the `?test=` query cache-buster) so this suite's
+  // client mock doesn't leak into the unmocked shims describe above.
+  const mockClientQuery = mock(() =>
+    Promise.resolve({ json: () => Promise.resolve([{ count: '1' }]) })
+  )
+  const mockClient = { query: mockClientQuery }
+  const mockCreateClient = mock(() => mockClient)
+
+  mock.module('@clickhouse/client', () => ({
+    createClient: mockCreateClient,
+  }))
+  mock.module('@clickhouse/client-web', () => ({
+    createClient: mockCreateClient,
+  }))
+
+  let l2cache: typeof import('../table-existence-cache')
+
+  beforeEach(async () => {
+    process.env.CLICKHOUSE_HOST = 'http://localhost:8123'
+    process.env.CLICKHOUSE_USER = 'default'
+    process.env.CLICKHOUSE_PASSWORD = ''
+    mockCreateClient.mockReset()
+    mockClientQuery.mockReset()
+    mockCreateClient.mockReturnValue(mockClient)
+    mockClientQuery.mockResolvedValue({
+      json: () => Promise.resolve([{ count: '1' }]),
+    })
+
+    l2cache = await import(
+      new URL('../table-existence-cache.ts?test=l2', import.meta.url).href
+    )
+    l2cache.clearTableCache()
+    l2cache.setTableExistenceL2Provider(null)
+  })
+
+  it('returns the L2 cache hit without querying ClickHouse', async () => {
+    l2cache.setTableExistenceL2Provider(() => ({
+      get: async () => true,
+      set: async () => {},
+    }))
+
+    const result = await l2cache.checkTableExists(0, 'system', 'backup_log')
+
+    expect(result).toBe(true)
+    expect(mockClientQuery).not.toHaveBeenCalled()
+  })
+
+  it('queries ClickHouse and populates the L2 cache on an L2 miss', async () => {
+    const setSpy = mock(async () => {})
+    l2cache.setTableExistenceL2Provider(() => ({
+      get: async () => null,
+      set: setSpy,
+    }))
+
+    const result = await l2cache.checkTableExists(0, 'system', 'backup_log')
+
+    expect(result).toBe(true)
+    expect(mockClientQuery).toHaveBeenCalledTimes(1)
+    expect(setSpy).toHaveBeenCalledTimes(1)
+    const [key, exists, ttlSeconds] = setSpy.mock.calls[0]
+    expect(key).toBe('0:system.backup_log')
+    expect(exists).toBe(true)
+    expect(ttlSeconds).toBe(5 * 60) // 5min, matching the L1 TTL
+  })
+
+  it('degrades to L1-LRU-only when no L2 provider is registered (Node/self-hosted path)', async () => {
+    // No `setTableExistenceL2Provider` call — mirrors the Node/self-hosted
+    // build, where `src/start.ts` never wires a provider.
+    const first = await l2cache.checkTableExists(0, 'system', 'backup_log')
+    expect(first).toBe(true)
+    expect(mockClientQuery).toHaveBeenCalledTimes(1)
+
+    const second = await l2cache.checkTableExists(0, 'system', 'backup_log')
+    expect(second).toBe(true)
+    expect(mockClientQuery).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/clickhouse-client/src/clickhouse-version.ts
+++ b/packages/clickhouse-client/src/clickhouse-version.ts
@@ -49,6 +49,41 @@ const versionCache = new Map<
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000
 
 /**
+ * L2 cache contract for `getClickHouseVersion` (issue #2183) — survives Worker
+ * isolate churn, unlike the per-isolate `versionCache` Map above.
+ *
+ * This package must not import `apps/dashboard` (dependency-cruiser
+ * `no-packages-to-apps`), so the KV-backed implementation lives app-side
+ * (`apps/dashboard/src/lib/version-cache.ts`) and is injected here via
+ * `setVersionCacheL2Provider`, registered once from `src/start.ts`. When no
+ * provider is registered (self-hosted Node/Docker path, or before the app
+ * wires it up), this is a pure no-op and `getClickHouseVersion` behaves
+ * exactly as before — L1-memory-only.
+ */
+export interface VersionCacheL2 {
+  get(hostId: number): Promise<ClickHouseVersion | null>
+  set(
+    hostId: number,
+    version: ClickHouseVersion,
+    ttlSeconds: number
+  ): Promise<void>
+}
+
+let l2CacheProvider: (() => VersionCacheL2 | null) | null = null
+
+/**
+ * Register (or clear, with `null`) the L2 cache provider. The provider is a
+ * factory rather than an instance so registration can happen eagerly at
+ * module load (`start.ts`) without constructing the KV adapter before the
+ * Worker env is available.
+ */
+export function setVersionCacheL2Provider(
+  provider: (() => VersionCacheL2 | null) | null
+): void {
+  l2CacheProvider = provider
+}
+
+/**
  * Parse a version string like "24.3.1.1" into components
  */
 export function parseVersion(versionStr: string): ClickHouseVersion {
@@ -98,10 +133,27 @@ export function meetsMinVersion(
 export async function getClickHouseVersion(
   hostId: number
 ): Promise<ClickHouseVersion | null> {
-  // Check cache first
+  // L1: check the per-isolate cache first
   const cached = versionCache.get(hostId)
   if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
     return cached.version
+  }
+
+  // L2: KV cache (survives Worker isolate churn). No-op when no provider is
+  // registered (self-hosted Node/Docker, or Cloudflare before the KV
+  // namespace is provisioned — see #2183).
+  const l2 = l2CacheProvider?.()
+  if (l2) {
+    try {
+      const l2Version = await l2.get(hostId)
+      if (l2Version) {
+        versionCache.set(hostId, { version: l2Version, timestamp: Date.now() })
+        debug(`[clickhouse-version] L2 (KV) cache hit for host ${hostId}`)
+        return l2Version
+      }
+    } catch (err) {
+      logError('[clickhouse-version] L2 cache get error:', err)
+    }
   }
 
   try {
@@ -133,6 +185,14 @@ export async function getClickHouseVersion(
 
     const version = parseVersion(versionStr)
     versionCache.set(hostId, { version, timestamp: Date.now() })
+
+    if (l2) {
+      try {
+        await l2.set(hostId, version, CACHE_TTL_MS / 1000)
+      } catch (err) {
+        logError('[clickhouse-version] L2 cache set error:', err)
+      }
+    }
 
     debug(`[clickhouse-version] Host ${hostId}: ${version.raw}`)
     return version

--- a/packages/clickhouse-client/src/table-existence-cache.ts
+++ b/packages/clickhouse-client/src/table-existence-cache.ts
@@ -8,8 +8,10 @@ import { LRUCache } from 'lru-cache'
  * - maxSize: 1MB total memory limit
  * - TTL: 5 minutes
  */
+const CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes
+
 const cache = new LRUCache<string, boolean>({
-  ttl: 5 * 60 * 1000, // 5 minutes
+  ttl: CACHE_TTL_MS,
   max: 500, // Reduced from 1000 for memory efficiency
   maxSize: 1024 * 1024, // 1MB total cache size limit
   sizeCalculation: () => 1, // Each entry counts as 1 unit (simplified size tracking)
@@ -17,6 +19,34 @@ const cache = new LRUCache<string, boolean>({
     debug(`[Table Cache] Evicted: ${key} = ${value}`)
   },
 })
+
+/**
+ * L2 cache contract for `checkTableExists` (issue #2183) — survives Worker
+ * isolate churn, unlike the per-isolate LRU above.
+ *
+ * This package must not import `apps/dashboard` (dependency-cruiser
+ * `no-packages-to-apps`), so the KV-backed implementation lives app-side
+ * (`apps/dashboard/src/lib/table-existence-kv-cache.ts`) and is injected here
+ * via `setTableExistenceL2Provider`, registered once from `src/start.ts`. When
+ * no provider is registered (self-hosted Node/Docker path), this is a pure
+ * no-op and `checkTableExists` behaves exactly as before — L1-LRU-only.
+ */
+export interface TableExistenceCacheL2 {
+  get(key: string): Promise<boolean | null>
+  set(key: string, exists: boolean, ttlSeconds: number): Promise<void>
+}
+
+let l2CacheProvider: (() => TableExistenceCacheL2 | null) | null = null
+
+/**
+ * Register (or clear, with `null`) the L2 cache provider — see
+ * `setVersionCacheL2Provider` in `clickhouse-version.ts` for the same pattern.
+ */
+export function setTableExistenceL2Provider(
+  provider: (() => TableExistenceCacheL2 | null) | null
+): void {
+  l2CacheProvider = provider
+}
 
 export async function checkTableExists(
   hostId: number,
@@ -27,6 +57,23 @@ export async function checkTableExists(
   const cached = cache.get(key)
   if (cached !== undefined) {
     return cached
+  }
+
+  // L2: KV cache (survives Worker isolate churn). No-op when no provider is
+  // registered (self-hosted Node/Docker, or Cloudflare before the KV
+  // namespace is provisioned — see #2183).
+  const l2 = l2CacheProvider?.()
+  if (l2) {
+    try {
+      const l2Exists = await l2.get(key)
+      if (l2Exists !== null) {
+        cache.set(key, l2Exists)
+        debug(`[Table Cache] L2 (KV) cache hit for ${key}`)
+        return l2Exists
+      }
+    } catch (err) {
+      error('[Table Cache] L2 cache get error:', err)
+    }
   }
 
   try {
@@ -46,6 +93,13 @@ export async function checkTableExists(
     const exists = parseInt(data?.[0]?.count || '0', 10) > 0
 
     cache.set(key, exists)
+    if (l2) {
+      try {
+        await l2.set(key, exists, CACHE_TTL_MS / 1000)
+      } catch (err) {
+        error('[Table Cache] L2 cache set error:', err)
+      }
+    }
     return exists
   } catch (err) {
     error(`Error checking table ${database}.${table}:`, err)


### PR DESCRIPTION
## Summary

- Wires `getClickHouseVersion` (24h TTL) and `checkTableExists` (5min TTL) to a Cloudflare KV L2 cache behind the existing per-isolate L1 cache/LRU, so both survive Worker isolate churn instead of re-querying `SELECT version()` / `system.tables` on every cold start.
- `@chm/clickhouse-client` cannot import `apps/dashboard` (dependency-cruiser `no-packages-to-apps`), so the KV adapters live app-side (`lib/version-cache.ts`, new `lib/table-existence-kv-cache.ts`) and are injected into the package via `setVersionCacheL2Provider` / `setTableExistenceL2Provider`, registered once from `src/start.ts` on the first real request.
- Fixes the pre-existing dead `CloudflareKVCache`/`getVersionCache` `globalThis`-based binding lookup — Worker bindings never live on `globalThis`, so this never actually worked; it went unnoticed because the file had zero callers.
- Drops the unused/unbuildable `RedisCache` path (`ioredis` isn't a dependency; it silently never got bundled because the file had zero callers — wiring it up surfaced the broken import).

## A build constraint worth flagging for reviewers

The KV binding resolution **must** happen inside a `.server()` middleware body in `start.ts`, not at module top-level scope. TanStack Start splits code outside `.server()` callbacks into an isomorphic chunk that doesn't carry the `cloudflare:workers` virtual module — reading `env` eagerly at import time there breaks the Vite build (confirmed by bisecting against a clean checkout of `origin/main`; the failure is 100% reproducible regardless of my other changes, purely from *where* the `env` read happens). `wireVersionCacheKvOnce()` in `start.ts` documents this in a comment.

## Production activation — manual step required (tracked in #2319)

**No `[[kv_namespaces]]` binding is declared in `wrangler.toml` yet.** Declaring one requires a real Cloudflare KV namespace `id`, and I don't have authorization to provision cloud infrastructure as part of this change. Filed #2319 to track provisioning it:

```
wrangler kv namespace create VERSION_CACHE_KV
```

and uncomment the `[[kv_namespaces]]` block in `wrangler.toml` (mirrored to `[env.preview]` if desired) with the real id. Until that's done, `target().kv('VERSION_CACHE_KV')` resolves to `null` everywhere — self-hosted Docker/K8s, Node build, **and production Cloudflare alike** — and both caches transparently degrade to their current in-memory-only behavior. This PR is a safe, inert scaffold: it changes no runtime behavior until #2319 is resolved.

## Test plan

- [x] `packages/clickhouse-client/src/__tests__/clickhouse-version.test.ts` — new `getClickHouseVersion — L2 (KV) cache wiring` suite: KV hit (skips ClickHouse), KV miss populates L2 with the correct TTL, degrades to L1-memory-only when no provider is registered, and doesn't throw when the L2 provider rejects.
- [x] `packages/clickhouse-client/src/__tests__/table-existence-cache.test.ts` — equivalent suite for `checkTableExists`.
- [x] `apps/dashboard/src/lib/version-cache.test.ts` / `table-existence-kv-cache.test.ts` (new) — unit tests for the app-side adapters, including explicit "degrades to memory-only when no KV binding is passed (Node/self-hosted path)" cases.
- [x] `bun run test:packages` (906 pass) and `apps/dashboard`'s full `bun run test:coverage:ci` (5746 pass) — no regressions.
- [x] `bun run lint`, `bun run depcruise` (no new violations — the only violations are pre-existing, unrelated `router.tsx ↔ routeTree.gen.ts` circular-reference warnings).
- [x] `bun run build` (Cloudflare target) — passes.
- [x] `apps/dashboard`'s `tsc -p tsconfig.test.json` (the dashboard CI type-check) — passes.
- [ ] `bun run build:node` — hangs at the tail of prerendering in this sandbox on a **clean `origin/main` checkout with zero of my changes**, confirming it's a pre-existing environment issue unrelated to this PR (matches the known `fix/dashboard-tsr-prerender-hang` history in this repo). I could not get a clean exit code from it here, but the Node-path degradation is directly covered by the unit tests above (`getVersionCache(null)` / `getTableExistenceCache(null)` → in-memory only), and `lib/target`'s `NodeAdapter.kv()` already has its own passing test coverage returning `null`.

Closes #2183