### PR TITLE
feat(agent): tool-first operating rules + behavioral eval tracking

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -122,6 +122,27 @@ src/lib/ai/agent/__tests__/scenarios.test.ts --isolate`; it also runs as part
 of the existing `bun run test` / `bun run test:coverage` CI job since those
 already glob all of `src/`.
 
+### Behavioral (tool-first) tracking — `bun run test:agent`
+
+The mocked golden scenarios above verify tool *wiring and safety*, but the
+answer text is authored by the test, so they cannot measure whether a **live
+model** actually chooses to call a tool. That behavioral signal — the
+"Operating Rules (tool-first)" section of the system prompt — is tracked by a
+[promptfoo](https://promptfoo.dev) suite at `tests/agent/promptfooconfig.yaml`,
+run against a running dev server:
+
+```bash
+export AGENT_API_TOKEN=your-token   # bearer for /api/v1/agent
+bun run dev                         # in another shell
+bun run test:agent                  # promptfoo eval; `test:agent:view` for the UI
+```
+
+Each golden asserts the agent emits a `[tool:...]` call (not a memory answer)
+and stays under a latency threshold. Treat the pass rate + latency as the
+**self-improvement metric**: when tuning the prompt for faster/more-accurate
+tool use, re-run this suite before and after and keep the numbers moving the
+right way. Add a golden here whenever you change tool-selection behavior.
+
 ## Writing New Component Tests
 
 When contributing new component tests, please follow these guidelines:

--- a/apps/dashboard/src/lib/ai/agent/prompts/clickhouse-instructions.ts
+++ b/apps/dashboard/src/lib/ai/agent/prompts/clickhouse-instructions.ts
@@ -11,6 +11,34 @@
 
 export const CLICKHOUSE_AGENT_INSTRUCTIONS = `You are a ClickHouse database expert assistant integrated into a monitoring dashboard. Your role is to help users analyze their ClickHouse databases through natural language queries.
 
+## Operating Rules (tool-first) — read this first
+
+These rules make you faster and more accurate. They override any habit of
+answering from memory.
+
+1. **Act, don't ask.** For anything answerable from the live cluster, call a
+   tool immediately. Never ask permission to run a read-only query, and never
+   ask the user for information a tool can retrieve. Only use \`ask_user\` when
+   the request is genuinely ambiguous (multiple valid interpretations) or before
+   an expensive/destructive action — not to confirm routine reads.
+2. **Ground every factual claim in a tool result.** Do NOT state cluster state
+   (versions, sizes, counts, running queries, settings) from prior knowledge —
+   query it first. If you did not call a tool for a number, do not assert the
+   number. This is the single biggest driver of accuracy.
+3. **Prefer the specific primitive.** If a dedicated tool fits (e.g.
+   \`get_slow_queries\`, \`get_replication_status\`), use it instead of hand-writing
+   the same SQL with \`query\` — it is faster and less error-prone.
+4. **Parallelize independent reads.** When steps do not depend on each other
+   (e.g. the same check across \`hostId: 0\` and \`hostId: 1\`, or schema + metrics),
+   issue those tool calls together in one turn rather than sequentially.
+5. **One orient, then go.** On an unfamiliar host call \`get_metrics\` once to
+   learn the version, then proceed — do not re-explore what you already know.
+6. **Recover, don't stall.** On an "unknown column"/missing-table error, call
+   \`get_table_schema\`/\`load_skill\` and retry automatically; do not hand the error
+   back to the user.
+7. **Load the skill before hand-writing system-table SQL.** \`load_skill\` gives
+   you the exact column names and a vetted recipe — cheaper than trial-and-error.
+
 ## Dashboard Context
 
 You are part of a monitoring dashboard that provides real-time insights into ClickHouse clusters. Users can navigate to different views like:

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "test:component:headless": "cd apps/dashboard && bun run test:component:headless",
     "test:e2e": "cd apps/dashboard && bun run test:e2e",
     "test:e2e:headless": "cd apps/dashboard && bun run test:e2e:headless",
+    "test:agent": "promptfoo eval -c tests/agent/promptfooconfig.yaml",
+    "test:agent:view": "promptfoo view",
     "cf:deploy": "cd apps/dashboard && bun run cf:deploy",
     "cf:config": "bun scripts/set-secrets.ts --from-env",
     "cf:typegen": "cd apps/dashboard && bun run cf-typegen",

--- a/tests/agent/promptfooconfig.yaml
+++ b/tests/agent/promptfooconfig.yaml
@@ -106,6 +106,39 @@ tests:
       - type: not-regex
         value: '\\[error:'
 
+  # --- Tool-first behavior tracking (self-improvement regression signal) ---
+  # These goldens exist to MEASURE the "Operating Rules (tool-first)" prompt
+  # section over time: the agent must ground factual/state answers in a tool
+  # call rather than answering from memory, use specific primitives, and not
+  # stall on routine reads. A drop in pass rate here means a prompt regression.
+
+  - description: 'Grounding — version question must be answered via a tool, not from memory'
+    vars:
+      prompt: 'What ClickHouse version is this server running?'
+    assert:
+      - type: contains
+        value: '[tool:'
+      - type: not-regex
+        value: '\\[error:'
+
+  - description: 'Specific primitive — slow-query ask should call a tool'
+    vars:
+      prompt: 'What are the slowest queries in the last hour?'
+    assert:
+      - type: contains
+        value: '[tool:'
+      - type: not-regex
+        value: '\\[error:'
+
+  - description: 'Act, don''t ask — routine read should not stall on a clarifying question'
+    vars:
+      prompt: 'Show disk usage for this server'
+    assert:
+      - type: contains
+        value: '[tool:'
+      - type: not-regex
+        value: '\\[error:'
+
 evaluateOptions:
   maxConcurrency: 1
   cache: false


### PR DESCRIPTION
Addresses the request to *tune the agent to call tools earlier, faster, and more accurately, with tracking for self-improvement.*

> **Stacked on #2320** (base = `fix/agent-prompt-tool-sync`). GitHub will retarget this to `main` once #2320 merges. Review the top commit only.

## Tool-first prompt tuning (behavioral)
New **"Operating Rules (tool-first)"** section at the very top of the system prompt:
- **Act, don't ask** — call a tool immediately for anything answerable from the cluster; don't ask permission for read-only queries.
- **Ground every factual claim in a tool result** — never state versions/sizes/counts from memory (biggest accuracy lever).
- **Prefer the specific primitive** over hand-written `query` SQL.
- **Parallelize independent reads** (multi-host, schema+metrics) — faster.
- One-orient-then-go, auto-recover on errors, load the skill before system-table SQL.

This mirrors what leading DB agents do (PostHog Max's `PROACTIVENESS_PROMPT` / `TOOL_USAGE_POLICY_PROMPT`, Grafana Assistant, Datadog Bits) per the research behind this work.

## Self-improvement tracking
The mocked golden scenarios verify tool *wiring/safety* but can't measure whether a **live model** actually chooses to call a tool. So:
- Wire `bun run test:agent` (+ `test:agent:view`) to run the existing `tests/agent/promptfooconfig.yaml` suite.
- Add **tool-first goldens** (grounding, specific-primitive, act-don't-ask) that assert the live agent emits `[tool:...]` rather than a memory answer, under a latency threshold.
- Document the suite in `TESTING.md` as the tool-first self-improvement metric (run before/after prompt changes; keep pass-rate + latency moving the right way).

## Verification
- `bun run check` clean; `tool-docs-sync` prompt↔tools guard green (from #2320).
- `test:agent` requires a running dev server + `AGENT_API_TOKEN` (documented) — not part of the required compile check.

Behavioral change — **please gate on review** (no automated test catches an answer-quality regression).

https://claude.ai/code/session_01WAMNuXxTQcJpwMqbrzdu6W