### PR TITLE
feat(landing): remove 'Open source, built in public' section from homepage

### DIFF
--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -7,7 +7,6 @@ import DataExplorer from '../components/DataExplorer.astro'
 import Insights from '../components/Insights.astro'
 import Health from '../components/Health.astro'
 import Capabilities from '../components/Capabilities.astro'
-import SocialProof from '../components/SocialProof.astro'
 import Comparison from '../components/Comparison.astro'
 import Pricing from '../components/Pricing.astro'
 import FAQ from '../components/FAQ.astro'
@@ -26,7 +25,6 @@ import { useCases } from '../data/use-cases'
     <Health />
     <Capabilities />
     <UseCaseLinks items={useCases} eyebrow="Use cases" heading="Explore by use case" soft />
-    <SocialProof />
     <Comparison />
     <Pricing />
     <FAQ />


### PR DESCRIPTION
## Summary
- Remove the "Open source, built in public" community/GitHub-stats block from the main landing page (`index.astro`).
- Left untouched on the use-case pages (`LandingPage.astro`), which weren't part of the request.

## Test plan
- [x] `bun run build` succeeds
- [x] Block confirmed absent from built `index.html`, still present on `monitor-queries/index.html` (use-case page)