### PR TITLE
refactor(dashboard): move Inbound Events into the Others menu section

### DIFF
--- a/apps/dashboard/src/menu.ts
+++ b/apps/dashboard/src/menu.ts
@@ -127,7 +127,7 @@ export const menuItemsConfig: MenuItem[] = [
     description:
       'Alertmanager, Datadog, and generic webhook events ingested via POST /api/events/ingest',
     icon: RssIcon,
-    section: 'main',
+    section: 'others',
     isNew: true,
     permission: { feature: 'health' },
   },


### PR DESCRIPTION
## Summary
- Move "Inbound Events" from the `main` menu section to `others`, matching where similar secondary/ops-adjacent items already live.