### PR TITLE
fix(theme): brighten dark-mode --primary for readable filter pills

### DIFF
--- a/apps/dashboard/src/styles.css
+++ b/apps/dashboard/src/styles.css
@@ -450,7 +450,12 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.269 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.424 0.199 265.638);
+  /* Brightened for dark mode: the previous 0.424 was darker than the light-mode
+     primary (0.488), leaving `text-primary`/`border-primary` chips (e.g. Slow
+     Queries filter pills) unreadable on near-black cards (~2:1). 0.61 lifts chip
+     text to WCAG AA (~4.5:1) while keeping white-on-primary buttons legible
+     (~3.6:1, above the shipped sidebar-primary floor). */
+  --primary: oklch(0.61 0.21 264.376);
   --primary-foreground: oklch(0.97 0.014 254.604);
   --secondary: oklch(0.274 0.006 286.033);
   --secondary-foreground: oklch(0.985 0 0);


### PR DESCRIPTION
## Problem
On the Slow Queries page (and other filter-pill views) in **dark mode**, the active filter pill's blue label/border was hard to read.

## Root cause
`apps/dashboard/src/styles.css` `.dark` block set `--primary: oklch(0.424 0.199 265.638)` — *darker and less saturated* than the light-mode primary (`0.488`). Unlike `--destructive` (0.577→0.704) and `--sidebar-primary` (0.546→0.623), `--primary` was never brightened for dark mode. The copy-pasted `border-primary bg-primary/10 text-primary` active-pill pattern therefore rendered blue text on near-black cards at only ~2:1 contrast.

## Fix (path a — fix the token)
Lift `--primary` to `oklch(0.61 0.21 264.376)` in the `.dark` block **only** (light mode reads fine). This is the root-cause fix, so it corrects the pills in **all** call sites at once (Slow Queries, Expensive Queries, User Processes, Bulk Explain) plus the derived markdown/link colors — no per-component patching.

### Why 0.61 (not a naive 0.65+ bump)
`--primary` is also the **solid** fill for the default Button (`bg-primary` + near-white `--primary-foreground`), so chip readability (wants brighter) and button legibility (wants darker) pull in opposite directions. Measured WCAG contrast in dark mode:

| Pair | Before (0.424) | After (0.61) |
|------|---------------|--------------|
| chip text on card | **2.03:1** (fails) | **4.54:1** (AA pass) |
| chip text on background | 2.24:1 | 5.02:1 |
| white button text on primary fill | 8.11:1 | **3.62:1** |

0.61 gives the small 11px pill text a clean AA pass while keeping the solid Button at 3.62:1 — *above* the app's already-shipped `--sidebar-primary` white-on-blue floor (3.45:1), so it's not a regression against an accepted in-app standard.

## Verification
- WCAG contrast computed via OKLCH→linear-sRGB→relative-luminance (values above).
- `bun run build` (Vite + `tsc --noEmit` + prerender) passes clean.
- Biome does not lint CSS, so `bun run lint` is unaffected.

## Notes
- Scope kept surgical (single token value); the copy-pasted chip pattern was **not** de-duplicated into a shared component — the token fix already resolves it everywhere, and extracting it across 4 files with slightly varying markup would be out-of-scope for this bug. Flagging as a possible follow-up.

https://claude.ai/code/session_01Gh1QiyYp93RokWM6vGzFKA