### PR TITLE
perf(history-queries): default 24h window, lift window fns out of LIMIT, keep filter bar on empty

### DIFF
--- a/apps/dashboard/src/components/tables/table-client.tsx
+++ b/apps/dashboard/src/components/tables/table-client.tsx
@@ -8,6 +8,7 @@ import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { CardToolbar } from '@/components/cards/card-toolbar'
 import { DataTable } from '@/components/data-table/data-table'
+import { FilterBar } from '@/components/filters/filter-bar'
 import { TableSkeleton } from '@/components/skeletons'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
@@ -204,6 +205,11 @@ export const TableClient = function TableClient({
 
   // Get SQL for display in toolbars
   const sql = queryConfig.sql ? getSqlForDisplay(queryConfig.sql) : undefined
+
+  // Whether the schema-driven filter bar should render. When true, the empty
+  // state keeps the filter bar mounted (see the zero-rows branch) so filters
+  // stay reachable instead of disappearing with the table.
+  const showSchemaFilterBar = Boolean(showFilterBar && queryConfig.filterSchema)
 
   if (error) {
     const serverVersion = hostStatus.data?.version
@@ -447,7 +453,7 @@ export const TableClient = function TableClient({
   }
 
   if (!data || (Array.isArray(data) && data.length === 0)) {
-    return (
+    const emptyCard = (
       <Card
         className={cn(
           'rounded-md border-warning/30 bg-warning/5 shadow-none py-2 group relative',
@@ -460,9 +466,13 @@ export const TableClient = function TableClient({
         <CardContent className="p-6">
           <div className="flex flex-col items-center gap-4">
             <EmptyState
-              variant="no-data"
+              variant={showSchemaFilterBar ? 'filtered-empty' : 'no-data'}
               title={title || 'No Data'}
-              description="No data available for this query. Try adjusting your filters or check back later."
+              description={
+                showSchemaFilterBar
+                  ? 'No queries match the current filters. Adjust or clear them above to widen the results.'
+                  : 'No data available for this query. Try adjusting your filters or check back later.'
+              }
             />
             {queryConfig.suggestion && (
               <SuggestionCard
@@ -473,6 +483,33 @@ export const TableClient = function TableClient({
           </div>
         </CardContent>
       </Card>
+    )
+
+    // Keep the schema-driven filter bar mounted even with zero rows, so the
+    // user can widen/clear filters without the controls vanishing. Only the
+    // results area below shows the empty state. Non-schema tables keep the
+    // plain empty card.
+    if (!showSchemaFilterBar) return emptyCard
+
+    return (
+      <div className={cn('flex min-w-0 flex-col', className)}>
+        <div className="flex flex-col gap-2.5 pb-2.5">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <h1 className="text-xl font-bold tracking-tight text-foreground">
+                {title}
+              </h1>
+              <p className="text-xs sm:text-sm text-muted-foreground truncate mt-0.5">
+                {description || queryConfig.description}
+              </p>
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-2 bg-card/65 dark:bg-card/40 border border-border/60 p-2 rounded-xl shadow-xs">
+            <FilterBar queryConfig={queryConfig} />
+          </div>
+        </div>
+        {emptyCard}
+      </div>
     )
   }
 

--- a/apps/dashboard/src/lib/query-config/queries/history-queries.ts
+++ b/apps/dashboard/src/lib/query-config/queries/history-queries.ts
@@ -25,15 +25,82 @@ import { QUERY_LOG } from '@/lib/table-notes'
 import { ColumnFormat } from '@/types/column-format'
 
 /**
- * Query tail shared by every version variant. The {@link FILTER_PLACEHOLDER}
- * marker is replaced server-side with a parameterized `WHERE` clause built
- * from the {@link historyQueryFilterSchema}.
+ * Raw columns projected by the inner subquery — the minimal set the outer
+ * SELECT needs to derive every `readable_*` / `pct_*` display column. Filters
+ * reference base columns (`written_rows`, `tables`, `client_agent`, …) that are
+ * NOT in this list, which is fine: the {@link FILTER_PLACEHOLDER} `WHERE` is
+ * applied INSIDE the subquery directly on `system.query_log`, where every base
+ * column is in scope regardless of what the projection selects.
  */
-const historyQueryTail = `
-          FROM system.query_log
-          ${FILTER_PLACEHOLDER}
-          ORDER BY event_time DESC
-          LIMIT 250`
+const baseInnerColumns = [
+  'type',
+  'query_id',
+  'query_duration_ms',
+  'event_time',
+  'query',
+  'user',
+  'read_rows',
+  'written_rows',
+  'result_rows',
+  'memory_usage',
+  'query_kind',
+  'client_name',
+]
+
+/**
+ * Build one version variant of the History Queries SQL.
+ *
+ * `extraColumns` are version-gated raw columns carried through from the
+ * subquery to the outer projection (`query_cache_usage` since 24.1,
+ * `client_agent` since 26.6).
+ *
+ * Performance shape: the {@link FILTER_PLACEHOLDER} `WHERE` and
+ * `ORDER BY event_time DESC LIMIT 250` live in the INNER subquery over
+ * `system.query_log`. `event_time` is part of the table's sorting key, so
+ * ClickHouse prunes granules and the `LIMIT` short-circuits the scan. The
+ * `MAX(...) OVER ()` window columns are computed in the OUTER query over those
+ * ≤250 rows — NOT over the whole filtered set. This keeps `pct_*` "relative to
+ * the displayed page" (matching the expand panel's label) and avoids buffering
+ * the entire filtered window: measured 884k → 41k rows read on a 1-day window.
+ */
+function buildHistoryQuerySql(extraColumns: string[]): string {
+  const innerColumns = [...baseInnerColumns, ...extraColumns]
+  const outerExtras = extraColumns.length
+    ? `,\n              ${extraColumns.join(',\n              ')}`
+    : ''
+
+  return `
+          SELECT
+              type,
+              query_id,
+              query_duration_ms,
+              query_duration_ms / 1000 as query_duration,
+              event_time,
+              query,
+              user,
+              read_rows,
+              formatReadableQuantity(read_rows) AS readable_read_rows,
+              round(100 * read_rows / MAX(read_rows) OVER ()) AS pct_read_rows,
+              written_rows,
+              formatReadableQuantity(written_rows) AS readable_written_rows,
+              round(100 * written_rows / MAX(written_rows) OVER ()) AS pct_written_rows,
+              result_rows,
+              formatReadableQuantity(result_rows) AS readable_result_rows,
+              memory_usage,
+              formatReadableSize(memory_usage) AS readable_memory_usage,
+              round(100 * memory_usage / MAX(memory_usage) OVER ()) AS pct_memory_usage,
+              query_kind,
+              client_name${outerExtras}
+          FROM (
+              SELECT
+                  ${innerColumns.join(',\n                  ')}
+              FROM system.query_log
+              ${FILTER_PLACEHOLDER}
+              ORDER BY event_time DESC
+              LIMIT 250
+          )
+          ORDER BY event_time DESC`
+}
 
 /** Service users excluded from the result by default (configurable per deploy). */
 const defaultExcludedUsers = process.env.CLICKHOUSE_EXCLUDE_USER_DEFAULT || ''
@@ -68,6 +135,12 @@ export const historyQueryFilterSchema: FilterSchema = {
         { label: 'Last 30 days', value: '720' },
       ],
       description: 'Relative window or an explicit date range.',
+      // Default to the last 24h so the page never issues an unbounded scan of
+      // the full `system.query_log` history. `event_time` is part of the
+      // table's sorting key, so this predicate prunes granules/partitions and
+      // is the primary performance lever — users can widen (7d/30d) or clear it
+      // via the filter bar. Renders as an active "Time: Last 24 hours" chip.
+      defaultValue: { operator: 'withinHours', value: '24' },
     },
     {
       key: 'user',
@@ -370,89 +443,17 @@ export const historyQueriesConfig: QueryConfig = {
     {
       since: '23.8',
       description: 'Base query without query_cache_usage',
-      sql: `
-          SELECT
-              type,
-              query_id,
-              query_duration_ms,
-              query_duration_ms / 1000 as query_duration,
-              event_time,
-              query,
-              user,
-              read_rows,
-              formatReadableQuantity(read_rows) AS readable_read_rows,
-              round(100 * read_rows / MAX(read_rows) OVER ()) AS pct_read_rows,
-              written_rows,
-              formatReadableQuantity(written_rows) AS readable_written_rows,
-              round(100 * written_rows / MAX(written_rows) OVER ()) AS pct_written_rows,
-              result_rows,
-              formatReadableQuantity(result_rows) AS readable_result_rows,
-              memory_usage,
-              formatReadableSize(memory_usage) AS readable_memory_usage,
-              round(100 * memory_usage / MAX(memory_usage) OVER ()) AS pct_memory_usage,
-              query_kind,
-              client_name
-${historyQueryTail}
-      `,
+      sql: buildHistoryQuerySql([]),
     },
     {
       since: '24.1',
       description: 'Added query_cache_usage column',
-      sql: `
-          SELECT
-              type,
-              query_id,
-              query_duration_ms,
-              query_duration_ms / 1000 as query_duration,
-              event_time,
-              query,
-              user,
-              read_rows,
-              formatReadableQuantity(read_rows) AS readable_read_rows,
-              round(100 * read_rows / MAX(read_rows) OVER ()) AS pct_read_rows,
-              written_rows,
-              formatReadableQuantity(written_rows) AS readable_written_rows,
-              round(100 * written_rows / MAX(written_rows) OVER ()) AS pct_written_rows,
-              result_rows,
-              formatReadableQuantity(result_rows) AS readable_result_rows,
-              memory_usage,
-              formatReadableSize(memory_usage) AS readable_memory_usage,
-              round(100 * memory_usage / MAX(memory_usage) OVER ()) AS pct_memory_usage,
-              query_kind,
-              query_cache_usage,
-              client_name
-${historyQueryTail}
-      `,
+      sql: buildHistoryQuerySql(['query_cache_usage']),
     },
     {
       since: '26.6',
       description: 'Added client_agent column (CH 26.6+)',
-      sql: `
-          SELECT
-              type,
-              query_id,
-              query_duration_ms,
-              query_duration_ms / 1000 as query_duration,
-              event_time,
-              query,
-              user,
-              read_rows,
-              formatReadableQuantity(read_rows) AS readable_read_rows,
-              round(100 * read_rows / MAX(read_rows) OVER ()) AS pct_read_rows,
-              written_rows,
-              formatReadableQuantity(written_rows) AS readable_written_rows,
-              round(100 * written_rows / MAX(written_rows) OVER ()) AS pct_written_rows,
-              result_rows,
-              formatReadableQuantity(result_rows) AS readable_result_rows,
-              memory_usage,
-              formatReadableSize(memory_usage) AS readable_memory_usage,
-              round(100 * memory_usage / MAX(memory_usage) OVER ()) AS pct_memory_usage,
-              query_kind,
-              query_cache_usage,
-              client_name,
-              client_agent
-${historyQueryTail}
-      `,
+      sql: buildHistoryQuerySql(['query_cache_usage', 'client_agent']),
     },
   ],
 


### PR DESCRIPTION
## Problem

`https://dash.chmonitor.dev/history-queries?host=0` loaded slowly. With no active filter the page ran `FROM system.query_log <no WHERE> ORDER BY event_time DESC LIMIT 250` — an **unbounded scan of the entire query_log history**. Worse, the `MAX(...) OVER ()` window columns (`pct_read_rows` etc.) buffered the **whole filtered set** before the `LIMIT` could apply, so the `LIMIT 250` never short-circuited the scan.

## What changed (one standalone PR, History Queries only)

**1. Performance — default 24h time window**
Added `defaultValue: { operator: 'withinHours', value: '24' }` to the `event_time` filter field. `event_time` is part of `system.query_log`'s sorting key, so the predicate prunes granules/partitions instead of scanning all history. It's honored both client-side (route) and server-side (`getTableQuery` → `buildWhereClause`), and renders as an editable **"Time · within last 24 hours"** chip.

**2. Performance — lift window functions out of the LIMIT**
Restructured the SQL (via a DRY `buildHistoryQuerySql(extraColumns)` builder for the 3 version variants) so the `MAX(...) OVER ()` window columns are computed in an **outer SELECT over a `LIMIT 250` subquery**, not over the whole filtered set. The `LIMIT` now short-circuits the scan and `pct_*` becomes relative to the displayed page (matching the expand panel's "relative to result set" label). The filter `WHERE` stays **inside** the subquery on `system.query_log`, so filters on non-projected base columns (`written_rows`, `tables`, `client_agent`, …) still resolve.

**3. Dynamic control**
The existing time-range selector (1h/6h/24h/7d/30d + "within last"/explicit range) is now the primary scope/perf lever — always present as an active chip, widen/narrow/clear at will.

**4. Filter bar visibility on empty results**
`table-client.tsx` previously replaced the whole content area (including the filter bar) with a `no-data` card when a query returned zero rows, trapping the user. Now, when the config has a `filterSchema` (and `showFilterBar`), the FilterBar stays mounted and only the **results area** shows the `filtered-empty` state — so filters remain reachable. Non-schema tables keep the plain empty card. This is a shared-component fix (DataTable already guarded `data.length > 0 || hasActiveSchemaFilters`; TableClient short-circuited before it).

## Evidence (measured on a `system.query_log` analog: `default.trips`, 3.46B rows, `PARTITION BY toYYYYMM(pickup_date) ORDER BY pickup_datetime`)

| Query shape | Rows read |
|---|---|
| No time filter (old default), window over full set | **3,465,634,142 rows / 424,307 granules** (`EXPLAIN ESTIMATE`) |
| + time predicate | **1 mark** (granule/partition pruning) |
| Window over full 1-day window (old shape) | **884,736 rows read**, 0.040s |
| Window over LIMIT-250 subquery (new shape) | **40,960 rows read**, 0.008s (~21× fewer) |

## Verification
- Driven in a real browser against a local **ClickHouse 26.6** `query_log` (exercises the newest `client_agent` variant): default 24h returns 250 rows with all columns; an impossible filter returns 0 rows and the filter bar stays visible with the empty state in the results area only.
- `bun run test:query-config` (1044 pass, incl. version-compatibility monotonicity), filter tests (34 pass), `bun run lint` clean, type-check clean for the changed files.

https://claude.ai/code/session_01Gh1QiyYp93RokWM6vGzFKA