### PR TITLE
feat(ui): blur dialog background, document anti-slop design rule

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -36,6 +36,10 @@ values and file paths: `docs/knowledge/product-design.md`.
    `useHostId()` / `useChartData()` itself — do NOT prop-drill `hostId`.
 5. **`?host=N` routing**, never dynamic `/N/...` segments. Preserve other search
    params with `buildUrl(pathname, { host }, searchParams)`.
+6. **No "AI slop" decoration** — one clear signal per state, not several
+   redundant ones. No full-saturation accent bars/rails stacked on an
+   already-colored border; no gradient blobs/glow orbs behind icons. See
+   "Anti-patterns" in `docs/knowledge/product-design.md`.
 
 ## Tokens (semantic — use these names, not hex/oklch literals)
 

--- a/apps/dashboard/src/components/ui/dialog.tsx
+++ b/apps/dashboard/src/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        'fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0',
+        'fixed inset-0 z-50 bg-black/50 backdrop-blur-sm data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0',
         className
       )}
       {...props}

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -60,6 +60,32 @@ dialog, drawer, dropdown-menu, empty-state, form, hover-card, icon-button, input
 input-group, label, popover, progress, resizable, scroll-area, select, separator,
 sheet, sidebar, skeleton, tabs, tooltip (+ more).
 
+## Anti-patterns ("AI slop")
+
+Signals that a component was over-decorated rather than designed — each of
+these adds a channel that duplicates a signal another element already carries.
+Prefer ONE clear signal per piece of state, not several redundant ones.
+
+- **No decorative full-saturation accent bars/rails on cards.** A colored
+  left/top border stripe on top of an already-colored card border is
+  redundant — severity should already read from the border color, a status
+  pill/badge, and/or the value color. Incident: `health-card-shell.tsx` had
+  both a subtle `border-amber-500/30` AND a full-opacity 3px left rail for
+  the same warning state — the rail was removed, the border alone carries it.
+- **No gradient blobs / glow orbs behind icons or headers** unless the brand
+  system itself uses them (it doesn't — see Brand below). A plain icon in a
+  bordered square (`InsightsGlyph` pattern) reads cleaner than a soft-glow
+  circle.
+- **Don't stack more than one severity/status signal per element** — pick the
+  cheapest that reads clearly (usually: border/text color + a labeled pill).
+  Sparklines, icons, and badges are fine in combination when each carries
+  *different* information (trend vs. category vs. severity), not the same one
+  restated.
+- **Prefer the design system's existing idiom over inventing a new visual
+  language.** Before adding a new card treatment, dialog style, or badge
+  variant, grep for an existing one in `components/` — see "Canonical idioms"
+  in the `product-design` skill.
+
 ## Component patterns
 
 - **Charts:** `ChartContainer` (`components/charts/chart-container.tsx`) handles


### PR DESCRIPTION
## Summary
- Add `backdrop-blur-sm` to the shared `DialogOverlay` (`components/ui/dialog.tsx`) so every dialog in the app gets a frosted-glass background instead of a flat `bg-black/50` tint. Edited the shared primitive directly (per project convention this normally requires avoiding) since this tunes the component's own default and needs to apply to all ~20+ dialog call sites at once, not a one-off custom variant
- Document an "Anti-patterns (AI slop)" section in the `product-design` skill + knowledge doc — the class of over-decoration this project should avoid (redundant severity channels like a colored rail stacked on an already-colored border, gradient blobs, stacking multiple signals for the same state), using the recent health-card-shell left-rail removal as the concrete precedent

## Test plan
- [x] `bun run build` (vite build + tsc --noEmit) passes
- [x] Biome check clean on changed files
- [x] Verified locally in browser: opening a dialog (Health detail) now shows a visibly blurred background behind the overlay
- [x] Full test suite (906 tests) passes via pre-push hook