### PR TITLE
fix(ui): neutral chart skeleton on dark, wider failed-query dialogs

### DIFF
--- a/apps/dashboard/src/components/skeletons/chart.tsx
+++ b/apps/dashboard/src/components/skeletons/chart.tsx
@@ -28,7 +28,7 @@ const AreaChartSkeleton = () => (
     {/* Simulated wave SVG with gradient sweep */}
     <div className="relative w-full h-[90px] mt-auto">
       <svg
-        className="w-full h-full text-primary/10 dark:text-primary/5"
+        className="w-full h-full text-muted-foreground/15 dark:text-muted-foreground/10"
         viewBox="0 0 400 100"
         preserveAspectRatio="none"
       >
@@ -81,7 +81,7 @@ const LineChartSkeleton = () => (
     {/* Simulated wave SVG with gradient sweep */}
     <div className="relative w-full h-[90px] mt-auto">
       <svg
-        className="w-full h-full text-primary/20 dark:text-primary/10"
+        className="w-full h-full text-muted-foreground/25 dark:text-muted-foreground/15"
         viewBox="0 0 400 100"
         preserveAspectRatio="none"
       >
@@ -148,7 +148,7 @@ const MetricCardSkeleton = () => (
     </div>
 
     {/* Trend Sparkline line */}
-    <div className="w-[30%] h-12 self-end pb-1 opacity-25 dark:opacity-15 text-primary">
+    <div className="w-[30%] h-12 self-end pb-1 opacity-25 dark:opacity-15 text-muted-foreground">
       <svg
         className="h-full w-full"
         viewBox="0 0 100 30"

--- a/apps/dashboard/src/lib/query-config/queries/failed-queries.ts
+++ b/apps/dashboard/src/lib/query-config/queries/failed-queries.ts
@@ -235,6 +235,10 @@ export const failedQueriesConfig: QueryConfig = {
         max_truncate: 100,
         dialog_title: 'Exception',
         trigger_classname: '!max-w-[280px] overflow-hidden',
+        // Exception payloads are often long, wide stack-ish text — give them a
+        // wider dialog than the default so lines wrap less; the body still
+        // scrolls (ScrollArea) when the content overflows vertically.
+        dialog_classname: 'w-[min(97vw,1400px)]',
       },
     ],
     stack_trace: [
@@ -243,6 +247,7 @@ export const failedQueriesConfig: QueryConfig = {
         max_truncate: 100,
         dialog_title: 'Stack Trace',
         trigger_classname: '!max-w-[280px] overflow-hidden',
+        dialog_classname: 'w-[min(97vw,1400px)]',
       },
     ],
     client: ColumnFormat.CodeDialog,


### PR DESCRIPTION
Two small UI fixes reported after the Base UI work:

**1. Chart skeleton dark-mode color** — the area/line/bar chart skeletons tinted their simulated wave with the blue `primary` token, which reads as a colored mini-chart on the dark surface. Switched to neutral `muted-foreground` so the placeholder reads as absence-of-content (matching the shadcn `Skeleton` primitive).

**2. `/failed-queries` Exception / Stack Trace dialogs** — widened to `min(97vw,1400px)` so long payloads wrap less. The body still scrolls vertically via the existing `ScrollArea` (whose scroll behavior was itself repaired by #2363).