### PR TITLE
fix(health): remove redundant card border, fix detail dialog overflow

### DIFF
--- a/apps/dashboard/src/components/health/health-card-shell.tsx
+++ b/apps/dashboard/src/components/health/health-card-shell.tsx
@@ -201,7 +201,7 @@ function HealthCheckCard({
     <div
       {...interactiveProps(title, onExpand)}
       className={cn(
-        'group relative flex min-h-[188px] flex-col overflow-hidden rounded-xl border bg-card p-4 shadow-sm transition-all',
+        'group flex min-h-[188px] flex-col overflow-hidden rounded-xl border bg-card p-4 shadow-sm transition-all',
         onExpand &&
           'cursor-pointer hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
         status === 'critical'
@@ -211,19 +211,6 @@ function HealthCheckCard({
             : 'hover:border-foreground/20'
       )}
     >
-      {/* Status accent: a thin left rail carrying the severity color. */}
-      <span
-        aria-hidden
-        className={cn(
-          'absolute inset-y-0 left-0 w-[3px]',
-          status === 'critical'
-            ? 'bg-red-500'
-            : status === 'warning'
-              ? 'bg-amber-500'
-              : 'bg-transparent'
-        )}
-      />
-
       {/* Header: plain icon glyph + title · severity pill */}
       <div className="flex items-start justify-between gap-2">
         <div className="flex min-w-0 items-center gap-2">

--- a/apps/dashboard/src/components/health/health-detail-dialog.tsx
+++ b/apps/dashboard/src/components/health/health-detail-dialog.tsx
@@ -92,7 +92,9 @@ export function HealthDetailDialog({
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="max-w-3xl">
+        <DialogContent
+          className={cn('max-w-3xl', check.detailChartName && 'sm:max-w-5xl')}
+        >
           <DialogHeader>
             <div className="flex items-center gap-2">
               <DialogTitle>{check.title}</DialogTitle>
@@ -103,7 +105,7 @@ export function HealthDetailDialog({
             )}
           </DialogHeader>
 
-          <ScrollArea className="max-h-[60vh] pr-3">
+          <ScrollArea className="min-w-0 max-h-[60vh] pr-3">
             <div className="flex flex-col gap-4">
               <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
                 <div className="rounded-md border p-3">


### PR DESCRIPTION
## Summary
- `health-card-shell`: remove the absolutely-positioned left accent rail on warning/critical health cards — severity is already signaled by the card border color, the WARNING/CRITICAL pill, and the value/sparkline color, so the rail was a redundant (and visually heavy) fourth channel
- `health-detail-dialog`: add `min-w-0` to the `ScrollArea` so a wide detail-rows result table can no longer force the dialog past its own bounds (classic flex/grid `min-width: auto` overflow), and widen the dialog to `max-w-5xl` when it renders a detail table

## Test plan
- [x] `bun run build` (vite build + tsc --noEmit) passes
- [x] Biome check clean on changed files
- [x] Verified locally in browser: health card renders without the left rail; Memory Usage detail dialog content stays within the dialog bounds and widens to 1024px when showing detail rows
- [x] Full test suite (906 tests) passes via pre-push hook