### PR TITLE
feat(agent): clickable follow-up suggestion chips (#2324)

### DIFF
--- a/apps/dashboard/src/components/assistant-ui/-thread/follow-up-chips.tsx
+++ b/apps/dashboard/src/components/assistant-ui/-thread/follow-up-chips.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+/**
+ * Deterministic follow-up chips.
+ *
+ * Renders 2-3 rule-based next-step suggestions (from
+ * `lib/ai/agent/follow-up-prompts.ts`) as clickable chips. Unlike
+ * `FollowUpSuggestions` (which fetches LLM-generated follow-ups from an
+ * AI-enriched conversation backend), these are computed instantly, client-side,
+ * from the last exchange — so they render for every backend, including
+ * localStorage-only threads.
+ */
+
+import { cn } from '@/lib/utils'
+
+interface FollowUpChipsProps {
+  /** Suggestion strings to render, in order. Renders nothing when empty. */
+  prompts: readonly string[]
+  /** Called with the chip's text when clicked. */
+  onSelect: (text: string) => void
+  className?: string
+}
+
+export function FollowUpChips({
+  prompts,
+  onSelect,
+  className,
+}: FollowUpChipsProps) {
+  if (prompts.length === 0) return null
+
+  return (
+    <div className={cn('flex flex-wrap items-center gap-1.5', className)}>
+      {prompts.map((prompt) => (
+        <button
+          key={prompt}
+          type="button"
+          onClick={() => onSelect(prompt)}
+          className="border-border text-foreground hover:bg-muted/60 rounded-full border px-2.5 py-1 text-[11.5px] transition-colors"
+        >
+          {prompt}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/assistant-ui/thread.tsx
+++ b/apps/dashboard/src/components/assistant-ui/thread.tsx
@@ -47,6 +47,7 @@ import {
   renderGroupedPart,
 } from './-thread/chain-of-thought'
 import { ThreadComposer, WelcomeComposer } from './-thread/composer'
+import { FollowUpChips } from './-thread/follow-up-chips'
 import { FollowUpSuggestions } from './-thread/follow-up-suggestions'
 import { MessageStatsFooter } from './-thread/message-stats'
 import { SessionStats } from './-thread/session-stats'
@@ -77,6 +78,7 @@ import {
   MessageScrollerProvider,
   MessageScrollerViewport,
 } from '@/components/ui/message-scroller'
+import { getFollowUpPrompts } from '@/lib/ai/agent/follow-up-prompts'
 import { resolveConversationBackend } from '@/lib/conversation-store/adapter/resolve-thread-list-adapter'
 import { useAgentSkills } from '@/lib/hooks/use-agent-skills'
 import { track } from '@/lib/telemetry'
@@ -373,10 +375,75 @@ const AssistantMessage: FC = () => {
 
             {/* Tasks #3 + #12: per-message stats + timestamp */}
             <MessageStatsFooter />
+
+            {/* Deterministic, rule-based follow-up chips (issue #2324) */}
+            <AssistantFollowUpChips />
           </MessageContent>
         </Message>
       </MessagePrimitive.Root>
     </MessageScrollerItem>
+  )
+}
+
+/** Joins the text parts of a message's `content`/parts array into one string. */
+function messagePartsText(parts: readonly unknown[]): string {
+  return (parts as { type?: string; text?: string }[])
+    .filter((part) => part?.type === 'text')
+    .map((part) => part.text ?? '')
+    .join(' ')
+}
+
+/**
+ * Deterministic follow-up chips (issue #2324) — rendered only under the last
+ * assistant message, once it has finished streaming. Unlike
+ * `FollowUpSuggestions` (LLM-generated, AgentState-only), these are computed
+ * instantly client-side from the last exchange via
+ * `lib/ai/agent/follow-up-prompts.ts`, so they work for every conversation
+ * backend.
+ */
+function AssistantFollowUpChips() {
+  const isLast = useMessage((m) => m.isLast)
+  const isRunning = useMessage((m) => m.status?.type === 'running')
+  // assistant-ui exposes the AI SDK parts array as `message.content`
+  // (same pattern as MessageStatsFooter above).
+  const content = useMessage((m) => m.content) as readonly unknown[]
+  const messages = useThread((t) => t.messages)
+  const threadRuntime = useThreadRuntime()
+  const { ensureAuthed } = useAgentAuthGate()
+
+  if (!isLast || isRunning) return null
+
+  const lastAssistantText = messagePartsText(content)
+
+  const toolsUsed = (content as { type?: string; toolName?: string }[])
+    .filter((part) => part?.type === 'tool-call')
+    .map((part) => part.toolName)
+    .filter((name): name is string => Boolean(name))
+
+  const lastUserMessage = [...messages]
+    .reverse()
+    .find((message) => message.role === 'user')
+  const lastUserText = messagePartsText(
+    (lastUserMessage?.content ?? []) as readonly unknown[]
+  )
+
+  const prompts = getFollowUpPrompts({
+    lastUserText,
+    lastAssistantText,
+    toolsUsed,
+  })
+
+  const handleSelect = (text: string) => {
+    if (!ensureAuthed()) return
+    threadRuntime.append({
+      role: 'user',
+      content: [{ type: 'text', text }],
+    })
+    track('ai_query_sent')
+  }
+
+  return (
+    <FollowUpChips prompts={prompts} onSelect={handleSelect} className="mt-1" />
   )
 }
 

--- a/apps/dashboard/src/lib/ai/agent/__tests__/follow-up-prompts.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/__tests__/follow-up-prompts.test.ts
@@ -1,0 +1,118 @@
+import { getFollowUpPrompts } from '../follow-up-prompts'
+import { STARTER_PROMPTS } from '../suggested-prompts'
+import { describe, expect, test } from 'bun:test'
+
+describe('getFollowUpPrompts', () => {
+  test('routes slow-query exchanges to performance follow-ups', () => {
+    const prompts = getFollowUpPrompts({
+      lastUserText: 'What are the slowest queries today?',
+      lastAssistantText: 'Here are the 5 slowest queries in the last 24h.',
+    })
+
+    expect(prompts).toEqual([
+      'Explain the slowest one',
+      'Show its EXPLAIN plan',
+      'Compare to yesterday',
+    ])
+  })
+
+  test('routes table/storage exchanges to storage follow-ups', () => {
+    const prompts = getFollowUpPrompts({
+      lastUserText: 'Show me the largest tables by disk usage',
+      lastAssistantText: 'events_local uses 400GB of disk across 12 parts.',
+    })
+
+    expect(prompts).toEqual([
+      'Show largest partitions',
+      'Suggest a TTL',
+      'Break down by column',
+    ])
+  })
+
+  test('routes replication exchanges to replication follow-ups', () => {
+    const prompts = getFollowUpPrompts({
+      lastUserText: 'How is replication lag looking?',
+      lastAssistantText: 'All replicas are within 2 seconds of the leader.',
+    })
+
+    expect(prompts).toEqual([
+      'Show the replication queue',
+      'Which replica is behind?',
+    ])
+  })
+
+  test('matches on assistant text alone when the user question is generic', () => {
+    const prompts = getFollowUpPrompts({
+      lastUserText: 'What just happened?',
+      lastAssistantText: 'One replica fell behind in the ZooKeeper queue.',
+    })
+
+    expect(prompts[0]).toBe('Show the replication queue')
+  })
+
+  test('matches on tool names used, not just message text', () => {
+    const prompts = getFollowUpPrompts({
+      lastUserText: 'Anything I should know?',
+      lastAssistantText: 'Everything looks fine.',
+      toolsUsed: ['get_replication_queue'],
+    })
+
+    expect(prompts[0]).toBe('Show the replication queue')
+  })
+
+  test('matches the plural form of a keyword (e.g. "tables")', () => {
+    const prompts = getFollowUpPrompts({
+      lastUserText: 'How many tables do we have?',
+      lastAssistantText: 'There are 42 tables across 3 databases.',
+    })
+
+    expect(prompts[0]).toBe('Show largest partitions')
+  })
+
+  test('does not match a keyword that is only a substring of another word', () => {
+    // "table" must not fire on "notable"/"acceptable" — whole-word match only.
+    const prompts = getFollowUpPrompts({
+      lastUserText: 'Anything worth flagging?',
+      lastAssistantText: 'There are no notable or acceptable anomalies.',
+    })
+
+    expect(prompts).toEqual(
+      STARTER_PROMPTS.slice(0, 2).map((prompt) => prompt.text)
+    )
+  })
+
+  test('falls back to starter prompts when nothing matches', () => {
+    const prompts = getFollowUpPrompts({
+      lastUserText: 'Hello there',
+      lastAssistantText: 'Hi! How can I help?',
+    })
+
+    expect(prompts).toEqual(
+      STARTER_PROMPTS.slice(0, 2).map((prompt) => prompt.text)
+    )
+  })
+
+  test('respects a smaller limit', () => {
+    const prompts = getFollowUpPrompts({
+      lastUserText: 'slowest query please',
+      lastAssistantText: '',
+      limit: 1,
+    })
+
+    expect(prompts).toEqual(['Explain the slowest one'])
+  })
+
+  test('returns an empty array for a zero or negative limit', () => {
+    expect(
+      getFollowUpPrompts({ lastUserText: 'slow query', limit: 0 })
+    ).toEqual([])
+    expect(
+      getFollowUpPrompts({ lastUserText: 'slow query', limit: -5 })
+    ).toEqual([])
+  })
+
+  test('handles no arguments at all', () => {
+    const prompts = getFollowUpPrompts()
+    expect(prompts).toEqual(STARTER_PROMPTS.slice(0, 2).map((p) => p.text))
+  })
+})

--- a/apps/dashboard/src/lib/ai/agent/follow-up-prompts.ts
+++ b/apps/dashboard/src/lib/ai/agent/follow-up-prompts.ts
@@ -1,0 +1,104 @@
+import {
+  STARTER_PROMPTS,
+  type SuggestedPromptCategory,
+} from './suggested-prompts'
+
+const DEFAULT_LIMIT = 3
+const FALLBACK_COUNT = 2
+
+/**
+ * A deterministic, rule-based follow-up suggestion set for one topic. Matched
+ * by simple keyword lookup against the last exchange — no LLM call involved.
+ */
+interface FollowUpRule {
+  readonly category: SuggestedPromptCategory
+  readonly keywords: readonly string[]
+  readonly prompts: readonly string[]
+}
+
+const FOLLOW_UP_RULES: readonly FollowUpRule[] = [
+  {
+    category: 'Performance',
+    keywords: [
+      'slow',
+      'slowest',
+      'performance',
+      'latency',
+      'query time',
+      'duration',
+    ],
+    prompts: [
+      'Explain the slowest one',
+      'Show its EXPLAIN plan',
+      'Compare to yesterday',
+    ],
+  },
+  {
+    category: 'Storage',
+    keywords: ['table', 'storage', 'disk', 'partition', 'compression'],
+    prompts: [
+      'Show largest partitions',
+      'Suggest a TTL',
+      'Break down by column',
+    ],
+  },
+  {
+    category: 'Replication',
+    keywords: ['replication', 'replica', 'zookeeper', 'keeper'],
+    prompts: ['Show the replication queue', 'Which replica is behind?'],
+  },
+] as const
+
+/**
+ * Whether `keyword` appears in `haystack` as a whole word (optionally
+ * pluralized with a trailing "s"), not merely as a substring — so "table"
+ * doesn't match inside "notable"/"acceptable". Boundaries are "not a-z"
+ * rather than regex `\b` so snake_case tool names (e.g.
+ * `get_replication_queue`) still match on the underscore.
+ */
+function keywordMatches(haystack: string, keyword: string): boolean {
+  const escaped = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`(?:^|[^a-z])${escaped}s?(?:$|[^a-z])`).test(haystack)
+}
+
+export interface FollowUpPromptsInput {
+  /** Text of the user's last message in the exchange. */
+  readonly lastUserText?: string
+  /** Text of the assistant's last reply in the exchange. */
+  readonly lastAssistantText?: string
+  /** Names of tools invoked while producing the last reply, if any. */
+  readonly toolsUsed?: readonly string[]
+  /** Max number of suggestions to return. */
+  readonly limit?: number
+}
+
+/**
+ * Derives 2-3 contextual next-step suggestions from the last chat exchange.
+ *
+ * Purely rule-based (keyword matching, no LLM call) so it is instant and
+ * deterministic. Falls back to a couple of the existing STARTER_PROMPTS when
+ * nothing in the exchange matches a known topic.
+ */
+export function getFollowUpPrompts({
+  lastUserText = '',
+  lastAssistantText = '',
+  toolsUsed = [],
+  limit = DEFAULT_LIMIT,
+}: FollowUpPromptsInput = {}): string[] {
+  const clampedLimit = Math.max(0, limit)
+  if (clampedLimit === 0) return []
+
+  const haystack = [lastUserText, lastAssistantText, ...toolsUsed]
+    .join(' ')
+    .toLowerCase()
+
+  const matchedRule = FOLLOW_UP_RULES.find((rule) =>
+    rule.keywords.some((keyword) => keywordMatches(haystack, keyword))
+  )
+
+  const prompts = matchedRule
+    ? matchedRule.prompts
+    : STARTER_PROMPTS.slice(0, FALLBACK_COUNT).map((prompt) => prompt.text)
+
+  return prompts.slice(0, clampedLimit)
+}


### PR DESCRIPTION
## Summary

- Adds deterministic, rule-based follow-up suggestion chips rendered under the last assistant message in the AI agent chat thread, so users get 2-3 instant next-step prompts (e.g. after a slow-query answer: "Explain the slowest one", "Show its EXPLAIN plan", "Compare to yesterday") with no extra LLM call.
- New pure function `getFollowUpPrompts()` (`apps/dashboard/src/lib/ai/agent/follow-up-prompts.ts`) matches whole-word keywords (with plural handling, snake_case-tool-name aware) against the last user/assistant text + any tool names used, and falls back to existing `STARTER_PROMPTS` when nothing matches.
- New presentational `FollowUpChips` component (`apps/dashboard/src/components/assistant-ui/-thread/follow-up-chips.tsx`) renders the suggestions as clickable chips, styled to match the existing `FollowUpSuggestions` chip look.
- Wired into `apps/dashboard/src/components/assistant-ui/thread.tsx`: renders only under the last, non-streaming assistant message; clicking a chip submits it the same way `ThreadWelcome`/`FollowUpSuggestions` do (`threadRuntime.append` + auth gate + `ai_query_sent` telemetry).

This is purely additive — no existing behavior is changed or removed. It is a separate, deterministic mechanism from the existing `FollowUpSuggestions` (LLM-generated, AgentState-only, shown above the composer); both can appear at the same time on AgentState/cloud backends, which is intended (instant heuristic chips vs. richer LLM-generated ones). The deterministic chips also render for local/D1-only backends where `FollowUpSuggestions` never appears.

Closes #2324

## Test plan

- [x] `bun test src/lib/ai/agent/__tests__/follow-up-prompts.test.ts` — 11 tests covering: slow-query/storage/replication routing, matching via assistant-only text, matching via tool names (snake_case), plural keyword matching, whole-word-only matching (regression: "notable"/"acceptable" must not fire the "table" keyword), fallback to starter prompts, limit clamping (0/negative), and no-args default.
- [x] `bun run check` (Biome) — clean on all changed files.
- [ ] Manual smoke test in the running dashboard (not run in this environment).