### PR TITLE
fix(ui): repair Radix to Base UI migration style regressions

### DIFF
--- a/apps/dashboard/src/styles.css
+++ b/apps/dashboard/src/styles.css
@@ -6,6 +6,16 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* Base UI orientation variants. Base UI emits `data-orientation="horizontal|vertical"`
+   (verified against @base-ui/react tabs/separator/scroll-area). The shadcn Base UI
+   components (tabs, separator, scroll-area, button-group) style off `data-horizontal:`
+   / `data-vertical:` (and their `group-` forms). Without these declarations Tailwind v4
+   compiles `data-horizontal:` to `&[data-horizontal]`, which never matches
+   `data-orientation="horizontal"` — leaving those components with the wrong flex axis
+   (e.g. Tabs list + panel sit side-by-side and the panel collapses to empty). */
+@custom-variant data-horizontal (&[data-orientation='horizontal']);
+@custom-variant data-vertical (&[data-orientation='vertical']);
+
 /* Theme extensions ported from the Next app's tailwind.config.js. The Next
    globals.css loads them via `@config '../tailwind.config.js'`; the TanStack
    app is pure Tailwind v4 CSS-first, so they live inline here. Keyframes and


### PR DESCRIPTION
## Problem

The Radix→Base UI migration (#2361) shipped several regressions that `tsc` could not catch because they are **CSS/attribute-name mismatches only**. Most visible: **Tabs** rendered the list and panel side-by-side with an empty panel on `/overview`, `/agents/settings`, and every tabbed page.

## Root causes & fixes

**1. Orientation variants never declared** (`styles.css`)
The shadcn Base UI components (`tabs`, `separator`, `scroll-area`, `button-group`) style off `data-horizontal:`/`data-vertical:` variants. Base UI emits `data-orientation="horizontal|vertical"`, so Tailwind v4 compiled `data-horizontal:` to the attribute-existence selector `&[data-horizontal]` — never matching. Added the two `@custom-variant` aliases mapping to `[data-orientation=...]`. This alone repairs **tabs, separator, scroll-area, button-group** (incl. the failed-queries exception dialog scroll).

**2. Radix CSS vars still referenced** (undefined under Base UI → dead animation/layout)
- Accordion keyframes: `--radix-accordion-content-height` → `--accordion-panel-height`.
- Collapsible: registered local keyframes off `--collapsible-panel-height` (tw-animate-css uses the Radix var); switched Panel selectors `data-[state=open|closed]` → `data-open`/`data-closed`.
- Dropdown width: `w-[--radix-dropdown-menu-trigger-width]` → `w-(--anchor-width)` (nav-user, host-switcher, clerk-nav).
- Popover clamp: `--radix-popover-content-available-height` → `--available-height` (composer toolbar).

**3. Data-attribute mismatch**
- Collapsible chevron (queue): Base UI trigger emits `data-panel-open`, not `data-state=closed` → `-rotate-90 group-data-[panel-open]:rotate-0`.

## Verification
- `pnpm run build` passes (tsc + Vite + prerender of all routes).
- Pre-push suite: 906 tests, 0 fail.
- Compiled CSS confirmed: orientation selectors now target `[data-orientation=...]`; **no `radix-` CSS vars remain** in the built stylesheet.

Ground truth verified against `@base-ui/react` `*DataAttributes.js` / `*CssVars.js` for every attribute and var name.