### PR TITLE
fix(ui): de-slop Example card icon and Health summary banner

### DIFF
--- a/apps/dashboard/src/components/health/health-summary-banner.tsx
+++ b/apps/dashboard/src/components/health/health-summary-banner.tsx
@@ -15,8 +15,6 @@ interface BannerTheme {
   sub: string
   /** Card surface tint + border. Kept faint — the banner sets a tone, not a flag. */
   container: string
-  /** Left accent rail color. */
-  rail: string
   icon_: string
   title_: string
 }
@@ -28,7 +26,6 @@ function resolveTheme({ critical, warning, ok }: HealthCounts): BannerTheme {
       title: 'Action required',
       sub: `${critical} critical issue${critical > 1 ? 's' : ''}${warning > 0 ? ` and ${warning} warning${warning > 1 ? 's' : ''}` : ''} need attention`,
       container: 'border-red-500/20 bg-red-500/[0.035]',
-      rail: 'bg-red-500',
       icon_: 'text-red-600 dark:text-red-500',
       title_: 'text-red-600 dark:text-red-500',
     }
@@ -39,7 +36,6 @@ function resolveTheme({ critical, warning, ok }: HealthCounts): BannerTheme {
       title: 'Minor issues',
       sub: `${warning} warning${warning > 1 ? 's' : ''} worth a look — nothing critical`,
       container: 'border-amber-500/20 bg-amber-500/[0.035]',
-      rail: 'bg-amber-500',
       icon_: 'text-amber-600 dark:text-amber-500',
       title_: 'text-amber-600 dark:text-amber-500',
     }
@@ -53,7 +49,6 @@ function resolveTheme({ critical, warning, ok }: HealthCounts): BannerTheme {
         : 'Waiting for health checks to report',
     // Healthy is the quietest state: a plain card surface, no tint.
     container: 'border-border bg-card',
-    rail: 'bg-emerald-500',
     icon_: 'text-emerald-600 dark:text-emerald-500',
     title_: 'text-foreground',
   }
@@ -61,9 +56,9 @@ function resolveTheme({ critical, warning, ok }: HealthCounts): BannerTheme {
 
 /**
  * Aggregate health banner: a restrained, severity-toned summary line (action
- * required / minor issues / all healthy). A thin left rail and a subtle tint
- * carry the severity — no saturated fill, no count pills (the filter tabs below
- * already carry the critical / warning / healthy tallies).
+ * required / minor issues / all healthy). A subtle tint plus the colored icon +
+ * title carry the severity — no accent rail, no saturated fill, no count pills
+ * (the filter tabs below already carry the critical / warning / healthy tallies).
  */
 export function HealthSummaryBanner({ counts }: { counts: HealthCounts }) {
   const theme = resolveTheme(counts)
@@ -72,15 +67,11 @@ export function HealthSummaryBanner({ counts }: { counts: HealthCounts }) {
   return (
     <div
       className={cn(
-        'relative flex items-center gap-3 overflow-hidden rounded-xl border py-3.5 pl-5 pr-4',
+        'flex items-center gap-3 rounded-xl border py-3.5 pl-4 pr-4',
         theme.container
       )}
       role="status"
     >
-      <span
-        aria-hidden
-        className={cn('absolute inset-y-0 left-0 w-1', theme.rail)}
-      />
       <Icon className={cn('size-5 flex-none', theme.icon_)} aria-hidden />
       <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5">
         <span className={cn('text-sm font-semibold', theme.title_)}>

--- a/apps/dashboard/src/components/insights/insights-preview.tsx
+++ b/apps/dashboard/src/components/insights/insights-preview.tsx
@@ -46,7 +46,7 @@ export function InsightsPreview({
     <Card>
       <CardHeader className="flex flex-row items-center justify-between gap-2 space-y-0">
         <CardTitle className="flex items-center gap-2 text-base">
-          <FlaskConical className="size-4 text-violet-500" />
+          <FlaskConical className="size-4 text-muted-foreground" />
           Example
           <Badge variant="secondary" className="font-normal text-[10px]">
             Sample

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -180,10 +180,12 @@ Prefer ONE clear signal per piece of state, not several redundant ones.
   border`) of `[status dot] [muted icon] [title] [sublabel] [value] [chevron]`
   rows — no per-row sparkline (a flat healthy trend is decoration). Partition the
   already severity-sorted, filter-narrowed list into cards vs rows so the same
-  split also drives the filter tabs. Keep the aggregate banner restrained (subtle
-  tint + thin left accent rail, not a saturated fill; let the tabs carry the
-  counts). Reference: `components/health/{health-grid,health-card-shell,
-  health-summary-banner}.tsx` (`HealthCardShell` `variant: 'card' | 'row'`).
+  split also drives the filter tabs. Keep the aggregate banner restrained: a
+  subtle tint plus the colored icon + title carry the severity — NO left accent
+  rail (a saturated rail reads as slop; removed 2026-07-05), no saturated fill,
+  no count pills (let the tabs carry the counts). Reference:
+  `components/health/{health-grid,health-card-shell,health-summary-banner}.tsx`
+  (`HealthCardShell` `variant: 'card' | 'row'`).
 - Graceful revalidation: keep data on `staleError`, show hover-revealed amber
   `ChartStaleIndicator`; only blank out on initial `error && !hasData`.
 - Icons: `lucide-react`, `size-4` / `size-3.5`, `strokeWidth={1.5}`.


### PR DESCRIPTION
Two small anti-slop fixes flagged on the live site:

- **Insights Example card** (`/insights-settings`): the flask icon used a full-saturation `text-violet-500` accent — neutralized to `text-muted-foreground`.
- **Health summary banner** (`/health`): removed the saturated full-opacity left accent rail. The subtle tint + colored icon + title already carry severity — the standalone bright rail was the exact redundant-rail anti-pattern the earlier `health-card-shell` incident removed. Updated the `product-design` doc's banner guidance to match (no rail).

Type-check passes; JSX/CSS-only.