### PR TITLE
fix(ui): stop Base UI MenuGroupContext crash on dropdown open

### DIFF
--- a/apps/dashboard/src/components/ai-elements/open-in-chat.tsx
+++ b/apps/dashboard/src/components/ai-elements/open-in-chat.tsx
@@ -16,6 +16,7 @@ import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -228,7 +229,9 @@ export const OpenInItem = (props: OpenInItemProps) => (
 export type OpenInLabelProps = ComponentProps<typeof DropdownMenuLabel>
 
 export const OpenInLabel = (props: OpenInLabelProps) => (
-  <DropdownMenuLabel {...props} />
+  <DropdownMenuGroup>
+    <DropdownMenuLabel {...props} />
+  </DropdownMenuGroup>
 )
 
 export type OpenInSeparatorProps = ComponentProps<typeof DropdownMenuSeparator>

--- a/apps/dashboard/src/components/data-table/cells/actions/action-menu.tsx
+++ b/apps/dashboard/src/components/data-table/cells/actions/action-menu.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
@@ -54,7 +55,9 @@ function ActionMenuComponent<TData extends RowData, TValue>({
         <MoreHorizontal className="size-4" />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuLabel>Actions</DropdownMenuLabel>
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>Actions</DropdownMenuLabel>
+        </DropdownMenuGroup>
         <DropdownMenuSeparator />
         <NoSsr>
           <Suspense fallback={null}>

--- a/apps/dashboard/src/components/data-table/components/data-table-header-parts.tsx
+++ b/apps/dashboard/src/components/data-table/components/data-table-header-parts.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
@@ -93,9 +94,11 @@ export function DisplayOptionsDropdown<TData extends RowData>({
         align="end"
         className="w-56 max-h-[80vh] overflow-y-auto rounded-xl shadow-lg"
       >
-        <DropdownMenuLabel className="text-xs font-semibold px-2.5 py-1.5 text-muted-foreground uppercase tracking-wider">
-          Density
-        </DropdownMenuLabel>
+        <DropdownMenuGroup>
+          <DropdownMenuLabel className="text-xs font-semibold px-2.5 py-1.5 text-muted-foreground uppercase tracking-wider">
+            Density
+          </DropdownMenuLabel>
+        </DropdownMenuGroup>
         {onDensityChange && (
           <DropdownMenuRadioGroup
             value={density}
@@ -126,9 +129,11 @@ export function DisplayOptionsDropdown<TData extends RowData>({
           </DropdownMenuRadioGroup>
         )}
         <DropdownMenuSeparator />
-        <DropdownMenuLabel className="text-xs font-semibold px-2.5 py-1.5 text-muted-foreground uppercase tracking-wider">
-          Columns
-        </DropdownMenuLabel>
+        <DropdownMenuGroup>
+          <DropdownMenuLabel className="text-xs font-semibold px-2.5 py-1.5 text-muted-foreground uppercase tracking-wider">
+            Columns
+          </DropdownMenuLabel>
+        </DropdownMenuGroup>
         <div className="px-1">
           {table
             .getAllColumns()

--- a/apps/dashboard/src/components/data-table/components/mobile-table-cards.tsx
+++ b/apps/dashboard/src/components/data-table/components/mobile-table-cards.tsx
@@ -39,6 +39,7 @@ import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -149,7 +150,9 @@ export function MobileSortMenu<TData extends RowData>({
         align="end"
         className="max-h-80 w-56 overflow-y-auto"
       >
-        <DropdownMenuLabel>Sort by</DropdownMenuLabel>
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>Sort by</DropdownMenuLabel>
+        </DropdownMenuGroup>
         {sortableColumns.map((column) => {
           const label = getColumnLabel(column)
           const isAsc =

--- a/apps/dashboard/src/components/host/host-switcher.tsx
+++ b/apps/dashboard/src/components/host/host-switcher.tsx
@@ -12,6 +12,7 @@ import { ChmonitorLogo } from '@/components/icons/chmonitor-logo'
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -258,9 +259,11 @@ export function HostSwitcher() {
                 side={isMobile ? 'bottom' : 'right'}
                 sideOffset={4}
               >
-                <DropdownMenuLabel className="text-xs text-muted-foreground">
-                  ClickHouse Hosts
-                </DropdownMenuLabel>
+                <DropdownMenuGroup>
+                  <DropdownMenuLabel className="text-xs text-muted-foreground">
+                    ClickHouse Hosts
+                  </DropdownMenuLabel>
+                </DropdownMenuGroup>
                 <DropdownMenuSeparator />
                 {hosts.map((host) => (
                   <DropdownMenuItem

--- a/apps/dashboard/src/components/nav-user.tsx
+++ b/apps/dashboard/src/components/nav-user.tsx
@@ -118,34 +118,38 @@ export function NavUser({
                 align="end"
                 sideOffset={4}
               >
-                <DropdownMenuLabel className="p-0 font-normal">
-                  <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
-                    <Avatar className="avatar size-8 rounded-lg">
-                      <AvatarImage
-                        src={displayUser.avatar}
-                        alt={displayUser.name}
-                      />
-                      <AvatarFallback className="rounded-lg">G</AvatarFallback>
-                    </Avatar>
-                    <div className="grid flex-1 text-left text-sm leading-tight">
-                      <span className="truncate font-medium">
-                        {displayUser.name}
-                      </span>
-                      <span className="truncate text-xs">
-                        {displayUser.email}
-                      </span>
-                      {authSourceLabel && (
-                        <span
-                          className="mt-0.5 flex items-center gap-1 text-[10px] uppercase tracking-wide text-muted-foreground"
-                          data-testid="nav-user-auth-source"
-                        >
-                          <ShieldCheck className="size-3 shrink-0" />
-                          <span className="truncate">{authSourceLabel}</span>
+                <DropdownMenuGroup>
+                  <DropdownMenuLabel className="p-0 font-normal">
+                    <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
+                      <Avatar className="avatar size-8 rounded-lg">
+                        <AvatarImage
+                          src={displayUser.avatar}
+                          alt={displayUser.name}
+                        />
+                        <AvatarFallback className="rounded-lg">
+                          G
+                        </AvatarFallback>
+                      </Avatar>
+                      <div className="grid flex-1 text-left text-sm leading-tight">
+                        <span className="truncate font-medium">
+                          {displayUser.name}
                         </span>
-                      )}
+                        <span className="truncate text-xs">
+                          {displayUser.email}
+                        </span>
+                        {authSourceLabel && (
+                          <span
+                            className="mt-0.5 flex items-center gap-1 text-[10px] uppercase tracking-wide text-muted-foreground"
+                            data-testid="nav-user-auth-source"
+                          >
+                            <ShieldCheck className="size-3 shrink-0" />
+                            <span className="truncate">{authSourceLabel}</span>
+                          </span>
+                        )}
+                      </div>
                     </div>
-                  </div>
-                </DropdownMenuLabel>
+                  </DropdownMenuLabel>
+                </DropdownMenuGroup>
                 <DropdownMenuSeparator />
                 <DropdownMenuGroup>
                   <DropdownMenuItem

--- a/apps/dashboard/src/components/nav-user/clerk-nav.tsx
+++ b/apps/dashboard/src/components/nav-user/clerk-nav.tsx
@@ -203,47 +203,49 @@ export function ClerkNavWrapper() {
                 align="end"
                 sideOffset={4}
               >
-                <DropdownMenuLabel className="p-0 font-normal">
-                  <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
-                    <Avatar className="avatar size-8 rounded-lg">
-                      <AvatarImage
-                        src={user?.imageUrl}
-                        alt={user?.fullName ?? 'User'}
-                      />
-                      <AvatarFallback className="rounded-lg">
-                        {getUserInitials(user?.fullName)}
-                      </AvatarFallback>
-                    </Avatar>
-                    <div className="grid flex-1 text-left text-sm leading-tight">
-                      <span className="truncate font-medium">
-                        {user?.fullName ?? 'User'}
-                      </span>
-                      <span className="truncate text-xs">
-                        {user?.primaryEmailAddress?.emailAddress}
-                      </span>
-                      <span className="mt-1 flex items-center gap-1.5">
-                        {organization && (
-                          <span className="text-muted-foreground flex min-w-0 items-center gap-1 text-[11px]">
-                            <Building2 className="size-3 shrink-0" />
-                            <span className="truncate">
-                              {organization.name}
+                <DropdownMenuGroup>
+                  <DropdownMenuLabel className="p-0 font-normal">
+                    <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
+                      <Avatar className="avatar size-8 rounded-lg">
+                        <AvatarImage
+                          src={user?.imageUrl}
+                          alt={user?.fullName ?? 'User'}
+                        />
+                        <AvatarFallback className="rounded-lg">
+                          {getUserInitials(user?.fullName)}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div className="grid flex-1 text-left text-sm leading-tight">
+                        <span className="truncate font-medium">
+                          {user?.fullName ?? 'User'}
+                        </span>
+                        <span className="truncate text-xs">
+                          {user?.primaryEmailAddress?.emailAddress}
+                        </span>
+                        <span className="mt-1 flex items-center gap-1.5">
+                          {organization && (
+                            <span className="text-muted-foreground flex min-w-0 items-center gap-1 text-[11px]">
+                              <Building2 className="size-3 shrink-0" />
+                              <span className="truncate">
+                                {organization.name}
+                              </span>
                             </span>
-                          </span>
-                        )}
-                        {planLabel && planLabel !== 'free' && (
-                          <Badge
-                            className={cn(
-                              'h-4 px-1.5 text-[10px]',
-                              planBadgeClassName(planLabel)
-                            )}
-                          >
-                            {planLabel}
-                          </Badge>
-                        )}
-                      </span>
+                          )}
+                          {planLabel && planLabel !== 'free' && (
+                            <Badge
+                              className={cn(
+                                'h-4 px-1.5 text-[10px]',
+                                planBadgeClassName(planLabel)
+                              )}
+                            >
+                              {planLabel}
+                            </Badge>
+                          )}
+                        </span>
+                      </div>
                     </div>
-                  </div>
-                </DropdownMenuLabel>
+                  </DropdownMenuLabel>
+                </DropdownMenuGroup>
                 <DropdownMenuSeparator />
                 <DropdownMenuGroup>
                   <DropdownMenuItem

--- a/apps/dashboard/src/components/query-tables/column-visibility-menu.tsx
+++ b/apps/dashboard/src/components/query-tables/column-visibility-menu.tsx
@@ -4,6 +4,7 @@ import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
@@ -39,7 +40,9 @@ export function ColumnVisibilityMenu<TKey extends string>({
         <SlidersHorizontal className="size-3.5" />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-44">
-        <DropdownMenuLabel>Columns</DropdownMenuLabel>
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>Columns</DropdownMenuLabel>
+        </DropdownMenuGroup>
         <DropdownMenuSeparator />
         {columns.map((col) => (
           <DropdownMenuCheckboxItem

--- a/apps/dashboard/src/components/running-queries/running-queries-table.tsx
+++ b/apps/dashboard/src/components/running-queries/running-queries-table.tsx
@@ -34,6 +34,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
@@ -219,7 +220,9 @@ export const RunningQueriesTable = memo(function RunningQueriesTable({
             <ChevronDown className="size-3 opacity-60" />
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start" className="w-48">
-            <DropdownMenuLabel>Filter by user</DropdownMenuLabel>
+            <DropdownMenuGroup>
+              <DropdownMenuLabel>Filter by user</DropdownMenuLabel>
+            </DropdownMenuGroup>
             <DropdownMenuSeparator />
             <DropdownMenuRadioGroup
               value={filterUser}


### PR DESCRIPTION
## Problem
Clicking **any dropdown** (host switcher, nav-user, table action/column/sort menus, …) crashed the entire page:

> Base UI: MenuGroupContext is missing. Menu group parts must be used within `<Menu.Group>` or `<Menu.RadioGroup>`.

## Root cause
The Radix→Base UI migration (#2361) left `DropdownMenuLabel` rendering `Menu.GroupLabel`. Unlike Radix (which tolerated standalone labels), Base UI's `Menu.GroupLabel` **requires a `Menu.Group` ancestor** and throws on open when used standalone. Every call site used the label as a bare header.

Confirmed the canonical shadcn **base-nova** `dropdown-menu` is byte-identical (also uses `Menu.GroupLabel`), so reinstalling via the CLI does not fix it — the component must be *used* the way Base UI intends: inside a group.

## Fix
Keep `components/ui/*` **canonical/untouched**; wrap each standalone `DropdownMenuLabel` in a `DropdownMenuGroup` at the 9 call sites (10 labels). `SelectLabel` was already inside a `SelectGroup`.

## Verification
`pnpm build` passes. Will confirm dropdowns open without crashing on the deploy.