### PR TITLE
feat(insights): AI Insights section + schema optimization suggestions

### DIFF
--- a/apps/dashboard/src/components/insights/insights-empty-cta.tsx
+++ b/apps/dashboard/src/components/insights/insights-empty-cta.tsx
@@ -34,7 +34,7 @@ export function InsightsEmptyCta({
       <div className="flex items-center gap-2 text-sm text-muted-foreground">
         <Activity className="size-4 shrink-0" />
         <span>
-          No insights right now. Generate a fresh analysis of this cluster.
+          No AI Insights yet. Generate a fresh AI analysis of this cluster.
         </span>
       </div>
       <div className="flex items-center gap-1">

--- a/apps/dashboard/src/components/insights/insights-panel.tsx
+++ b/apps/dashboard/src/components/insights/insights-panel.tsx
@@ -11,6 +11,7 @@ import {
   ShieldAlert,
   Sparkles,
   TriangleAlert,
+  Wrench,
   X,
 } from 'lucide-react'
 
@@ -50,6 +51,7 @@ const CATEGORY_META: Record<string, { label: string; icon: LucideIcon }> = {
   performance: { label: 'Performance', icon: Gauge },
   storage: { label: 'Storage', icon: HardDrive },
   reliability: { label: 'Reliability', icon: ShieldAlert },
+  optimization: { label: 'Optimization', icon: Wrench },
   queries: { label: 'Queries', icon: Search },
   cost: { label: 'Cost', icon: CircleDollarSign },
 }

--- a/apps/dashboard/src/lib/insights/collectors.ts
+++ b/apps/dashboard/src/lib/insights/collectors.ts
@@ -18,6 +18,10 @@ import {
   checkLongRunningQuery,
   checkStuckMutations,
 } from './operational-checks'
+import {
+  type AnalyzedQuery,
+  selectSchemaOptimizations,
+} from './schema-optimizations'
 import { refitBaselineIfStale, scoreAnomaly } from './statistical-baseline'
 
 function extractValue(result: unknown): number | null {
@@ -424,6 +428,75 @@ async function collectOperational(hostId: number): Promise<InsightCandidate[]> {
   return out
 }
 
+// ---------------------------------------------------------------------------
+// Schema-optimization collector — reuses the query advisor's `analyzeQuery`
+// (skip index / projection / partition key / PREWHERE) against a few
+// representative heavy recent queries and surfaces the ranked recommendations
+// as "Optimization" insights. Read-only end to end (EXPLAIN + system tables);
+// the pure ranking/mapping lives in ./schema-optimizations so it is unit-tested.
+// ---------------------------------------------------------------------------
+
+/** How many representative queries to analyze per sweep (bounds ClickHouse round-trips). */
+const SCHEMA_OPT_MAX_QUERIES = 3
+
+/**
+ * A few of the heaviest recent SELECTs, one per normalized query shape, so the
+ * advisor analyzes distinct workloads rather than the same query repeated.
+ */
+const HEAVY_QUERIES_SQL = `SELECT any(query) AS query
+  FROM system.query_log
+  WHERE type = 'QueryFinish'
+    AND event_time > now() - INTERVAL 24 HOUR
+    AND query_kind = 'Select'
+    AND read_bytes > 10000000
+    AND query NOT ILIKE '%system.%'
+  GROUP BY normalized_query_hash
+  ORDER BY max(read_bytes) DESC
+  LIMIT ${SCHEMA_OPT_MAX_QUERIES}`
+
+async function collectSchemaOptimizations(
+  hostId: number
+): Promise<InsightCandidate[]> {
+  try {
+    const rows = await readOnlyQuery({
+      query: HEAVY_QUERIES_SQL,
+      hostId,
+    }).catch(() => null)
+    if (!Array.isArray(rows) || rows.length === 0) return []
+
+    const queries = rows
+      .map((r) => (r as Record<string, unknown>)?.query)
+      .filter((q): q is string => typeof q === 'string' && q.trim().length > 0)
+    if (queries.length === 0) return []
+
+    // Dynamic import (like advisor-tools.ts) keeps the heavy recommendation
+    // engine out of anything that merely imports the collectors module.
+    const { analyzeQuery } = await import('../ai/advisor/recommendation-engine')
+
+    const analyzed = await Promise.all(
+      queries.map(async (sql): Promise<AnalyzedQuery | null> => {
+        try {
+          const res = await analyzeQuery({ hostId, sql })
+          if (!res.ok || res.recommendations.length === 0) return null
+          return {
+            database: res.database,
+            table: res.table,
+            recommendations: res.recommendations,
+          }
+        } catch {
+          return null
+        }
+      })
+    )
+
+    return selectSchemaOptimizations(
+      analyzed.filter((a): a is AnalyzedQuery => a !== null)
+    )
+  } catch {
+    return []
+  }
+}
+
 /**
  * Run all collectors for a host and return de-duplicated candidates,
  * highest severity first.
@@ -436,6 +509,7 @@ export async function collectInsights(
     collectStorage(hostId).catch(() => []),
     collectReliability(hostId).catch(() => []),
     collectOperational(hostId).catch(() => []),
+    collectSchemaOptimizations(hostId).catch(() => []),
   ])
 
   const seen = new Set<string>()

--- a/apps/dashboard/src/lib/insights/read-insights.ts
+++ b/apps/dashboard/src/lib/insights/read-insights.ts
@@ -46,6 +46,16 @@ function deriveAction(
     default:
       if (category === 'storage')
         return { label: 'View tables', href: '/tables' }
+      // Schema-optimization suggestions use a dynamic per-recommendation metric
+      // (`schema_opt:...`), so they never match a case above. Re-derive a
+      // generic agent deep-link — the specific DDL/rewrite only lives in the
+      // immediate generate() response (scalar findings store drops it).
+      if (category === 'optimization')
+        return {
+          label: 'Ask the agent',
+          prompt:
+            'Review this schema optimization suggestion and show the DDL or rewrite to apply, with its estimated impact and risk.',
+        }
       return undefined
   }
 }

--- a/apps/dashboard/src/lib/insights/schema-optimizations.test.ts
+++ b/apps/dashboard/src/lib/insights/schema-optimizations.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for the pure schema-optimization mapper.
+ *
+ * No ClickHouse / advisor I/O — the mapper is fed synthetic advisor results so
+ * its ranking, de-dup, filtering, and (crucially) stable-key determinism are
+ * asserted directly. The `metric` + `title` must depend only on kind/table/title
+ * (never on run-to-run impact numbers) or a dismissed suggestion resurrects on
+ * the next cron sweep; the determinism test below guards exactly that.
+ */
+
+import type { Recommendation } from '@/lib/ai/advisor/types'
+
+import {
+  MAX_SCHEMA_OPTIMIZATIONS,
+  metricSlug,
+  schemaOptMetric,
+  selectSchemaOptimizations,
+} from './schema-optimizations'
+import { describe, expect, test } from 'bun:test'
+
+function rec(overrides: Partial<Recommendation> = {}): Recommendation {
+  return {
+    kind: 'skip_index',
+    title: 'Add a skip index on `user_id`',
+    rationale: '`user_id` is filtered but not in the sorting key.',
+    ddl: 'ALTER TABLE default.events ADD INDEX ...',
+    risk: 'low',
+    riskNote: 'additive',
+    effort: 'low',
+    estImpact: {
+      granulesSaved: 100,
+      granulesRead: 200,
+      bytesSaved: 1000,
+      summary: 'Estimated ~100 granules saved.',
+      unknown: false,
+    },
+    ...overrides,
+  }
+}
+
+describe('metricSlug', () => {
+  test('lowercases, collapses non-alphanumerics, trims', () => {
+    expect(metricSlug('Add a skip index on `user_id`')).toBe(
+      'add_a_skip_index_on_user_id'
+    )
+  })
+
+  test('is stable for the same input', () => {
+    const title = 'Add a projection ordered by day, region'
+    expect(metricSlug(title)).toBe(metricSlug(title))
+  })
+})
+
+describe('selectSchemaOptimizations', () => {
+  test('drops recommendations with an unknown estimate', () => {
+    const out = selectSchemaOptimizations([
+      {
+        database: 'default',
+        table: 'events',
+        recommendations: [
+          rec({ estImpact: { ...rec().estImpact, unknown: true } }),
+        ],
+      },
+    ])
+    expect(out).toHaveLength(0)
+  })
+
+  test('maps a known recommendation to an info optimization candidate', () => {
+    const [candidate] = selectSchemaOptimizations([
+      { database: 'default', table: 'events', recommendations: [rec()] },
+    ])
+    expect(candidate.severity).toBe('info')
+    expect(candidate.category).toBe('optimization')
+    expect(candidate.title).toBe(
+      'Add a skip index on `user_id` on default.events'
+    )
+    expect(candidate.action?.prompt).toContain('default.events')
+    expect(candidate.metric).toBe(schemaOptMetric('default', 'events', rec()))
+  })
+
+  test('metric is distinct per kind/table so collectInsights dedup keeps all', () => {
+    const skip = rec()
+    const projection = rec({
+      kind: 'projection',
+      title: 'Add a projection ordered by day',
+    })
+    const out = selectSchemaOptimizations([
+      {
+        database: 'default',
+        table: 'events',
+        recommendations: [skip, projection],
+      },
+    ])
+    expect(out).toHaveLength(2)
+    expect(new Set(out.map((c) => c.metric)).size).toBe(2)
+  })
+
+  test('de-duplicates the same suggestion seen across two sampled queries', () => {
+    const out = selectSchemaOptimizations([
+      { database: 'default', table: 'events', recommendations: [rec()] },
+      { database: 'default', table: 'events', recommendations: [rec()] },
+    ])
+    expect(out).toHaveLength(1)
+  })
+
+  test('ranks by estimated granules saved and caps the count', () => {
+    const results = Array.from({ length: MAX_SCHEMA_OPTIMIZATIONS + 2 }).map(
+      (_, i) => ({
+        database: 'default',
+        table: `t${i}`,
+        recommendations: [
+          rec({
+            title: `Add a skip index on col${i}`,
+            estImpact: { ...rec().estImpact, granulesSaved: i * 10 },
+          }),
+        ],
+      })
+    )
+    const out = selectSchemaOptimizations(results)
+    expect(out).toHaveLength(MAX_SCHEMA_OPTIMIZATIONS)
+    // Highest granulesSaved first.
+    expect(out[0].value).toBeGreaterThan(out[1].value as number)
+  })
+
+  test('metric + title are impact-independent (stable dismissal key)', () => {
+    const base = { database: 'default', table: 'events' }
+    const [a] = selectSchemaOptimizations([
+      {
+        ...base,
+        recommendations: [
+          rec({ estImpact: { ...rec().estImpact, granulesSaved: 5 } }),
+        ],
+      },
+    ])
+    const [b] = selectSchemaOptimizations([
+      {
+        ...base,
+        recommendations: [
+          rec({ estImpact: { ...rec().estImpact, granulesSaved: 9999 } }),
+        ],
+      },
+    ])
+    // Different impact numbers must NOT change the key-forming fields.
+    expect(a.metric).toBe(b.metric)
+    expect(a.title).toBe(b.title)
+  })
+})

--- a/apps/dashboard/src/lib/insights/schema-optimizations.ts
+++ b/apps/dashboard/src/lib/insights/schema-optimizations.ts
@@ -1,0 +1,107 @@
+/**
+ * Schema-optimization insight mapping (pure).
+ *
+ * Turns the query advisor's ranked {@link Recommendation}s (skip index,
+ * projection, partition key, PREWHERE rewrite) into insight candidates surfaced
+ * on the `/insights` page under the "Optimization" category. The I/O — picking
+ * representative slow queries and calling `analyzeQuery` per query — lives in
+ * `collectors.ts`; this module is the pure classifier/mapper so it is
+ * unit-tested without ClickHouse (mirrors `operational-checks.ts`).
+ *
+ * Determinism matters: the stable dismissal key is `host:category:metric:title`
+ * (see `types.ts`). Both `metric` and `title` are derived only from the
+ * recommendation kind, table, and title text — never from run-to-run impact
+ * numbers (granulesSaved, bytes) — so a dismissed suggestion does not resurrect
+ * on the next cron sweep when the estimate shifts. Impact numbers are carried in
+ * `detail`/`value` only, which are not part of the key.
+ */
+
+import type { Recommendation } from '@/lib/ai/advisor/types'
+import type { InsightCandidate } from './types'
+
+/** A single query's advisor analysis, reduced to what the mapper needs. */
+export interface AnalyzedQuery {
+  readonly database: string
+  readonly table: string
+  readonly recommendations: readonly Recommendation[]
+}
+
+/** Cap on how many optimization cards the page surfaces at once. */
+export const MAX_SCHEMA_OPTIMIZATIONS = 3
+
+/** Slugify a recommendation title into a stable, key-safe metric fragment. */
+export function metricSlug(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 60)
+}
+
+/**
+ * Build the deterministic machine metric for a recommendation. Distinct per
+ * (kind, table, recommendation) so `collectInsights`' `${category}:${metric}`
+ * dedup does not collapse several suggestions into one, and stable across runs
+ * so dismissals stick.
+ */
+export function schemaOptMetric(
+  database: string,
+  table: string,
+  rec: Recommendation
+): string {
+  return `schema_opt:${rec.kind}:${database}.${table}:${metricSlug(rec.title)}`
+}
+
+/**
+ * Map advisor analysis results to schema-optimization insight candidates.
+ *
+ * - Keeps only recommendations with a *known* estimate (`!unknown`) so the card
+ *   states a real figure rather than "unknown".
+ * - De-duplicates by the deterministic metric (same suggestion on the same
+ *   table appears once even if two sampled queries hit it).
+ * - Ranks by estimated granules saved (desc) and caps at
+ *   {@link MAX_SCHEMA_OPTIMIZATIONS}.
+ *
+ * All suggestions are `info` severity — they are recommend-only optimizations,
+ * not incidents. The action deep-links to the agent so the operator can pull the
+ * full DDL/rewrite (which the scalar findings store does not persist).
+ */
+export function selectSchemaOptimizations(
+  results: readonly AnalyzedQuery[]
+): InsightCandidate[] {
+  const byMetric = new Map<
+    string,
+    { candidate: InsightCandidate; granulesSaved: number }
+  >()
+
+  for (const result of results) {
+    for (const rec of result.recommendations) {
+      if (rec.estImpact.unknown) continue
+
+      const metric = schemaOptMetric(result.database, result.table, rec)
+      if (byMetric.has(metric)) continue
+
+      const table = `${result.database}.${result.table}`
+      byMetric.set(metric, {
+        granulesSaved: rec.estImpact.granulesSaved,
+        candidate: {
+          severity: 'info',
+          category: 'optimization',
+          metric,
+          title: `${rec.title} on ${table}`,
+          detail: `${rec.rationale} ${rec.estImpact.summary}`,
+          value: rec.estImpact.granulesSaved,
+          action: {
+            label: 'Ask the agent',
+            prompt: `Analyze ${table} and show the DDL for: ${rec.title}. Explain the estimated impact, risk, and how to validate it.`,
+          },
+        },
+      })
+    }
+  }
+
+  return [...byMetric.values()]
+    .sort((a, b) => b.granulesSaved - a.granulesSaved)
+    .slice(0, MAX_SCHEMA_OPTIMIZATIONS)
+    .map((entry) => entry.candidate)
+}

--- a/apps/dashboard/src/routes/(dashboard)/insights.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/insights.tsx
@@ -1,3 +1,4 @@
+import { BarChart3 } from 'lucide-react'
 import { createFileRoute } from '@tanstack/react-router'
 
 import { ChartsSection } from './-insights/charts-section'
@@ -32,7 +33,7 @@ function InsightsPage() {
             Cluster Insights
           </h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            Record-breaking queries, storage statistics, and performance
+            AI-generated findings, record-breaking queries, and storage
             highlights (showing {rangeLabel})
           </p>
         </div>
@@ -50,8 +51,16 @@ function InsightsPage() {
 
       <Separator className="my-1" />
 
-      <StatsGrid hostId={hostId} lastHours={lastHours} />
-      <ChartsSection hostId={hostId} />
+      <section className="flex flex-col gap-3" aria-label="Cluster statistics">
+        <div className="flex items-center gap-2">
+          <BarChart3 className="size-4 shrink-0 text-muted-foreground" />
+          <h2 className="text-sm font-medium text-foreground">
+            Cluster Statistics
+          </h2>
+        </div>
+        <StatsGrid hostId={hostId} lastHours={lastHours} />
+        <ChartsSection hostId={hostId} />
+      </section>
     </div>
   )
 }

--- a/docs/knowledge/ai-insights.md
+++ b/docs/knowledge/ai-insights.md
@@ -33,6 +33,7 @@ is fragmented", "replication is lagging" — generated and **cached server-side*
 |-------|--------|
 | Collect (deterministic) | `src/lib/insights/collectors.ts` |
 | Operational classifiers (pure) | `src/lib/insights/operational-checks.ts` |
+| Schema-optimization mapper (pure) | `src/lib/insights/schema-optimizations.ts` |
 | Enrich (optional LLM) | `src/lib/insights/llm-enrich.ts` |
 | Orchestrate + persist | `src/lib/insights/generate-insights.ts` |
 | Read + de-dupe | `src/lib/insights/read-insights.ts` |
@@ -43,6 +44,25 @@ is fragmented", "replication is lagging" — generated and **cached server-side*
   porting the SQL/severity heuristics from the agent's `anomaly-tools.ts` /
   `insights-tools.ts`. They **never throw** — any failure yields `[]` so the
   feature degrades on read-only clusters or missing system tables.
+- **Schema-optimization collector** (`collectSchemaOptimizations` in
+  `collectors.ts`, category `optimization`) reuses the query advisor's
+  `analyzeQuery` (`lib/ai/advisor/recommendation-engine.ts`) — the same engine
+  behind the agent's `get_optimization_recommendations` tool. It pulls a few
+  (≤3) of the heaviest recent `SELECT`s (one per `normalized_query_hash`), runs
+  the read-only advisor (EXPLAIN + `system.tables`/`columns`/`parts`/
+  `data_skipping_indexes`) on each, and surfaces the ranked skip-index /
+  projection / partition-key / PREWHERE recommendations as `info` insights. The
+  ranking + mapping is a pure function in `schema-optimizations.ts`
+  (`selectSchemaOptimizations`), unit-tested without I/O. **Determinism is
+  load-bearing:** the `metric` (`schema_opt:<kind>:<db>.<table>:<title-slug>`)
+  and `title` derive only from kind/table/title — never from the run-to-run
+  impact estimate — so a dismissed suggestion does not resurrect when the
+  estimate shifts; impact numbers ride in `detail`/`value` only (not part of the
+  stable key). The distinct per-recommendation `metric` is also what stops the
+  `${category}:${metric}` dedup in `collectInsights` from collapsing several
+  suggestions into one. `deriveAction` returns a generic "Ask the agent"
+  deep-link for `category === 'optimization'` (the full DDL only survives the
+  immediate `generate()` response, not the scalar findings store).
 - **Operational collectors** (`collectOperational` in `collectors.ts`) add cheap
   point-in-time checks across categories — detached parts (`storage`), stuck /
   failing mutations + FAILED dictionaries (`reliability`), and the longest
@@ -231,7 +251,8 @@ stay in sync) and the same card + severity styling:
   a **"View all insights"** deep link to `/insights`.
 - `src/components/insights/insights-panel.tsx` — **`/insights` page board**:
   insights **grouped by category** (Anomalies / Performance / Storage /
-  Reliability, extensible to Queries / Cost) with section headers, a segmented
+  Reliability / Optimization, extensible to Queries / Cost) with section headers,
+  a segmented
   **filter row** (All · a tinted **"Needs attention"** tab for critical+warning ·
   one tab per present category), and header severity count badges.
 - `src/components/insights/insight-card.tsx` — shadcn `Card` wrapper (never edits
@@ -265,6 +286,10 @@ stay in sync) and the same card + severity styling:
 
 ## Follow-ups
 
+- **Schema-optimization suggestions — done.** The advisor engine is now wired
+  into the collect pipeline as the `optimization` category (see the
+  schema-optimization collector above), reusing `analyzeQuery` rather than
+  reimplementing schema analysis.
 - **More detectors.** The operational collectors are a starter set. Natural next
   detectors (each still a cheap single system-table read + a pure classifier in
   `operational-checks.ts`): long-running merges (`system.merges`), high


### PR DESCRIPTION
Three related improvements to `/insights?host=0`.

## 1. Clearer empty-state copy
`insights-empty-cta.tsx`: "No insights right now. Generate a fresh analysis…" →
**"No AI Insights yet. Generate a fresh AI analysis of this cluster."** — this
surface is specifically the AI-generated insights feature, so the copy now names
it. Shared by the overview strip and the `/insights` board.

## 2. Clearly labeled sections
The AI Insights board already carried its own `AI Insights` heading; the
deterministic stats below it were unlabeled at the top level. Added a
**"Cluster Statistics"** section heading wrapping `StatsGrid` (Record Breakers /
Query Insights / Cluster Activity / …) + `ChartsSection`, and reconciled the page
description (which described the stats, not the AI section now leading the page)
to "AI-generated findings, record-breaking queries, and storage highlights". No
rebuild of the working `StatsGrid` sub-sections.

## 3. Schema optimization suggestions in AI Insights
New **`optimization`** insight category, generated by reusing the existing query
advisor (`lib/ai/advisor/recommendation-engine.ts` `analyzeQuery` — the same
engine behind the agent's `get_optimization_recommendations` tool), **not** a
reimplementation. A new `collectSchemaOptimizations` collector picks the few
heaviest recent `SELECT`s (one per `normalized_query_hash`), runs the read-only
advisor on each (EXPLAIN + system tables — no query execution), and surfaces the
ranked skip-index / projection / partition-key / PREWHERE recommendations as
`info` insights, hooked into the existing collect→enrich→persist pipeline and
5-min cron sweep (no new infra).

- Ranking/mapping is a **pure, unit-tested** function (`schema-optimizations.ts`,
  8 tests) mirroring the `operational-checks.ts` split.
- **Stable-key dismissal preserved:** the per-recommendation `metric`
  (`schema_opt:<kind>:<db>.<table>:<title-slug>`) and `title` derive only from
  kind/table/title — never from run-to-run impact numbers — so a dismissed
  suggestion does not resurrect on the next sweep, and the distinct metric stops
  `collectInsights`' `${category}:${metric}` dedup from collapsing several
  suggestions into one. `deriveAction` gains an `optimization` branch (agent
  deep-link) so the card keeps its action after a reload.
- Knowledge doc `docs/knowledge/ai-insights.md` updated in the same change.

## Verification
- `bun run build` ✅ (prerenders `/insights`), `bun run lint` ✅,
  `tsc --noEmit` ✅ (0 errors).
- New unit suite: 8/8 pass. Full `bun test src/lib/insights` shows only the 6
  pre-existing `collectors.test.ts` failures documented in ai-insights.md
  (process-global `mock.module` poisoning; pass in isolation) — unrelated.
- All 4 UI strings confirmed compiled into the shipped client bundle; the app +
  route were screenshot-verified rendering (first-run gate). A live populated
  insights render could not be driven headlessly here (bun/undici SSR DNS-pinning
  + chrome-extension permission gate); the schema-opt card path is
  **test-verified**, not observed live.

https://claude.ai/code/session_01Gh1QiyYp93RokWM6vGzFKA