### PR TITLE
feat(insights): add memory, read-throughput, top-users charts; widen zoom dialog

### DIFF
--- a/apps/dashboard/src/components/charts/chart-zoom-dialog.tsx
+++ b/apps/dashboard/src/components/charts/chart-zoom-dialog.tsx
@@ -253,7 +253,7 @@ export const ChartZoomDialog = function ChartZoomDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         ref={contentRef}
-        className="max-w-[95vw] w-[95vw] flex flex-col p-0 pb-6"
+        className="w-[80vw] max-w-[80vw] sm:max-w-[80vw] flex flex-col p-0 pb-6"
         style={{ height: dialogHeight, maxHeight: '95vh' }}
       >
         <DialogHeader className="px-6 pt-6 pb-4 border-b shrink-0">

--- a/apps/dashboard/src/components/charts/query-performance/query-insights-memory.tsx
+++ b/apps/dashboard/src/components/charts/query-performance/query-insights-memory.tsx
@@ -1,0 +1,25 @@
+import { createAreaChart } from '@/components/charts/factory'
+import { chartTickFormatters } from '@/lib/utils'
+
+/** Tile 7 of the Query Insights overview: avg + p95/p99 peak memory per query. */
+export const ChartQueryInsightsMemory = createAreaChart({
+  chartName: 'query-insights-memory',
+  index: 'event_time',
+  categories: ['avg_memory', 'p95_memory', 'p99_memory'],
+  defaultTitle: 'Memory Usage',
+  defaultInterval: 'toStartOfHour',
+  defaultLastHours: 24,
+  dataTestId: 'query-insights-memory-chart',
+  dateRangeConfig: 'query-activity',
+  areaChartProps: {
+    readable: 'bytes',
+    stack: false,
+    showLegend: true,
+    showXAxis: true,
+    showCartesianGrid: true,
+    colors: ['--chart-1', '--chart-2', '--chart-3'],
+    yAxisTickFormatter: chartTickFormatters.bytes,
+  },
+})
+
+export default ChartQueryInsightsMemory

--- a/apps/dashboard/src/components/charts/query-performance/query-insights-read-throughput.tsx
+++ b/apps/dashboard/src/components/charts/query-performance/query-insights-read-throughput.tsx
@@ -1,0 +1,25 @@
+import { createAreaChart } from '@/components/charts/factory'
+import { chartTickFormatters } from '@/lib/utils'
+
+/** Tile 8 of the Query Insights overview: bytes read from storage vs returned. */
+export const ChartQueryInsightsReadThroughput = createAreaChart({
+  chartName: 'query-insights-read-throughput',
+  index: 'event_time',
+  categories: ['read_bytes', 'result_bytes'],
+  defaultTitle: 'Read Throughput',
+  defaultInterval: 'toStartOfHour',
+  defaultLastHours: 24,
+  dataTestId: 'query-insights-read-throughput-chart',
+  dateRangeConfig: 'query-activity',
+  areaChartProps: {
+    readable: 'bytes',
+    stack: false,
+    showLegend: true,
+    showXAxis: true,
+    showCartesianGrid: true,
+    colors: ['--chart-1', '--chart-2'],
+    yAxisTickFormatter: chartTickFormatters.bytes,
+  },
+})
+
+export default ChartQueryInsightsReadThroughput

--- a/apps/dashboard/src/components/charts/query-performance/query-insights-top-users.tsx
+++ b/apps/dashboard/src/components/charts/query-performance/query-insights-top-users.tsx
@@ -1,0 +1,34 @@
+import { createCustomChart } from '@/components/charts/factory'
+import { ProportionList } from '@/components/charts/primitives/proportion-list'
+import { formatCount } from '@/lib/utils'
+
+interface TopUsersData {
+  user: string
+  query_count: number
+}
+
+/** Tile 9 of the Query Insights overview: query volume by user. */
+export const ChartQueryInsightsTopUsers = createCustomChart({
+  chartName: 'query-insights-top-users',
+  defaultTitle: 'Top Users',
+  defaultLastHours: 24,
+  dataTestId: 'query-insights-top-users-chart',
+  dateRangeConfig: 'query-activity',
+  render: (dataArray) => {
+    const data = dataArray as TopUsersData[]
+
+    return (
+      <ProportionList
+        items={data.map((d, index) => ({
+          label: d.user || 'Unknown',
+          value: d.query_count,
+          colorClass: `bg-chart-${(index % 5) + 1}`,
+        }))}
+        formatValue={(v) => formatCount(v)}
+        emptyMessage="No query activity recorded"
+      />
+    )
+  },
+})
+
+export default ChartQueryInsightsTopUsers

--- a/apps/dashboard/src/components/charts/registry/imports/query-perf-charts.ts
+++ b/apps/dashboard/src/components/charts/registry/imports/query-perf-charts.ts
@@ -77,4 +77,25 @@ export const queryPerfChartImports: ChartRegistryMap = {
       })
     )
   ),
+  'query-insights-memory': lazy(() =>
+    import('@/components/charts/query-performance/query-insights-memory').then(
+      (m) => ({
+        default: m.ChartQueryInsightsMemory,
+      })
+    )
+  ),
+  'query-insights-read-throughput': lazy(() =>
+    import(
+      '@/components/charts/query-performance/query-insights-read-throughput'
+    ).then((m) => ({
+      default: m.ChartQueryInsightsReadThroughput,
+    }))
+  ),
+  'query-insights-top-users': lazy(() =>
+    import(
+      '@/components/charts/query-performance/query-insights-top-users'
+    ).then((m) => ({
+      default: m.ChartQueryInsightsTopUsers,
+    }))
+  ),
 }

--- a/apps/dashboard/src/components/charts/registry/type-hints.ts
+++ b/apps/dashboard/src/components/charts/registry/type-hints.ts
@@ -33,6 +33,9 @@ export const CHART_TYPE_HINTS: Record<string, ChartSkeletonType> = {
   'query-insights-rows': 'area',
   'query-insights-cache-hit-ratio': 'bar',
   'query-insights-errors': 'area',
+  'query-insights-memory': 'area',
+  'query-insights-read-throughput': 'area',
+  'query-insights-top-users': 'bar',
 
   // Merge Charts - area and metric
   'merge-count': 'area',

--- a/apps/dashboard/src/lib/api/__tests__/charts/query-insights-charts.test.ts
+++ b/apps/dashboard/src/lib/api/__tests__/charts/query-insights-charts.test.ts
@@ -18,6 +18,9 @@ describe('queryInsightsCharts', () => {
     expect(names).toContain('query-insights-rows')
     expect(names).toContain('query-insights-cache-hit-ratio')
     expect(names).toContain('query-insights-errors')
+    expect(names).toContain('query-insights-memory')
+    expect(names).toContain('query-insights-read-throughput')
+    expect(names).toContain('query-insights-top-users')
   })
 
   test.each(
@@ -71,5 +74,29 @@ describe('queryInsightsCharts', () => {
     expect(result.query).toMatch(/quantile\(0\.50\)/)
     expect(result.query).toMatch(/quantile\(0\.95\)/)
     expect(result.query).toMatch(/quantile\(0\.99\)/)
+  })
+
+  test('memory tile aggregates avg + p95/p99 peak memory_usage', () => {
+    const result = queryInsightsCharts['query-insights-memory'](
+      defaultParams
+    ) as any
+    expect(result.query).toMatch(/avg\(memory_usage\)/)
+    expect(result.query).toMatch(/quantile\(0\.95\)\(memory_usage\)/)
+    expect(result.query).toMatch(/quantile\(0\.99\)\(memory_usage\)/)
+  })
+
+  test('read throughput tile sums read_bytes and result_bytes', () => {
+    const result = queryInsightsCharts['query-insights-read-throughput'](
+      defaultParams
+    ) as any
+    expect(result.query).toMatch(/sum\(read_bytes\)/)
+    expect(result.query).toMatch(/sum\(result_bytes\)/)
+  })
+
+  test('top users tile groups by user', () => {
+    const result = queryInsightsCharts['query-insights-top-users'](
+      defaultParams
+    ) as any
+    expect(result.query).toMatch(/GROUP BY user/)
   })
 })

--- a/apps/dashboard/src/lib/api/charts/query-insights-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/query-insights-charts.ts
@@ -134,4 +134,63 @@ export const queryInsightsCharts: Record<string, ChartQueryBuilder> = {
   `
     return { query, sql: [{ since: '19.1', sql: query }] }
   },
+
+  // Tile 7: Memory usage — avg + p95/p99 of per-query peak memory_usage.
+  'query-insights-memory': ({ interval = 'toStartOfHour', lastHours = 24 }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    const query = `
+    SELECT ${applyInterval(interval, 'event_time')},
+           round(avg(memory_usage)) AS avg_memory,
+           round(quantile(0.95)(memory_usage)) AS p95_memory,
+           round(quantile(0.99)(memory_usage)) AS p99_memory
+    FROM system.query_log
+    WHERE type = 'QueryFinish'
+          ${timeFilter ? `AND ${timeFilter}` : ''}
+    GROUP BY event_time
+    ORDER BY event_time ASC
+    WITH FILL TO ${nowOrToday(interval)} STEP ${fillStep(interval)}
+    SETTINGS max_execution_time = 25
+  `
+    return { query, sql: [{ since: '19.1', sql: query }] }
+  },
+
+  // Tile 8: Read throughput — bytes read from storage vs bytes returned.
+  'query-insights-read-throughput': ({
+    interval = 'toStartOfHour',
+    lastHours = 24,
+  }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    const query = `
+    SELECT ${applyInterval(interval, 'event_time')},
+           sum(read_bytes) AS read_bytes,
+           sum(result_bytes) AS result_bytes
+    FROM system.query_log
+    WHERE type = 'QueryFinish'
+          ${timeFilter ? `AND ${timeFilter}` : ''}
+    GROUP BY event_time
+    ORDER BY event_time ASC
+    WITH FILL TO ${nowOrToday(interval)} STEP ${fillStep(interval)}
+    SETTINGS max_execution_time = 25
+  `
+    return { query, sql: [{ since: '19.1', sql: query }] }
+  },
+
+  // Tile 9: Top users — query volume broken down by the user who ran them.
+  'query-insights-top-users': ({ lastHours = 24 }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    const query = `
+    SELECT
+      user,
+      COUNT() AS query_count,
+      round(100 * query_count / sum(query_count) OVER (), 2) AS percentage
+    FROM system.query_log
+    WHERE type = 'QueryFinish'
+          ${timeFilter ? `AND ${timeFilter}` : ''}
+    GROUP BY user
+    ORDER BY query_count DESC
+    LIMIT 8
+    SETTINGS max_execution_time = 25
+  `
+    return { query, sql: [{ since: '19.1', sql: query }] }
+  },
 }

--- a/apps/dashboard/src/routes/(dashboard)/queries/insights.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/queries/insights.tsx
@@ -3,9 +3,12 @@ import { createFileRoute } from '@tanstack/react-router'
 import { ChartQueryInsightsCacheHitRatio } from '@/components/charts/query-performance/query-insights-cache-hit-ratio'
 import { ChartQueryInsightsErrors } from '@/components/charts/query-performance/query-insights-errors'
 import { ChartQueryInsightsLatency } from '@/components/charts/query-performance/query-insights-latency'
+import { ChartQueryInsightsMemory } from '@/components/charts/query-performance/query-insights-memory'
 import { ChartQueryInsightsOperations } from '@/components/charts/query-performance/query-insights-operations'
 import { ChartQueryInsightsQps } from '@/components/charts/query-performance/query-insights-qps'
+import { ChartQueryInsightsReadThroughput } from '@/components/charts/query-performance/query-insights-read-throughput'
 import { ChartQueryInsightsRows } from '@/components/charts/query-performance/query-insights-rows'
+import { ChartQueryInsightsTopUsers } from '@/components/charts/query-performance/query-insights-top-users'
 
 function QueryInsightsPage() {
   return (
@@ -15,8 +18,8 @@ function QueryInsightsPage() {
           Query Insights
         </h1>
         <p className="mt-1 text-sm text-muted-foreground">
-          Query volume, latency, operations, resource usage, cache
-          effectiveness, and errors from system.query_log
+          Query volume, latency, operations, memory, read throughput, cache
+          effectiveness, errors, and top users from system.query_log
         </p>
       </div>
 
@@ -27,6 +30,9 @@ function QueryInsightsPage() {
         <ChartQueryInsightsRows />
         <ChartQueryInsightsCacheHitRatio />
         <ChartQueryInsightsErrors />
+        <ChartQueryInsightsMemory />
+        <ChartQueryInsightsReadThroughput />
+        <ChartQueryInsightsTopUsers />
       </div>
     </div>
   )


### PR DESCRIPTION
## Query Insights: 3 new charts + wider zoom dialog

### 1. Three new charts on \`/queries/insights\`
All backed by real \`system.query_log\` columns, wired through the existing chart factory/registry pattern (builder in \`queryInsightsCharts\`, lazy component import in \`registry/imports/query-perf-charts.ts\`, skeleton type-hint, page render) — identical to the 6 charts already on the page.

| Chart | Type | SQL |
|-------|------|-----|
| **Memory Usage** | area (bytes) | `avg(memory_usage)` + `quantile(0.95/0.99)(memory_usage)` over time |
| **Read Throughput** | area (bytes) | `sum(read_bytes)` vs `sum(result_bytes)` over time |
| **Top Users** | proportion list | query volume grouped by `user` (top 8) |

Chosen to complement, not duplicate, the existing tiles (QPS, latency, operations-by-kind, rows read/returned, cache hit ratio, errors-over-time). Memory and read-**bytes** add the resource-usage dimension the page lacked; Top Users adds a per-user breakdown. Every column used (`memory_usage`, `read_bytes`, `result_bytes`, `user`) is long-standing in `system.query_log`, so the SQL uses the same `since: '19.1'` version-aware pattern as the neighbours.

### 2. Wider zoom/expand dialog
The shared chart zoom dialog (`chart-zoom-dialog.tsx`, used by every chart via `ChartZoomButton`) was effectively capped at ~512px on desktop: the base shadcn `DialogContent` carries `sm:max-w-lg`, and because that's a separate responsive key from the dialog's `max-w-[95vw]`, tailwind-merge kept it and it won at `≥sm`. Fixed by setting `w-[80vw] max-w-[80vw] sm:max-w-[80vw]`, so the zoomed chart uses ~80% of the viewport width.

### Verification
- `bun run lint` clean; targeted query-config test suite green (18 pass, incl. new assertions for the 3 builders).
- `tsc --noEmit` reports zero errors in the touched files.
- Note: a full `bun run build` / live dev-server browser drive could not complete in this sandbox — the worktree's partial/hoisted `node_modules` (missing `@sentry/*`, `@modelcontextprotocol/sdk` subpaths, etc.) prevents the `@cloudflare/vite-plugin` dev server from starting reliably. The change is otherwise fully verified statically and follows the exact pattern of the existing charts; CI's compile build will confirm.

https://claude.ai/code/session_01Gh1QiyYp93RokWM6vGzFKA