### PR TITLE
fix(charts): replace dev-facing empty state with a user-friendly one

### DIFF
--- a/apps/dashboard/src/routes/(dashboard)/charts.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/charts.tsx
@@ -1,10 +1,31 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { BarChart3 } from 'lucide-react'
+import { createFileRoute, Link } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { getChartComponent, hasChart } from '@/components/charts/chart-registry'
 import { ChartSkeleton, ChartsOnlyPageSkeleton } from '@/components/skeletons'
+import { EmptyState } from '@/components/ui/empty-state'
 import { useSearchParams } from '@/lib/next-compat'
 import { useHostId } from '@/lib/swr'
+import { buildUrl } from '@/lib/url/url-builder'
+
+// A small, curated set of charts spanning query / system / merge / table
+// categories, surfaced as quick picks when no ?name= is set.
+const FEATURED_CHARTS = [
+  'query-count',
+  'query-duration',
+  'memory-usage',
+  'cpu-usage',
+  'disk-size',
+  'merge-count',
+] as const
+
+function formatChartLabel(name: string): string {
+  return name
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
 
 interface DynamicChartProps {
   chartName: string
@@ -47,11 +68,30 @@ function ChartsPageContent() {
 
   if (chartNames.length === 0) {
     return (
-      <div className="p-4">
-        <h1 className="text-xl font-semibold mb-2">Charts</h1>
-        <p className="text-muted-foreground">
-          No charts specified. Use ?name=chart-name to view charts.
-        </p>
+      <div className="flex flex-col items-center justify-center px-4 py-16">
+        <EmptyState
+          variant="no-data"
+          title="Select a chart to view"
+          description="Choose from the charts below to visualize your ClickHouse metrics."
+          icon={
+            <BarChart3
+              className="h-10 w-10 text-muted-foreground/60"
+              strokeWidth={1.5}
+            />
+          }
+          className="py-0"
+        />
+        <div className="mt-6 flex flex-wrap items-center justify-center gap-2">
+          {FEATURED_CHARTS.map((chartName) => (
+            <Link
+              key={chartName}
+              href={buildUrl('/charts', { name: chartName }, searchParams)}
+              className="inline-flex items-center rounded-md border border-border bg-background px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+            >
+              {formatChartLabel(chartName)}
+            </Link>
+          ))}
+        </div>
       </div>
     )
   }

--- a/apps/dashboard/src/routes/(dashboard)/charts.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/charts.tsx
@@ -1,9 +1,10 @@
 import { BarChart3 } from 'lucide-react'
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { getChartComponent, hasChart } from '@/components/charts/chart-registry'
 import { ChartSkeleton, ChartsOnlyPageSkeleton } from '@/components/skeletons'
+import { AppLink as Link } from '@/components/ui/app-link'
 import { EmptyState } from '@/components/ui/empty-state'
 import { useSearchParams } from '@/lib/next-compat'
 import { useHostId } from '@/lib/swr'


### PR DESCRIPTION
## What
The `/charts` page leaked developer syntax (`?name=chart-name`) when no chart was selected. Replaced with a clean `EmptyState` and quick-pick chips for charts from the registry.

## Why
Empty states should guide users, not expose query-param internals.

## Test
- `pnpm run build` runs in CI (required `dashboard` check).