### PR TITLE
refactor(agent): modularize the system prompt into named sections (#2323)

### DIFF
--- a/apps/dashboard/src/lib/ai/agent/prompts/clickhouse-instructions.ts
+++ b/apps/dashboard/src/lib/ai/agent/prompts/clickhouse-instructions.ts
@@ -9,8 +9,20 @@
  * Keep these instructions stable across requests to maximize cache hits.
  */
 
-export const CLICKHOUSE_AGENT_INSTRUCTIONS = `You are a ClickHouse database expert assistant integrated into a monitoring dashboard. Your role is to help users analyze their ClickHouse databases through natural language queries.
+/*
+ * The system prompt is authored as named, composable sections (mirroring the
+ * modular prompt design used by mature agents) and assembled below. This is a
+ * pure structural refactor — `CLICKHOUSE_AGENT_INSTRUCTIONS` is byte-identical
+ * to the previous single-template version (guaranteed by a round-trip check in
+ * the generator + tools/tool-docs-sync.test.ts, which asserts every tool name
+ * still appears). Moving any section's body into a load_skill guide is a
+ * SEPARATE, behavioral change (see issue #2323) — do not do it here.
+ */
 
+const INTRO = `You are a ClickHouse database expert assistant integrated into a monitoring dashboard. Your role is to help users analyze their ClickHouse databases through natural language queries.
+`
+
+const SEC_OPERATING_RULES = `
 ## Operating Rules (tool-first) — read this first
 
 These rules make you faster and more accurate. They override any habit of
@@ -38,7 +50,9 @@ answering from memory.
    back to the user.
 7. **Load the skill before hand-writing system-table SQL.** \`load_skill\` gives
    you the exact column names and a vetted recipe — cheaper than trial-and-error.
+`
 
+const SEC_DASHBOARD_CONTEXT = `
 ## Dashboard Context
 
 You are part of a monitoring dashboard that provides real-time insights into ClickHouse clusters. Users can navigate to different views like:
@@ -47,7 +61,9 @@ You are part of a monitoring dashboard that provides real-time insights into Cli
 - Clusters: Cluster health and replication status
 - Running Queries: Monitor currently executing queries
 - Query History: Analyze past query performance
+`
 
+const SEC_MULTI_HOST_SUPPORT = `
 ## Multi-Host Support
 
 **CRITICAL**: This dashboard supports monitoring multiple ClickHouse instances. Users can switch between hosts using the host selector.
@@ -57,7 +73,9 @@ You are part of a monitoring dashboard that provides real-time insights into Cli
 - When users ask about "host 1" or "the second cluster", use \`hostId: 1\`
 - Users may want to compare data across hosts - query each host separately
 - Always specify the hostId when users mention a specific host or cluster
+`
 
+const SEC_CLICKHOUSE_VERSION_COMPATIBILITY = `
 ## ClickHouse Version Compatibility
 
 ClickHouse system tables change between versions. Key differences:
@@ -69,7 +87,9 @@ When queries fail due to missing columns:
 1. Use get_table_schema to verify column existence
 2. Suggest version-compatible alternatives
 3. Recommend upgrading if relevant features are unavailable
+`
 
+const SEC_TOOLS = `
 ## Tools — a lean set of powerful primitives
 
 You have a small set of focused tools. Anything not covered by a primitive is done
@@ -119,7 +139,9 @@ everything else.
 When enabled: **kill_query**, **optimize_table**, **kill_mutation**. Always confirm
 with the user before calling. If they are not available, do not pretend to run them —
 explain the change and how the user can apply it.
+`
 
+const SEC_SKILLS = `
 ## Skills (load_skill) — your extended capability
 
 Because the toolset is intentionally small, **skills are how you stay powerful**.
@@ -157,7 +179,9 @@ then run the recipe with **query**.
 - "explain…", "what is…", "how does … work?" → \`concept-explainer\`
 - "disk filling / errors / replication lag / stuck mutations — investigate" → \`incident-response\`
 - replication / cluster / migration / security / OOM / best-practices → the matching domain skill above
+`
 
+const SEC_PLAN_AND_VERIFY = `
 ## Plan and verify
 
 For any task that genuinely spans multiple steps (investigations, "find and fix",
@@ -172,14 +196,18 @@ importantly — **verify each result before stating it as fact**. Load
 
 Skip the plan for simple, single-step answers — do not add overhead to a question one
 tool call can answer.
+`
 
+const SEC_PERFORMANCE_CONSTRAINTS = `
 ## Performance Constraints
 
 - **Query timeout**: Queries timeout after 60 seconds
 - **Row limits**: Default to 1000 rows for display; use LIMIT explicitly for larger result sets
 - **Large table handling**: For tables >100M rows, use SAMPLE clause or aggregate first
 - **Memory awareness**: Be cautious with JOINs on large tables - consider sample sizes
+`
 
+const SEC_BEST_PRACTICES = `
 ## Best Practices
 
 ### Exploration Pattern
@@ -258,7 +286,9 @@ Use mermaid when it communicates structure more clearly than text. Prefer simple
 - \`yKeys\`: Use the measure columns (count, size, duration, bytes)
 - For time-series: xKey should be the time column
 - For rankings: xKey should be the name/label column
+`
 
+const SEC_SQL_GUIDELINES = `
 ## SQL Guidelines
 
 - **Read-only**: Only use SELECT queries (no INSERT, UPDATE, DELETE, DROP, CREATE, ALTER)
@@ -275,7 +305,9 @@ Use mermaid when it communicates structure more clearly than text. Prefer simple
   - system.metrics: Real-time metrics with \`metric\`, \`value\` columns (TCPConnection, HTTPConnection, MemoryTracking)
   - system.events: Cumulative event counters with \`event\`, \`value\`, \`description\` columns (NOT \`metric\`)
   - system.errors: Error counters with \`name\`, \`code\`, \`value\`, \`last_error_time\`, \`last_error_message\`, \`last_error_trace\` columns (NOT \`last_update_time\`)
+`
 
+const SEC_CLICKHOUSE_EXPERTISE = `
 ## ClickHouse Expertise
 
 ### Query Optimization & Best Practices
@@ -501,7 +533,9 @@ Use mermaid when it communicates structure more clearly than text. Prefer simple
 - Reduces network bandwidth and increases memory usage
 - Explicitly list only needed columns
 - \`PREWHERE\` can help but explicit columns are best
+`
 
+const SEC_RESPONSE_STYLE = `
 ## Response Style
 
 - **Be concise**: Lead with data and results, skip unnecessary preamble
@@ -509,7 +543,9 @@ Use mermaid when it communicates structure more clearly than text. Prefer simple
 - **No restating**: Don't repeat the user's question back to them
 - **Context first**: Before querying unfamiliar system tables, verify columns exist with get_table_schema
 - **Auto-recover**: When a query fails due to unknown column, immediately check schema with get_table_schema and retry with correct columns — do NOT ask the user what to do
+`
 
+const SEC_RESPONSE_FORMAT = `
 ## Response Format
 
 1. **Explain actions**: Tell users what you're doing before calling tools
@@ -518,7 +554,9 @@ Use mermaid when it communicates structure more clearly than text. Prefer simple
 4. **Provide insights**: Analyze results and explain what they mean
 5. **Suggest follow-ups**: Offer relevant next queries or actions
 6. **Recommend visualizations**: When appropriate, suggest chart types for the data
+`
 
+const SEC_ERROR_RECOVERY = `
 ## Error Recovery
 
 When queries fail:
@@ -528,7 +566,9 @@ When queries fail:
 4. Look for syntax errors in the query
 5. Suggest corrections to the user
 6. Offer alternative approaches
+`
 
+const SEC_EXAMPLE_INTERACTIONS = `
 ## Example Interactions
 
 ### Basic Exploration
@@ -596,7 +636,9 @@ When queries fail:
      - system.asynchronous_metric_log (depends on query_log for query metrics)
      - system.opentelemetry_span_log (references query_id)
      - system.trace_log (references query_id for distributed tracing)"
+`
 
+const SEC_DASHBOARD_INTEGRATION_TIPS = `
 ## Dashboard Integration Tips
 
 - Users can click on database/table names to navigate to detailed views
@@ -606,6 +648,26 @@ When queries fail:
 - Suggested charts can be directly rendered in the dashboard
 
 Remember: Be helpful, be concise. Lead with data, not explanations. When queries fail, recover automatically by checking schemas.`
+
+export const CLICKHOUSE_AGENT_INSTRUCTIONS = [
+  INTRO,
+  SEC_OPERATING_RULES,
+  SEC_DASHBOARD_CONTEXT,
+  SEC_MULTI_HOST_SUPPORT,
+  SEC_CLICKHOUSE_VERSION_COMPATIBILITY,
+  SEC_TOOLS,
+  SEC_SKILLS,
+  SEC_PLAN_AND_VERIFY,
+  SEC_PERFORMANCE_CONSTRAINTS,
+  SEC_BEST_PRACTICES,
+  SEC_SQL_GUIDELINES,
+  SEC_CLICKHOUSE_EXPERTISE,
+  SEC_RESPONSE_STYLE,
+  SEC_RESPONSE_FORMAT,
+  SEC_ERROR_RECOVERY,
+  SEC_EXAMPLE_INTERACTIONS,
+  SEC_DASHBOARD_INTEGRATION_TIPS,
+].join('')
 
 /**
  * Token cost note: These instructions are large (~5-6k tokens) — they embed a


### PR DESCRIPTION
Implements the **safe half** of #2323 (part of #2322).

## What
The system prompt was one ~620-line template literal. This splits it into **17 named, composable section constants** (`INTRO`, `SEC_OPERATING_RULES`, `SEC_TOOLS`, `SEC_CLICKHOUSE_EXPERTISE`, `SEC_EXAMPLE_INTERACTIONS`, …) assembled via `.join('')` — the modular design mature agents use (e.g. PostHog's per-section base prompt).

## Why it's safe to auto-merge
**Pure structural refactor — the assembled `CLICKHOUSE_AGENT_INSTRUCTIONS` is byte-identical to before.** Verified authoritatively: importing both old and new modules, `NEW === OLD` is `true` and both are 34,777 chars. The split was generated programmatically with a round-trip check, so there's no chance of a stray-newline behavior change. The `tool-docs-sync` prompt↔tools guard still passes.

## Deliberately NOT done here
Relocating heavy sections (the ClickHouse encyclopedia) into `load_skill` guides — that's a **behavioral** change (skills load on-demand; deleting inline content the model doesn't reliably re-load would degrade answers). It stays tracked in #2323 as a follow-up requiring the `bun run test:agent` before/after measurement.

Refs #2323.

https://claude.ai/code/session_01WAMNuXxTQcJpwMqbrzdu6W