### PR TITLE
feat(charts): collapse to per-row mini preview instead of unmounting

### DIFF
--- a/apps/dashboard/src/components/layout/query-page/layout.tsx
+++ b/apps/dashboard/src/components/layout/query-page/layout.tsx
@@ -80,7 +80,7 @@ export const QueryPageLayout = function QueryPageLayout({
 }: QueryPageLayoutProps) {
   const { config, isLoading } = useFeaturePermissions()
   const relatedCharts = queryConfig.relatedCharts || []
-  const { isCollapsed, toggleCollapsed, collapsedRows, toggleRow } =
+  const { isCollapsed, toggleCollapsed, isRowCollapsed, toggleRow } =
     useChartsCollapsed()
   const hasCharts = relatedCharts.length > 0
   const featureState = resolveFeatureState(queryConfig.permission, config)
@@ -103,16 +103,17 @@ export const QueryPageLayout = function QueryPageLayout({
       {hasCharts && (
         <div className="flex flex-col gap-2">
           <ChartsToggle isCollapsed={isCollapsed} onToggle={toggleCollapsed} />
-          {!isCollapsed && (
-            <FadeIn duration={200}>
-              <RelatedCharts
-                relatedCharts={relatedCharts}
-                gridClass={chartsGridClass}
-                collapsedRows={collapsedRows}
-                onToggleRow={toggleRow}
-              />
-            </FadeIn>
-          )}
+          {/* Always mounted — collapsing shows a lightweight per-row summary
+              (ChartRowSummary/ChartChip, its own slow-polling fetch) instead
+              of the full chart grid, rather than unmounting it entirely. */}
+          <FadeIn duration={200}>
+            <RelatedCharts
+              relatedCharts={relatedCharts}
+              gridClass={chartsGridClass}
+              isRowCollapsed={isRowCollapsed}
+              onToggleRow={toggleRow}
+            />
+          </FadeIn>
         </div>
       )}
 

--- a/apps/dashboard/src/components/layout/query-page/related-charts.tsx
+++ b/apps/dashboard/src/components/layout/query-page/related-charts.tsx
@@ -24,8 +24,8 @@ import { cn } from '@/lib/utils'
 export interface RelatedChartsProps {
   relatedCharts: QueryConfig['relatedCharts']
   gridClass?: string
-  /** Row indices that are collapsed (only used for multi-row layout) */
-  collapsedRows?: Set<number>
+  /** Whether a given row index is collapsed (only used for multi-row layout) */
+  isRowCollapsed?: (rowIndex: number) => boolean
   /** Callback to toggle a specific row (only used for multi-row layout) */
   onToggleRow?: (rowIndex: number) => void
 }
@@ -33,7 +33,7 @@ export interface RelatedChartsProps {
 export const RelatedCharts = function RelatedCharts({
   relatedCharts,
   gridClass,
-  collapsedRows,
+  isRowCollapsed,
   onToggleRow,
 }: RelatedChartsProps) {
   if (!relatedCharts || relatedCharts.length === 0) {
@@ -53,7 +53,7 @@ export const RelatedCharts = function RelatedCharts({
           key={`row-${rowIndex}`}
           rowIndex={rowIndex}
           charts={rowCharts}
-          isCollapsed={collapsedRows?.has(rowIndex) ?? false}
+          isCollapsed={isRowCollapsed?.(rowIndex) ?? false}
           onToggle={() => onToggleRow?.(rowIndex)}
         />
       ))}

--- a/apps/dashboard/src/components/layout/query-page/use-charts-collapsed.ts
+++ b/apps/dashboard/src/components/layout/query-page/use-charts-collapsed.ts
@@ -18,7 +18,6 @@ interface ChartsRowsState {
 
 export interface UseChartsCollapsedReturn {
   isCollapsed: boolean
-  collapsedRows: Set<number>
   toggleCollapsed: () => void
   toggleRow: (index: number) => void
   isRowCollapsed: (index: number) => boolean
@@ -76,11 +75,14 @@ export function useChartsCollapsed(
     typeof window !== 'undefined' ? loadFromStorage() : DEFAULT_STATE
   )
 
+  // The master switch resets per-row overrides — a row explicitly toggled
+  // under one master state (e.g. "Show" while collapsed) shouldn't carry an
+  // ambiguous meaning once the master state flips again.
   const toggleCollapsed = () => {
     setState((prev) => {
       const newState = {
         allCollapsed: !prev.allCollapsed,
-        collapsedRows: prev.collapsedRows,
+        collapsedRows: [],
       }
       persistState(newState)
       return newState
@@ -106,13 +108,18 @@ export function useChartsCollapsed(
     })
   }
 
+  // When the master switch is off, collapsedRows lists rows individually
+  // collapsed. When it's on, every row is collapsed by default and
+  // collapsedRows instead lists exceptions the user expanded back out (via
+  // the row's own "Show" control) — so toggleRow's plain flip works
+  // correctly in both directions without knowing which mode it's in.
   const isRowCollapsed = (index: number): boolean => {
-    return state.collapsedRows.includes(index)
+    const isException = state.collapsedRows.includes(index)
+    return state.allCollapsed ? !isException : isException
   }
 
   return {
     isCollapsed: state.allCollapsed,
-    collapsedRows: new Set(state.collapsedRows),
     toggleCollapsed,
     toggleRow,
     isRowCollapsed,


### PR DESCRIPTION
## Summary
Previously "Collapse Charts" fully unmounted the entire related-charts strip. Now it shows every row as a dense one-line summary (chart name, latest value, trend %, mini sparkline) instead of nothing — reusing the existing `ChartRowSummary`/`ChartChip` component (which already had its own slow 5m-refresh data fetch, separate from the heavy `DynamicChart` it replaces), so heavy charts still get unmounted per the project's documented pattern while the collapsed state stays informative rather than blank.

- `use-charts-collapsed`: the master toggle now clears per-row overrides and flips their meaning — `collapsedRows` lists individually-collapsed rows when the master is off, but lists expanded *exceptions* when the master is on, so each row's own Show/Hide control keeps working correctly in both directions regardless of master state. `isRowCollapsed` (already part of the hook's public API, just unwired until now) is now the single source of truth for both call sites.
- `related-charts` / `layout`: consume `isRowCollapsed` instead of a raw `collapsedRows` Set, and always render `RelatedCharts` rather than gating it on the master `isCollapsed` flag.

## Test plan
- [x] `bun run build` (vite build + tsc --noEmit) passes
- [x] Biome check clean on changed files
- [x] Verified locally in browser (`/history-queries`, 5 chart rows): Collapse Charts shows all rows as compact summaries with mini sparklines; hovering a row reveals "Show"; clicking it expands just that row to full charts while others stay compact; Expand Charts restores the full grid
- [x] Full test suite (906 tests) passes via pre-push hook