### PR TITLE
feat(query): child-query lineage + heuristic insights on detail page

### DIFF
--- a/apps/dashboard/src/components/query-detail/query-detail-view.tsx
+++ b/apps/dashboard/src/components/query-detail/query-detail-view.tsx
@@ -8,6 +8,7 @@ import {
   Database,
   ExternalLink,
   HardDrive,
+  Lightbulb,
   ListTree,
   MemoryStick,
   RowsIcon,
@@ -27,6 +28,7 @@ import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { buildExplorerQueryUrl } from '@/lib/explorer-url'
 import { formatReadableSize } from '@/lib/format-readable'
+import { deriveQueryInsights } from '@/lib/query/query-insights'
 import { useTableData } from '@/lib/query/use-table-data'
 import { formatSql } from '@/lib/sql-format'
 import { useHostId } from '@/lib/swr/use-host'
@@ -79,6 +81,22 @@ interface QueryDetailRow {
   interfaces?: string
   ProfileEvents?: Record<string, number | string>
   Settings?: Record<string, string>
+  [key: string]: unknown
+}
+
+/** Row from the `query-children` config (distributed/parallel query leaves). */
+interface ChildQueryRow {
+  query_id?: string
+  type?: string
+  event_time?: string
+  query_duration?: number | string
+  user?: string
+  query_kind?: string
+  read_rows?: number | string
+  readable_read_rows?: string
+  memory_usage?: number | string
+  readable_memory_usage?: string
+  query_preview?: string
   [key: string]: unknown
 }
 
@@ -402,7 +420,19 @@ export const QueryDetailView = function QueryDetailView({
     { query_id: queryId }
   )
 
+  // Child queries spawned by this one (distributed/parallel leaves). Fetched
+  // unconditionally to keep hook order stable; rendered only when non-empty.
+  const { data: childrenData } = useTableData<ChildQueryRow>(
+    'query-children',
+    hostId,
+    { query_id: queryId }
+  )
+
   const row = data?.[0]
+
+  // Cheap client-side red-flags from the loaded row (exception, slow, memory,
+  // full-scan, low selectivity). Memoized on the row reference.
+  const insights = useMemo(() => (row ? deriveQueryInsights(row) : []), [row])
 
   // Hooks must be called unconditionally — compute from `row` (may be undefined)
   // before any early returns.
@@ -688,12 +718,85 @@ export const QueryDetailView = function QueryDetailView({
       {/* ── 3. SQL block ── */}
       {queryText && <SqlBlock query={queryText} />}
 
-      {/* ── 4. ProfileEvents + Settings ── */}
+      {/* ── 4. Insights ── client-side red flags derived from the row. */}
+      {insights.length > 0 && (
+        <div className="rounded-xl border border-border bg-card p-4">
+          <h2 className="mb-3 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+            <Lightbulb className="size-3.5" />
+            Insights
+          </h2>
+          <ul className="space-y-2.5">
+            {insights.map((insight) => (
+              <li key={insight.id} className="flex items-start gap-2.5">
+                <span
+                  className={cn(
+                    'mt-1 size-2 shrink-0 rounded-full',
+                    insight.severity === 'critical'
+                      ? 'bg-rose-500'
+                      : insight.severity === 'warning'
+                        ? 'bg-amber-500'
+                        : 'bg-sky-500'
+                  )}
+                />
+                <div className="min-w-0">
+                  <p className="text-[12.5px] font-medium">{insight.title}</p>
+                  <p className="text-[11.5px] leading-relaxed text-muted-foreground">
+                    {insight.detail}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* ── 5. ProfileEvents + Settings ── */}
       {profileEntries.length > 0 && (
         <CollapsibleSection title="Profile Events" entries={profileEntries} />
       )}
       {settingsEntries.length > 0 && (
         <CollapsibleSection title="Query Settings" entries={settingsEntries} />
+      )}
+
+      {/* ── 6. Child queries ── distributed/parallel leaves spawned by this
+          root (initial_query_id match). Linked back into /query detail. */}
+      {childrenData && childrenData.length > 0 && (
+        <div className="overflow-hidden rounded-xl border border-border bg-card">
+          <div className="flex items-center justify-between gap-2 border-b border-border bg-muted/40 px-4 py-2.5">
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Child queries
+            </span>
+            <span className="text-[10.5px] tabular-nums text-muted-foreground">
+              {childrenData.length} spawned by this query
+            </span>
+          </div>
+          <ul className="divide-y divide-border">
+            {childrenData.map((child) => (
+              <li
+                key={String(child.query_id)}
+                className="flex items-center gap-3 px-4 py-2"
+              >
+                <Link
+                  href={buildUrl('/query', {
+                    query_id: String(child.query_id),
+                    host: hostId,
+                  })}
+                  className="min-w-0 flex-1 truncate font-mono text-[12px] hover:underline"
+                >
+                  {String(child.query_id)}
+                </Link>
+                <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+                  {formatDurationSeconds(toNumber(child.query_duration))}
+                </span>
+                {toStr(child.readable_read_rows) && (
+                  <span className="shrink-0 text-[11px] text-muted-foreground">
+                    {toStr(child.readable_read_rows)} rows
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
       )}
     </div>
   )

--- a/apps/dashboard/src/lib/query-config/index.ts
+++ b/apps/dashboard/src/lib/query-config/index.ts
@@ -66,6 +66,7 @@ import { historyQueriesConfig } from './queries/history-queries'
 import { parallelizationConfig } from './queries/parallelization'
 import { profilerConfig } from './queries/profiler'
 import { queryCacheConfig } from './queries/query-cache'
+import { queryChildrenConfig } from './queries/query-children'
 import { queryConditionCacheConfig } from './queries/query-condition-cache'
 import { queryDetailConfig } from './queries/query-detail'
 import { queryViewsLogConfig } from './queries/query-views-log'
@@ -168,6 +169,7 @@ export const queries: Array<QueryConfig> = [
   queryConditionCacheConfig,
   queryViewsLogConfig,
   queryDetailConfig,
+  queryChildrenConfig,
   runningQueriesConfig,
   historyQueriesConfig,
   recentQueriesConfig,

--- a/apps/dashboard/src/lib/query-config/queries/query-children.ts
+++ b/apps/dashboard/src/lib/query-config/queries/query-children.ts
@@ -1,0 +1,62 @@
+import type { QueryConfig } from '@/types/query-config'
+
+import { QUERY_LOG } from '@/lib/table-notes'
+
+/**
+ * query-children: queries spawned by a given root query.
+ *
+ * ClickHouse links a distributed/parallel query's leaves to their root via
+ * `initial_query_id`: every leaf row has the root's id in `initial_query_id`
+ * and its own `query_id`. This config lists the leaves for a given root —
+ * i.e. the child queries the /query detail page's "Child queries" section
+ * renders.
+ *
+ * Filters to `type = 'QueryFinish'` so we show one finished row per child
+ * (query_log records multiple event types per execution).
+ *
+ * All columns exist since well before the 20.0 version boundary.
+ */
+export const queryChildrenConfig: QueryConfig = {
+  name: 'query-children',
+  description:
+    'Queries spawned by a distributed/parallel query (initial_query_id match)',
+  docs: QUERY_LOG,
+  permission: { feature: 'queries' },
+  tableCheck: 'system.query_log',
+  sql: `
+    SELECT
+      query_id,
+      type,
+      event_time,
+      query_duration_ms / 1000 AS query_duration,
+      user,
+      query_kind,
+      read_rows,
+      formatReadableQuantity(read_rows) AS readable_read_rows,
+      memory_usage,
+      formatReadableSize(memory_usage) AS readable_memory_usage,
+      substring(query, 1, 200) AS query_preview
+    FROM system.query_log
+    WHERE initial_query_id = {query_id: String}
+      AND query_id != initial_query_id
+      AND type = 'QueryFinish'
+    ORDER BY event_time DESC
+    LIMIT 50
+  `,
+  columns: [
+    'query_id',
+    'type',
+    'event_time',
+    'query_duration',
+    'user',
+    'query_kind',
+    'read_rows',
+    'readable_read_rows',
+    'memory_usage',
+    'readable_memory_usage',
+    'query_preview',
+  ],
+  defaultParams: {
+    query_id: '',
+  },
+}

--- a/apps/dashboard/src/lib/query/query-insights.test.ts
+++ b/apps/dashboard/src/lib/query/query-insights.test.ts
@@ -1,0 +1,108 @@
+import { deriveQueryInsights } from './query-insights'
+import { describe, expect, test } from 'bun:test'
+
+describe('deriveQueryInsights', () => {
+  test('flags an exception as critical and surfaces it first', () => {
+    const out = deriveQueryInsights({
+      query: 'SELECT 1',
+      exception_code: 48,
+      exception_text: 'ADASTRA: limit exceeded',
+      query_duration: 0.1,
+      read_rows: 0,
+      result_rows: 0,
+      memory_usage: 0,
+    })
+    expect(out[0].id).toBe('exception')
+    expect(out[0].severity).toBe('critical')
+  })
+
+  test('no findings for a cheap, well-formed query', () => {
+    const out = deriveQueryInsights({
+      query: 'SELECT count() FROM t WHERE x = 1',
+      query_duration: 0.05,
+      read_rows: 1000,
+      result_rows: 1,
+      memory_usage: 5_000_000,
+    })
+    expect(out).toEqual([])
+  })
+
+  test('warns on slow (>=10s) and critical on very slow (>=60s)', () => {
+    const slow = deriveQueryInsights({
+      query: 'SELECT 1 WHERE 1',
+      query_duration: 12,
+      read_rows: 1,
+      result_rows: 1,
+      memory_usage: 0,
+    })
+    expect(slow.find((i) => i.id === 'duration-warn')?.severity).toBe('warning')
+
+    const very = deriveQueryInsights({
+      query: 'SELECT 1 WHERE 1',
+      query_duration: 90,
+      read_rows: 1,
+      result_rows: 1,
+      memory_usage: 0,
+    })
+    expect(very.find((i) => i.id === 'duration-critical')?.severity).toBe(
+      'critical'
+    )
+    // critical threshold should not ALSO emit the warn duplicate
+    expect(very.find((i) => i.id === 'duration-warn')).toBeUndefined()
+  })
+
+  test('flags SELECT without WHERE but leaves DDL alone', () => {
+    const select = deriveQueryInsights({
+      query: 'SELECT * FROM events',
+      query_duration: 0.1,
+      read_rows: 10,
+      result_rows: 10,
+      memory_usage: 0,
+    })
+    expect(select.find((i) => i.id === 'no-where')).toBeDefined()
+
+    const ddl = deriveQueryInsights({
+      query: 'CREATE TABLE t (x UInt8) ENGINE = MergeTree ORDER BY x',
+      query_duration: 0.1,
+      read_rows: 0,
+      result_rows: 0,
+      memory_usage: 0,
+    })
+    expect(ddl.find((i) => i.id === 'no-where')).toBeUndefined()
+  })
+
+  test('low-selectivity only fires on a material scan, not tiny reads', () => {
+    const big = deriveQueryInsights({
+      query: 'SELECT 1 WHERE 1',
+      query_duration: 1,
+      read_rows: 5_000_000,
+      result_rows: 1,
+      memory_usage: 0,
+    })
+    expect(big.find((i) => i.id === 'low-selectivity')).toBeDefined()
+
+    const small = deriveQueryInsights({
+      query: 'SELECT 1 WHERE 1',
+      query_duration: 1,
+      read_rows: 5000,
+      result_rows: 1,
+      memory_usage: 0,
+    })
+    expect(small.find((i) => i.id === 'low-selectivity')).toBeUndefined()
+  })
+
+  test('orders critical before warning before info', () => {
+    const out = deriveQueryInsights({
+      query: 'SELECT * FROM big_table',
+      query_duration: 30,
+      read_rows: 50_000_000,
+      result_rows: 1,
+      memory_usage: 5_000_000_000,
+    })
+    const severities = out.map((i) => i.severity)
+    // critical entries must come before warning before info
+    const ranks = { critical: 0, warning: 1, info: 2 }
+    const nums = severities.map((s) => ranks[s])
+    expect([...nums].sort((a, b) => a - b)).toEqual(nums)
+  })
+})

--- a/apps/dashboard/src/lib/query/query-insights.ts
+++ b/apps/dashboard/src/lib/query/query-insights.ts
@@ -1,0 +1,157 @@
+/**
+ * Heuristic, fully client-side query insights for the /query detail page.
+ *
+ * These are cheap red-flags derived from the `system.query_log` row the page
+ * already loads — no extra fetch, no LLM. They surface the obvious "why is this
+ * slow / why did it fail" signals a human would point at first: a thrown
+ * exception, a long duration, a large memory footprint, a full scan, or a tiny
+ * result set relative to rows read.
+ *
+ * Keep the bar conservative — only flag what is clearly actionable, so the
+ * section earns trust rather than crying wolf.
+ */
+
+export interface QueryInsightInput {
+  query?: string
+  query_kind?: string
+  type?: string
+  exception_code?: number | string
+  exception_text?: string
+  /** Seconds (query_log.query_duration_ms / 1000). */
+  query_duration?: number | string
+  read_rows?: number | string
+  result_rows?: number | string
+  written_rows?: number | string
+  /** Bytes. */
+  memory_usage?: number | string
+  /** query_log.query_cache_usage — a 0..1 ratio. */
+  query_cache_usage?: number | string
+}
+
+export type InsightSeverity = 'critical' | 'warning' | 'info'
+
+export interface QueryInsight {
+  id: string
+  severity: InsightSeverity
+  title: string
+  detail: string
+}
+
+const DURATION_WARN_S = 10
+const DURATION_CRITICAL_S = 60
+const MEMORY_WARN_B = 1_000_000_000 // 1 GB
+const MEMORY_CRITICAL_B = 10_000_000_000 // 10 GB
+/** Flag low selectivity only when both non-trivial: avoids noise on tiny scans. */
+const SELECTIVITY_MIN_READ = 1_000_000
+const SELECTIVITY_RATIO = 1000
+
+function toNum(v: unknown): number {
+  if (v == null) return 0
+  const n = Number(v)
+  return Number.isFinite(n) ? n : 0
+}
+
+function looksLikeSelect(query: string): boolean {
+  return /\bSELECT\b/i.test(query) || /\bWITH\b/i.test(query)
+}
+
+function hasWhereClause(query: string): boolean {
+  return /\bWHERE\b/i.test(query)
+}
+
+/**
+ * Derive insight cards from a single query-log row. Order is stable: critical
+ * findings first, then warnings, then info — so the most important signal is
+ * seen first.
+ */
+export function deriveQueryInsights(row: QueryInsightInput): QueryInsight[] {
+  const insights: QueryInsight[] = []
+
+  const duration = toNum(row.query_duration)
+  const memory = toNum(row.memory_usage)
+  const readRows = toNum(row.read_rows)
+  const resultRows = toNum(row.result_rows)
+  const exceptionCode = toNum(row.exception_code)
+  const query = row.query ?? ''
+
+  // 1. Exception — the single most useful signal on a failed query.
+  if (exceptionCode !== 0) {
+    insights.push({
+      id: 'exception',
+      severity: 'critical',
+      title: 'Query ended with an error',
+      detail: row.exception_text
+        ? `${row.exception_text.split('\n')[0].slice(0, 200)} (code ${exceptionCode})`
+        : `Exception code ${exceptionCode}`,
+    })
+  }
+
+  // 2. Duration.
+  if (duration >= DURATION_CRITICAL_S) {
+    insights.push({
+      id: 'duration-critical',
+      severity: 'critical',
+      title: 'Very slow query',
+      detail: `${duration.toFixed(2)}s — beyond the 60s "very slow" threshold.`,
+    })
+  } else if (duration >= DURATION_WARN_S) {
+    insights.push({
+      id: 'duration-warn',
+      severity: 'warning',
+      title: 'Slow query',
+      detail: `${duration.toFixed(2)}s — over the 10s slow-query threshold.`,
+    })
+  }
+
+  // 3. Memory.
+  if (memory >= MEMORY_CRITICAL_B) {
+    insights.push({
+      id: 'memory-critical',
+      severity: 'critical',
+      title: 'Very high memory usage',
+      detail:
+        'Over 10 GB — risk of OOM cancellations on memory-constrained nodes.',
+    })
+  } else if (memory >= MEMORY_WARN_B) {
+    insights.push({
+      id: 'memory-warn',
+      severity: 'warning',
+      title: 'High memory usage',
+      detail:
+        'Over 1 GB — worth checking for broad scans or missing aggregation limits.',
+    })
+  }
+
+  // 4. Full-scan heuristic — SELECT without a WHERE. Deliberately info-level
+  //    (a missing WHERE is sometimes intended, e.g. small dimension tables).
+  if (query && looksLikeSelect(query) && !hasWhereClause(query)) {
+    insights.push({
+      id: 'no-where',
+      severity: 'info',
+      title: 'No WHERE clause',
+      detail:
+        'This read has no filter — if the table is large, consider adding a predicate to avoid a full scan.',
+    })
+  }
+
+  // 5. Low selectivity — read a lot, returned a little. Only when material.
+  if (
+    readRows >= SELECTIVITY_MIN_READ &&
+    resultRows > 0 &&
+    readRows / resultRows >= SELECTIVITY_RATIO
+  ) {
+    insights.push({
+      id: 'low-selectivity',
+      severity: 'info',
+      title: 'Low selectivity',
+      detail: `Read ${readRows.toLocaleString()} rows to return ${resultRows.toLocaleString()} — a tighter filter or pre-aggregation could cut the scan.`,
+    })
+  }
+
+  const order: Record<InsightSeverity, number> = {
+    critical: 0,
+    warning: 1,
+    info: 2,
+  }
+  return insights.sort((a, b) => order[a.severity] - order[b.severity])
+}


### PR DESCRIPTION
## What
Adds two sections to the \`/query\` detail page:

- **Insights** — client-side red-flags from the loaded row via \`deriveQueryInsights\` (new pure module, unit-tested): thrown exception, slow / very-slow duration, high / very-high memory, SELECT without WHERE, low selectivity. Severity-ordered (critical → info), shown right under the SQL.
- **Child queries** — lists queries spawned by this one (distributed/parallel leaves), backed by a new \`query-children\` config that filters \`system.query_log\` on \`initial_query_id\`. Each row links back into \`/query\` detail with duration + rows read.

## Why
Asks #5 (insights) and the child-query part of #6 from the /query enhancement group. The lineage direction is now bidirectional: F2 added the **parent** (Initial query) link; this adds the **children**.

## Changes
- \`lib/query/query-insights.ts\` (+ \`.test.ts\`) — pure heuristic module, 6 unit tests.
- \`lib/query-config/queries/query-children.ts\` — new config (\`WHERE initial_query_id = {query_id} AND query_id != initial_query_id AND type = 'QueryFinish'\`, LIMIT 50); columns stable across all supported CH versions.
- \`lib/query-config/index.ts\` — registers \`queryChildrenConfig\`.
- \`components/query-detail/query-detail-view.tsx\` — Insights + Child queries sections.

## Test
- \`bun test src/lib/query/query-insights.test.ts\` → 6 pass.
- \`pnpm run build\` (Vite + \`tsc --noEmit\`) → green.