### PR TITLE
feat(host): edit/details dialog on host switcher, permission-gated

### DIFF
--- a/apps/dashboard/src/components/host/host-details-dialog.tsx
+++ b/apps/dashboard/src/components/host/host-details-dialog.tsx
@@ -1,0 +1,224 @@
+import { Info, Loader2, Lock, Pencil } from 'lucide-react'
+
+import type { MergedHostInfo } from '@/lib/swr/use-merged-hosts'
+
+import { useEffect, useState } from 'react'
+import {
+  ConnectionForm,
+  type ConnectionFormData,
+} from '@/components/connections/connection-form'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { useBrowserConnections } from '@/lib/hooks/use-browser-connections'
+import { useUserConnectionsMutations } from '@/lib/hooks/use-user-connections'
+import { canEditHost, getHostSourceMeta } from '@/lib/host-permissions'
+import { useHostStatus } from '@/lib/swr/use-host-status'
+import { isServerHost } from '@/lib/swr/use-merged-hosts'
+import { cn } from '@/lib/utils'
+
+interface HostDetailsDialogProps {
+  host: MergedHostInfo | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+function DetailRow({
+  label,
+  value,
+  mono,
+}: {
+  label: string
+  value: React.ReactNode
+  mono?: boolean
+}) {
+  return (
+    <div className="grid grid-cols-[5.5rem_1fr] items-center gap-3 py-1">
+      <dt className="text-xs font-medium text-muted-foreground">{label}</dt>
+      <dd
+        className={cn(
+          'min-w-0 truncate text-sm',
+          mono && 'font-mono text-[13px]'
+        )}
+        title={typeof value === 'string' ? value : undefined}
+      >
+        {value}
+      </dd>
+    </div>
+  )
+}
+
+export function HostDetailsDialog({
+  host,
+  open,
+  onOpenChange,
+}: HostDetailsDialogProps) {
+  const [mode, setMode] = useState<'view' | 'edit'>('view')
+  const [saving, setSaving] = useState(false)
+
+  const source = host?.source
+  const editable = source ? canEditHost(source) : false
+  const meta = source ? getHostSourceMeta(source) : null
+  const serverHost = host ? isServerHost(host.source) : false
+
+  // Live status only resolves for server hosts (env/demo). Browser/database
+  // hosts have no server-side status entry — skip the poll entirely.
+  const { data: status, isLoading: statusLoading } = useHostStatus(
+    serverHost ? host!.id : null,
+    { refreshInterval: 60000, revalidateOnFocus: false }
+  )
+
+  const { updateConnection: updateBrowserConnection, getConnectionByHostId } =
+    useBrowserConnections()
+  const { updateConnection: updateDbConnection } = useUserConnectionsMutations()
+
+  const browserConn =
+    host?.source === 'browser' ? getConnectionByHostId(host.id) : undefined
+
+  // Reset to the view whenever a different host is opened or the dialog closes,
+  // so reopening never shows a stale edit form from a previous host.
+  useEffect(() => {
+    if (open) setMode('view')
+  }, [open, host?.id])
+
+  if (!host || !meta) return null
+
+  const handleSave = async (data: ConnectionFormData) => {
+    if (!host || saving) return
+    setSaving(true)
+    try {
+      // Never overwrite a stored password with an empty string. The browser
+      // store writes the field directly, so it's omitted when blank; the server
+      // PATCH makes the same guard for database connections.
+      const updates = {
+        name: data.name,
+        host: data.host,
+        user: data.user,
+        ...(data.password ? { password: data.password } : {}),
+      }
+
+      if (host.source === 'browser') {
+        if (!browserConn) return
+        updateBrowserConnection(browserConn.id, updates)
+      } else if (host.source === 'database' && host.connectionId) {
+        await updateDbConnection(host.connectionId, updates)
+      }
+      setMode('view')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const name = host.name || host.host
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        {mode === 'view' ? (
+          <>
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2 pr-6">
+                <span className="truncate">{name}</span>
+                <Badge
+                  variant="secondary"
+                  className="shrink-0 text-[10px] font-medium"
+                >
+                  {meta.label}
+                </Badge>
+              </DialogTitle>
+              <DialogDescription className="sr-only">
+                Connection details for {name}
+              </DialogDescription>
+            </DialogHeader>
+
+            <dl className="border-t pt-2">
+              <DetailRow label="Name" value={host.name || '—'} />
+              <DetailRow label="Host URL" value={host.host} mono />
+              <DetailRow label="Username" value={host.user || '—'} mono />
+              {serverHost && (
+                <DetailRow
+                  label="Server"
+                  value={
+                    statusLoading ? (
+                      <span className="inline-flex items-center gap-1.5 text-muted-foreground">
+                        <Loader2 className="size-3 animate-spin" />
+                        Checking…
+                      </span>
+                    ) : status ? (
+                      <span className="text-muted-foreground">
+                        {status.hostname} · v{status.version} · up{' '}
+                        {status.uptime}
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground">Unavailable</span>
+                    )
+                  }
+                />
+              )}
+            </dl>
+
+            <p className="flex items-start gap-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+              <Info className="mt-0.5 size-3.5 shrink-0" />
+              <span>{meta.note}</span>
+            </p>
+
+            <DialogFooter className="flex-row justify-between gap-2">
+              {editable ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setMode('edit')}
+                  data-testid="host-details-edit"
+                >
+                  <Pencil className="size-3.5" />
+                  Edit
+                </Button>
+              ) : (
+                <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <Lock className="size-3.5" />
+                  Editing disabled
+                </span>
+              )}
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => onOpenChange(false)}
+              >
+                Close
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>Edit connection</DialogTitle>
+              <DialogDescription>
+                Update the credentials for {name}. The host keeps its slot in
+                the switcher — your current view won&rsquo;t reset.
+              </DialogDescription>
+            </DialogHeader>
+            <ConnectionForm
+              initialValues={{
+                name: host.name,
+                host: host.host,
+                user: host.user,
+                // Browser connections have the password locally; prefill it so
+                // a no-op save preserves it. Server connections never expose it.
+                password: browserConn?.password ?? '',
+              }}
+              onSave={handleSave}
+              onCancel={() => setMode('view')}
+            />
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/dashboard/src/components/host/host-switcher.tsx
+++ b/apps/dashboard/src/components/host/host-switcher.tsx
@@ -1,5 +1,6 @@
-import { ChevronsUpDown, GlobeIcon, PlusIcon } from 'lucide-react'
+import { ChevronsUpDown, GlobeIcon, Info, Pencil, PlusIcon } from 'lucide-react'
 
+import { HostDetailsDialog } from './host-details-dialog'
 import { HostMenuRow } from './host-menu-row'
 import { HostVersionWithStatus } from './host-version-status'
 import {
@@ -25,9 +26,14 @@ import {
   useSidebar,
 } from '@/components/ui/sidebar'
 import { Skeleton } from '@/components/ui/skeleton'
+import { canEditHost } from '@/lib/host-permissions'
 import { usePathname, useRouter, useSearchParams } from '@/lib/next-compat'
 import { useHostId } from '@/lib/swr'
-import { isServerHost, useMergedHosts } from '@/lib/swr/use-merged-hosts'
+import {
+  isServerHost,
+  type MergedHostInfo,
+  useMergedHosts,
+} from '@/lib/swr/use-merged-hosts'
 import { buildUrl } from '@/lib/url/url-builder'
 import { cn, getHost } from '@/lib/utils'
 
@@ -45,6 +51,10 @@ export function HostSwitcher() {
   const { hosts, isLoading, error, isUnauthorized } = useMergedHosts()
   const currentHostId = useHostId()
   const [addDialogOpen, setAddDialogOpen] = useState(false)
+  // Controlled so a per-row "details/edit" click can close the menu before the
+  // dialog opens — otherwise the dropdown's focus trap fights the dialog's.
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [detailsHost, setDetailsHost] = useState<MergedHostInfo | null>(null)
 
   const activeHost =
     hosts.find((h) => h.id === currentHostId) ?? hosts[0] ?? null
@@ -205,7 +215,7 @@ export function HostSwitcher() {
       <SidebarMenu>
         <SidebarMenuItem>
           {showDropdown ? (
-            <DropdownMenu>
+            <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
               <DropdownMenuTrigger
                 render={
                   <SidebarMenuButton
@@ -265,24 +275,55 @@ export function HostSwitcher() {
                   </DropdownMenuLabel>
                 </DropdownMenuGroup>
                 <DropdownMenuSeparator />
-                {hosts.map((host) => (
-                  <DropdownMenuItem
-                    key={`${host.source}-${host.id}`}
-                    onClick={() => handleHostChange(host.id)}
-                    className="gap-2 p-2"
-                    data-testid={`host-option-${host.id}`}
-                  >
-                    {!isServerHost(host.source) && (
-                      <GlobeIcon className="size-3 shrink-0 text-muted-foreground" />
-                    )}
-                    <HostMenuRow
-                      hostId={isServerHost(host.source) ? host.id : null}
-                      hostName={host.name || getHost(host.host)}
-                      isActive={host.id === currentHostId}
-                      skipStatus={!isServerHost(host.source)}
-                    />
-                  </DropdownMenuItem>
-                ))}
+                {hosts.map((host) => {
+                  const hostLabel = host.name || getHost(host.host)
+                  const editable = canEditHost(host.source)
+                  return (
+                    <DropdownMenuItem
+                      key={`${host.source}-${host.id}`}
+                      onClick={() => handleHostChange(host.id)}
+                      className="gap-2 p-2"
+                      data-testid={`host-option-${host.id}`}
+                    >
+                      {!isServerHost(host.source) && (
+                        <GlobeIcon className="size-3 shrink-0 text-muted-foreground" />
+                      )}
+                      <div className="min-w-0 flex-1">
+                        <HostMenuRow
+                          hostId={isServerHost(host.source) ? host.id : null}
+                          hostName={hostLabel}
+                          isActive={host.id === currentHostId}
+                          skipStatus={!isServerHost(host.source)}
+                        />
+                      </div>
+                      {/* stopPropagation keeps the click from also switching the
+                          active host; closing the menu first avoids a focus-trap
+                          clash with the dialog that opens next. */}
+                      <button
+                        type="button"
+                        className="inline-flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground opacity-60 transition-opacity hover:bg-accent hover:text-foreground hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                        aria-label={
+                          editable
+                            ? `Edit ${hostLabel}`
+                            : `View ${hostLabel} details`
+                        }
+                        data-testid={`host-option-${host.id}-details`}
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          e.preventDefault()
+                          setDetailsHost(host)
+                          setMenuOpen(false)
+                        }}
+                      >
+                        {editable ? (
+                          <Pencil className="size-3.5" />
+                        ) : (
+                          <Info className="size-3.5" />
+                        )}
+                      </button>
+                    </DropdownMenuItem>
+                  )
+                })}
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
                   onClick={() => setAddDialogOpen(true)}
@@ -327,6 +368,13 @@ export function HostSwitcher() {
         </SidebarMenuItem>
       </SidebarMenu>
       <AddHostDialog open={addDialogOpen} onOpenChange={setAddDialogOpen} />
+      <HostDetailsDialog
+        host={detailsHost}
+        open={detailsHost !== null}
+        onOpenChange={(o) => {
+          if (!o) setDetailsHost(null)
+        }}
+      />
     </>
   )
 }

--- a/apps/dashboard/src/lib/hooks/use-user-connections.ts
+++ b/apps/dashboard/src/lib/hooks/use-user-connections.ts
@@ -99,6 +99,32 @@ export function useUserConnectionsMutations() {
     }>
   }
 
+  const updateConnection = async (
+    id: string,
+    input: {
+      name: string
+      host: string
+      user: string
+      /** Omit/blank to leave the stored password unchanged (server-side guard). */
+      password?: string
+    }
+  ): Promise<{
+    success: boolean
+    data: UserConnectionInfo
+  }> => {
+    const response = await apiFetch(`/api/v1/user-connections/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    })
+    await throwIfNotOk(response, 'Failed to update connection')
+    invalidate()
+    return response.json() as Promise<{
+      success: boolean
+      data: UserConnectionInfo
+    }>
+  }
+
   const deleteConnection = async (id: string) => {
     const response = await apiFetch(`/api/v1/user-connections/${id}`, {
       method: 'DELETE',
@@ -107,5 +133,5 @@ export function useUserConnectionsMutations() {
     invalidate()
   }
 
-  return { createConnection, deleteConnection, invalidate }
+  return { createConnection, updateConnection, deleteConnection, invalidate }
 }

--- a/apps/dashboard/src/lib/host-permissions.test.ts
+++ b/apps/dashboard/src/lib/host-permissions.test.ts
@@ -1,0 +1,50 @@
+import type { MergedHostInfo } from '@/lib/swr/use-merged-hosts'
+
+import { canEditHost, getHostSourceMeta } from './host-permissions'
+import { describe, expect, test } from 'bun:test'
+
+const SOURCES: MergedHostInfo['source'][] = [
+  'env',
+  'demo',
+  'browser',
+  'database',
+]
+
+describe('canEditHost', () => {
+  test('user-owned sources (browser, database) are editable', () => {
+    expect(canEditHost('browser')).toBe(true)
+    expect(canEditHost('database')).toBe(true)
+  })
+
+  test('operator/read-only sources (env, demo) are not editable', () => {
+    // env hosts come from CLICKHOUSE_HOST; demo is the public read-only host.
+    // The edit UI must be gated off for both so users never see a dead form.
+    expect(canEditHost('env')).toBe(false)
+    expect(canEditHost('demo')).toBe(false)
+  })
+
+  test('every known source resolves to a boolean (no accidental undefined)', () => {
+    for (const source of SOURCES) {
+      expect(typeof canEditHost(source)).toBe('boolean')
+    }
+  })
+})
+
+describe('getHostSourceMeta', () => {
+  test('returns a non-empty label + note for every source', () => {
+    for (const source of SOURCES) {
+      const meta = getHostSourceMeta(source)
+      expect(meta.label.length).toBeGreaterThan(0)
+      expect(meta.note.length).toBeGreaterThan(0)
+    }
+  })
+
+  test('non-editable sources explain why in the note', () => {
+    // The note is what the dialog shows when editing is disabled, so it must
+    // actually tell the user why they can't edit.
+    const env = getHostSourceMeta('env')
+    const demo = getHostSourceMeta('demo')
+    expect(env.note.toLowerCase()).toContain('operator')
+    expect(demo.note.toLowerCase()).toContain('read-only')
+  })
+})

--- a/apps/dashboard/src/lib/host-permissions.ts
+++ b/apps/dashboard/src/lib/host-permissions.ts
@@ -1,0 +1,51 @@
+import type { MergedHostInfo } from '@/lib/swr/use-merged-hosts'
+
+/**
+ * Whether a host's connection credentials can be edited in-app.
+ *
+ * Only user-owned storage (`browser` localStorage + `database` D1 connections)
+ * is editable. Operator-configured env hosts (`env`) come from CLICKHOUSE_HOST
+ * and the public read-only `demo` is fixed — neither has an in-app edit path.
+ *
+ * This is the single source of truth for the "disable edit based on permission"
+ * gate used by the host details dialog.
+ */
+export function canEditHost(source: MergedHostInfo['source']): boolean {
+  return source === 'browser' || source === 'database'
+}
+
+export interface HostSourceMeta {
+  /** Short badge label for the host details dialog header. */
+  label: string
+  /** Why this host can / can't be edited — shown as a muted note. */
+  note: string
+}
+
+/** Display + explanation metadata for each host source. */
+export function getHostSourceMeta(
+  source: MergedHostInfo['source']
+): HostSourceMeta {
+  switch (source) {
+    case 'env':
+      return {
+        label: 'Operator',
+        note: 'Configured by the operator via environment variables. Edit the CLICKHOUSE_HOST env var to change it.',
+      }
+    case 'demo':
+      return {
+        label: 'Demo · read-only',
+        note: 'Public read-only ClickHouse demo. Credentials are fixed; switch to your own host to make changes.',
+      }
+    case 'database':
+      return {
+        label: 'Server (synced)',
+        note: 'Stored encrypted on the server and synced across devices when signed in.',
+      }
+    case 'browser':
+    default:
+      return {
+        label: 'This browser',
+        note: 'Stored encrypted in this browser only.',
+      }
+  }
+}


### PR DESCRIPTION
## What

Adds a per-row Pencil/Info affordance in the host dropdown that opens a **Host Details** dialog showing the full host info (name, host URL, user, source badge, live version/uptime/hostname for server hosts), with **edit gated by host source** — satisfying "disable edit based on permission setup".

## Permission gate (`canEditHost`)

| Source | Editable? | Why |
|---|---|---|
| `browser` (localStorage) | ✅ | user-owned |
| `database` (D1, synced) | ✅ | user-owned |
| `env` (CLICKHOUSE_HOST) | ❌ | operator-configured |
| `demo` (public read-only) | ❌ | fixed credentials |

Non-editable hosts render a details-only view with a note explaining why and an "Editing disabled" indicator.

## Changes

- **`lib/host-permissions.ts`** (+ `.test.ts`) — `canEditHost` + `getHostSourceMeta`, the single source of truth for the edit gate. Pure module, no React imports → unit-tested directly (5 tests).
- **`components/host/host-details-dialog.tsx`** — new dialog; view + edit modes; reuses the existing `ConnectionForm` for editing.
- **`components/host/host-switcher.tsx`** — dropdown made **controlled** so the menu closes before the dialog opens (avoids a focus-trap clash); per-row button uses `stopPropagation` so the click doesn't also switch the active host.
- **`lib/hooks/use-user-connections.ts`** — adds `updateConnection` (PATCH `/api/v1/user-connections/$id` — server endpoint already existed). Password is omitted from the payload when blank so a no-op save preserves stored credentials (matches the server's own guard).

## Notes

- `hostId` is immutable on update, so editing a connection keeps its slot in the switcher — the current `?host=` view does not reset.
- The `readOnly` flag already on `MergedHostInfo` is set but never read elsewhere; this change keys off `source` (consistent with `isServerHost` / `resolve-host-fetch`) rather than introducing a second signal.

## Test

- `bun test src/lib/host-permissions.test.ts` → 5 pass / 18 expects.
- `pnpm run build` (Vite + `tsc --noEmit`) → green.