### PR TITLE
feat(health): add mini trend sparkline to dense health check rows

### DIFF
--- a/apps/dashboard/src/components/health/health-card-shell.tsx
+++ b/apps/dashboard/src/components/health/health-card-shell.tsx
@@ -126,9 +126,10 @@ function interactiveProps(title: string, onExpand: (() => void) | undefined) {
 }
 
 /**
- * Dense single-line layout for healthy / unavailable checks. No sparkline — a
- * healthy check sits flat, so a trend line here would be pure decoration. Links
- * stay reachable via the detail dialog, keeping the row uncluttered.
+ * Dense single-line layout for healthy / unavailable checks. Carries a small
+ * trend sparkline — even a flat healthy line answers "was this always 0, or
+ * did it just drop?" at a glance, without the row growing into a full card.
+ * Links stay reachable via the detail dialog, keeping the row uncluttered.
  */
 function HealthCheckRow({
   icon: Icon,
@@ -136,8 +137,11 @@ function HealthCheckRow({
   status,
   displayValue,
   sublabel,
+  spark,
   onExpand,
 }: HealthCardShellProps) {
+  const series = toSeries(spark)
+
   return (
     <div
       {...interactiveProps(title, onExpand)}
@@ -165,6 +169,15 @@ function HealthCheckRow({
       <span className="hidden min-w-0 flex-1 truncate text-xs text-muted-foreground sm:block">
         {sublabel}
       </span>
+      {series && (
+        <div className="hidden h-4 w-12 flex-none sm:block" aria-hidden>
+          <MiniAreaChart
+            data={series}
+            label={title}
+            color={SPARK_COLOR[status]}
+          />
+        </div>
+      )}
       <span
         className={cn(
           'ml-auto flex-none font-mono text-sm font-semibold tabular-nums sm:ml-0',


### PR DESCRIPTION
## Summary
The dense row layout (healthy/unavailable checks on `/health`) previously rendered no trend line, on the theory that a flat healthy line would be pure decoration. In practice a flat line still answers a real question — "was this always 0, or did it just drop?" — so it's now rendered at a small size consistent with the row's density (hidden on mobile, matching the existing sublabel's responsive behavior).

The data was already flowing through unused: `health-grid.tsx` computes and passes spark history to row items exactly as it does for cards (`item.render(spark(item), 'row')`), and `HealthCardShellProps` already carried `spark` for both variants — only the row layout itself (`HealthCheckRow`) was ignoring it.

## Test plan
- [x] `bun run build` (vite build + tsc --noEmit) passes
- [x] Biome check clean on changed file
- [x] Verified locally in browser (`/health`): sparkline renders in dense rows using real (if currently flat, single-observation) data
- [x] Full test suite (906 tests) passes via pre-push hook