### PR TITLE
feat(recent-queries): expandable rows + readable column headers

### DIFF
--- a/apps/dashboard/src/components/data-table/cells/recent-query-expanded-details.tsx
+++ b/apps/dashboard/src/components/data-table/cells/recent-query-expanded-details.tsx
@@ -1,0 +1,194 @@
+import {
+  AlertTriangleIcon,
+  ClockIcon,
+  DatabaseIcon,
+  FingerprintIcon,
+  GaugeIcon,
+  MemoryStickIcon,
+  MonitorIcon,
+  RowsIcon,
+  TimerIcon,
+  UserIcon,
+} from 'lucide-react'
+
+import {
+  CodeBlock,
+  CodeBlockCopyButton,
+} from '@/components/ai-elements/code-block'
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+
+interface RecentQueryExpandedDetailsProps {
+  row: Record<string, unknown>
+}
+
+function hasValue(value: unknown): boolean {
+  return value !== undefined && value !== null && String(value) !== ''
+}
+
+function toStringSafe(value: unknown): string {
+  return hasValue(value) ? String(value) : ''
+}
+
+function toNumberOrNull(value: unknown): number | null {
+  if (!hasValue(value)) return null
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function formatDuration(row: Record<string, unknown>): string {
+  const seconds = toNumberOrNull(row.query_duration)
+  if (seconds === null) return ''
+  if (seconds < 1) return `${(seconds * 1000).toFixed(0)} ms`
+  return `${seconds.toFixed(2)} s`
+}
+
+interface DetailFieldProps {
+  label: string
+  value: React.ReactNode
+  icon?: React.ComponentType<{ className?: string }>
+  mono?: boolean
+  className?: string
+}
+
+function DetailField({
+  label,
+  value,
+  icon: Icon,
+  mono = false,
+  className,
+}: DetailFieldProps) {
+  if (!hasValue(value)) return null
+
+  return (
+    <div
+      className={cn(
+        'min-w-0 rounded-md border border-border/60 bg-background/60 px-3 py-2',
+        className
+      )}
+    >
+      <div className="flex min-w-0 items-center gap-1.5 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+        {Icon && <Icon className="size-3.5 shrink-0" aria-hidden="true" />}
+        <span className="truncate">{label}</span>
+      </div>
+      <div
+        className={cn(
+          'mt-1 min-w-0 truncate text-sm text-foreground',
+          mono && 'font-mono',
+          'tabular-nums'
+        )}
+        title={typeof value === 'string' ? value : undefined}
+      >
+        {value}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Inline expanded-row detail panel for the recent-queries table.
+ *
+ * The collapsed row truncates the SQL (`CodeDialog max_truncate`) and shows
+ * only compact metrics; expanding surfaces the full, syntax-highlighted query,
+ * the row's identity + runtime metrics in a clean grid, and — for failed rows
+ * (non-zero `exception_code`) — the full exception message, which is the single
+ * most valuable field to read when a query errored.
+ */
+export const RecentQueryExpandedDetails = function RecentQueryExpandedDetails({
+  row,
+}: RecentQueryExpandedDetailsProps) {
+  const query = toStringSafe(row.query)
+  const queryId = toStringSafe(row.query_id)
+  const user = toStringSafe(row.user)
+  const database = toStringSafe(row.database)
+  const queryKind = toStringSafe(row.query_kind)
+  const clientName = toStringSafe(row.client_name)
+  const eventTime = toStringSafe(row.event_time)
+  const duration = formatDuration(row)
+  const readRows = toStringSafe(row.readable_read_rows)
+  const readBytes = toStringSafe(row.readable_read_bytes)
+  const resultRows = toStringSafe(row.readable_result_rows)
+  const memory = toStringSafe(row.readable_memory_usage)
+
+  const exceptionCode = toNumberOrNull(row.exception_code) ?? 0
+  const exception = toStringSafe(row.exception)
+  const failed = exceptionCode !== 0
+
+  return (
+    <div
+      data-slot="recent-query-expanded"
+      className="border-t border-border/60 bg-muted/20 p-4"
+    >
+      <div className="flex flex-wrap items-center gap-1.5 pb-3">
+        {queryKind && (
+          <Badge
+            variant="secondary"
+            className="font-mono text-[10.5px] uppercase"
+          >
+            {queryKind}
+          </Badge>
+        )}
+        {database && (
+          <Badge variant="outline" className="font-mono text-[10.5px]">
+            {database}
+          </Badge>
+        )}
+        {failed && (
+          <Badge
+            variant="outline"
+            className="gap-1 border-red-500/40 font-mono text-[10.5px] text-red-600 dark:text-red-400"
+          >
+            <AlertTriangleIcon className="size-3" aria-hidden="true" />
+            exit code {exceptionCode}
+          </Badge>
+        )}
+      </div>
+
+      {failed && exception && (
+        <div className="mb-4 rounded-md border border-red-500/30 bg-red-50/60 p-3 dark:bg-red-950/30">
+          <div className="mb-1 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-red-600 dark:text-red-400">
+            <AlertTriangleIcon className="size-3.5" aria-hidden="true" />
+            <span>Exception</span>
+          </div>
+          <pre className="m-0 overflow-x-auto whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-red-700 dark:text-red-300">
+            {exception}
+          </pre>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        <DetailField
+          icon={FingerprintIcon}
+          label="Query ID"
+          value={queryId}
+          mono
+          className="xl:col-span-2"
+        />
+        <DetailField icon={UserIcon} label="User" value={user} />
+        <DetailField icon={DatabaseIcon} label="Database" value={database} />
+        <DetailField icon={ClockIcon} label="Event time" value={eventTime} />
+        <DetailField icon={TimerIcon} label="Duration" value={duration} />
+        <DetailField icon={RowsIcon} label="Read rows" value={readRows} />
+        <DetailField icon={GaugeIcon} label="Read bytes" value={readBytes} />
+        <DetailField icon={RowsIcon} label="Result rows" value={resultRows} />
+        <DetailField
+          icon={MemoryStickIcon}
+          label="Peak memory"
+          value={memory}
+        />
+        <DetailField icon={MonitorIcon} label="Client" value={clientName} />
+      </div>
+
+      {query && (
+        <div className="mt-4">
+          <div className="mb-2 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+            <span>Query</span>
+          </div>
+          <CodeBlock code={query} language="sql" className="text-xs">
+            <CodeBlockCopyButton />
+          </CodeBlock>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/dashboard/src/lib/query-config/queries/recent-queries.tsx
+++ b/apps/dashboard/src/lib/query-config/queries/recent-queries.tsx
@@ -2,6 +2,7 @@ import { ClockIcon, DatabaseIcon, LayersIcon, UserIcon } from 'lucide-react'
 
 import type { QueryConfig } from '@/types/query-config'
 
+import { RecentQueryExpandedDetails } from '@/components/data-table/cells/recent-query-expanded-details'
 import { FILTER_PLACEHOLDER } from '@/lib/filters/where-builder'
 import { queryInsightsFilterSchema } from '@/lib/query-config/queries/query-insights-filters'
 import { QUERY_LOG } from '@/lib/table-notes'
@@ -50,7 +51,8 @@ export const recentQueriesConfig: QueryConfig = {
         memory_usage,
         formatReadableSize(memory_usage) AS readable_memory_usage,
         client_name,
-        exception_code
+        exception_code,
+        exception
     FROM (
       SELECT * FROM system.query_log
       WHERE type IN ('QueryFinish', 'ExceptionWhileProcessing')
@@ -90,9 +92,21 @@ export const recentQueriesConfig: QueryConfig = {
     event_time: { size: 180, minSize: 150, maxSize: 220 },
     query_kind: { size: 120, minSize: 100, maxSize: 160 },
     query: { size: 360, minSize: 240, maxSize: 520 },
-    query_duration: { size: 110, minSize: 96, maxSize: 140 },
+    // Header label "query_duration" (14 chars) + sort caret + info icon needs
+    // more room than the old 110px, which clipped it to "query_durat…".
+    query_duration: { size: 132, minSize: 120, maxSize: 160 },
     database: { size: 140, minSize: 100, maxSize: 200 },
     user: { size: 104, minSize: 88, maxSize: 140 },
+    // The metric columns below had no explicit sizing and fell back to the
+    // content-width estimator, which sizes to the (short) formatted values and
+    // clips the longer snake_case header labels (e.g. "result_rows",
+    // "memory_usage"). Give each enough room for its header plus the info-icon
+    // + sort-caret chrome.
+    readable_read_rows: { size: 132, minSize: 116, maxSize: 180 },
+    readable_read_bytes: { size: 132, minSize: 116, maxSize: 180 },
+    readable_result_rows: { size: 138, minSize: 122, maxSize: 190 },
+    readable_memory_usage: { size: 150, minSize: 132, maxSize: 210 },
+    client_name: { size: 132, minSize: 112, maxSize: 200 },
   },
   columnFormats: {
     action: [
@@ -120,6 +134,15 @@ export const recentQueriesConfig: QueryConfig = {
     readable_read_bytes: 'Bytes read from disk/memory while executing',
     readable_result_rows: 'Rows returned to the client',
     readable_memory_usage: 'Peak memory used by the query',
+  },
+  /**
+   * Click-to-expand inline detail panel below each row. The collapsed row
+   * truncates the SQL and hides several fields; the panel surfaces the full
+   * syntax-highlighted query, identity/runtime metrics, and — for failed rows
+   * — the full exception message.
+   */
+  expandable: {
+    renderExpanded: (row) => <RecentQueryExpandedDetails row={row} />,
   },
   relatedCharts: [
     ['query-count', {}],


### PR DESCRIPTION
## What

Two UX fixes for `/recent-queries` (`system.query_log` per-execution log).

### 1. Expandable rows
Rows are now click-to-expand using the existing `expandable` QueryConfig
pattern (same as Running Queries). A new `RecentQueryExpandedDetails` panel
(modeled on `running-query-expanded-details.tsx`) shows:
- the **full, syntax-highlighted SQL** (collapsed row truncates it),
- an identity/runtime metric grid (query id, user, database, event time,
  duration, read rows/bytes, result rows, peak memory, client),
- for **failed rows**, the full **exception message** — previously the red
  row background hinted at a failure but the error text was unavailable.

`exception` is now selected from `system.query_log` (already used by
`failed-queries` / `query-detail` / `expensive-queries`, so no version risk).

### 2. Truncated column headers
Widened `query_duration` and added explicit `columnSizing` for the metric
columns that previously fell back to the content-width estimator and clipped
their snake_case labels (`read_rows`, `read_bytes`, `result_rows`,
`memory_usage`, `client_name`). Fix is scoped to the config — no change to
shared header components.

## Verification
- `tsc --noEmit`: 0 errors · Biome lint: clean · `vite build` succeeds
- SSR page renders (HTTP 200)
- Query plans/resolves against real ClickHouse — the `exception` column binds
  (the local data-API returned a 500 for a pre-existing reason: error 719
  `QUERY_CACHE_USED_WITH_SYSTEM_TABLE`, a server-side query-cache-on-system-table
  setting that affects every system-table page identically, not this change)
- Added a headless unit test for `RecentQueryExpandedDetails` (success + failed
  rows) covering the net-new exception-message branch
- Interactive browser drive was blocked by a local Chrome-extension permission
  prompt (unrelated to the code); behavior otherwise follows the already-shipped
  Running Queries expandable pattern verbatim

## Files
- `apps/dashboard/src/lib/query-config/queries/recent-queries.ts` → `.tsx`
  (needs JSX for `renderExpanded`, matching `running-queries.tsx`)
- `apps/dashboard/src/components/data-table/cells/recent-query-expanded-details.tsx` (new)
- `apps/dashboard/src/components/data-table/cells/__tests__/recent-query-expanded-details.test.tsx` (new)