### PR TITLE
feat(insights): separate AI Insights from Statistics Insights

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -66,6 +66,12 @@ primary secondary accent destructive border input ring`. Charts:
   `from-background`→`transparent` edge fade per scrollable side, paging via
   `scrollBy`. Re-measure on scroll / `ResizeObserver` / content-count change.
   Copy `components/insights/insights-strip.tsx`.
+- **Paired page sections** (e.g. AI-generated vs. plain-statistics content):
+  identical-weight header on both — `icon (size-4, muted-foreground) + <h2
+  className="text-sm font-medium text-foreground">`. An empty section still
+  gets the header, with an `EmptyState variant="no-data" compact` placeholder
+  card below it rather than being omitted. See `/insights` and
+  `/insights-settings` (`AI Insights` vs `Statistics Insights`).
 
 ## Charts — always wrap state, never hand-roll it
 

--- a/apps/dashboard/src/components/insights/insights-panel.tsx
+++ b/apps/dashboard/src/components/insights/insights-panel.tsx
@@ -117,15 +117,25 @@ export function InsightsPanel({ hostId, className }: InsightsPanelProps) {
       .sort((a, b) => a.topRank - b.topRank || b.items.length - a.items.length)
   }, [insights])
 
-  // Empty + idle → slim CTA row, so the panel never shows an empty box.
+  // Empty + idle → slim CTA row, so the panel never shows an empty box. Still
+  // carries the section header so "AI Insights" reads as a peer of "Cluster
+  // Statistics" below it, rather than a stray banner.
   if (!hasInsights && !isLoading) {
     return (
-      <InsightsEmptyCta
-        hostId={hostId}
-        isGenerating={isGenerating}
-        onGenerate={generate}
-        className={className}
-      />
+      <section
+        className={cn('flex flex-col gap-3', className)}
+        aria-label="AI insights"
+      >
+        <div className="flex items-center gap-2">
+          <Sparkles className="size-4 shrink-0 text-muted-foreground" />
+          <h2 className="text-sm font-medium text-foreground">AI Insights</h2>
+        </div>
+        <InsightsEmptyCta
+          hostId={hostId}
+          isGenerating={isGenerating}
+          onGenerate={generate}
+        />
+      </section>
     )
   }
 

--- a/apps/dashboard/src/routes/(dashboard)/insights-settings.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/insights-settings.tsx
@@ -1,10 +1,13 @@
-import { ArrowLeft } from 'lucide-react'
+import { ArrowLeft, BarChart3 } from 'lucide-react'
 import { createFileRoute } from '@tanstack/react-router'
 
 import { InsightsPreview } from '@/components/insights/insights-preview'
 import { InsightsSettingsForm } from '@/components/insights/insights-settings-form'
 import { AppLink } from '@/components/ui/app-link'
 import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { EmptyState } from '@/components/ui/empty-state'
+import { Separator } from '@/components/ui/separator'
 import { useHostId } from '@/lib/swr'
 import { buildUrl } from '@/lib/url/url-builder'
 
@@ -129,13 +132,44 @@ function InsightsSettingsPage() {
         </div>
       </div>
 
-      {/* Settings left, live example right — stacks on mobile. */}
-      <div className="grid gap-5 lg:grid-cols-[1fr_minmax(320px,380px)]">
-        <InsightsSettingsForm />
-        <div className="lg:sticky lg:top-6 lg:self-start">
-          <InsightsPreview hostId={hostId} autoRun />
+      {/* AI Insights — model, prompt style, enrichment; settings left, live example right. */}
+      <section className="space-y-3">
+        <div className="flex items-center gap-2">
+          <InsightsGlyph />
+          <h2 className="text-sm font-medium text-foreground">AI Insights</h2>
         </div>
-      </div>
+        <div className="grid gap-5 lg:grid-cols-[1fr_minmax(320px,380px)]">
+          <InsightsSettingsForm />
+          <div className="lg:sticky lg:top-6 lg:self-start">
+            <InsightsPreview hostId={hostId} autoRun />
+          </div>
+        </div>
+      </section>
+
+      <Separator />
+
+      {/* Statistics Insights — Record Breakers, Query Insights, and the other
+          Cluster Statistics sections on /insights. No per-section controls
+          exist yet; this is a placeholder so the settings surface stays
+          visible rather than silently absent. */}
+      <section className="space-y-3">
+        <div className="flex items-center gap-2">
+          <BarChart3 className="size-4 shrink-0 text-muted-foreground" />
+          <h2 className="text-sm font-medium text-foreground">
+            Statistics Insights
+          </h2>
+        </div>
+        <Card>
+          <CardContent className="pt-6">
+            <EmptyState
+              variant="no-data"
+              compact
+              title="No settings yet"
+              description="Record Breakers, Query Insights, and the other Cluster Statistics sections are always shown. Per-section visibility controls are planned."
+            />
+          </CardContent>
+        </Card>
+      </section>
     </div>
   )
 }

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -3,7 +3,7 @@ id: product-design
 title: Product design system & UX conventions
 type: reference
 status: active
-updated: 2026-07-04
+updated: 2026-07-05
 tags:
   - design-system
   - ui
@@ -129,6 +129,16 @@ sheet, sidebar, skeleton, tabs, tooltip (+ more).
 - Class idioms: card `rounded-xl border bg-card shadow-sm`; dense text
   `text-[13px]`; meta `text-xs text-muted-foreground`; hero title `text-xl
   font-semibold tracking-tight`.
+- **Paired page sections (e.g. AI-generated vs. plain-statistics content):**
+  give each section an identical-weight header — `icon (size-4, muted-foreground)
+  + <h2 className="text-sm font-medium text-foreground">` — never let one
+  section get a bold heading and the other just a bare CTA banner; that reads as
+  one being an afterthought. If a section has no content/settings yet, render a
+  labeled placeholder (`EmptyState variant="no-data" compact` inside a `Card`)
+  rather than omitting the section. Reference: `/insights` (`AI Insights` vs
+  `Cluster Statistics`) and `/insights-settings` (`AI Insights` vs
+  `Statistics Insights`) — `components/insights/insights-panel.tsx`,
+  `routes/(dashboard)/insights-settings.tsx`.
 - Overflow strip: for a single-row scroller that must not wrap, use
   `scrollbar-hide overflow-x-auto` (util in `styles.css`; also on the overview
   tab bar) with `py-*` so card shadows/accents/focus rings aren't clipped


### PR DESCRIPTION
## Summary
- `/insights`: the empty-state AI Insights CTA now carries a proper "AI Insights" section header, so it reads as a peer of "Cluster Statistics" below rather than a stray unlabeled banner (the populated state already had this header; only the empty/idle branch was missing it)
- `/insights-settings`: split into two labeled, equal-weight sections — **AI Insights** (existing templates/model/prompt-style form, unchanged) and **Statistics Insights** (a placeholder `EmptyState` card, since no per-section controls exist yet for Record Breakers / Query Insights / Cluster Activity / etc. — confirmed scope with the requester before building rather than guessing a full toggle system)
- Documented the paired-section-header convention (`icon + <h2 className="text-sm font-medium">`, identical weight on both sections, empty section still gets a labeled placeholder) in the `product-design` skill + its knowledge doc for reuse

## Test plan
- [x] `bun run build` (vite build + tsc --noEmit) passes
- [x] Biome check clean on changed files
- [x] Verified locally in browser: `/insights` shows symmetric "AI Insights" / "Cluster Statistics" headers in both empty and stat-grid states; `/insights-settings` shows the new "AI Insights" / "Statistics Insights" sections with the existing form intact and the new placeholder rendering correctly
- [x] Full test suite (906 tests) passes via pre-push hook