### PR TITLE
fix(ui): fix Base UI CSS-var and data-attr mismatches from #2361

### DIFF
--- a/apps/dashboard/src/components/agents/welcome/composer-toolbar.tsx
+++ b/apps/dashboard/src/components/agents/welcome/composer-toolbar.tsx
@@ -106,7 +106,7 @@ export function ComposerToolbar({
         <PopoverContent
           align="start"
           sideOffset={4}
-          className="flex max-h-[min(28rem,var(--radix-popover-content-available-height))] w-[340px] flex-col overflow-hidden p-1"
+          className="flex max-h-[min(28rem,var(--available-height))] w-[340px] flex-col overflow-hidden p-1"
         >
           <div className="text-muted-foreground shrink-0 px-2 py-1.5 text-[10px] font-semibold tracking-wider uppercase">
             Skills
@@ -193,7 +193,7 @@ export function ComposerToolbar({
         <PopoverContent
           align="start"
           sideOffset={4}
-          className="flex max-h-[min(28rem,var(--radix-popover-content-available-height))] w-[320px] flex-col overflow-hidden p-1"
+          className="flex max-h-[min(28rem,var(--available-height))] w-[320px] flex-col overflow-hidden p-1"
         >
           <div className="text-muted-foreground flex shrink-0 items-center justify-between px-2 py-1.5 text-[10px] font-semibold tracking-wider uppercase">
             <span>Tools</span>

--- a/apps/dashboard/src/components/ai-elements/queue.tsx
+++ b/apps/dashboard/src/components/ai-elements/queue.tsx
@@ -245,7 +245,7 @@ export const QueueSectionLabel = ({
   ...props
 }: QueueSectionLabelProps) => (
   <span className={cn('flex items-center gap-2', className)} {...props}>
-    <ChevronDownIcon className="group-data-[state=closed]:-rotate-90 size-4 transition-transform" />
+    <ChevronDownIcon className="-rotate-90 group-data-[panel-open]:rotate-0 size-4 transition-transform" />
     {icon}
     <span>
       {count} {label}

--- a/apps/dashboard/src/components/assistant-ui/reasoning.tsx
+++ b/apps/dashboard/src/components/assistant-ui/reasoning.tsx
@@ -149,8 +149,8 @@ export function ReasoningContent({
     <CollapsibleContent
       className={cn(
         'overflow-hidden',
-        'data-[state=closed]:animate-collapsible-up',
-        'data-[state=open]:animate-collapsible-down'
+        'data-closed:animate-collapsible-up',
+        'data-open:animate-collapsible-down'
       )}
     >
       <div className={cn('px-3 py-2', className)}>{children}</div>

--- a/apps/dashboard/src/components/assistant-ui/tool-group.tsx
+++ b/apps/dashboard/src/components/assistant-ui/tool-group.tsx
@@ -156,8 +156,8 @@ export function ToolGroupContent({
     <CollapsibleContent
       className={cn(
         'overflow-hidden',
-        'data-[state=closed]:animate-collapsible-up',
-        'data-[state=open]:animate-collapsible-down'
+        'data-closed:animate-collapsible-up',
+        'data-open:animate-collapsible-down'
       )}
     >
       <div className={cn('flex flex-col gap-0', className)}>{children}</div>

--- a/apps/dashboard/src/components/host/host-switcher.tsx
+++ b/apps/dashboard/src/components/host/host-switcher.tsx
@@ -253,7 +253,7 @@ export function HostSwitcher() {
                 )}
               </DropdownMenuTrigger>
               <DropdownMenuContent
-                className="w-[--radix-dropdown-menu-trigger-width] min-w-56 rounded-lg"
+                className="w-(--anchor-width) min-w-56 rounded-lg"
                 align="start"
                 side={isMobile ? 'bottom' : 'right'}
                 sideOffset={4}

--- a/apps/dashboard/src/components/nav-user.tsx
+++ b/apps/dashboard/src/components/nav-user.tsx
@@ -113,7 +113,7 @@ export function NavUser({
             <DropdownMenu modal={false}>
               <DropdownMenuTrigger render={userButton} />
               <DropdownMenuContent
-                className="w-[--radix-dropdown-menu-trigger-width] min-w-56 rounded-lg"
+                className="w-(--anchor-width) min-w-56 rounded-lg"
                 side={isMobile ? 'bottom' : 'right'}
                 align="end"
                 sideOffset={4}

--- a/apps/dashboard/src/components/nav-user/clerk-nav.tsx
+++ b/apps/dashboard/src/components/nav-user/clerk-nav.tsx
@@ -198,7 +198,7 @@ export function ClerkNavWrapper() {
                 <ChevronsUpDown className="ml-auto size-4" />
               </DropdownMenuTrigger>
               <DropdownMenuContent
-                className="w-[--radix-dropdown-menu-trigger-width] min-w-56 rounded-lg"
+                className="w-(--anchor-width) min-w-56 rounded-lg"
                 side={isMobile ? 'bottom' : 'right'}
                 align="end"
                 sideOffset={4}

--- a/apps/dashboard/src/styles.css
+++ b/apps/dashboard/src/styles.css
@@ -24,6 +24,12 @@
   --animate-shimmer: shimmer 1.5s infinite;
   --animate-accordion-down: accordion-down 0.2s ease-out;
   --animate-accordion-up: accordion-up 0.2s ease-out;
+  /* Override tw-animate-css's collapsible animations, which drive height off the
+     Radix var `--radix-collapsible-content-height`. Base UI's Collapsible.Panel
+     exposes `--collapsible-panel-height` instead, so the imported keyframes
+     resolved to nothing and the expand/collapse was dead. */
+  --animate-collapsible-down: collapsible-down 0.2s ease-out;
+  --animate-collapsible-up: collapsible-up 0.2s ease-out;
   --animate-fade-in: fade-in 0.2s ease-out;
   --animate-scale-in: scale-in 0.2s ease-out;
   --animate-pulse-subtle: pulse-subtle 3s ease-in-out infinite;
@@ -40,12 +46,28 @@
       height: 0;
     }
     to {
-      height: var(--radix-accordion-content-height);
+      height: var(--accordion-panel-height);
     }
   }
   @keyframes accordion-up {
     from {
-      height: var(--radix-accordion-content-height);
+      height: var(--accordion-panel-height);
+    }
+    to {
+      height: 0;
+    }
+  }
+  @keyframes collapsible-down {
+    from {
+      height: 0;
+    }
+    to {
+      height: var(--collapsible-panel-height);
+    }
+  }
+  @keyframes collapsible-up {
+    from {
+      height: var(--collapsible-panel-height);
     }
     to {
       height: 0;


### PR DESCRIPTION
Follow-up to #2363. That PR fixed the orientation-variant breakage (tabs, separator, scroll-area, button-group); this one fixes the remaining Radix→Base UI **CSS-var / data-attribute** mismatches from #2361 that `tsc` can't catch (they live only in classNames and keyframes).

- **Accordion**: keyframes drove height off `--radix-accordion-content-height`; Base UI exposes `--accordion-panel-height`.
- **Collapsible**: registered local keyframes off `--collapsible-panel-height` (tw-animate-css uses the Radix var), and switched Panel selectors `data-[state=open|closed]` → `data-open`/`data-closed` (reasoning, tool-group).
- **Collapsible chevron** (queue): Base UI trigger emits `data-panel-open`, not `data-state=closed` → `-rotate-90 group-data-[panel-open]:rotate-0`.
- **Dropdown width**: `w-[--radix-dropdown-menu-trigger-width]` → `w-(--anchor-width)` (nav-user, host-switcher, clerk-nav).
- **Popover clamp**: `--radix-popover-content-available-height` → `--available-height` (composer toolbar).

Verified: build passes; no `radix-` CSS vars remain in the compiled stylesheet. Attribute/var names confirmed against `@base-ui/react` `*DataAttributes.js` / `*CssVars.js`.