### PR TITLE
chore(cf): prefix Cloudflare resource names/bindings with chm/chmonitor

### DIFF
--- a/apps/dashboard/src/lib/api/data/dashboard-query-kv-cache.test.ts
+++ b/apps/dashboard/src/lib/api/data/dashboard-query-kv-cache.test.ts
@@ -28,13 +28,13 @@ interface FakeKV {
 
 function installKV(kv: FakeKV) {
   ;(
-    globalThis as unknown as { DASHBOARD_QUERY_KV: FakeKV }
-  ).DASHBOARD_QUERY_KV = kv
+    globalThis as unknown as { CHM_DASHBOARD_QUERY_KV: FakeKV }
+  ).CHM_DASHBOARD_QUERY_KV = kv
 }
 
 function removeKV() {
-  delete (globalThis as unknown as { DASHBOARD_QUERY_KV?: FakeKV })
-    .DASHBOARD_QUERY_KV
+  delete (globalThis as unknown as { CHM_DASHBOARD_QUERY_KV?: FakeKV })
+    .CHM_DASHBOARD_QUERY_KV
 }
 
 beforeEach(() => {

--- a/apps/dashboard/src/lib/api/data/dashboard-query-kv-cache.ts
+++ b/apps/dashboard/src/lib/api/data/dashboard-query-kv-cache.ts
@@ -4,8 +4,8 @@
  * Backs the in-memory per-isolate allowlist cache (`cache-manager.ts`, L1)
  * with an optional Cloudflare Workers KV layer that survives isolate churn
  * (cold starts, isolate eviction). Zero-config, same pattern as
- * `lib/version-cache.ts`'s `VERSION_CACHE_KV`: the code auto-detects the
- * `DASHBOARD_QUERY_KV` binding via `globalThis` and is a silent no-op when
+ * `lib/version-cache.ts`'s `CHM_VERSION_CACHE_KV`: the code auto-detects the
+ * `CHM_DASHBOARD_QUERY_KV` binding via `globalThis` and is a silent no-op when
  * it's absent — self-hosted Docker/K8s deploys (no Cloudflare KV) are
  * unaffected and keep working exactly as before.
  *
@@ -42,11 +42,14 @@ function getKeyName(hostId: number): string {
   return `dashboard-queries:${hostId}`
 }
 
-/** Resolve the `DASHBOARD_QUERY_KV` binding if the runtime provides one. */
+/** Resolve the `CHM_DASHBOARD_QUERY_KV` binding if the runtime provides one. */
 function getKV(): KVNamespace | undefined {
-  if (typeof globalThis !== 'undefined' && 'DASHBOARD_QUERY_KV' in globalThis) {
-    return (globalThis as unknown as { DASHBOARD_QUERY_KV: KVNamespace })
-      .DASHBOARD_QUERY_KV
+  if (
+    typeof globalThis !== 'undefined' &&
+    'CHM_DASHBOARD_QUERY_KV' in globalThis
+  ) {
+    return (globalThis as unknown as { CHM_DASHBOARD_QUERY_KV: KVNamespace })
+      .CHM_DASHBOARD_QUERY_KV
   }
   return undefined
 }

--- a/apps/dashboard/src/lib/api/data/dashboard-query-validator.test.ts
+++ b/apps/dashboard/src/lib/api/data/dashboard-query-validator.test.ts
@@ -3,7 +3,7 @@
  * layer added in #2185 on top of the existing in-memory (L1) cache.
  *
  * The single invariant under test: a KV miss, a KV read error, or a missing
- * `DASHBOARD_QUERY_KV` binding (self-hosted/Node) must NEVER be treated as
+ * `CHM_DASHBOARD_QUERY_KV` binding (self-hosted/Node) must NEVER be treated as
  * "allow" — it must always fall through to the authoritative ClickHouse
  * allowlist query, preserving the fail-closed behavior of the validator.
  */
@@ -62,13 +62,13 @@ interface FakeKV {
 
 function installKV(kv: FakeKV) {
   ;(
-    globalThis as unknown as { DASHBOARD_QUERY_KV: FakeKV }
-  ).DASHBOARD_QUERY_KV = kv
+    globalThis as unknown as { CHM_DASHBOARD_QUERY_KV: FakeKV }
+  ).CHM_DASHBOARD_QUERY_KV = kv
 }
 
 function removeKV() {
-  delete (globalThis as unknown as { DASHBOARD_QUERY_KV?: FakeKV })
-    .DASHBOARD_QUERY_KV
+  delete (globalThis as unknown as { CHM_DASHBOARD_QUERY_KV?: FakeKV })
+    .CHM_DASHBOARD_QUERY_KV
 }
 
 let hostCounter = 1000

--- a/apps/dashboard/src/lib/table-existence-kv-cache.ts
+++ b/apps/dashboard/src/lib/table-existence-kv-cache.ts
@@ -5,7 +5,7 @@
  * TTL) guarding optional system tables (`system.backup_log`,
  * `system.zookeeper`, …). On Cloudflare that cache is wiped on every Worker
  * isolate churn, forcing a fresh `SELECT count() FROM system.tables` per cold
- * start. This adapter backs it with the same `VERSION_CACHE_KV` namespace
+ * start. This adapter backs it with the same `CHM_VERSION_CACHE_KV` namespace
  * used by `version-cache.ts` (different key prefix, same binding — a table's
  * existence rarely changes, so one small KV namespace covers both caches),
  * and is registered as that package's L2 provider from `src/start.ts`.

--- a/apps/dashboard/src/lib/target/target.test.ts
+++ b/apps/dashboard/src/lib/target/target.test.ts
@@ -62,7 +62,7 @@ describe('CloudflareAdapter contract', () => {
     // Under bun test `cloudflare:workers` env is the process.env shim, so a
     // non-object value probes to null.
     expect(a.d1('CHM_CLOUD_D1')).toBeNull()
-    expect(a.kv('VERSION_CACHE_KV')).toBeNull()
+    expect(a.kv('CHM_VERSION_CACHE_KV')).toBeNull()
     expect(a.durableObject('SOME_DO')).toBeNull()
   })
 
@@ -91,7 +91,7 @@ describe('NodeAdapter contract', () => {
 
   test('binding accessors return null on Node', () => {
     expect(a.d1('CHM_CLOUD_D1')).toBeNull()
-    expect(a.kv('VERSION_CACHE_KV')).toBeNull()
+    expect(a.kv('CHM_VERSION_CACHE_KV')).toBeNull()
     expect(a.durableObject('SOME_DO')).toBeNull()
   })
 

--- a/apps/dashboard/src/lib/version-cache.ts
+++ b/apps/dashboard/src/lib/version-cache.ts
@@ -3,7 +3,7 @@
  *
  * Zero-config cache layer for ClickHouse version caching.
  * Auto-detects environment and uses appropriate caching strategy:
- * 1. Cloudflare Workers KV (if VERSION_CACHE_KV binding exists)
+ * 1. Cloudflare Workers KV (if CHM_VERSION_CACHE_KV binding exists)
  * 2. In-memory fallback (always works — self-hosted Node/Docker, or
  *    Cloudflare before the KV namespace is provisioned)
  *
@@ -27,7 +27,7 @@ import type { ClickHouseVersion } from '@chm/clickhouse-client/clickhouse-versio
 import { debug, warn } from '@chm/logger'
 
 /** The wrangler.toml binding name this module reads (see issue #2183). */
-export const VERSION_CACHE_KV_BINDING = 'VERSION_CACHE_KV'
+export const CHM_VERSION_CACHE_KV_BINDING = 'CHM_VERSION_CACHE_KV'
 
 /**
  * Cache adapter interface
@@ -126,7 +126,7 @@ let cacheInstance: VersionCacheAdapter | null = null
  * Get the appropriate cache adapter for the current environment
  *
  * Priority order:
- * 1. Cloudflare Workers KV (if VERSION_CACHE_KV binding exists)
+ * 1. Cloudflare Workers KV (if CHM_VERSION_CACHE_KV binding exists)
  * 2. In-memory fallback
  *
  * @returns Cache adapter instance

--- a/apps/dashboard/src/start.ts
+++ b/apps/dashboard/src/start.ts
@@ -31,7 +31,10 @@ import { forceFlushOtel, getOtelTracer } from '@/lib/otel/exporter'
 import { withSpan } from '@/lib/otel/with-span'
 import { withSecurityHeaders } from '@/lib/security-headers'
 import { getTableExistenceCache } from '@/lib/table-existence-kv-cache'
-import { getVersionCache, VERSION_CACHE_KV_BINDING } from '@/lib/version-cache'
+import {
+  CHM_VERSION_CACHE_KV_BINDING,
+  getVersionCache,
+} from '@/lib/version-cache'
 
 // Returning a Response from a request middleware short-circuits the chain and
 // sends that Response without running the route handler (same mechanism the
@@ -53,7 +56,7 @@ function wireVersionCacheKvOnce(): void {
   kvCacheWired = true
 
   const binding = (env as Record<string, unknown> | undefined)?.[
-    VERSION_CACHE_KV_BINDING
+    CHM_VERSION_CACHE_KV_BINDING
   ]
   const kv =
     binding && typeof binding === 'object' ? (binding as KVNamespace) : null

--- a/apps/dashboard/wrangler.toml
+++ b/apps/dashboard/wrangler.toml
@@ -26,12 +26,12 @@ migrations_dir = "./src/db/conversations-migrations"
 # the in-memory L1 (cache-manager.ts, 5-min TTL) with an L2 that survives
 # Worker isolate churn on cold starts. Optional/zero-config: code auto-detects
 # this binding (see lib/api/data/dashboard-query-kv-cache.ts, same pattern as
-# lib/version-cache.ts's VERSION_CACHE_KV) and falls back to in-memory-only
+# lib/version-cache.ts's CHM_VERSION_CACHE_KV) and falls back to in-memory-only
 # when absent, so self-hosted/Docker/K8s deploys (no KV binding) are unaffected.
 # A KV miss or read error is always treated as a cache miss (fail-closed) —
 # never as an implicit allow.
 [[kv_namespaces]]
-binding = "DASHBOARD_QUERY_KV"
+binding = "CHM_DASHBOARD_QUERY_KV"
 id = "98b43d2d6fcf438cbd91e18e38b4212d"
 preview_id = "44390b843ada46d8beb47c99bcf24115"
 
@@ -77,13 +77,16 @@ custom_domain = true
 # back to their in-memory-only (L1) behavior — identical to today — until an
 # operator completes this setup:
 #
-#   1. wrangler kv namespace create VERSION_CACHE_KV
+#   1. wrangler kv namespace create chmonitor-version-cache
+#      (the namespace TITLE is chmonitor-prefixed so it's identifiable in the
+#      shared Cloudflare account; the worker BINDING below stays
+#      CHM_VERSION_CACHE_KV — title and binding are independent.)
 #   2. Uncomment the block below with the real `id` from step 1 (mirror into
 #      [env.preview] with its own namespace, or reuse the same one).
 #   3. Redeploy.
 #
 # [[kv_namespaces]]
-# binding = "VERSION_CACHE_KV"
+# binding = "CHM_VERSION_CACHE_KV"
 # id = "<namespace id from `wrangler kv namespace create`>"
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -197,7 +200,7 @@ migrations_dir = "./src/db/conversations-migrations"
 # for now, same pattern as CHM_CLOUD_D1 above). Cached entries are non-secret
 # (they mirror rows already readable from the dashboard's own charts table).
 [[env.preview.kv_namespaces]]
-binding = "DASHBOARD_QUERY_KV"
+binding = "CHM_DASHBOARD_QUERY_KV"
 id = "98b43d2d6fcf438cbd91e18e38b4212d"
 preview_id = "44390b843ada46d8beb47c99bcf24115"
 

--- a/apps/telemetry/src/index.ts
+++ b/apps/telemetry/src/index.ts
@@ -17,12 +17,12 @@
 // over HTTP — only the project's Cloudflare account can query the dataset.
 
 export interface Env {
-  TELEMETRY: AnalyticsEngineDataset
+  CHM_TELEMETRY_AE: AnalyticsEngineDataset
   // Optional forever-retention store. Analytics Engine keeps data for only 3
   // months; when a D1 binding is present we ALSO record one deduped row per
   // install per UTC day, which D1 keeps indefinitely (CF-native, free tier).
   // Deploy works without it (AE-only) until the binding is configured.
-  DB?: D1Database
+  CHM_TELEMETRY_DB?: D1Database
 }
 
 const MAX_BODY_BYTES = 2048
@@ -110,7 +110,7 @@ export default {
       const deployTarget = asEnum(data.deploy_target, DEPLOY_TARGETS, 'unknown')
       const chVersion = asVersion(data.ch_version)
 
-      env.TELEMETRY.writeDataPoint({
+      env.CHM_TELEMETRY_AE.writeDataPoint({
         // index1 — distinct-install key. Count installs with uniqExact(index1).
         indexes: [instanceHash],
         // blob1=kind, blob2=deploy_target, blob3=ch_version
@@ -122,10 +122,10 @@ export default {
       // binding is present also record one deduped row per install per UTC day.
       // INSERT OR IGNORE on (day, instance_hash) keeps storage to one row per
       // install per day; D1 retains it indefinitely. Runs after the response.
-      if (env.DB) {
+      if (env.CHM_TELEMETRY_DB) {
         const day = new Date().toISOString().slice(0, 10) // YYYY-MM-DD (UTC)
         ctx.waitUntil(
-          env.DB.prepare(
+          env.CHM_TELEMETRY_DB.prepare(
             'INSERT OR IGNORE INTO ping_daily (day, instance_hash, deploy_target, ch_version) VALUES (?, ?, ?, ?)'
           )
             .bind(day, instanceHash, deployTarget, chVersion || null)
@@ -151,7 +151,7 @@ export default {
       const chVersion = asVersion(props.ch_version)
       const chFlavor = asEnum(props.ch_flavor, CH_FLAVORS, 'unknown')
 
-      env.TELEMETRY.writeDataPoint({
+      env.CHM_TELEMETRY_AE.writeDataPoint({
         // events carry no instance identity — index by event name.
         indexes: [event],
         // blob1=kind, blob2=event, blob3=deploy_target, blob4=ch_version, blob5=ch_flavor

--- a/apps/telemetry/wrangler.toml
+++ b/apps/telemetry/wrangler.toml
@@ -28,7 +28,7 @@ enabled = true
 # Analytics Engine — hot store (3-month retention, ad-hoc SQL). No binding-side
 # config needed beyond the dataset name; rows go in via writeDataPoint().
 [[analytics_engine_datasets]]
-binding = "TELEMETRY"
+binding = "CHM_TELEMETRY_AE"
 dataset = "chm_telemetry"
 
 # D1 — forever store (optional). AE auto-deletes after 3 months; D1 keeps one
@@ -40,7 +40,7 @@ dataset = "chm_telemetry"
 #
 # then uncomment:
 # [[d1_databases]]
-# binding = "DB"
+# binding = "CHM_TELEMETRY_DB"
 # database_name = "chm_telemetry"
 # database_id = "<paste id from `wrangler d1 create`>"
 # migrations_dir = "migrations"
@@ -57,7 +57,7 @@ custom_domain = true
 name = "preview-chmonitor-telemetry"
 
 [[env.preview.analytics_engine_datasets]]
-binding = "TELEMETRY"
+binding = "CHM_TELEMETRY_AE"
 dataset = "chm_telemetry_preview"
 
 [[env.preview.routes]]


### PR DESCRIPTION
## Why

The Cloudflare account is shared across many projects (anyrouter, stamp, agentstate, duyetbot, openclaw, …). Generic resource names like `DASHBOARD_QUERY_KV` / `VERSION_CACHE_KV` are indistinguishable in the account dashboard. Closes the naming half of #2319.

Two conventions, applied consistently (both already de-facto in the repo):
- **Global resource TITLES** → `chmonitor-*` (worker names, queue names)
- **Worker BINDINGS** → `CHM_*` (matches existing `CHM_CLOUD_D1`, `CHM_EVENTS_QUEUE`)

> A CF resource has two independent names — the global *title* (collides across projects) and the code *binding*. Renaming one never touches the other, so binding renames move in lockstep across `wrangler.toml` + every code reference.

## Live resources renamed (id-stable via API — no redeploy)

| id | old title | new title |
|----|-----------|-----------|
| `98b4…` | `DASHBOARD_QUERY_KV` | `chmonitor-dashboard-query` |
| `4439…` | `DASHBOARD_QUERY_KV_preview` | `chmonitor-dashboard-query-preview` |

wrangler binds by `id`/`preview_id`, not title, so these took effect immediately with no deploy.

## Binding renames (code + wrangler.toml, lockstep)

- KV `DASHBOARD_QUERY_KV` → `CHM_DASHBOARD_QUERY_KV`
- KV `VERSION_CACHE_KV` → `CHM_VERSION_CACHE_KV` (+ `*_BINDING` const)
- Telemetry AE `TELEMETRY` → `CHM_TELEMETRY_AE`
- Telemetry D1 `DB` → `CHM_TELEMETRY_DB`
- #2319 provisioning comment now creates a `chmonitor-version-cache` title

## Already conformant (verified, unchanged)

Workers (`chmonitor-*`), D1 `chm-cloud`/`chm_telemetry`, queue `chmonitor-inbound-events`, AE dataset `chm_telemetry`.

## Left untouched (owner will delete separately)

Legacy Next.js resources: KV `clickhouse-monitor`, D1 `clickhouse-monitor` + `clickhouse-monitor-conversations`, R2 `clickhouse-monitoring-inc-cache`.

## Verification

- Zero un-prefixed residual binding strings — checked both `'X'` string-literal and `env.X` property forms (silent-null fallback means a miss would NOT fail the build)
- Telemetry `tsc --noEmit` clean; dashboard worker types regenerated
- KV-cache + validator tests 17/17 pass
- The one `target.test.ts` failure is a pre-existing `cloudflare:workers` virtual-module test-env limitation (confirmed identical on clean `main`)

Co-Authored-By: duyetbot <bot@duyet.net>