### PR TITLE
feat(queries-insights): moving-average band + threshold anomaly overlays

### DIFF
--- a/apps/dashboard/src/components/charts/primitives/area.tsx
+++ b/apps/dashboard/src/components/charts/primitives/area.tsx
@@ -21,6 +21,8 @@ import {
   ChartLegendContent,
 } from '@/components/ui/chart'
 import { getYAxisDomain, resolveYAxisScale } from '@/lib/chart-scale'
+import { augmentWithBand, OVERLAY_KEYS } from '@/lib/insights/anomaly-overlay'
+import { useStatsInsightsSettings } from '@/lib/query/use-stats-insights-settings'
 import { cn } from '@/lib/utils'
 
 /**
@@ -94,6 +96,33 @@ function DeploymentMarkerLabel({
   )
 }
 
+/**
+ * Custom recharts `dot` renderer for the anomaly-overlay series: draws a small
+ * red dot only on points flagged `__anomaly` (outside the ±k·σ band), and
+ * nothing otherwise. Kept as a plain Area `dot` so it works without recharts'
+ * `ReferenceDot` (not resolvable in this build).
+ */
+function AnomalyDot(props: {
+  cx?: number
+  cy?: number
+  payload?: Record<string, unknown>
+}) {
+  const { cx, cy, payload } = props
+  if (!payload?.[OVERLAY_KEYS.anomaly] || cx == null || cy == null) {
+    return <g />
+  }
+  return (
+    <circle
+      cx={cx}
+      cy={cy}
+      r={3}
+      fill="var(--chart-red, var(--destructive))"
+      stroke="var(--background)"
+      strokeWidth={1}
+    />
+  )
+}
+
 export const AreaChart = function AreaChart({
   data,
   index,
@@ -121,12 +150,38 @@ export const AreaChart = function AreaChart({
   height = 'h-full',
   deployments,
   onDeploymentSelect,
+  anomalyOverlay,
 }: AreaChartProps & {
   yAxisTickFormatter?: (value: string | number) => string
   height?: string
 }) {
   // Get scale preference from context (if available)
   const contextScale = useChartScaleValue()
+
+  // Statistics-Insights overlay settings (moving-average band + threshold).
+  // Read unconditionally (hooks rule) but only applied when a chart opts in via
+  // `anomalyOverlay`; every other area chart is unaffected.
+  const { settings: statsSettings } = useStatsInsightsSettings()
+  const overlay =
+    anomalyOverlay && index && categories.includes(anomalyOverlay.category)
+      ? anomalyOverlay
+      : undefined
+  const bandEnabled = Boolean(overlay) && statsSettings.showMovingAverage
+  const thresholdEnabled =
+    Boolean(overlay) &&
+    statsSettings.showThreshold &&
+    statsSettings.threshold != null
+
+  const augmented = bandEnabled
+    ? augmentWithBand(
+        data as Record<string, unknown>[],
+        index as string,
+        (overlay as { category: string }).category,
+        statsSettings.maWindow,
+        statsSettings.bandMultiplier
+      )
+    : null
+  const chartData = augmented ? augmented.rows : data
 
   // Use prop if provided, otherwise use context, otherwise 'linear'
   const effectiveScale = yAxisScale ?? contextScale ?? 'linear'
@@ -199,7 +254,7 @@ export const AreaChart = function AreaChart({
     >
       <RechartAreaChart
         accessibilityLayer
-        data={data}
+        data={chartData}
         margin={{
           top: 4,
           left: 12,
@@ -251,8 +306,65 @@ export const AreaChart = function AreaChart({
             stackId={stack ? 'a' : undefined}
             type="linear"
             fillOpacity={opacity}
+            // Flag out-of-band points on the analyzed series only.
+            dot={
+              bandEnabled && overlay?.category === category ? (
+                <AnomalyDot />
+              ) : (
+                false
+              )
+            }
           />
         ))}
+
+        {/* Statistics-Insights anomaly overlay (opt-in, driven by settings). */}
+        {bandEnabled && (
+          <Area
+            key="__ma-band"
+            dataKey={OVERLAY_KEYS.band}
+            stroke="none"
+            fill="var(--muted-foreground)"
+            fillOpacity={0.12}
+            isAnimationActive={false}
+            legendType="none"
+            tooltipType="none"
+            activeDot={false}
+            connectNulls
+          />
+        )}
+        {bandEnabled && (
+          // Drawn as an Area with no fill — recharts' AreaChart only renders
+          // Area children as graphical items (a <Line> child is ignored), so a
+          // stroke-only Area is how we get the moving-average line.
+          <Area
+            key="__ma-line"
+            dataKey={OVERLAY_KEYS.ma}
+            fill="none"
+            stroke="var(--muted-foreground)"
+            strokeWidth={1.5}
+            strokeDasharray="5 4"
+            dot={false}
+            activeDot={false}
+            isAnimationActive={false}
+            legendType="none"
+            tooltipType="none"
+            connectNulls
+          />
+        )}
+        {thresholdEnabled && (
+          <ReferenceLine
+            y={statsSettings.threshold as number}
+            stroke="var(--chart-red, var(--destructive))"
+            strokeDasharray="6 4"
+            strokeWidth={1.5}
+            label={{
+              value: `threshold ${statsSettings.threshold}`,
+              position: 'insideTopRight',
+              fill: 'var(--muted-foreground)',
+              fontSize: 10,
+            }}
+          />
+        )}
 
         {showLegend && <ChartLegend content={<ChartLegendContent />} />}
 

--- a/apps/dashboard/src/components/charts/query-performance/query-insights-errors.tsx
+++ b/apps/dashboard/src/components/charts/query-performance/query-insights-errors.tsx
@@ -12,6 +12,7 @@ export const ChartQueryInsightsErrors = createAreaChart({
   dataTestId: 'query-insights-errors-chart',
   dateRangeConfig: 'query-activity',
   areaChartProps: {
+    anomalyOverlay: { category: 'errors' },
     readable: 'number',
     stack: false,
     showLegend: false,

--- a/apps/dashboard/src/components/charts/query-performance/query-insights-latency.tsx
+++ b/apps/dashboard/src/components/charts/query-performance/query-insights-latency.tsx
@@ -17,6 +17,7 @@ export const ChartQueryInsightsLatency = createAreaChart({
   dataTestId: 'query-insights-latency-chart',
   dateRangeConfig: 'query-activity',
   areaChartProps: {
+    anomalyOverlay: { category: 'avg_duration_ms' },
     readable: 'duration',
     stack: false,
     showLegend: true,

--- a/apps/dashboard/src/components/charts/query-performance/query-insights-memory.tsx
+++ b/apps/dashboard/src/components/charts/query-performance/query-insights-memory.tsx
@@ -12,6 +12,7 @@ export const ChartQueryInsightsMemory = createAreaChart({
   dataTestId: 'query-insights-memory-chart',
   dateRangeConfig: 'query-activity',
   areaChartProps: {
+    anomalyOverlay: { category: 'avg_memory' },
     readable: 'bytes',
     stack: false,
     showLegend: true,

--- a/apps/dashboard/src/components/charts/query-performance/query-insights-qps.tsx
+++ b/apps/dashboard/src/components/charts/query-performance/query-insights-qps.tsx
@@ -12,6 +12,7 @@ export const ChartQueryInsightsQps = createAreaChart({
   dataTestId: 'query-insights-qps-chart',
   dateRangeConfig: 'query-activity',
   areaChartProps: {
+    anomalyOverlay: { category: 'qps' },
     readable: 'number',
     stack: false,
     showLegend: false,

--- a/apps/dashboard/src/components/charts/query-performance/query-insights-read-throughput.tsx
+++ b/apps/dashboard/src/components/charts/query-performance/query-insights-read-throughput.tsx
@@ -12,6 +12,7 @@ export const ChartQueryInsightsReadThroughput = createAreaChart({
   dataTestId: 'query-insights-read-throughput-chart',
   dateRangeConfig: 'query-activity',
   areaChartProps: {
+    anomalyOverlay: { category: 'read_bytes' },
     readable: 'bytes',
     stack: false,
     showLegend: true,

--- a/apps/dashboard/src/components/charts/query-performance/query-insights-rows.tsx
+++ b/apps/dashboard/src/components/charts/query-performance/query-insights-rows.tsx
@@ -12,6 +12,7 @@ export const ChartQueryInsightsRows = createAreaChart({
   dataTestId: 'query-insights-rows-chart',
   dateRangeConfig: 'query-activity',
   areaChartProps: {
+    anomalyOverlay: { category: 'read_rows' },
     readable: 'quantity',
     stack: false,
     showLegend: true,

--- a/apps/dashboard/src/lib/insights/anomaly-overlay.test.ts
+++ b/apps/dashboard/src/lib/insights/anomaly-overlay.test.ts
@@ -1,0 +1,67 @@
+import {
+  augmentWithBand,
+  computeMovingAverageBand,
+  OVERLAY_KEYS,
+} from './anomaly-overlay'
+import { describe, expect, test } from 'bun:test'
+
+describe('computeMovingAverageBand', () => {
+  test('average uses at most `window` PRIOR points (excludes current)', () => {
+    const out = computeMovingAverageBand([2, 4, 6, 8], 2, 2)
+    // Prior-window: ma[2] = mean(2,4) = 3; ma[3] = mean(4,6) = 5
+    expect(out[2].ma).toBe(3)
+    expect(out[3].ma).toBe(5)
+  })
+
+  test('flat series has zero-width band and flags no anomalies', () => {
+    const out = computeMovingAverageBand([5, 5, 5, 5], 3, 2)
+    expect(out.every((p) => p.anomaly === false)).toBe(true)
+    const last = out[3]
+    expect(last.band?.[0]).toBe(5)
+    expect(last.band?.[1]).toBe(5)
+  })
+
+  test('a spike outside the band is flagged once the window is full', () => {
+    // Steady ~10 then a 100 spike; with a full window and non-zero σ it's an anomaly.
+    const out = computeMovingAverageBand([10, 11, 9, 10, 100], 4, 2)
+    expect(out[4].anomaly).toBe(true)
+  })
+
+  test('early points (partial window) are never anomalies', () => {
+    const out = computeMovingAverageBand([100, 1, 1, 1], 4, 2)
+    expect(out[0].anomaly).toBe(false)
+    expect(out[1].anomaly).toBe(false)
+  })
+
+  test('nulls/NaN are gaps: null band point, skipped in later averages', () => {
+    const out = computeMovingAverageBand([10, null, 20], 3, 2)
+    expect(out[1].ma).toBe(10) // prior window is just the real 10
+    expect(out[2].ma).toBe(10) // prior window skips the null, uses 10 (excludes current 20)
+    const gapOut = computeMovingAverageBand([null], 3, 2)
+    expect(gapOut[0]).toEqual({ ma: null, band: null, anomaly: false })
+  })
+
+  test('window and k are clamped to sane minimums', () => {
+    // window 0 → 1 (one prior point); k negative → 0-width band.
+    const out = computeMovingAverageBand([3, 7], 0, -5)
+    expect(out[1].ma).toBe(3) // the single prior point
+    expect(out[1].band).toEqual([3, 3])
+  })
+})
+
+describe('augmentWithBand', () => {
+  test('adds overlay keys to every row and collects anomaly points', () => {
+    const data = [
+      { t: 'a', v: 10 },
+      { t: 'b', v: 11 },
+      { t: 'c', v: 9 },
+      { t: 'd', v: 10 },
+      { t: 'e', v: 100 },
+    ]
+    const { rows, anomalies } = augmentWithBand(data, 't', 'v', 4, 2)
+    expect(rows).toHaveLength(5)
+    expect(rows[0]).toHaveProperty(OVERLAY_KEYS.ma)
+    expect(rows[0]).toHaveProperty(OVERLAY_KEYS.band)
+    expect(anomalies).toEqual([{ indexValue: 'e', value: 100 }])
+  })
+})

--- a/apps/dashboard/src/lib/insights/anomaly-overlay.ts
+++ b/apps/dashboard/src/lib/insights/anomaly-overlay.ts
@@ -1,0 +1,129 @@
+/**
+ * Client-side anomaly overlay math for the statistical charts.
+ *
+ * Given a single numeric series, computes a trailing moving average and a
+ * ±k·σ band around it; points that fall outside the band are flagged as
+ * anomalies. Pure and deterministic (no time, no randomness) so it is safe for
+ * SSR/prerender and easy to unit-test. Consumed by the AreaChart primitive when
+ * a chart opts into `anomalyOverlay`, parameterized by `useStatsInsightsSettings`.
+ */
+
+export interface BandPoint {
+  /** Trailing moving-average value, or null until the window has any data. */
+  readonly ma: number | null
+  /** `[lower, upper]` band bounds, or null when no average exists. */
+  readonly band: readonly [number, number] | null
+  /** True when the point's value lies outside the band (an anomaly). */
+  readonly anomaly: boolean
+}
+
+/** Population standard deviation of a non-empty numeric list. */
+function stddev(values: number[], mean: number): number {
+  if (values.length === 0) return 0
+  const variance =
+    values.reduce((acc, v) => acc + (v - mean) ** 2, 0) / values.length
+  return Math.sqrt(variance)
+}
+
+/**
+ * Compute a trailing moving-average band for `values`.
+ *
+ * The window is the *prior* points (it excludes the current point), so the band
+ * is a baseline of recent history the current value is judged against — this
+ * avoids self-masking.
+ *
+ * - `window` is the number of prior points averaged (clamped to ≥1).
+ * - `k` is the band half-width in standard deviations (clamped to ≥0).
+ * - `null`/`NaN` entries are gaps: they produce a null band point and are
+ *   skipped when building later windows.
+ */
+export function computeMovingAverageBand(
+  values: readonly (number | null)[],
+  window: number,
+  k: number
+): BandPoint[] {
+  const w = Math.max(1, Math.floor(window))
+  const mult = Math.max(0, k)
+
+  return values.map((value, i) => {
+    const current =
+      typeof value === 'number' && Number.isFinite(value) ? value : null
+
+    // Collect up to `w` prior real numbers ending at i-1. Excluding the current
+    // point keeps a spike from inflating its own band and masking itself —
+    // especially at small window sizes.
+    const win: number[] = []
+    for (let j = i - 1; j >= 0 && win.length < w; j--) {
+      const v = values[j]
+      if (typeof v === 'number' && Number.isFinite(v)) win.push(v)
+    }
+
+    if (win.length === 0) {
+      return { ma: null, band: null, anomaly: false }
+    }
+
+    const mean = win.reduce((a, b) => a + b, 0) / win.length
+    const sd = stddev(win, mean)
+    const band: [number, number] = [mean - mult * sd, mean + mult * sd]
+    const anomaly =
+      current !== null &&
+      // Require a full prior window so early points (partial history) never
+      // read as anomalies. A zero-width band (flat history) still flags a value
+      // that differs from it — a spike off a flat baseline.
+      win.length >= w &&
+      (current < band[0] || current > band[1])
+
+    return { ma: mean, band, anomaly }
+  })
+}
+
+/** Keys the overlay adds to each chart row. Prefixed to avoid clashing with data columns. */
+export const OVERLAY_KEYS = {
+  ma: '__ma',
+  band: '__maBand',
+  anomaly: '__anomaly',
+} as const
+
+export interface AugmentedRow extends Record<string, unknown> {
+  readonly __ma?: number | null
+  readonly __maBand?: readonly [number, number] | null
+  readonly __anomaly?: boolean
+}
+
+/**
+ * Augment chart rows with overlay keys computed from `category`. Returns the
+ * rows with `__ma` / `__maBand` / `__anomaly` added, plus the anomaly rows
+ * (with their index value) so the caller can draw markers.
+ */
+export function augmentWithBand(
+  data: readonly Record<string, unknown>[],
+  index: string,
+  category: string,
+  window: number,
+  k: number
+): {
+  rows: AugmentedRow[]
+  anomalies: { indexValue: unknown; value: number }[]
+} {
+  const values = data.map((row) => {
+    const v = row[category]
+    return typeof v === 'number' ? v : v == null ? null : Number(v)
+  })
+  const band = computeMovingAverageBand(values, window, k)
+  const anomalies: { indexValue: unknown; value: number }[] = []
+
+  const rows = data.map((row, i) => {
+    const point = band[i]
+    if (point.anomaly && typeof values[i] === 'number') {
+      anomalies.push({ indexValue: row[index], value: values[i] as number })
+    }
+    return {
+      ...row,
+      [OVERLAY_KEYS.ma]: point.ma,
+      [OVERLAY_KEYS.band]: point.band,
+      [OVERLAY_KEYS.anomaly]: point.anomaly,
+    }
+  })
+
+  return { rows, anomalies }
+}

--- a/apps/dashboard/src/types/charts.ts
+++ b/apps/dashboard/src/types/charts.ts
@@ -207,6 +207,15 @@ export interface AreaChartProps extends BaseChartProps {
    * to deploy window"), reusing the existing date-range mechanism.
    */
   onDeploymentSelect?: (deployment: AreaChartDeploymentMarker) => void
+
+  /**
+   * Opt-in Statistics-Insights anomaly overlay: draws a moving-average line +
+   * ±k·σ band (and flags out-of-band points) on the given `category`, plus an
+   * absolute threshold line. Undefined = zero rendering change. The band/MA/
+   * threshold visibility and parameters come from `useStatsInsightsSettings`,
+   * so this only names WHICH series to analyze — the operator controls the how.
+   */
+  anomalyOverlay?: { category: string }
 }
 
 export interface RadialChartProps extends Omit<BaseChartProps, 'onClick'> {


### PR DESCRIPTION
Follow-up to #2366 (which added the Statistics Insights threshold settings). Implements the anomaly overlays on the `/queries/insights` charts, driven entirely by those settings.

## What
- **Moving-average band**: a trailing MA line + ±k·σ band on a chosen series. Points outside the band are flagged with a red dot (abnormal detection).
- **Absolute threshold**: an optional horizontal `ReferenceLine`.
- Both are controlled by `useStatsInsightsSettings` (window, band multiplier, threshold, and the two visibility toggles) — set on `/insights-settings`.

## How
- Opt-in `anomalyOverlay: { category }` prop on the `AreaChart` primitive (undefined ⇒ zero change for every other area chart). Enabled on six charts: QPS, latency, memory, read-throughput, rows, errors.
- The band uses a **prior-only window** (excludes the current point) so a spike can't inflate and mask its own band — verified by tests.
- Rendered with `Area` (a `fill:none` Area is the MA line; recharts' `AreaChart` ignores `<Line>` children) + a custom Area `dot` for anomalies (this build can't resolve `<ReferenceDot>`).

## Tests
Pure math in `lib/insights/anomaly-overlay.ts` unit-tested: trailing window, spike detection, partial-window & flat-series guards, null gaps, clamping, row augmentation. `bun test` green; `pnpm build` passes.