### PR TITLE
feat(insights): mock example preview (no LLM) + threshold settings

### DIFF
--- a/apps/dashboard/src/components/insights/insights-preview.tsx
+++ b/apps/dashboard/src/components/insights/insights-preview.tsx
@@ -3,70 +3,44 @@
 /**
  * AI Insights settings example/preview.
  *
- * Runs insight generation with the operator's *current* settings (model / prompt
- * style / enrichment) via an isolated mutation — it never touches the overview
- * panel's TanStack Query cache, so the settings page acts as a sandbox for
- * A/B-ing prompt styles and models before relying on them. With `autoRun` it
- * generates one example on mount so the page shows a live sample immediately.
+ * Renders a **static, illustrative** set of example insight cards that reflect
+ * the operator's current settings (prompt style / enrichment / window). It makes
+ * NO network or LLM call, so the example always renders — including for
+ * anonymous visitors and read-only demo hosts, which previously only saw
+ * "Couldn't generate — the cluster may be unreachable or read-only."
+ *
+ * This is sample data, not live cluster analysis; the header labels it "Sample".
+ * The real generation still runs on the overview panel and via the cron.
  */
 
 import { FlaskConical, RefreshCw } from 'lucide-react'
-import { useMutation } from '@tanstack/react-query'
 
-import type { InsightCard as InsightCardData } from '@/lib/insights/types'
-
-import { useEffect, useRef, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { InsightCard } from '@/components/insights/insight-card'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Skeleton } from '@/components/ui/skeleton'
-import { generateParamsFromSettings } from '@/lib/insights/settings'
+import { buildMockInsights } from '@/lib/insights/mock-preview'
 import { useInsightsSettings } from '@/lib/query/use-insights-settings'
-import { apiFetch } from '@/lib/swr/api-fetch'
-
-interface PreviewResponse {
-  insights: InsightCardData[]
-  count: number
-}
 
 export function InsightsPreview({
   hostId,
-  autoRun = false,
+  // `autoRun` is kept for API compatibility with call sites; the example now
+  // renders synchronously so there is nothing to defer.
+  autoRun: _autoRun = false,
 }: {
   hostId: number
   autoRun?: boolean
 }) {
   const { settings } = useInsightsSettings()
+  const [seed, setSeed] = useState(0)
   const [dismissed, setDismissed] = useState<Set<string>>(new Set())
 
-  const preview = useMutation({
-    mutationFn: async (): Promise<PreviewResponse> => {
-      // Explicit "Regenerate example" click → force past the server throttle.
-      const params = generateParamsFromSettings(hostId, settings, {
-        force: true,
-      })
-      const res = await apiFetch(`/api/v1/insights/generate?${params}`, {
-        method: 'POST',
-      })
-      if (!res.ok) throw new Error('Failed to generate preview')
-      return res.json()
-    },
-    onMutate: () => setDismissed(new Set()),
-  })
-
-  // Generate one example on mount when asked, so the page is never empty.
-  const mutate = preview.mutate
-  const didAutoRun = useRef(false)
-  useEffect(() => {
-    if (autoRun && !didAutoRun.current) {
-      didAutoRun.current = true
-      mutate()
-    }
-  }, [autoRun, mutate])
-
-  const results = (preview.data?.insights ?? []).filter(
-    (i) => !dismissed.has(i.key)
+  const insights = useMemo(
+    () => buildMockInsights(hostId, settings, seed),
+    [hostId, settings, seed]
   )
+  const results = insights.filter((i) => !dismissed.has(i.key))
 
   return (
     <Card>
@@ -74,38 +48,28 @@ export function InsightsPreview({
         <CardTitle className="flex items-center gap-2 text-base">
           <FlaskConical className="size-4 text-violet-500" />
           Example
+          <Badge variant="secondary" className="font-normal text-[10px]">
+            Sample
+          </Badge>
         </CardTitle>
         <Button
           type="button"
           variant="ghost"
           size="sm"
           className="h-7 shrink-0 gap-1.5 px-2 text-xs"
-          onClick={() => preview.mutate()}
-          disabled={preview.isPending}
-          aria-label="Regenerate example"
+          onClick={() => {
+            setDismissed(new Set())
+            setSeed((s) => s + 1)
+          }}
+          aria-label="Show another example"
         >
-          <RefreshCw
-            className={preview.isPending ? 'size-3.5 animate-spin' : 'size-3.5'}
-          />
-          {preview.isPending ? 'Generating…' : 'Regenerate'}
+          <RefreshCw className="size-3.5" />
+          Regenerate
         </Button>
       </CardHeader>
 
-      <CardContent>
-        {preview.isPending && results.length === 0 ? (
-          <div className="space-y-3">
-            <Skeleton className="h-24 w-full rounded-lg" />
-            <Skeleton className="h-24 w-full rounded-lg" />
-          </div>
-        ) : preview.isError ? (
-          <p className="text-sm text-destructive">
-            Couldn’t generate — the cluster may be unreachable or read-only.
-          </p>
-        ) : preview.isSuccess && results.length === 0 ? (
-          <p className="text-sm text-muted-foreground">
-            Nothing notable on this cluster right now.
-          </p>
-        ) : results.length > 0 ? (
+      <CardContent className="space-y-3">
+        {results.length > 0 ? (
           <div className="grid grid-cols-1 gap-3">
             {results.map((insight) => (
               <InsightCard
@@ -120,9 +84,13 @@ export function InsightsPreview({
           </div>
         ) : (
           <p className="text-sm text-muted-foreground">
-            Regenerate to preview insights with your current settings.
+            All examples dismissed — Regenerate to show another set.
           </p>
         )}
+        <p className="text-[11px] leading-relaxed text-muted-foreground">
+          Illustrative sample reflecting your settings — not live analysis of
+          this cluster. Real insights appear on the overview page.
+        </p>
       </CardContent>
     </Card>
   )

--- a/apps/dashboard/src/components/insights/stats-insights-settings-form.tsx
+++ b/apps/dashboard/src/components/insights/stats-insights-settings-form.tsx
@@ -1,0 +1,164 @@
+'use client'
+
+/**
+ * Statistics Insights settings form.
+ *
+ * Per-user controls for the anomaly overlays drawn on the statistical charts
+ * (`/queries/insights`, Cluster Statistics): a moving-average line + ±k·σ band,
+ * and an optional absolute threshold line. Persisted by
+ * `useStatsInsightsSettings`; changes apply immediately and broadcast to the
+ * charts. Mirrors the AI Insights settings form layout.
+ */
+
+import { RotateCcw } from 'lucide-react'
+
+import { useId } from 'react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
+import {
+  BAND_MULTIPLIER_RANGE,
+  MA_WINDOW_RANGE,
+} from '@/lib/insights/stats-settings'
+import { useStatsInsightsSettings } from '@/lib/query/use-stats-insights-settings'
+import { cn } from '@/lib/utils'
+
+export function StatsInsightsSettingsForm({
+  className,
+}: {
+  className?: string
+}) {
+  const { settings, update, reset } = useStatsInsightsSettings()
+  const maId = useId()
+  const bandId = useId()
+  const thresholdId = useId()
+
+  return (
+    <Card className={cn(className)}>
+      <CardContent className="space-y-5 pt-6">
+        {/* Moving average + band */}
+        <div className="space-y-3">
+          <div className="flex items-center justify-between gap-4">
+            <div className="space-y-0.5">
+              <Label className="text-sm font-medium">Moving average band</Label>
+              <p className="text-xs text-muted-foreground">
+                Overlay a rolling average with a ±k·σ band; points outside the
+                band are flagged as anomalies.
+              </p>
+            </div>
+            <Switch
+              checked={settings.showMovingAverage}
+              onCheckedChange={(v) => update({ showMovingAverage: v })}
+              aria-label="Toggle moving-average band"
+            />
+          </div>
+
+          <div
+            className={cn(
+              'grid grid-cols-2 gap-3',
+              !settings.showMovingAverage && 'pointer-events-none opacity-50'
+            )}
+          >
+            <div className="space-y-1.5">
+              <Label htmlFor={maId} className="text-xs text-muted-foreground">
+                Window (points)
+              </Label>
+              <Input
+                id={maId}
+                type="number"
+                inputMode="numeric"
+                min={MA_WINDOW_RANGE.min}
+                max={MA_WINDOW_RANGE.max}
+                value={settings.maWindow}
+                disabled={!settings.showMovingAverage}
+                onChange={(e) => update({ maWindow: Number(e.target.value) })}
+                className="h-8"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor={bandId} className="text-xs text-muted-foreground">
+                Band width (×σ)
+              </Label>
+              <Input
+                id={bandId}
+                type="number"
+                inputMode="decimal"
+                step={0.5}
+                min={BAND_MULTIPLIER_RANGE.min}
+                max={BAND_MULTIPLIER_RANGE.max}
+                value={settings.bandMultiplier}
+                disabled={!settings.showMovingAverage}
+                onChange={(e) =>
+                  update({ bandMultiplier: Number(e.target.value) })
+                }
+                className="h-8"
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Absolute threshold */}
+        <div className="space-y-3 border-t pt-4">
+          <div className="flex items-center justify-between gap-4">
+            <div className="space-y-0.5">
+              <Label className="text-sm font-medium">Absolute threshold</Label>
+              <p className="text-xs text-muted-foreground">
+                Draw a fixed horizontal line; points above it are highlighted.
+              </p>
+            </div>
+            <Switch
+              checked={settings.showThreshold}
+              onCheckedChange={(v) => update({ showThreshold: v })}
+              aria-label="Toggle absolute threshold line"
+            />
+          </div>
+
+          <div
+            className={cn(
+              'space-y-1.5',
+              !settings.showThreshold && 'pointer-events-none opacity-50'
+            )}
+          >
+            <Label
+              htmlFor={thresholdId}
+              className="text-xs text-muted-foreground"
+            >
+              Threshold value
+            </Label>
+            <Input
+              id={thresholdId}
+              type="number"
+              inputMode="decimal"
+              min={0}
+              placeholder="e.g. 1000"
+              value={settings.threshold ?? ''}
+              disabled={!settings.showThreshold}
+              onChange={(e) =>
+                update({
+                  threshold:
+                    e.target.value === '' ? null : Number(e.target.value),
+                })
+              }
+              className="h-8"
+            />
+          </div>
+        </div>
+
+        <div className="flex justify-end">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1.5 text-xs text-muted-foreground"
+            onClick={reset}
+          >
+            <RotateCcw className="size-3" />
+            Reset
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/dashboard/src/lib/insights/mock-preview.test.ts
+++ b/apps/dashboard/src/lib/insights/mock-preview.test.ts
@@ -1,0 +1,52 @@
+import { buildMockInsights } from './mock-preview'
+import { DEFAULT_INSIGHTS_SETTINGS } from './settings'
+import { describe, expect, test } from 'bun:test'
+
+describe('buildMockInsights', () => {
+  test('is deterministic for the same inputs (SSR-safe, no randomness)', () => {
+    const a = buildMockInsights(0, DEFAULT_INSIGHTS_SETTINGS, 0)
+    const b = buildMockInsights(0, DEFAULT_INSIGHTS_SETTINGS, 0)
+    expect(a).toEqual(b)
+    expect(a).toHaveLength(3)
+  })
+
+  test('every card has a stable dismissal key and required fields', () => {
+    for (const card of buildMockInsights(2, DEFAULT_INSIGHTS_SETTINGS)) {
+      expect(card.key).toContain('2:')
+      expect(card.title.length).toBeGreaterThan(0)
+      expect(card.detail.length).toBeGreaterThan(0)
+    }
+  })
+
+  test('seed rotates which templates are shown', () => {
+    const s0 = buildMockInsights(0, DEFAULT_INSIGHTS_SETTINGS, 0)
+    const s1 = buildMockInsights(0, DEFAULT_INSIGHTS_SETTINGS, 1)
+    expect(s0.map((c) => c.title)).not.toEqual(s1.map((c) => c.title))
+  })
+
+  test('enrich=false yields the terse deterministic copy; enrich=true is richer', () => {
+    const off = buildMockInsights(0, {
+      ...DEFAULT_INSIGHTS_SETTINGS,
+      enrich: false,
+    })
+    const on = buildMockInsights(0, {
+      ...DEFAULT_INSIGHTS_SETTINGS,
+      enrich: true,
+      promptStyle: 'detailed',
+    })
+    // Same first card, but the enriched detail is longer than the raw metric line.
+    expect(on[0].detail.length).toBeGreaterThan(off[0].detail.length)
+  })
+
+  test('window is interpolated into enriched copy, never leaks the {window} token', () => {
+    const cards = buildMockInsights(0, {
+      ...DEFAULT_INSIGHTS_SETTINGS,
+      enrich: true,
+      promptStyle: 'detailed',
+      window: '24 HOUR',
+    })
+    const joined = cards.map((c) => c.detail).join(' ')
+    expect(joined).toContain('the last 24 hours')
+    expect(joined).not.toContain('{window}')
+  })
+})

--- a/apps/dashboard/src/lib/insights/mock-preview.ts
+++ b/apps/dashboard/src/lib/insights/mock-preview.ts
@@ -1,0 +1,148 @@
+/**
+ * Static, deterministic mock insights for the settings "Example" preview.
+ *
+ * The settings page shows an example of what AI Insights look like. Calling the
+ * real generation endpoint there is a poor fit: it needs a reachable, writable
+ * cluster and a configured LLM, so anonymous visitors (and read-only demo hosts)
+ * only ever saw "Couldn't generate — the cluster may be unreachable or
+ * read-only." These mock cards let the example always render, with NO network or
+ * LLM call, while still reflecting the operator's current settings so the page
+ * stays a useful sandbox for A/B-ing prompt style / enrichment.
+ *
+ * This is illustrative sample data, never real cluster analysis — the preview UI
+ * labels it as such.
+ */
+
+import type { InsightsSettings } from './settings'
+
+import { type InsightCard, insightKey } from './types'
+
+interface MockTemplate {
+  readonly severity: InsightCard['severity']
+  readonly category: string
+  readonly metric: string
+  readonly value: number
+  readonly title: string
+  /** Copy variants keyed by prompt style; `deterministic` is the un-enriched form. */
+  readonly detail: Record<
+    InsightsSettings['promptStyle'] | 'deterministic',
+    string
+  >
+  readonly action?: InsightCard['action']
+}
+
+/** Human label for the read window, e.g. `6 HOUR` → "the last 6 hours". */
+function windowPhrase(window: string): string {
+  const [n, unit] = window.split(' ')
+  const lower = (unit ?? '').toLowerCase()
+  const plural = n === '1' ? lower : `${lower}s`
+  return `the last ${n} ${plural}`
+}
+
+const TEMPLATES: readonly MockTemplate[] = [
+  {
+    severity: 'warning',
+    category: 'performance',
+    metric: 'slow_query_p99',
+    value: 4200,
+    title: 'p99 query latency climbing',
+    detail: {
+      deterministic: 'p99 query duration is 4.2s (baseline 1.8s).',
+      concise:
+        'p99 query latency reached 4.2s, ~2.3× the 1.8s baseline — a handful of large scans on `events` are dominating.',
+      detailed:
+        'p99 query duration rose to 4.2s over {window}, about 2.3× the 1.8s weekly baseline. The regression traces to a few full scans on `events` that read ~9.4B rows each; adding a partition filter or a projection on `event_date` would cut the read set sharply.',
+      beginner:
+        'The slowest 1% of queries now take about 4.2 seconds — more than double the usual 1.8 seconds. This is because some queries read the whole `events` table instead of just the days they need. Filtering by date, or adding a projection, lets ClickHouse skip most of the data.',
+    },
+    action: { label: 'View slow queries', href: '/queries/insights' },
+  },
+  {
+    severity: 'critical',
+    category: 'storage',
+    metric: 'disk_free_pct',
+    value: 8,
+    title: 'Disk nearly full on one node',
+    detail: {
+      deterministic: 'Free disk on `default` is 8% (below 15% threshold).',
+      concise:
+        'Free disk dropped to 8% on the `default` disk — parts for `logs` grew 40% this week. TTL or a move-to-cold policy will reclaim space.',
+      detailed:
+        'The `default` disk is at 8% free, under the 15% warning threshold, after `logs` parts grew ~40% over {window}. At the current ingest rate the node has roughly 3 days of headroom; a TTL on `logs.event_date` or a tiered storage move policy would reclaim space before it becomes an incident.',
+      beginner:
+        'One node is almost out of disk space — only 8% is free. The `logs` table has been growing quickly. Setting a TTL (an automatic expiry on old rows) or moving old data to cheaper storage will free space and prevent an outage.',
+    },
+    action: { label: 'View storage', href: '/tables-overview' },
+  },
+  {
+    severity: 'info',
+    category: 'reliability',
+    metric: 'error_rate',
+    value: 0.3,
+    title: 'Error rate stable and low',
+    detail: {
+      deterministic: 'Query error rate is 0.3% over the window.',
+      concise:
+        'Error rate held at 0.3% across {window} — no new exception signatures, nothing to action.',
+      detailed:
+        'The query error rate stayed at 0.3% over {window}, in line with the trailing baseline. No new exception signatures appeared and the top error (`MEMORY_LIMIT_EXCEEDED`, 11 events) is unchanged from last week — informational only.',
+      beginner:
+        'Very few queries are failing — about 0.3%, which is normal and healthy. No new kinds of errors showed up, so there is nothing to fix here.',
+    },
+  },
+  {
+    severity: 'warning',
+    category: 'anomaly',
+    metric: 'insert_throughput',
+    value: -37,
+    title: 'Insert throughput dip detected',
+    detail: {
+      deterministic: 'Insert rows/s is 37% below the moving average.',
+      concise:
+        'Insert throughput fell 37% below its moving average during {window} — likely backpressure from merges on `metrics`.',
+      detailed:
+        'Insert throughput dipped to 37% below the 7-point moving average over {window}, crossing the anomaly band. It correlates with a merge backlog on `metrics` (parts count rose to 380); the dip should recover as merges drain, but sustained backpressure would warrant raising `background_pool_size`.',
+      beginner:
+        'Data is being inserted more slowly than usual — about 37% below the typical rate. This often happens when ClickHouse is busy merging table parts in the background. It usually recovers on its own once the merges finish.',
+    },
+    action: { label: 'View merges', href: '/merges' },
+  },
+]
+
+/**
+ * Build a deterministic set of example insight cards for the given settings.
+ *
+ * `seed` (a monotonically increasing reroll counter from the UI) rotates which
+ * subset of templates is shown so "Regenerate" visibly changes the example
+ * without any randomness that would break SSR / snapshots.
+ */
+export function buildMockInsights(
+  hostId: number,
+  settings: InsightsSettings,
+  seed = 0
+): InsightCard[] {
+  const phrase = windowPhrase(settings.window)
+  // Rotate the template order by the seed, then take three cards.
+  const count = 3
+  const rotated = TEMPLATES.map(
+    (_, i) => TEMPLATES[(i + seed) % TEMPLATES.length]
+  ).slice(0, count)
+
+  return rotated.map((t) => {
+    const raw = settings.enrich
+      ? t.detail[settings.promptStyle]
+      : t.detail.deterministic
+    const detail = raw.replaceAll('{window}', phrase)
+    return {
+      severity: t.severity,
+      category: t.category,
+      title: t.title,
+      detail,
+      metric: t.metric,
+      value: t.value,
+      action: t.action,
+      key: insightKey(hostId, t),
+      generatedAt: undefined,
+    }
+  })
+}

--- a/apps/dashboard/src/lib/insights/stats-settings.test.ts
+++ b/apps/dashboard/src/lib/insights/stats-settings.test.ts
@@ -1,0 +1,67 @@
+import {
+  BAND_MULTIPLIER_RANGE,
+  DEFAULT_STATS_INSIGHTS_SETTINGS,
+  MA_WINDOW_RANGE,
+  sanitizeStatsInsightsSettings,
+} from './stats-settings'
+import { describe, expect, test } from 'bun:test'
+
+describe('sanitizeStatsInsightsSettings', () => {
+  test('null/garbage input returns a fresh copy of defaults', () => {
+    const a = sanitizeStatsInsightsSettings(null)
+    expect(a).toEqual(DEFAULT_STATS_INSIGHTS_SETTINGS)
+    // Must not hand back the shared module constant (callers may spread/mutate).
+    expect(a).not.toBe(DEFAULT_STATS_INSIGHTS_SETTINGS)
+    expect(sanitizeStatsInsightsSettings('nope' as unknown as null)).toEqual(
+      DEFAULT_STATS_INSIGHTS_SETTINGS
+    )
+  })
+
+  test('clamps maWindow to its range and rounds to an integer', () => {
+    expect(sanitizeStatsInsightsSettings({ maWindow: 0 }).maWindow).toBe(
+      MA_WINDOW_RANGE.min
+    )
+    expect(sanitizeStatsInsightsSettings({ maWindow: 999 }).maWindow).toBe(
+      MA_WINDOW_RANGE.max
+    )
+    expect(sanitizeStatsInsightsSettings({ maWindow: 7.8 }).maWindow).toBe(8)
+  })
+
+  test('clamps bandMultiplier to its range', () => {
+    expect(
+      sanitizeStatsInsightsSettings({ bandMultiplier: 0 }).bandMultiplier
+    ).toBe(BAND_MULTIPLIER_RANGE.min)
+    expect(
+      sanitizeStatsInsightsSettings({ bandMultiplier: 100 }).bandMultiplier
+    ).toBe(BAND_MULTIPLIER_RANGE.max)
+  })
+
+  test('threshold: positive numbers pass, non-positive/blank/garbage → null', () => {
+    expect(sanitizeStatsInsightsSettings({ threshold: 1000 }).threshold).toBe(
+      1000
+    )
+    expect(sanitizeStatsInsightsSettings({ threshold: '250' }).threshold).toBe(
+      250
+    )
+    expect(sanitizeStatsInsightsSettings({ threshold: 0 }).threshold).toBeNull()
+    expect(
+      sanitizeStatsInsightsSettings({ threshold: -5 }).threshold
+    ).toBeNull()
+    expect(
+      sanitizeStatsInsightsSettings({ threshold: '' }).threshold
+    ).toBeNull()
+    expect(
+      sanitizeStatsInsightsSettings({ threshold: 'abc' }).threshold
+    ).toBeNull()
+  })
+
+  test('coerces boolean toggles from query-string strings', () => {
+    expect(
+      sanitizeStatsInsightsSettings({ showMovingAverage: 'false' })
+        .showMovingAverage
+    ).toBe(false)
+    expect(
+      sanitizeStatsInsightsSettings({ showThreshold: 'true' }).showThreshold
+    ).toBe(true)
+  })
+})

--- a/apps/dashboard/src/lib/insights/stats-settings.ts
+++ b/apps/dashboard/src/lib/insights/stats-settings.ts
@@ -1,0 +1,120 @@
+/**
+ * Statistics Insights user settings — pure, isomorphic model.
+ *
+ * These per-user preferences (persisted client-side, like AI insight settings)
+ * control the anomaly overlays drawn on the statistical charts (`/queries/insights`
+ * and the Cluster Statistics sections): a moving-average line with a ±k·stddev
+ * band, plus an optional absolute threshold line.
+ *
+ * Pure module (no React / server imports) so the client hook, the settings UI,
+ * and the chart-overlay math can all share it.
+ */
+
+export interface StatsInsightsSettings {
+  /** Moving-average window in data points. */
+  readonly maWindow: number
+  /** Band half-width as a multiple of the rolling standard deviation (±k·σ). */
+  readonly bandMultiplier: number
+  /**
+   * Absolute horizontal threshold value, or null when no absolute threshold is
+   * set (only the moving-average band flags anomalies).
+   */
+  readonly threshold: number | null
+  /** Draw the moving-average line + ±k·σ band. */
+  readonly showMovingAverage: boolean
+  /** Draw the absolute threshold line (only meaningful when `threshold` is set). */
+  readonly showThreshold: boolean
+}
+
+export const MA_WINDOW_RANGE = { min: 3, max: 60 } as const
+export const BAND_MULTIPLIER_RANGE = { min: 0.5, max: 5 } as const
+
+export const DEFAULT_STATS_INSIGHTS_SETTINGS: StatsInsightsSettings = {
+  maWindow: 7,
+  bandMultiplier: 2,
+  threshold: null,
+  showMovingAverage: true,
+  showThreshold: false,
+}
+
+function clampNumber(
+  value: unknown,
+  min: number,
+  max: number,
+  fallback: number
+): number {
+  const n = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(n)) return fallback
+  return Math.min(max, Math.max(min, n))
+}
+
+/**
+ * Coerce arbitrary input (parsed localStorage, query params) into valid
+ * settings. Out-of-range / malformed fields fall back to defaults so a corrupt
+ * payload never breaks the charts.
+ */
+export function sanitizeStatsInsightsSettings(
+  input:
+    | Partial<Record<keyof StatsInsightsSettings, unknown>>
+    | null
+    | undefined
+): StatsInsightsSettings {
+  if (!input || typeof input !== 'object') {
+    return { ...DEFAULT_STATS_INSIGHTS_SETTINGS }
+  }
+
+  const maWindow = Math.round(
+    clampNumber(
+      input.maWindow,
+      MA_WINDOW_RANGE.min,
+      MA_WINDOW_RANGE.max,
+      DEFAULT_STATS_INSIGHTS_SETTINGS.maWindow
+    )
+  )
+
+  const bandMultiplier = clampNumber(
+    input.bandMultiplier,
+    BAND_MULTIPLIER_RANGE.min,
+    BAND_MULTIPLIER_RANGE.max,
+    DEFAULT_STATS_INSIGHTS_SETTINGS.bandMultiplier
+  )
+
+  let threshold: number | null = null
+  if (
+    input.threshold !== null &&
+    input.threshold !== undefined &&
+    input.threshold !== ''
+  ) {
+    const n =
+      typeof input.threshold === 'number'
+        ? input.threshold
+        : Number(input.threshold)
+    threshold = Number.isFinite(n) && n > 0 ? n : null
+  }
+
+  const showMovingAverage =
+    typeof input.showMovingAverage === 'boolean'
+      ? input.showMovingAverage
+      : input.showMovingAverage === 'true'
+        ? true
+        : input.showMovingAverage === 'false'
+          ? false
+          : DEFAULT_STATS_INSIGHTS_SETTINGS.showMovingAverage
+
+  const showThreshold =
+    typeof input.showThreshold === 'boolean'
+      ? input.showThreshold
+      : input.showThreshold === 'true'
+        ? true
+        : input.showThreshold === 'false'
+          ? false
+          : DEFAULT_STATS_INSIGHTS_SETTINGS.showThreshold
+
+  return {
+    maWindow,
+    bandMultiplier,
+    threshold,
+    showMovingAverage,
+    showThreshold,
+  }
+}

--- a/apps/dashboard/src/lib/query/use-stats-insights-settings.ts
+++ b/apps/dashboard/src/lib/query/use-stats-insights-settings.ts
@@ -1,0 +1,94 @@
+'use client'
+
+/**
+ * useStatsInsightsSettings — per-user Statistics Insights preferences.
+ *
+ * Persists the anomaly-overlay settings (moving-average window, ±k·σ band
+ * multiplier, absolute threshold, and the two visibility toggles) to
+ * localStorage and broadcasts a CustomEvent so the settings page and the charts
+ * stay in sync without a reload. Mirrors `useInsightsSettings`.
+ */
+
+import { useCallback, useEffect, useState } from 'react'
+import {
+  DEFAULT_STATS_INSIGHTS_SETTINGS,
+  type StatsInsightsSettings,
+  sanitizeStatsInsightsSettings,
+} from '@/lib/insights/stats-settings'
+
+const STORAGE_KEY = 'clickhouse-monitor-stats-insights-settings'
+const CHANGE_EVENT = 'clickhouse-monitor-stats-insights-settings-changed'
+
+export function getSavedStatsInsightsSettings(): StatsInsightsSettings {
+  if (typeof window === 'undefined') return DEFAULT_STATS_INSIGHTS_SETTINGS
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return DEFAULT_STATS_INSIGHTS_SETTINGS
+    return sanitizeStatsInsightsSettings(JSON.parse(raw))
+  } catch {
+    return DEFAULT_STATS_INSIGHTS_SETTINGS
+  }
+}
+
+function persist(settings: StatsInsightsSettings): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings))
+  } catch {
+    // localStorage may be full or disabled.
+  }
+}
+
+function emitChange(settings: StatsInsightsSettings): void {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(
+    new CustomEvent<StatsInsightsSettings>(CHANGE_EVENT, { detail: settings })
+  )
+}
+
+export interface UseStatsInsightsSettingsResult {
+  readonly settings: StatsInsightsSettings
+  update: (patch: Partial<StatsInsightsSettings>) => void
+  reset: () => void
+}
+
+export function useStatsInsightsSettings(): UseStatsInsightsSettingsResult {
+  const [settings, setSettings] = useState<StatsInsightsSettings>(
+    getSavedStatsInsightsSettings
+  )
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const onChange = (event: Event) => {
+      const detail = (event as CustomEvent<StatsInsightsSettings>).detail
+      setSettings(detail ?? getSavedStatsInsightsSettings())
+    }
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === STORAGE_KEY)
+        setSettings(getSavedStatsInsightsSettings())
+    }
+    window.addEventListener(CHANGE_EVENT, onChange)
+    window.addEventListener('storage', onStorage)
+    return () => {
+      window.removeEventListener(CHANGE_EVENT, onChange)
+      window.removeEventListener('storage', onStorage)
+    }
+  }, [])
+
+  const update = useCallback((patch: Partial<StatsInsightsSettings>) => {
+    setSettings((current) => {
+      const next = sanitizeStatsInsightsSettings({ ...current, ...patch })
+      persist(next)
+      emitChange(next)
+      return next
+    })
+  }, [])
+
+  const reset = useCallback(() => {
+    persist(DEFAULT_STATS_INSIGHTS_SETTINGS)
+    emitChange(DEFAULT_STATS_INSIGHTS_SETTINGS)
+    setSettings(DEFAULT_STATS_INSIGHTS_SETTINGS)
+  }, [])
+
+  return { settings, update, reset }
+}

--- a/apps/dashboard/src/routes/(dashboard)/insights-settings.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/insights-settings.tsx
@@ -3,10 +3,9 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { InsightsPreview } from '@/components/insights/insights-preview'
 import { InsightsSettingsForm } from '@/components/insights/insights-settings-form'
+import { StatsInsightsSettingsForm } from '@/components/insights/stats-insights-settings-form'
 import { AppLink } from '@/components/ui/app-link'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent } from '@/components/ui/card'
-import { EmptyState } from '@/components/ui/empty-state'
 import { Separator } from '@/components/ui/separator'
 import { useHostId } from '@/lib/swr'
 import { buildUrl } from '@/lib/url/url-builder'
@@ -146,10 +145,9 @@ function InsightsSettingsPage() {
 
       <Separator />
 
-      {/* Statistics Insights — Record Breakers, Query Insights, and the other
-          Cluster Statistics sections on /insights. No per-section controls
-          exist yet; this is a placeholder so the settings surface stays
-          visible rather than silently absent. */}
+      {/* Statistics Insights — anomaly overlays (moving-average band + absolute
+          threshold) drawn on the statistical charts (/queries/insights, Cluster
+          Statistics). These settings are consumed by the chart overlays. */}
       <section className="space-y-3">
         <div className="flex items-center gap-2">
           <BarChart3 className="size-4 shrink-0 text-muted-foreground" />
@@ -157,16 +155,11 @@ function InsightsSettingsPage() {
             Statistics Insights
           </h2>
         </div>
-        <Card>
-          <CardContent className="pt-6">
-            <EmptyState
-              variant="no-data"
-              compact
-              title="No settings yet"
-              description="Record Breakers, Query Insights, and the other Cluster Statistics sections are always shown. Per-section visibility controls are planned."
-            />
-          </CardContent>
-        </Card>
+        <p className="text-muted-foreground text-xs">
+          Anomaly detection overlays for the statistical charts — a
+          moving-average band and an optional absolute threshold.
+        </p>
+        <StatsInsightsSettingsForm />
       </section>
     </div>
   )


### PR DESCRIPTION
Addresses the /insights-settings feedback: the *Example* showed 'Couldn't generate — the cluster may be unreachable or read-only' for guests / read-only demo hosts, and the Statistics Insights section was an empty placeholder.

## AI Insights — Example now renders a static sample (no LLM call)
`InsightsPreview` renders a deterministic set of example insight cards (`buildMockInsights`) that reflect the current settings (prompt style / enrichment / window) with **no network or LLM call**, so it always renders — including for anonymous visitors and read-only demo hosts.
- Seed-rotated (not `Math.random()`) so it's SSR-safe and Regenerate visibly changes the sample.
- Labelled **Sample** with a footnote that it's illustrative, not live analysis (honest UX; real insights still run on the overview panel + cron).

## Statistics Insights — real threshold settings
Replaced the 'No settings yet' placeholder with a settings form:
- **Moving-average band**: window (points) + ±k·σ band multiplier.
- **Absolute threshold**: optional fixed horizontal line.
- Persisted via `useStatsInsightsSettings` (mirrors `useInsightsSettings`; localStorage + CustomEvent sync).

These settings will drive the anomaly overlays on `/queries/insights` and the Cluster Statistics charts in the follow-up PR.

## Tests
Added unit tests: sanitizer clamping / threshold coercion / boolean coercion, and mock-builder determinism, seed rotation, enrich variance, and window interpolation. `bun test` green (10/10); `pnpm build` passes.