### PR TITLE
ci(cloudflare): deploy apps/blog automatically on merge to main

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -704,6 +704,85 @@ jobs:
         run: bunx wrangler deploy
 
   # ──────────────────────────────────────────────────────────────────────────
+  # Blog (apps/blog): standalone Astro static-assets worker. Built outside the
+  # bun workspace (own bun.lock), like landing/docs. Production deploys
+  # chmonitor-blog (blog.chmonitor.dev); PRs deploy preview-chmonitor-blog.
+  # Posts live in apps/blog/src/content/blog; the landing footer's "latest
+  # posts" widget is a committed snapshot (apps/landing/src/data/latest-posts.json),
+  # not a live fetch, so it doesn't depend on this job.
+  # ──────────────────────────────────────────────────────────────────────────
+  blog:
+    name: blog
+    # Skip on forked PRs — deploy secrets must not leak to PR-controlled code.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/blog
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Detect changes
+        id: filter
+        if: >-
+          github.event_name == 'pull_request' ||
+          (github.event_name == 'push' && github.ref_type == 'branch')
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            blog:
+              - 'apps/blog/**'
+              - '.github/workflows/cloudflare.yml'
+
+      - name: Install dependencies
+        if: >-
+          steps.filter.outputs.blog == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'release' ||
+          github.ref_type == 'tag'
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        if: >-
+          steps.filter.outputs.blog == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'release' ||
+          github.ref_type == 'tag'
+        run: bun run build
+
+      - name: Deploy preview
+        if: >-
+          github.event_name == 'pull_request' &&
+          (steps.filter.outputs.blog == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'release' ||
+          github.ref_type == 'tag')
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: bunx wrangler deploy --env preview
+
+      - name: Deploy production
+        if: >-
+          github.event_name != 'pull_request' &&
+          (steps.filter.outputs.blog == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'release' ||
+          github.ref_type == 'tag')
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: bunx wrangler deploy
+
+  # ──────────────────────────────────────────────────────────────────────────
   # Bug-handler (apps/bug-handler): standalone Cloudflare EMAIL Worker. Receives
   # inbound mail (Sentry alerts → bug@chmonitor.dev) via Cloudflare Email Routing
   # and opens GitHub issues. Own bun.lock (not in the root workspace), like


### PR DESCRIPTION
## Summary
- `apps/blog` had a build-only CI check (`blog.yml`) but nothing that actually ran `wrangler deploy` — dashboard, landing and docs all auto-deploy via `cloudflare.yml` on merge to main; blog silently didn't. This is exactly how the "Alerting to Slack and Discord" post ended up 404ing in production (#2334) — its source merged to main but nothing ever deployed it.
- Add a `blog` job mirroring the existing `landing`/`docs` pattern: `paths-filter` scoped to `apps/blog/**`, deploys `preview-chmonitor-blog` on PRs and `chmonitor-blog` on push to main.
- `blog.yml`'s separate build-only check is left as-is per this file's existing reconciliation note (the resulting double-build on PRs touching `apps/blog` is bounded and already accepted for landing/docs).

## Test plan
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Mirrors the landing job's structure and `wrangler.toml` env names (`chmonitor-blog` / `preview-chmonitor-blog`, matching `apps/blog/wrangler.toml`) exactly
- [ ] First real deploy will run when this merges — will confirm `blog.chmonitor.dev` picks up the already-merged v0.3 update (#2337) once it does