### PR TITLE
refactor(agent): merge AI Agent nav into one group, add Agent Settings page

### DIFF
--- a/apps/dashboard/cypress/e2e/page-render-sweep.cy.ts
+++ b/apps/dashboard/cypress/e2e/page-render-sweep.cy.ts
@@ -19,6 +19,7 @@ const DASHBOARD_ROUTES = [
   '/insights',
   '/about',
   '/agents',
+  '/agents/settings',
   '/ai-chat',
   '/asynchronous-metrics',
   '/backups',

--- a/apps/dashboard/src/components/agents/settings/agent-settings-page.tsx
+++ b/apps/dashboard/src/components/agents/settings/agent-settings-page.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+/**
+ * `/agents/settings` — full-page home for everything agent-related: LLM
+ * provider status, model selection, the system prompt, skills, and external
+ * MCP server registrations.
+ *
+ * Replaces the standalone `/mcp-servers` page (its `McpServerManager` content
+ * now lives in the "MCP Servers" tab here) and complements the compact
+ * "Agent settings" side panel on the chat page (`/agents`) — that panel stays
+ * for quick in-conversation tweaks; this page is the fuller settings surface
+ * it links out to.
+ */
+
+import {
+  CpuIcon,
+  PlugZapIcon,
+  ScrollTextIcon,
+  ServerIcon,
+  SparklesIcon,
+} from 'lucide-react'
+
+import { ModelsTab } from './models-tab'
+import { ProviderTab } from './provider-tab'
+import { SkillsTab } from './skills-tab'
+import { SystemPromptTab } from './system-prompt-tab'
+import { useCallback, useMemo } from 'react'
+import { PageHeader } from '@/components/layout/page-header'
+import { McpServerManager } from '@/components/mcp/mcp-server-manager'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { useRouter, useSearchParams } from '@/lib/next-compat'
+
+const TAB_IDS = [
+  'provider',
+  'models',
+  'system-prompt',
+  'skills',
+  'mcp',
+] as const
+type TabId = (typeof TAB_IDS)[number]
+
+const DEFAULT_TAB: TabId = 'provider'
+
+function isTabId(value: string | null): value is TabId {
+  return value !== null && (TAB_IDS as readonly string[]).includes(value)
+}
+
+export function AgentSettingsPage() {
+  const searchParams = useSearchParams()
+  const router = useRouter()
+
+  const tab = useMemo(() => {
+    const raw = searchParams.get('tab')
+    return isTabId(raw) ? raw : DEFAULT_TAB
+  }, [searchParams])
+
+  // Merge into the existing query string (not a bare `?tab=` href) so other
+  // params — `host`, if ever present — survive the navigation. Mirrors
+  // `useExplorerState`'s `updateParams` (`use-explorer-state.ts`).
+  const setTab = useCallback(
+    (value: string) => {
+      if (value === tab) return
+      const params = new URLSearchParams(searchParams.toString())
+      params.set('tab', value)
+      router.replace(`/agents/settings?${params.toString()}`)
+    },
+    [tab, searchParams, router]
+  )
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-6">
+      <PageHeader
+        title="Agent settings"
+        description="Provider, model, system prompt, skills, and MCP servers for the AI Agent."
+      />
+
+      <Tabs value={tab} onValueChange={setTab}>
+        <TabsList>
+          <TabsTrigger value="provider" className="gap-1.5">
+            <ServerIcon className="size-3.5" />
+            Provider
+          </TabsTrigger>
+          <TabsTrigger value="models" className="gap-1.5">
+            <CpuIcon className="size-3.5" />
+            Models
+          </TabsTrigger>
+          <TabsTrigger value="system-prompt" className="gap-1.5">
+            <ScrollTextIcon className="size-3.5" />
+            System prompt
+          </TabsTrigger>
+          <TabsTrigger value="skills" className="gap-1.5">
+            <SparklesIcon className="size-3.5" />
+            Skills
+          </TabsTrigger>
+          <TabsTrigger value="mcp" className="gap-1.5">
+            <PlugZapIcon className="size-3.5" />
+            MCP servers
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="provider" className="mt-4">
+          <ProviderTab />
+        </TabsContent>
+        <TabsContent value="models" className="mt-4">
+          <ModelsTab />
+        </TabsContent>
+        <TabsContent value="system-prompt" className="mt-4">
+          <SystemPromptTab />
+        </TabsContent>
+        <TabsContent value="skills" className="mt-4">
+          <SkillsTab />
+        </TabsContent>
+        <TabsContent value="mcp" className="mt-4">
+          <McpServerManager />
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/agents/settings/models-tab.tsx
+++ b/apps/dashboard/src/components/agents/settings/models-tab.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+/**
+ * Models tab — `/agents/settings`.
+ *
+ * Reuses {@link AgentModelPicker} (the same picker rendered on the welcome
+ * toolbar and the chat sidebar) so model selection stays in one place.
+ */
+
+import { AgentModelPicker } from '@/components/agents/welcome/agent-model-picker'
+
+export function ModelsTab() {
+  return (
+    <div className="space-y-3">
+      <p className="text-muted-foreground text-[11.5px] leading-snug">
+        Choose which model the agent uses for new conversations. Saved to this
+        browser; existing conversations keep the model they started with.
+      </p>
+      <AgentModelPicker variant="panel" />
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/agents/settings/provider-tab.tsx
+++ b/apps/dashboard/src/components/agents/settings/provider-tab.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+/**
+ * Provider tab — `/agents/settings`.
+ *
+ * Read-only status of the LLM provider(s) the agent can call. The active
+ * provider/model and API keys are configured at deploy time via environment
+ * variables (`LLM_MODEL`, `OPENROUTER_API_KEY`, `ANYROUTER_API_KEY`, …), so
+ * this surfaces `GET /api/v1/agents/config-check` rather than an editable
+ * form — same "fixed at deploy time" framing as the Conversation History
+ * panel in the chat sidebar.
+ */
+
+import { CheckCircle2Icon, XCircleIcon } from 'lucide-react'
+
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
+import { docsSiteUrl } from '@/lib/docs-site'
+import { useAgentConfigCheck } from '@/lib/swr/use-agent-config-check'
+import { cn } from '@/lib/utils'
+
+export function ProviderTab() {
+  const { data, isLoading, error } = useAgentConfigCheck()
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        <Skeleton className="h-14 w-full" />
+        <Skeleton className="h-14 w-full" />
+        <Skeleton className="h-14 w-full" />
+      </div>
+    )
+  }
+
+  if (error || !data) {
+    return (
+      <Alert variant="destructive">
+        <AlertDescription>
+          Could not load provider configuration status.
+        </AlertDescription>
+      </Alert>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {!data.isFullyConfigured && (
+        <Alert variant="destructive">
+          <AlertDescription>
+            No provider is configured. Set{' '}
+            <code className="font-mono text-[11px]">
+              {data.requiredKeys.apiKey}
+            </code>{' '}
+            to enable the agent.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <div className="divide-border divide-y rounded-md border">
+        {data.providers.map((provider) => (
+          <div
+            key={provider.id}
+            className="flex items-center gap-3 px-3 py-2.5"
+          >
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="text-[13px] font-medium">{provider.name}</span>
+                {provider.configured ? (
+                  <Badge
+                    variant="outline"
+                    className="h-4 gap-1 px-1.5 text-[10px] font-normal text-emerald-700 dark:text-emerald-400"
+                  >
+                    <CheckCircle2Icon className="size-2.5" />
+                    Configured
+                  </Badge>
+                ) : (
+                  <Badge
+                    variant="outline"
+                    className="text-muted-foreground h-4 gap-1 px-1.5 text-[10px] font-normal"
+                  >
+                    <XCircleIcon className="size-2.5" />
+                    Not configured
+                  </Badge>
+                )}
+              </div>
+              <p className="text-muted-foreground mt-0.5 font-mono text-[10.5px]">
+                {provider.apiKeyEnvVar}
+                {provider.hasBaseURLOverride
+                  ? ' · custom base URL'
+                  : ` · ${provider.baseURL}`}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <p
+        className={cn(
+          'text-muted-foreground text-[11px] leading-snug',
+          'border-t pt-3'
+        )}
+      >
+        Provider selection and API keys are configured at deploy time via
+        environment variables and cannot be changed here. See the{' '}
+        <a
+          href={docsSiteUrl('guide/ai-agent')}
+          target="_blank"
+          rel="noreferrer"
+          className="text-foreground underline underline-offset-2"
+        >
+          AI Agent docs
+        </a>{' '}
+        for the full list of supported providers.
+      </p>
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/agents/settings/skills-tab.tsx
+++ b/apps/dashboard/src/components/agents/settings/skills-tab.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+/**
+ * Skills tab — `/agents/settings`.
+ *
+ * Full skill library with search + per-skill toggles. Wraps
+ * {@link SkillsLibraryList}, the same list used in the "Skill library" dialog
+ * opened from the chat sidebar, so toggles stay in sync everywhere.
+ */
+
+import { SkillsLibraryList } from '@/components/agents/welcome/skills-library-dialog'
+import { useAgentSkills } from '@/lib/hooks/use-agent-skills'
+
+export function SkillsTab() {
+  // Single hook instance shared with the list below (see the note in
+  // skills-library-dialog.tsx) — otherwise this header's count goes stale
+  // while the list's toggles keep working.
+  const agentSkills = useAgentSkills()
+  const { skills, activeSkillCount } = agentSkills
+
+  return (
+    <div className="flex max-h-[560px] flex-col overflow-hidden rounded-md border">
+      <div className="border-b px-4 py-3">
+        <p className="text-[13px] font-medium">
+          {activeSkillCount} of {skills.length} skills enabled
+        </p>
+        <p className="text-muted-foreground text-[11.5px]">
+          Toggle a skill to add or remove the tools it covers from the agent.
+        </p>
+      </div>
+      <SkillsLibraryList agentSkills={agentSkills} />
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/agents/settings/system-prompt-tab.tsx
+++ b/apps/dashboard/src/components/agents/settings/system-prompt-tab.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+/**
+ * System Prompt tab — `/agents/settings`.
+ *
+ * Read-only view of the instructions sent to the model on every request
+ * (`CLICKHOUSE_AGENT_INSTRUCTIONS`). There is no per-user override today — the
+ * prompt is a fixed, versioned asset (see `lib/ai/agent/prompts/`) that ships
+ * with the dashboard — so this is visibility, not an editor.
+ *
+ * Imported directly (not fetched from an API): the assembled instructions are
+ * a plain string constant with no server-only dependencies. It ships with the
+ * `/agents/settings` route chunk (code-split from the rest of the app like
+ * every other route) rather than a separate per-tab chunk — the ~5-6k tokens
+ * of prompt text only load when a user visits this page, not on every page.
+ */
+
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { CLICKHOUSE_AGENT_INSTRUCTIONS } from '@/lib/ai/agent/prompts/clickhouse-instructions'
+
+export function SystemPromptTab() {
+  return (
+    <div className="space-y-3">
+      <p className="text-muted-foreground text-[11.5px] leading-snug">
+        The instructions sent to the model at the start of every conversation.
+        Fixed for now — there is no per-user override.
+      </p>
+      <ScrollArea className="bg-muted/20 h-[480px] rounded-md border">
+        <pre className="whitespace-pre-wrap p-4 font-mono text-[11px] leading-relaxed">
+          {CLICKHOUSE_AGENT_INSTRUCTIONS}
+        </pre>
+      </ScrollArea>
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/agents/welcome/agent-mcp-panel.tsx
+++ b/apps/dashboard/src/components/agents/welcome/agent-mcp-panel.tsx
@@ -19,7 +19,8 @@
  * sends the enabled ones in each agent request body, and the agent connects
  * them (SSRF-guarded) alongside the built-in tools for that conversation. For
  * per-user servers that PERSIST server-side (D1) with auth + a template
- * library, see the MCP Servers manager route (`/mcp-servers`).
+ * library, see the "MCP Servers" tab on the Agent Settings page
+ * (`/agents/settings?tab=mcp`).
  */
 
 import { PlusIcon, Trash2Icon, WrenchIcon } from 'lucide-react'

--- a/apps/dashboard/src/components/agents/welcome/agent-settings-sidebar.tsx
+++ b/apps/dashboard/src/components/agents/welcome/agent-settings-sidebar.tsx
@@ -29,6 +29,7 @@ import { McpConnectAgentDialog } from '@/components/agents/welcome/mcp-connect-a
 import { SkillDetailDialog } from '@/components/agents/welcome/skill-detail-dialog'
 import { SkillsLibraryDialog } from '@/components/agents/welcome/skills-library-dialog'
 import { SUGGESTED_PROMPTS } from '@/components/agents/welcome/suggested-prompts'
+import { AppLink } from '@/components/ui/app-link'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -257,6 +258,13 @@ export function AgentSettingsSidebar({
             <DrawerDescription className="text-[11.5px]">
               Host, model, tools, and skills.
             </DrawerDescription>
+            <AppLink
+              href="/agents/settings"
+              className="text-muted-foreground hover:text-foreground inline-flex w-fit items-center gap-1 text-[11px] underline underline-offset-2"
+            >
+              Open full agent settings
+              <ArrowRightIcon className="size-2.5" />
+            </AppLink>
           </DrawerHeader>
           <div className="overflow-y-auto px-4 pb-6">{sections}</div>
         </DrawerContent>
@@ -289,9 +297,16 @@ export function AgentSettingsSidebar({
             <PanelRightCloseIcon className="size-3.5" />
           </Button>
         </div>
-        <p className="text-muted-foreground mb-4 text-[11.5px]">
+        <p className="text-muted-foreground mb-1 text-[11.5px]">
           Host, model, tools, and skills.
         </p>
+        <AppLink
+          href="/agents/settings"
+          className="text-muted-foreground hover:text-foreground mb-4 inline-flex items-center gap-1 text-[11px] underline underline-offset-2"
+        >
+          Open full agent settings
+          <ArrowRightIcon className="size-2.5" />
+        </AppLink>
         {sections}
       </div>
     </aside>

--- a/apps/dashboard/src/components/agents/welcome/skills-library-dialog.tsx
+++ b/apps/dashboard/src/components/agents/welcome/skills-library-dialog.tsx
@@ -2,13 +2,16 @@
 
 /**
  * Full skills library, opened from the "Skill library" button in the agent
- * settings sidebar. Lists every skill bundle (not just the top 3) with a
- * search box, full descriptions, the tools each bundle covers, and a per-skill
- * enable toggle. Reuses the shared `useAgentSkills` state so toggles here stay
- * in sync with the composer toolbar and sidebar.
+ * settings sidebar (and embedded inline in the Skills tab of `/agents/settings`
+ * via {@link SkillsLibraryList}). Lists every skill bundle (not just the top 3)
+ * with a search box, full descriptions, the tools each bundle covers, and a
+ * per-skill enable toggle. Reuses the shared `useAgentSkills` state so toggles
+ * here stay in sync with the composer toolbar, sidebar, and settings page.
  */
 
 import { SearchIcon } from 'lucide-react'
+
+import type { UseAgentSkillsResult } from '@/lib/hooks/use-agent-skills'
 
 import { useMemo, useState } from 'react'
 import { Badge } from '@/components/ui/badge'
@@ -34,8 +37,43 @@ export function SkillsLibraryDialog({
   open,
   onOpenChange,
 }: SkillsLibraryDialogProps) {
-  const { skills, isSkillEnabled, toggleSkill, activeSkillCount } =
-    useAgentSkills()
+  // Single hook instance shared by the header count and the list below —
+  // `useAgentSkills` seeds local state from localStorage per instance with no
+  // cross-instance sync, so a second call here would let the header count go
+  // stale while the list's toggles kept working.
+  const agentSkills = useAgentSkills()
+  const { skills, activeSkillCount } = agentSkills
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[85dvh] flex-col gap-0 overflow-hidden p-0 sm:max-w-2xl">
+        <DialogHeader className="border-b px-5 py-4">
+          <DialogTitle>Skill library</DialogTitle>
+          <DialogDescription>
+            {activeSkillCount} of {skills.length} skills enabled. Toggle a skill
+            to add or remove the tools it covers.
+          </DialogDescription>
+        </DialogHeader>
+        <SkillsLibraryList agentSkills={agentSkills} />
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+/**
+ * Search box + full skill list, extracted so it can render both inside the
+ * dialog above (chrome + portal) and inline as a settings-page tab (plain
+ * content, no dialog chrome). Takes the `useAgentSkills()` result as a prop
+ * rather than calling the hook itself, so callers that also show a live
+ * count (the dialog header, the settings-page tab header) share one state
+ * instance instead of drifting out of sync.
+ */
+export function SkillsLibraryList({
+  agentSkills,
+}: {
+  agentSkills: UseAgentSkillsResult
+}) {
+  const { skills, isSkillEnabled, toggleSkill } = agentSkills
   const [query, setQuery] = useState('')
 
   const filtered = useMemo(() => {
@@ -50,94 +88,84 @@ export function SkillsLibraryDialog({
   }, [skills, query])
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex max-h-[85dvh] flex-col gap-0 overflow-hidden p-0 sm:max-w-2xl">
-        <DialogHeader className="border-b px-5 py-4">
-          <DialogTitle>Skill library</DialogTitle>
-          <DialogDescription>
-            {activeSkillCount} of {skills.length} skills enabled. Toggle a skill
-            to add or remove the tools it covers.
-          </DialogDescription>
-        </DialogHeader>
-
-        <div className="border-b px-5 py-3">
-          <div className="relative">
-            <SearchIcon className="text-muted-foreground absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
-            <Input
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search skills or tools…"
-              className="h-9 pl-8 text-[12.5px]"
-            />
-          </div>
+    <>
+      <div className="border-b px-5 py-3">
+        <div className="relative">
+          <SearchIcon className="text-muted-foreground absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
+          <Input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search skills or tools…"
+            className="h-9 pl-8 text-[12.5px]"
+          />
         </div>
+      </div>
 
-        <ScrollArea className="min-h-0 flex-1">
-          <div className="space-y-1 p-3">
-            {filtered.length === 0 ? (
-              <p className="text-muted-foreground px-2 py-6 text-center text-[12px]">
-                No skills match “{query}”.
-              </p>
-            ) : (
-              filtered.map((skill) => {
-                const Icon = skill.icon
-                const on = isSkillEnabled(skill.id)
-                return (
-                  <div
-                    key={skill.id}
-                    className="hover:bg-muted/40 flex items-start gap-3 rounded-lg border p-3"
-                  >
-                    <div className="bg-muted text-muted-foreground inline-flex size-8 shrink-0 items-center justify-center rounded-md">
-                      <Icon className="size-4" />
-                    </div>
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-1.5">
-                        <span className="truncate text-[13px] font-medium">
-                          {skill.name}
-                        </span>
-                        <Badge
-                          variant={
-                            skill.source === 'system' ? 'default' : 'outline'
-                          }
-                          className={cn(
-                            'h-4 px-1.5 text-[10px] font-normal',
-                            skill.source === 'system'
-                              ? 'bg-blue-50 text-blue-700 hover:bg-blue-50 dark:bg-blue-500/10 dark:text-blue-300'
-                              : 'text-muted-foreground'
-                          )}
-                        >
-                          {skill.source}
-                        </Badge>
-                      </div>
-                      <p className="text-muted-foreground mt-0.5 text-[11.5px] leading-snug">
-                        {skill.description}
-                      </p>
-                      {skill.tools.length > 0 ? (
-                        <div className="mt-2 flex flex-wrap gap-1">
-                          {skill.tools.map((tool) => (
-                            <span
-                              key={tool}
-                              className="bg-muted text-muted-foreground rounded px-1.5 py-0.5 font-mono text-[10px]"
-                            >
-                              {tool}
-                            </span>
-                          ))}
-                        </div>
-                      ) : null}
-                    </div>
-                    <Switch
-                      checked={on}
-                      onCheckedChange={() => toggleSkill(skill.id)}
-                      className="mt-0.5 shrink-0"
-                      aria-label={`Toggle ${skill.name}`}
-                    />
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="space-y-1 p-3">
+          {filtered.length === 0 ? (
+            <p className="text-muted-foreground px-2 py-6 text-center text-[12px]">
+              No skills match “{query}”.
+            </p>
+          ) : (
+            filtered.map((skill) => {
+              const Icon = skill.icon
+              const on = isSkillEnabled(skill.id)
+              return (
+                <div
+                  key={skill.id}
+                  className="hover:bg-muted/40 flex items-start gap-3 rounded-lg border p-3"
+                >
+                  <div className="bg-muted text-muted-foreground inline-flex size-8 shrink-0 items-center justify-center rounded-md">
+                    <Icon className="size-4" />
                   </div>
-                )
-              })
-            )}
-          </div>
-        </ScrollArea>
-      </DialogContent>
-    </Dialog>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-1.5">
+                      <span className="truncate text-[13px] font-medium">
+                        {skill.name}
+                      </span>
+                      <Badge
+                        variant={
+                          skill.source === 'system' ? 'default' : 'outline'
+                        }
+                        className={cn(
+                          'h-4 px-1.5 text-[10px] font-normal',
+                          skill.source === 'system'
+                            ? 'bg-blue-50 text-blue-700 hover:bg-blue-50 dark:bg-blue-500/10 dark:text-blue-300'
+                            : 'text-muted-foreground'
+                        )}
+                      >
+                        {skill.source}
+                      </Badge>
+                    </div>
+                    <p className="text-muted-foreground mt-0.5 text-[11.5px] leading-snug">
+                      {skill.description}
+                    </p>
+                    {skill.tools.length > 0 ? (
+                      <div className="mt-2 flex flex-wrap gap-1">
+                        {skill.tools.map((tool) => (
+                          <span
+                            key={tool}
+                            className="bg-muted text-muted-foreground rounded px-1.5 py-0.5 font-mono text-[10px]"
+                          >
+                            {tool}
+                          </span>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
+                  <Switch
+                    checked={on}
+                    onCheckedChange={() => toggleSkill(skill.id)}
+                    className="mt-0.5 shrink-0"
+                    aria-label={`Toggle ${skill.name}`}
+                  />
+                </div>
+              )
+            })
+          )}
+        </div>
+      </ScrollArea>
+    </>
   )
 }

--- a/apps/dashboard/src/components/status/dynamic-title.tsx
+++ b/apps/dashboard/src/components/status/dynamic-title.tsx
@@ -24,6 +24,7 @@ const ROUTE_TITLE_MAP: Record<string, string> = {
   '/': 'Overview',
   '/overview': 'Overview',
   '/agents': 'AI Agent',
+  '/agents/settings': 'Agent Settings',
   '/insights': 'Insights',
   '/health': 'Health',
   '/running-queries': 'Running Queries',

--- a/apps/dashboard/src/lib/command-palette/nav-commands.ts
+++ b/apps/dashboard/src/lib/command-palette/nav-commands.ts
@@ -91,6 +91,12 @@ const NAV_ROUTES = [
     href: '/agents',
     keywords: ['ai', 'chat', 'assistant', 'llm'],
   },
+  {
+    id: 'nav-agent-settings',
+    label: 'Agent Settings',
+    href: '/agents/settings',
+    keywords: ['ai', 'mcp', 'model', 'skills', 'provider', 'settings'],
+  },
 ] as const
 
 /**

--- a/apps/dashboard/src/lib/swr/use-agent-config-check.ts
+++ b/apps/dashboard/src/lib/swr/use-agent-config-check.ts
@@ -1,0 +1,63 @@
+/**
+ * useAgentConfigCheck Hook
+ *
+ * Fetches the AI agent's LLM provider configuration status from
+ * `GET /api/v1/agents/config-check` — which provider(s) have API keys
+ * configured, the selected model's provider, and whether a base URL override
+ * is set. Provider/model selection itself is set at deploy time via
+ * environment variables (`LLM_MODEL`, `OPENROUTER_API_KEY`, etc.), so this is
+ * read-only status, not an editable form.
+ */
+
+import { useQuery } from '@tanstack/react-query'
+
+import { apiFetch } from './api-fetch'
+
+export interface AgentConfigCheckProvider {
+  id: string
+  name: string
+  configured: boolean
+  apiKeyEnvVar: string
+  hasBaseURLOverride: boolean
+  baseURL: string
+}
+
+export interface AgentConfigCheck {
+  configured: {
+    apiKey: boolean
+    apiBase: boolean
+  }
+  isFullyConfigured: boolean
+  requiredKeys: {
+    apiKey: string
+    apiBase: string
+  }
+  providers: AgentConfigCheckProvider[]
+}
+
+export interface AgentConfigCheckResult {
+  data: AgentConfigCheck | undefined
+  isLoading: boolean
+  error: Error | undefined
+}
+
+async function fetchAgentConfigCheck(): Promise<AgentConfigCheck> {
+  const response = await apiFetch('/api/v1/agents/config-check')
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch agent config check: ${response.statusText}`
+    )
+  }
+  return response.json()
+}
+
+export function useAgentConfigCheck(): AgentConfigCheckResult {
+  const { data, isLoading, error } = useQuery<AgentConfigCheck>({
+    queryKey: ['/api/v1/agents/config-check'],
+    queryFn: fetchAgentConfigCheck,
+    staleTime: 300_000, // Cache for 5 minutes — deploy-time config rarely changes
+    retry: 1,
+  })
+
+  return { data, isLoading, error: error ?? undefined }
+}

--- a/apps/dashboard/src/menu.ts
+++ b/apps/dashboard/src/menu.ts
@@ -65,24 +65,46 @@ export const menuItemsConfig: MenuItem[] = [
     permission: { feature: 'overview' },
   },
   {
+    // Parent groups the chat UI, its settings (provider, model, system
+    // prompt, skills, external MCP server registrations), and this
+    // dashboard's own MCP server endpoint — three previously flat,
+    // confusingly-named items ("AI Agent", "MCP Servers", "MCP Server").
+    // No `permission` here: children carry their own ('agent' vs 'mcp') so
+    // each is filtered independently instead of gating the whole group.
     title: 'AI Agent',
-    href: '/agents',
+    href: '',
     icon: SparklesIcon,
     section: 'main',
     isNew: true,
-    // The chat UI renders for everyone; the backend enforces auth on send (see
-    // AgentAuthGate / the /api/v1/agent route), not the client route gate.
-    permission: { feature: 'agent' },
-  },
-  {
-    title: 'MCP Servers',
-    href: '/mcp-servers',
-    description:
-      'Register external Model Context Protocol servers; their tools load with the agent at conversation start',
-    icon: WorkflowIcon,
-    section: 'main',
-    isNew: true,
-    permission: { feature: 'agent' },
+    items: [
+      {
+        title: 'Chat',
+        href: '/agents',
+        description: 'Ask questions about this cluster in natural language',
+        icon: SparklesIcon,
+        isNew: true,
+        // The chat UI renders for everyone; the backend enforces auth on send
+        // (see AgentAuthGate / the /api/v1/agent route), not the client route
+        // gate.
+        permission: { feature: 'agent' },
+      },
+      {
+        title: 'Agent Settings',
+        href: '/agents/settings',
+        description:
+          'Provider, model, system prompt, skills, and external MCP servers',
+        icon: SlidersHorizontalIcon,
+        permission: { feature: 'agent' },
+      },
+      {
+        title: 'MCP Server',
+        href: '/mcp',
+        description:
+          "Let external AI tools (Claude Desktop, Cursor, etc.) query this cluster via this dashboard's own MCP endpoint",
+        icon: UnplugIcon,
+        permission: { feature: 'mcp' },
+      },
+    ],
   },
   {
     title: 'Insights',
@@ -956,14 +978,6 @@ export const menuItemsConfig: MenuItem[] = [
         countLabel: 'views',
         icon: BarChartIcon,
         tableCheck: EVENTS_TABLE,
-      },
-      {
-        title: 'MCP Server',
-        href: '/mcp',
-        description: 'Connect AI assistants via Model Context Protocol',
-        icon: UnplugIcon,
-        isNew: true,
-        permission: { feature: 'mcp' },
       },
       {
         title: 'Docs',

--- a/apps/dashboard/src/routes/(dashboard)/agents/index.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/agents/index.tsx
@@ -7,7 +7,7 @@ function AgentsPage() {
   return <AgentsPageClient />
 }
 
-export const Route = createFileRoute('/(dashboard)/agents')({
+export const Route = createFileRoute('/(dashboard)/agents/')({
   component: AgentsPage,
   head: () => pageOgHead('agents'),
 })

--- a/apps/dashboard/src/routes/(dashboard)/agents/settings.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/agents/settings.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { AgentSettingsPage } from '@/components/agents/settings/agent-settings-page'
+
+export const Route = createFileRoute('/(dashboard)/agents/settings')({
+  component: AgentSettingsPage,
+})

--- a/apps/dashboard/src/routes/(dashboard)/mcp-servers.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/mcp-servers.tsx
@@ -1,20 +1,17 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, redirect } from '@tanstack/react-router'
 
-import { PageHeader } from '@/components/layout/page-header'
-import { McpServerManager } from '@/components/mcp/mcp-server-manager'
-
-function McpServersPage() {
-  return (
-    <div className="mx-auto w-full max-w-3xl space-y-6">
-      <PageHeader
-        title="MCP servers"
-        description="Register external Model Context Protocol servers. Their tools load alongside the agent's built-in tools at the start of every conversation."
-      />
-      <McpServerManager />
-    </div>
-  )
-}
-
+/**
+ * `/mcp-servers` moved into the "MCP Servers" tab of `/agents/settings`
+ * (menu/IA cleanup — the standalone registration page is now one section of
+ * the fuller Agent Settings page). Redirect so old bookmarks/links keep
+ * working.
+ */
 export const Route = createFileRoute('/(dashboard)/mcp-servers')({
-  component: McpServersPage,
+  beforeLoad: () => {
+    // `href` (not `to` + `search`) — `/agents/settings` doesn't declare a
+    // typed `tab` search param (its Tabs state reads the raw query string via
+    // the `next-compat` shim, matching the rest of the app), so a raw href
+    // is simpler than fighting the router's typed search for one param.
+    throw redirect({ href: '/agents/settings?tab=mcp' })
+  },
 })

--- a/docs/content/guide/ai-agent.mdx
+++ b/docs/content/guide/ai-agent.mdx
@@ -52,6 +52,24 @@ Then open `/agents` in the dashboard, pick a host, and start asking questions. T
 
 For full configuration options see [Configuration](/guide/ai-agent/configuration).
 
+## Agent Settings page
+
+`/agents/settings` is the full-page home for everything agent-related, reached
+from the sidebar under *AI Agent → Agent Settings* (or the "Open full agent
+settings" link in the chat page's settings panel). It groups five tabs:
+
+- **Provider** — read-only status of configured LLM providers (`GET
+  /api/v1/agents/config-check`); provider/model/API keys are still set via
+  environment variables at deploy time (see [Configuration](/guide/ai-agent/configuration)).
+- **Models** — the same model picker used on the chat page and its sidebar.
+- **System prompt** — read-only view of the instructions sent to the model on
+  every request; there is no per-user override yet.
+- **Skills** — the full skill library with search and per-skill toggles.
+- **MCP servers** — the persistent, per-user MCP server registry (see
+  [Persistent MCP server registry](#persistent-mcp-server-registry-per-user)
+  below). This replaces the old standalone `/mcp-servers` page, which now
+  redirects to `/agents/settings?tab=mcp`.
+
 ## Child pages
 
 <Cards>
@@ -224,7 +242,7 @@ The panel probes each enabled server on load (`POST /api/v1/mcp/probe`) to show 
 
 ### Persistent MCP server registry (per-user)
 
-The sidebar panel above stores servers in the browser (`localStorage`). For servers that **persist server-side per user** — with authentication and a template library — use the **MCP Servers** page (`/mcp-servers`, in the sidebar under *AI Agent*).
+The sidebar panel above stores servers in the browser (`localStorage`). For servers that **persist server-side per user** — with authentication and a template library — use the **MCP Servers** tab on the **Agent Settings** page (`/agents/settings?tab=mcp`, in the sidebar under *AI Agent → Agent Settings*). The old standalone `/mcp-servers` route redirects here.
 
 - **Register** a server with a name, endpoint URL, transport (`http` streamable or `sse`), and optional auth (a **bearer token** or a **custom header**). Saving first runs a **Test connection** probe and stores the server only if it connects — so the tool count shown reflects what the server actually advertised.
 - **Template library** — one-click presets prefill the form for **Slack**, **GitHub**, and **Datadog** (endpoint + expected auth kind); you supply your own token.


### PR DESCRIPTION
## Summary

- Merges three flat, confusingly-named top-level menu items — "AI Agent" (`/agents`), "MCP Servers" (`/mcp-servers`), and "MCP Server" (`/mcp`, under Operations) — into one "AI Agent" nav group with children: **Chat**, **Agent Settings**, **MCP Server**. Uses the existing `MenuItem.items` nested-menu support (already used by Queries/Cluster/Operations), so no new UI pattern was introduced.
- Adds a new `/agents/settings` page as the home for everything agent-related, with tabs: **Provider** (read-only status from `GET /api/v1/agents/config-check`), **Models** (reuses the existing model picker), **System prompt** (read-only view of the assembled instructions), **Skills** (full skill library, extracted from the existing skill-library dialog), and **MCP servers** (the `McpServerManager` content that used to live at the standalone `/mcp-servers` page).
- `/mcp-servers` now redirects to `/agents/settings?tab=mcp` so old links/bookmarks keep working.
- The compact "Agent settings" side panel on the chat page (`/agents`) is unchanged — it now links out to the fuller settings page.
- Updated `docs/content/guide/ai-agent.mdx`, the command palette nav list, the dynamic page-title map, and the Cypress page-render sweep route list to match.

## Assumptions made (flagged per the task brief)

- Tab set: Provider / Models / System Prompt / Skills / MCP Servers. Provider and System Prompt are **read-only** (env-configured at deploy time; there's no existing persistence layer for per-user overrides, so I didn't invent one).
- Renamed the chat child item from "AI Agent" to "Chat" to avoid "AI Agent → AI Agent" in the nested menu.
- No `permission` set on the new parent group; each child keeps its own (`agent` vs `mcp`) so they're gated independently — mirrors how `filterMenuItemsByPermissions` already handles per-child permission inheritance.

## Test plan

- [x] `bun run build` (Vite build + `tsc --noEmit`) — clean, `/agents/settings` prerenders
- [x] `bun run lint` (Biome) — clean
- [x] `bun run test` (apps/dashboard full unit suite) — 5931 pass / 0 fail
- [x] Manual end-to-end verification with a real browser (Cypress/Electron) against the dev server: default tab, tab switching preserves `?host=`, `/mcp-servers` → `/agents/settings?tab=mcp` redirect, Skills tab count stays in sync with toggles, System Prompt tab renders
- [ ] CI (armed for auto-merge)