### PR TITLE
fix(menu): remove docs link from Operations parent menu item

### DIFF
--- a/apps/dashboard/src/menu.ts
+++ b/apps/dashboard/src/menu.ts
@@ -54,7 +54,6 @@ import type { MenuItem } from '@/components/menu/types'
 
 import { PeerDBLogo } from '@/components/icons/peerdb-brand-logo'
 import { EVENTS_TABLE } from '@/lib/app-tables'
-import { DOCS_SITE_URL } from '@/lib/docs-site'
 
 export const menuItemsConfig: MenuItem[] = [
   {
@@ -999,13 +998,6 @@ export const menuItemsConfig: MenuItem[] = [
         countLabel: 'views',
         icon: BarChartIcon,
         tableCheck: EVENTS_TABLE,
-      },
-      {
-        title: 'Docs',
-        href: DOCS_SITE_URL,
-        description: 'Documentation and usage guides',
-        icon: BookOpenIcon,
-        permission: { feature: 'docs' },
       },
       {
         title: 'About',


### PR DESCRIPTION
## What
Removes the external docs link rendered on the Operations parent menu item in the sidebar.

## Why
The Operations group's docs link is not wanted in the UI; child items keep their own docs/deep-links where applicable.

## Test
- `pnpm run build` runs in CI (required `dashboard` check).