### PR TITLE
fix(billing,organization): hide cloud-only routes on OSS, fix org card

### DIFF
--- a/apps/dashboard/src/components/clerk/organization-members.tsx
+++ b/apps/dashboard/src/components/clerk/organization-members.tsx
@@ -4,6 +4,7 @@ import {
   OrganizationProfile,
   useOrganization,
 } from '@clerk/tanstack-react-start'
+import { CloudOnlyNotice } from '@/components/cloud-only-notice'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -30,7 +31,11 @@ import { isCloudModeClient } from '@/lib/cloud/cloud-mode'
  */
 export function OrganizationMembers() {
   if (!isClerkEnabled() || !isCloudModeClient()) {
-    return <NoOrgState selfHosted />
+    // OSS / non-cloud: the sidebar already hides this route; this guards direct
+    // URL access. Shown as a clean "cloud feature" notice rather than the old
+    // misleading "No organization yet" card (which implied the user could —
+    // and should — create one).
+    return <CloudOnlyNotice feature="Organizations" />
   }
   return (
     <div className="mx-auto max-w-4xl space-y-6 py-8">
@@ -116,7 +121,7 @@ function PlanSection() {
   )
 }
 
-function NoOrgState({ selfHosted = false }: { selfHosted?: boolean }) {
+function NoOrgState() {
   return (
     <div className="mx-auto max-w-xl py-16">
       <Card>
@@ -126,22 +131,19 @@ function NoOrgState({ selfHosted = false }: { selfHosted?: boolean }) {
           </div>
           <CardTitle>No organization yet</CardTitle>
           <CardDescription>
-            {selfHosted
-              ? 'Organizations are a cloud feature.'
-              : 'Upgrade to Pro or Max to create a team workspace — invite members, assign roles, and share your plan.'}
+            Upgrade to Pro or Max to create a team workspace — invite members,
+            assign roles, and share your plan.
           </CardDescription>
         </CardHeader>
-        {!selfHosted && (
-          <CardContent className="flex justify-center">
-            <Button
-              render={
-                <a href="/billing">
-                  <Sparkles className="size-4" /> View plans
-                </a>
-              }
-            />
-          </CardContent>
-        )}
+        <CardContent className="flex justify-center">
+          <Button
+            render={
+              <a href="/billing">
+                <Sparkles className="size-4" /> View plans
+              </a>
+            }
+          />
+        </CardContent>
       </Card>
     </div>
   )

--- a/apps/dashboard/src/components/cloud-only-notice.tsx
+++ b/apps/dashboard/src/components/cloud-only-notice.tsx
@@ -1,0 +1,56 @@
+import { CloudIcon, ExternalLinkIcon } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { docsSiteUrl } from '@/lib/docs-site'
+
+interface CloudOnlyNoticeProps {
+  /** Feature name, e.g. "Billing" or "Organizations". */
+  feature: string
+  /** Override the default explanation. */
+  description?: string
+}
+
+/**
+ * Placeholder shown when a cloud-only surface (/billing, /organization) is
+ * opened on a self-hosted (OSS) build. The sidebar already filters these out of
+ * the menu on OSS — this guards direct URL access so the feature UI never
+ * renders there either, and explains why instead of showing a dead page.
+ */
+export function CloudOnlyNotice({
+  feature,
+  description,
+}: CloudOnlyNoticeProps) {
+  return (
+    <div className="mx-auto max-w-xl py-16">
+      <Card>
+        <CardHeader className="items-center text-center">
+          <div className="bg-primary/10 mb-2 flex size-12 items-center justify-center rounded-xl">
+            <CloudIcon className="text-primary size-6" />
+          </div>
+          <CardTitle>{feature} is a cloud feature</CardTitle>
+          <CardDescription>
+            {description ??
+              'Self-hosting is free forever. This surface is part of the hosted cloud edition — sign in to the cloud product to use it.'}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex justify-center">
+          <Button
+            variant="outline"
+            render={
+              <a href={docsSiteUrl()} target="_blank" rel="noopener noreferrer">
+                <ExternalLinkIcon className="size-4" /> Read the docs
+              </a>
+            }
+          />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/apps/dashboard/src/routes/(dashboard)/billing.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/billing.tsx
@@ -20,6 +20,7 @@ import {
 import { PlanComparison } from '@/components/billing/plan-comparison'
 import { UsageSummary } from '@/components/billing/usage-summary'
 import { ClerkSignInButton as ClerkSignInButtonImpl } from '@/components/clerk/clerk-sign-in-button'
+import { CloudOnlyNotice } from '@/components/cloud-only-notice'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -38,6 +39,7 @@ import {
   useBillingSubscription,
 } from '@/lib/billing/use-billing'
 import { isClerkEnabled } from '@/lib/clerk/clerk-client'
+import { isCloudModeClient } from '@/lib/cloud/cloud-mode'
 
 /**
  * Sign-in primitives gated behind the build-time `isClerkEnabled()` constant —
@@ -333,6 +335,17 @@ function BillingSignedOut() {
   )
 }
 
+/**
+ * Route guard. The sidebar already hides /billing on OSS (app-sidebar.tsx
+ * `cloudOnlyHrefs`); this guards direct URL access so the billing UI never
+ * renders on a self-hosted build. Rendered as a wrapper so BillingPage's hooks
+ * stay below the guard without a conditional-return-before-hooks smell.
+ */
+function BillingRoute() {
+  if (!isCloudModeClient()) return <CloudOnlyNotice feature="Billing" />
+  return <BillingPage />
+}
+
 export const Route = createFileRoute('/(dashboard)/billing')({
-  component: BillingPage,
+  component: BillingRoute,
 })


### PR DESCRIPTION
## What

The sidebar already filters \`/billing\` and \`/organization\` out of the menu on OSS, but the routes were still reachable by direct URL. This guards direct access and fixes the misleading org card.

**On OSS (cloud mode off):**
- \`/billing\` renders a shared \`CloudOnlyNotice\` instead of the full billing UI. Previously the billing UI rendered on OSS because \`useClerkIsSignedIn\` returns \`true\` when Clerk is off.
- \`/organization\` replaces its **"No organization yet"** card (which implied the user should create an org) with the same \`CloudOnlyNotice\`.

**Unchanged:** the cloud "no org yet → upgrade" card now only shows in its legitimate context (signed-in cloud user without an org). The dead \`selfHosted\` branch on \`NoOrgState\` is removed.

## Why
- "Hide /billing and /organization on OSS" — menu already hides them; this closes the direct-URL gap.
- "Fix the 'No organization yet' card" — that title was misleading on OSS (orgs don't exist there at all).

## Changes
- \`components/cloud-only-notice.tsx\` (new) — reusable cloud-edition card with a docs link.
- \`routes/(dashboard)/billing.tsx\` — \`BillingRoute\` wrapper guards on \`isCloudModeClient()\` (wrapper form keeps \`BillingPage\`'s hooks below the guard).
- \`components/clerk/organization-members.tsx\` — OSS branch returns \`CloudOnlyNotice\`; \`NoOrgState\` simplified to cloud-only.

## Test
- \`pnpm run build\` (Vite + \`tsc --noEmit\`) → green locally.