### PR TITLE
feat(menu): nest Insights + Insights Settings under an Insights parent

### DIFF
--- a/apps/dashboard/src/menu.ts
+++ b/apps/dashboard/src/menu.ts
@@ -107,12 +107,33 @@ export const menuItemsConfig: MenuItem[] = [
     ],
   },
   {
+    // Parent groups the insights findings view and its settings — two pages
+    // sharing the same `insights` feature gate (set on the parent so the whole
+    // group is filtered together).
     title: 'Insights',
-    href: '/insights',
+    href: '',
     icon: TrendingUpIcon,
     section: 'main',
     isNew: true,
     permission: { feature: 'insights' },
+    items: [
+      {
+        title: 'Insights',
+        href: '/insights',
+        description:
+          'AI-generated findings, record breakers, and query insights for this cluster',
+        icon: TrendingUpIcon,
+        isNew: true,
+      },
+      {
+        title: 'Insights Settings',
+        href: '/insights-settings',
+        description:
+          'Configure how insights are generated — templates, AI enhancement, model, and prompt style',
+        icon: SlidersHorizontalIcon,
+        isNew: true,
+      },
+    ],
   },
   {
     title: 'Health',


### PR DESCRIPTION
## What

Restructure the flat **Insights** sidebar entry into a parent group with two children, reusing the existing nested `items[]` pattern already used by AI Agent, Queries, Tables, etc.

- **Insights** → `/insights` — AI-generated findings, record breakers, query insights
- **Insights Settings** → `/insights-settings` — templates, AI enhancement, model, prompt style

## Finding: `/insights-settings` was orphaned

`/insights-settings` had **no sidebar entry at all** — it was reachable only via in-page links (`insights-panel`, `insights-popover`, `insights-empty-cta`, `insights-strip`). So there was no duplicate to remove; this wires the page into the sidebar for the first time.

## Active-highlight correctness

The prior `/agents` vs `/agents/settings` double-highlight bug happened because `/agents/settings`.startsWith(`/agents/`). This pair is safe: `/insights` and `/insights-settings` share **no path prefix**, so `isMenuItemActive('/insights', '/insights-settings')` and the reverse both return `false` — the two children cannot co-highlight, and the `href: ''` parent highlights on `hasActiveChild` (same as the 8 other nested parents).

## Verification

- `bun run build` (vite + `tsc --noEmit`) clean, 107 pages prerendered; the compiled menu bundle contains both `/insights` and `/insights-settings` under the nested "Insights Settings" entry.
- `bun run lint` clean.
- Interactive browser check was blocked by the sandbox (Chrome extension can't navigate to localhost; dev server reaped with SIGTERM). Verified instead via the successful build/prerender + code-level active-state analysis above.

https://claude.ai/code/session_01Gh1QiyYp93RokWM6vGzFKA