### PR TITLE
feat(health): severity-tiered Health page redesign

### DIFF
--- a/apps/dashboard/src/components/health/health-card-shell.tsx
+++ b/apps/dashboard/src/components/health/health-card-shell.tsx
@@ -1,5 +1,5 @@
 import type { LucideIcon } from 'lucide-react'
-import { ArrowUpRight } from 'lucide-react'
+import { ArrowUpRight, ChevronRight } from 'lucide-react'
 
 import type { HealthStatus } from '@/lib/health/health-status'
 import type { RelatedLink } from './health-checks'
@@ -8,6 +8,9 @@ import { MiniAreaChart } from '@/components/charts/mini-charts'
 import { AppLink } from '@/components/ui/app-link'
 import { activateOnEnterOrSpace } from '@/lib/a11y'
 import { cn } from '@/lib/utils'
+
+/** How a health check presents itself. Issues expand; healthy checks recede. */
+export type HealthCardVariant = 'card' | 'row'
 
 /** Sparkline stroke color per severity (healthy → blue, matching KPI cards). */
 const SPARK_COLOR: Record<HealthStatus, string> = {
@@ -27,46 +30,32 @@ const VALUE_COLOR: Record<HealthStatus, string> = {
   loading: 'text-foreground',
 }
 
-/** Tinted square behind the header icon — a restrained status cue. */
-const ICON_WRAP: Record<HealthStatus, string> = {
-  critical: 'bg-red-500/10 text-red-600 dark:text-red-400',
-  warning: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
-  ok: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
-  error: 'bg-muted text-muted-foreground',
-  loading: 'bg-muted text-muted-foreground',
+/** A small severity dot — the quiet status cue used in the dense row layout. */
+const STATUS_DOT: Record<HealthStatus, string> = {
+  critical: 'bg-red-500',
+  warning: 'bg-amber-500',
+  ok: 'bg-emerald-500',
+  error: 'bg-muted-foreground/40',
+  loading: 'animate-pulse bg-muted-foreground/40',
 }
 
 /**
- * Status affordance: a labeled pill for issues (so severity reads at a glance),
- * a quiet dot otherwise. Restrained on purpose — the card stays neutral until
- * something actually needs attention.
+ * Status affordance for the expanded card: a labeled pill so severity reads at
+ * a glance. Cards are only rendered for issues, so this always has a label.
  */
-function StatusIndicator({ status }: { status: HealthStatus }) {
-  if (status === 'critical' || status === 'warning') {
-    return (
-      <span
-        className={cn(
-          'rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase leading-none tracking-wide',
-          status === 'critical'
-            ? 'bg-red-500/12 text-red-600 dark:text-red-400'
-            : 'bg-amber-500/12 text-amber-600 dark:text-amber-400'
-        )}
-      >
-        {status === 'critical' ? 'Critical' : 'Warning'}
-      </span>
-    )
-  }
+function IssuePill({ status }: { status: HealthStatus }) {
+  if (status !== 'critical' && status !== 'warning') return null
   return (
     <span
       className={cn(
-        'inline-block size-2 rounded-full',
-        status === 'ok' && 'bg-emerald-500',
-        status === 'loading' && 'animate-pulse bg-muted-foreground/40',
-        status === 'error' && 'bg-muted-foreground/40'
+        'rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase leading-none tracking-wide',
+        status === 'critical'
+          ? 'bg-red-500/12 text-red-600 dark:text-red-400'
+          : 'bg-amber-500/12 text-amber-600 dark:text-amber-400'
       )}
-      role="img"
-      aria-label={`Status: ${status}`}
-    />
+    >
+      {status === 'critical' ? 'Critical' : 'Warning'}
+    </span>
   )
 }
 
@@ -93,19 +82,107 @@ export interface HealthCardShellProps {
   hostId: number
   /** When provided, the WHOLE card opens details (keyboard + pointer). */
   onExpand?: () => void
+  /**
+   * `card` (default) — the full expanded treatment for checks that need
+   * attention. `row` — a dense, quiet single line for healthy / unavailable
+   * checks, so they recede instead of competing with real problems.
+   */
+  variant?: HealthCardVariant
 }
 
 /**
- * Shared visual chrome for every health card: a neutral card surface with a
- * restrained status accent (a left rail + tinted icon only when there is an
- * issue), a clear typographic hierarchy (title · headline value · sub-label),
- * a trend sparkline, and a footer of related-page chips.
+ * Shared presentation for a health check. Two layouts, one contract:
  *
- * The whole card is the click target when `onExpand` is provided — related-page
- * links stop propagation so they still navigate without opening the dialog.
- * Purely presentational: all status/value computation happens upstream.
+ * - `variant="card"` — the expanded treatment (icon glyph, headline value,
+ *   trend sparkline, related-page chips). Reserved for issues, which the grid
+ *   surfaces first so they dominate the page.
+ * - `variant="row"` — a dense line (`dot · icon · title · value · chevron`) for
+ *   healthy or unavailable checks, so a green cluster reads as one calm list
+ *   rather than a wall of identical cards.
+ *
+ * The whole element is the click target when `onExpand` is provided — related
+ * links stop propagation so they still navigate. Purely presentational: all
+ * status / value computation happens upstream.
  */
-export function HealthCardShell({
+export function HealthCardShell(props: HealthCardShellProps) {
+  return props.variant === 'row' ? (
+    <HealthCheckRow {...props} />
+  ) : (
+    <HealthCheckCard {...props} />
+  )
+}
+
+/** Shared interactive-target props: the whole element opens the detail dialog. */
+function interactiveProps(title: string, onExpand: (() => void) | undefined) {
+  return onExpand
+    ? {
+        role: 'button' as const,
+        tabIndex: 0,
+        onClick: onExpand,
+        onKeyDown: activateOnEnterOrSpace(onExpand),
+        'aria-label': `Open ${title} details`,
+      }
+    : {}
+}
+
+/**
+ * Dense single-line layout for healthy / unavailable checks. No sparkline — a
+ * healthy check sits flat, so a trend line here would be pure decoration. Links
+ * stay reachable via the detail dialog, keeping the row uncluttered.
+ */
+function HealthCheckRow({
+  icon: Icon,
+  title,
+  status,
+  displayValue,
+  sublabel,
+  onExpand,
+}: HealthCardShellProps) {
+  return (
+    <div
+      {...interactiveProps(title, onExpand)}
+      className={cn(
+        'group flex items-center gap-3 px-4 py-2.5 transition-colors',
+        onExpand &&
+          'cursor-pointer hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring'
+      )}
+    >
+      <span
+        className={cn('size-1.5 flex-none rounded-full', STATUS_DOT[status])}
+        role="img"
+        aria-label={`Status: ${status}`}
+      />
+      {Icon && (
+        <Icon
+          className="size-4 flex-none text-muted-foreground"
+          strokeWidth={1.5}
+          aria-hidden
+        />
+      )}
+      <span className="flex-none truncate text-[13px] font-medium">
+        {title}
+      </span>
+      <span className="hidden min-w-0 flex-1 truncate text-xs text-muted-foreground sm:block">
+        {sublabel}
+      </span>
+      <span
+        className={cn(
+          'ml-auto flex-none font-mono text-sm font-semibold tabular-nums sm:ml-0',
+          VALUE_COLOR[status]
+        )}
+      >
+        {displayValue}
+      </span>
+      <ChevronRight
+        className="size-4 flex-none text-muted-foreground/40 transition-colors group-hover:text-muted-foreground"
+        aria-hidden
+      />
+    </div>
+  )
+}
+
+/** Expanded card layout, reserved for checks that need attention. */
+function HealthCheckCard({
   icon: Icon,
   title,
   status,
@@ -120,61 +197,49 @@ export function HealthCardShell({
   const withHost = (href: string) =>
     `${href}${href.includes('?') ? '&' : '?'}host=${hostId}`
 
-  const isIssue = status === 'critical' || status === 'warning'
-
-  // Only make the card interactive when it can actually open something —
-  // avoids a role="button" with no handler. `onExpand` narrows to defined here.
-  const interactiveProps = onExpand
-    ? {
-        role: 'button' as const,
-        tabIndex: 0,
-        onClick: onExpand,
-        onKeyDown: activateOnEnterOrSpace(onExpand),
-        'aria-label': `Open ${title} details`,
-      }
-    : {}
-
   return (
     <div
-      {...interactiveProps}
+      {...interactiveProps(title, onExpand)}
       className={cn(
-        'group relative flex min-h-[200px] flex-col overflow-hidden rounded-xl border bg-card p-4 shadow-sm transition-all',
+        'group relative flex min-h-[188px] flex-col overflow-hidden rounded-xl border bg-card p-4 shadow-sm transition-all',
         onExpand &&
-          'cursor-pointer hover:border-foreground/20 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
-        status === 'critical' && 'border-red-500/25',
-        status === 'warning' && 'border-amber-500/25'
+          'cursor-pointer hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+        status === 'critical'
+          ? 'border-red-500/30 hover:border-red-500/50'
+          : status === 'warning'
+            ? 'border-amber-500/30 hover:border-amber-500/50'
+            : 'hover:border-foreground/20'
       )}
     >
-      {/* Restrained status accent: a thin left rail, issues only. */}
-      {isIssue && (
-        <span
-          aria-hidden
-          className={cn(
-            'absolute inset-y-0 left-0 w-[3px]',
-            status === 'critical' ? 'bg-red-500' : 'bg-amber-500'
-          )}
-        />
-      )}
+      {/* Status accent: a thin left rail carrying the severity color. */}
+      <span
+        aria-hidden
+        className={cn(
+          'absolute inset-y-0 left-0 w-[3px]',
+          status === 'critical'
+            ? 'bg-red-500'
+            : status === 'warning'
+              ? 'bg-amber-500'
+              : 'bg-transparent'
+        )}
+      />
 
-      {/* Header: tinted icon + title · status affordance */}
+      {/* Header: plain icon glyph + title · severity pill */}
       <div className="flex items-start justify-between gap-2">
-        <div className="flex min-w-0 items-center gap-2.5">
+        <div className="flex min-w-0 items-center gap-2">
           {Icon && (
-            <span
-              className={cn(
-                'grid size-8 flex-none place-items-center rounded-lg',
-                ICON_WRAP[status]
-              )}
-            >
-              <Icon className="size-4" strokeWidth={1.5} aria-hidden />
-            </span>
+            <Icon
+              className="size-4 flex-none text-muted-foreground"
+              strokeWidth={1.5}
+              aria-hidden
+            />
           )}
           <span className="truncate text-[13px] font-semibold leading-tight">
             {title}
           </span>
         </div>
         <div className="flex flex-none items-center pt-0.5">
-          <StatusIndicator status={status} />
+          <IssuePill status={status} />
         </div>
       </div>
 

--- a/apps/dashboard/src/components/health/health-card.tsx
+++ b/apps/dashboard/src/components/health/health-card.tsx
@@ -1,5 +1,6 @@
 import type { ComputedCheck, HealthStatus } from '@/lib/health/health-status'
 import type { Thresholds } from '@/lib/health/thresholds-storage'
+import type { HealthCardVariant } from './health-card-shell'
 import type { HealthCheckDef } from './health-checks'
 
 import { HealthCardShell } from './health-card-shell'
@@ -19,6 +20,8 @@ interface HealthCardProps {
   spark?: number[]
   /** ClickHouse version, forwarded to the detail dialog. */
   clickhouseVersion?: string
+  /** Expanded card (issues) or dense row (healthy) — decided by the grid. */
+  variant?: HealthCardVariant
 }
 
 /**
@@ -33,6 +36,7 @@ export function HealthCard({
   computed,
   spark,
   clickhouseVersion,
+  variant,
 }: HealthCardProps) {
   const [detailOpen, setDetailOpen] = useState(false)
   const { status, value, label, displayValue, row } = computed
@@ -49,6 +53,7 @@ export function HealthCard({
         links={check.relatedLinks}
         hostId={hostId}
         onExpand={() => setDetailOpen(true)}
+        variant={variant}
       />
 
       <HealthDetailDialog

--- a/apps/dashboard/src/components/health/health-grid.tsx
+++ b/apps/dashboard/src/components/health/health-grid.tsx
@@ -3,6 +3,7 @@ import { RefreshCw } from 'lucide-react'
 import type { ReactNode } from 'react'
 import type { HealthStatus } from '@/lib/health/health-status'
 import type { HistoryMap } from '@/lib/health/history-storage'
+import type { HealthCardVariant } from './health-card-shell'
 import type { HealthCounts } from './health-summary-banner'
 
 import { HealthCard } from './health-card'
@@ -53,7 +54,7 @@ interface GridItem {
   order: number
   /** Alert payload, dispatched on escalation regardless of the active filter. */
   alert: { title: string; value: number | null; label: string }
-  render: (spark: number[] | undefined) => ReactNode
+  render: (spark: number[] | undefined, variant: HealthCardVariant) => ReactNode
 }
 
 /** Short "Ns ago" relative label for the auto-refresh indicator. */
@@ -124,7 +125,7 @@ export function HealthGrid() {
           value: computed.value,
           label: computed.label,
         },
-        render: (spark) => (
+        render: (spark, variant) => (
           <HealthCard
             key={check.id}
             check={check}
@@ -133,6 +134,7 @@ export function HealthGrid() {
             computed={computed}
             spark={spark}
             clickhouseVersion={result.clickhouseVersion}
+            variant={variant}
           />
         ),
       })
@@ -152,13 +154,14 @@ export function HealthGrid() {
         value: stuck.value,
         label: stuck.label,
       },
-      render: (spark) => (
+      render: (spark, variant) => (
         <StuckMutationsCard
           key="stuck-mutations"
           hostId={hostId}
           computed={stuck}
           spark={spark}
           clickhouseVersion={results[STUCK_MUTATIONS_CHART]?.clickhouseVersion}
+          variant={variant}
         />
       ),
     })
@@ -177,7 +180,7 @@ export function HealthGrid() {
         value: running.value,
         label: running.label,
       },
-      render: (spark) => (
+      render: (spark, variant) => (
         <RunningMutationsCard
           key="running-mutations"
           hostId={hostId}
@@ -186,6 +189,7 @@ export function HealthGrid() {
           clickhouseVersion={
             results[RUNNING_MUTATIONS_CHART]?.clickhouseVersion
           }
+          variant={variant}
         />
       ),
     })
@@ -333,10 +337,61 @@ export function HealthGrid() {
             : 'No checks in this view.'}
         </div>
       ) : (
+        <HealthResults items={visible} history={history} hostId={hostId} />
+      )}
+    </div>
+  )
+}
+
+/**
+ * Renders the checks with a two-tier hierarchy so problems dominate and healthy
+ * checks recede:
+ *
+ * - **Issues** (critical / warning) → full cards in a responsive grid, at the
+ *   top, so an OOM incident is not buried under a wall of green.
+ * - **Everything else** (ok / unavailable) → one dense, quiet list of rows.
+ *
+ * Because `items` is already severity-sorted and filter-narrowed upstream, this
+ * partition also drives the filter tabs for free: the "Needs attention" tab
+ * yields only cards, the "Healthy" tab only rows.
+ */
+function HealthResults({
+  items,
+  history,
+  hostId,
+}: {
+  items: GridItem[]
+  history: HistoryMap
+  hostId: number
+}) {
+  const cardItems = items.filter(
+    (i) => i.status === 'critical' || i.status === 'warning'
+  )
+  const rowItems = items.filter(
+    (i) => i.status !== 'critical' && i.status !== 'warning'
+  )
+  const spark = (item: GridItem) => history[historyKey(hostId, item.id)]
+
+  return (
+    <div className="flex flex-col gap-6">
+      {cardItems.length > 0 && (
         <div className="grid gap-3.5 [grid-template-columns:repeat(auto-fill,minmax(280px,1fr))]">
-          {visible.map((item) =>
-            item.render(history[historyKey(hostId, item.id)])
+          {cardItems.map((item) => item.render(spark(item), 'card'))}
+        </div>
+      )}
+
+      {rowItems.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {/* Only label the quiet list when issues sit above it — the loud →
+              calm transition needs a marker; a filtered-only view does not. */}
+          {cardItems.length > 0 && (
+            <div className="px-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+              Operational · {rowItems.length}
+            </div>
           )}
+          <div className="divide-y overflow-hidden rounded-xl border bg-card">
+            {rowItems.map((item) => item.render(spark(item), 'row'))}
+          </div>
         </div>
       )}
     </div>

--- a/apps/dashboard/src/components/health/health-summary-banner.tsx
+++ b/apps/dashboard/src/components/health/health-summary-banner.tsx
@@ -13,8 +13,11 @@ interface BannerTheme {
   icon: LucideIcon
   title: string
   sub: string
+  /** Card surface tint + border. Kept faint — the banner sets a tone, not a flag. */
   container: string
-  iconWrap: string
+  /** Left accent rail color. */
+  rail: string
+  icon_: string
   title_: string
 }
 
@@ -23,9 +26,10 @@ function resolveTheme({ critical, warning, ok }: HealthCounts): BannerTheme {
     return {
       icon: CircleX,
       title: 'Action required',
-      sub: `${critical} critical issue${critical > 1 ? 's' : ''} and ${warning} warning${warning !== 1 ? 's' : ''} detected`,
-      container: 'border-red-500/30 bg-red-500/[0.06]',
-      iconWrap: 'bg-red-500/15 text-red-600 dark:text-red-500',
+      sub: `${critical} critical issue${critical > 1 ? 's' : ''}${warning > 0 ? ` and ${warning} warning${warning > 1 ? 's' : ''}` : ''} need attention`,
+      container: 'border-red-500/20 bg-red-500/[0.035]',
+      rail: 'bg-red-500',
+      icon_: 'text-red-600 dark:text-red-500',
       title_: 'text-red-600 dark:text-red-500',
     }
   }
@@ -34,8 +38,9 @@ function resolveTheme({ critical, warning, ok }: HealthCounts): BannerTheme {
       icon: TriangleAlert,
       title: 'Minor issues',
       sub: `${warning} warning${warning > 1 ? 's' : ''} worth a look — nothing critical`,
-      container: 'border-amber-500/30 bg-amber-500/[0.06]',
-      iconWrap: 'bg-amber-500/15 text-amber-600 dark:text-amber-500',
+      container: 'border-amber-500/20 bg-amber-500/[0.035]',
+      rail: 'bg-amber-500',
+      icon_: 'text-amber-600 dark:text-amber-500',
       title_: 'text-amber-600 dark:text-amber-500',
     }
   }
@@ -44,36 +49,21 @@ function resolveTheme({ critical, warning, ok }: HealthCounts): BannerTheme {
     title: 'All systems healthy',
     sub:
       ok > 0
-        ? 'No issues detected across any health check'
+        ? `No issues across ${ok} health check${ok > 1 ? 's' : ''}`
         : 'Waiting for health checks to report',
-    container: 'border-green-500/30 bg-green-500/[0.06]',
-    iconWrap: 'bg-green-500/15 text-green-600 dark:text-green-500',
-    title_: 'text-green-600 dark:text-green-500',
+    // Healthy is the quietest state: a plain card surface, no tint.
+    container: 'border-border bg-card',
+    rail: 'bg-emerald-500',
+    icon_: 'text-emerald-600 dark:text-emerald-500',
+    title_: 'text-foreground',
   }
 }
 
-function CountPill({
-  dot,
-  count,
-  label,
-}: {
-  dot: string
-  count: number
-  label: string
-}) {
-  return (
-    <div className="flex items-center gap-2 rounded-full border bg-card px-3 py-1.5">
-      <span className={cn('h-2 w-2 rounded-full', dot)} />
-      <span className="text-sm font-semibold tabular-nums">{count}</span>
-      <span className="text-xs text-muted-foreground">{label}</span>
-    </div>
-  )
-}
-
 /**
- * Aggregate health banner: a severity-themed summary (action required / minor
- * issues / all healthy) plus critical / warning / healthy count pills. Driven
- * entirely by the counts the grid computes.
+ * Aggregate health banner: a restrained, severity-toned summary line (action
+ * required / minor issues / all healthy). A thin left rail and a subtle tint
+ * carry the severity — no saturated fill, no count pills (the filter tabs below
+ * already carry the critical / warning / healthy tallies).
  */
 export function HealthSummaryBanner({ counts }: { counts: HealthCounts }) {
   const theme = resolveTheme(counts)
@@ -82,36 +72,21 @@ export function HealthSummaryBanner({ counts }: { counts: HealthCounts }) {
   return (
     <div
       className={cn(
-        'flex flex-col gap-4 rounded-xl border p-4 sm:flex-row sm:items-center sm:justify-between sm:p-5',
+        'relative flex items-center gap-3 overflow-hidden rounded-xl border py-3.5 pl-5 pr-4',
         theme.container
       )}
       role="status"
     >
-      <div className="flex items-center gap-4">
-        <div
-          className={cn(
-            'grid size-10 flex-none place-items-center rounded-xl',
-            theme.iconWrap
-          )}
-        >
-          <Icon className="size-5" aria-hidden />
-        </div>
-        <div className="min-w-0">
-          <div
-            className={cn('text-lg font-semibold leading-tight', theme.title_)}
-          >
-            {theme.title}
-          </div>
-          <div className="mt-0.5 text-sm text-muted-foreground">
-            {theme.sub}
-          </div>
-        </div>
-      </div>
-
-      <div className="flex flex-wrap items-center gap-2.5">
-        <CountPill dot="bg-red-500" count={counts.critical} label="critical" />
-        <CountPill dot="bg-amber-500" count={counts.warning} label="warning" />
-        <CountPill dot="bg-green-500" count={counts.ok} label="healthy" />
+      <span
+        aria-hidden
+        className={cn('absolute inset-y-0 left-0 w-1', theme.rail)}
+      />
+      <Icon className={cn('size-5 flex-none', theme.icon_)} aria-hidden />
+      <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5">
+        <span className={cn('text-sm font-semibold', theme.title_)}>
+          {theme.title}
+        </span>
+        <span className="text-[13px] text-muted-foreground">{theme.sub}</span>
       </div>
     </div>
   )

--- a/apps/dashboard/src/components/health/mutations-cards.tsx
+++ b/apps/dashboard/src/components/health/mutations-cards.tsx
@@ -1,6 +1,7 @@
 import { GitMerge, Wrench } from 'lucide-react'
 
 import type { ComputedMutations } from '@/lib/health/health-status'
+import type { HealthCardVariant } from './health-card-shell'
 import type { HealthCheckDef, RelatedLink } from './health-checks'
 
 import { HealthCardShell } from './health-card-shell'
@@ -15,6 +16,8 @@ interface MutationsCardProps {
   spark?: number[]
   /** ClickHouse version, forwarded to the detail dialog. */
   clickhouseVersion?: string
+  /** Expanded card (issues) or dense row (healthy) — decided by the grid. */
+  variant?: HealthCardVariant
 }
 
 const MUTATIONS_LINKS: readonly RelatedLink[] = [
@@ -91,6 +94,7 @@ function MutationsCard({
   computed,
   spark,
   clickhouseVersion,
+  variant,
 }: MutationsCardProps & { def: HealthCheckDef }) {
   const [detailOpen, setDetailOpen] = useState(false)
 
@@ -106,6 +110,7 @@ function MutationsCard({
         links={def.relatedLinks}
         hostId={hostId}
         onExpand={() => setDetailOpen(true)}
+        variant={variant}
       />
 
       <HealthDetailDialog

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -113,6 +113,16 @@ sheet, sidebar, skeleton, tabs, tooltip (+ more).
   hover/focus "Details" hint. Drive drill-down generically from a per-item field
   (e.g. each health check's `detailChartName`) rendered via `ResultTable`, not
   per-card code — see `components/health/{health-card-shell,health-detail-rows}.tsx`.
+- **Severity-tiered "many checks at a glance":** don't give every item equal
+  visual weight. Items that need attention expand to full cards; healthy/normal
+  items collapse into ONE dense, quiet bordered list (`divide-y … rounded-xl
+  border`) of `[status dot] [muted icon] [title] [sublabel] [value] [chevron]`
+  rows — no per-row sparkline (a flat healthy trend is decoration). Partition the
+  already severity-sorted, filter-narrowed list into cards vs rows so the same
+  split also drives the filter tabs. Keep the aggregate banner restrained (subtle
+  tint + thin left accent rail, not a saturated fill; let the tabs carry the
+  counts). Reference: `components/health/{health-grid,health-card-shell,
+  health-summary-banner}.tsx` (`HealthCardShell` `variant: 'card' | 'row'`).
 - Graceful revalidation: keep data on `staleError`, show hover-revealed amber
   `ChartStaleIndicator`; only blank out on initial `error && !hasData`.
 - Icons: `lucide-react`, `size-4` / `size-3.5`, `strokeWidth={1.5}`.


### PR DESCRIPTION
## What

Redesigns the **Health page** (`/health`) so it reads as considered rather than a stock dashboard template. Same data, same links, same drill-down — only the presentation changes.

The old page was a flat grid of ~17 identical cards, each with a colored icon-badge, a big number, a sparkline and a pill row, above a bold uniform banner — every check got equal visual weight regardless of severity (the "AI slop" tell).

## Changes

**Two-tier hierarchy** (the core fix)
- **Issues** (critical/warning) expand to full cards at the top, so an OOM or disk-pressure incident dominates the page.
- **Healthy / unavailable** checks collapse into **one** dense, quiet bordered list of rows (`dot · icon · title · value · chevron`) — no per-row sparkline (a flat healthy trend is decoration).
- The grid partitions the already severity-sorted list into cards vs rows, which also drives the filter tabs for free (Needs attention → cards only; Healthy → rows only).

**Restraint / removing the slop tells**
- Dropped the decorative colored icon-square on cards — the icon is now a plain glyph; severity is carried by the accent rail, the CRITICAL/WARNING pill and the value color.
- Toned the summary banner down: subtle tint + thin left accent rail instead of a saturated fill, and dropped the redundant count pills (the filter tabs already carry the critical/warning/healthy tallies).

`HealthCardShell` gains a `variant: 'card' | 'row'`. Data bindings, the detail dialog + related-page links, sparkline history, and alert dispatch are all unchanged.

## Verification

- `bun run lint` (Biome) + scoped `tsc --noEmit` clean on all changed files.
- Driven in a real browser (Playwright + Chrome) across states — **all healthy**, **mixed critical + warning**, **Needs-attention filter**, and **dark mode** — confirming the hierarchy, the restrained banner, the dense list, and correct light/dark rendering.
- Updated `docs/knowledge/product-design.md` with the severity-tiered "many checks at a glance" convention (per the repo's keep-skills-current rule).

https://claude.ai/code/session_01Gh1QiyYp93RokWM6vGzFKA