### PR TITLE
feat(query): query-stages chart (per-processor duration breakdown)

### DIFF
--- a/apps/dashboard/src/components/query-detail/query-detail-view.tsx
+++ b/apps/dashboard/src/components/query-detail/query-detail-view.tsx
@@ -21,6 +21,7 @@ import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { highlightCode } from '@/components/ai-elements/code-block'
 import { HLJS_TOKEN_CLASSES } from '@/components/ai-elements/hljs-token-classes'
 import { KpiCard } from '@/components/overview-charts/kpi-card'
+import { QueryStagesChart } from '@/components/query-detail/query-stages-chart'
 import { TableSkeleton } from '@/components/skeletons'
 import { AppLink as Link } from '@/components/ui/app-link'
 import { Button } from '@/components/ui/button'
@@ -717,6 +718,10 @@ export const QueryDetailView = function QueryDetailView({
 
       {/* ── 3. SQL block ── */}
       {queryText && <SqlBlock query={queryText} />}
+
+      {/* ── 3b. Query stages ── per-processor duration breakdown. Renders
+          nothing when the optional processors_profile_log table is empty. */}
+      <QueryStagesChart queryId={queryId} />
 
       {/* ── 4. Insights ── client-side red flags derived from the row. */}
       {insights.length > 0 && (

--- a/apps/dashboard/src/components/query-detail/query-stages-chart.tsx
+++ b/apps/dashboard/src/components/query-detail/query-stages-chart.tsx
@@ -1,0 +1,147 @@
+import { Activity } from 'lucide-react'
+
+import { useMemo } from 'react'
+import { Skeleton } from '@/components/ui/skeleton'
+import { useTableData } from '@/lib/query/use-table-data'
+import { formatMicros, segmentWidthPct } from '@/lib/query/format-micros'
+import { useHostId } from '@/lib/swr/use-host'
+import { cn } from '@/lib/utils'
+
+interface ProcessorRow {
+  name?: string
+  elapsed_us?: number | string
+  input_wait_us?: number | string
+  output_wait_us?: number | string
+  input_rows?: number | string
+  output_rows?: number | string
+  [key: string]: unknown
+}
+
+function toNum(v: unknown): number {
+  if (v == null) return 0
+  const n = Number(v)
+  return Number.isFinite(n) ? n : 0
+}
+
+function totalOf(r: ProcessorRow): number {
+  return toNum(r.elapsed_us) + toNum(r.input_wait_us) + toNum(r.output_wait_us)
+}
+
+/**
+ * "Query stages" — a duration-proportional horizontal bar chart of the
+ * per-processor time breakdown for a query (active vs input-wait vs
+ * output-wait), backed by `system.processors_profile_log` via the
+ * `query-processors` config.
+ *
+ * This is a duration breakdown, not a wall-clock Gantt — `processors_profile_log`
+ * carries aggregate elapsed per processor, not start/finish offsets. A true
+ * time-axis Gantt would need OpenTelemetry spans, which require tracing enabled.
+ *
+ * The source table is optional (`log_processor_profiles`); when it is missing
+ * or empty for this query the component renders nothing so the page stays clean.
+ */
+export function QueryStagesChart({ queryId }: { queryId: string }) {
+  const hostId = useHostId()
+  const { data, isLoading, error } = useTableData<ProcessorRow>(
+    'query-processors',
+    hostId,
+    { query_id: queryId }
+  )
+
+  const rows = data ?? []
+  const maxTotal = useMemo(
+    () => rows.reduce((m, r) => Math.max(m, totalOf(r)), 0),
+    [rows]
+  )
+
+  if (isLoading) return <StagesSkeleton />
+  // Optional table — hide silently when unavailable or empty for this query.
+  if (error || rows.length === 0 || maxTotal <= 0) return null
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-4">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <h2 className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+          <Activity className="size-3.5" />
+          Query stages
+        </h2>
+        <Legend />
+      </div>
+      <ul className="space-y-1.5">
+        {rows.map((r, i) => {
+          const active = toNum(r.elapsed_us)
+          const inputWait = toNum(r.input_wait_us)
+          const outputWait = toNum(r.output_wait_us)
+          return (
+            <li
+              key={`${toStr(r.name)}-${i}`}
+              className="grid grid-cols-[9rem_1fr_auto] items-center gap-3"
+            >
+              <span
+                className="truncate font-mono text-[11px] text-muted-foreground"
+                title={toStr(r.name)}
+              >
+                {toStr(r.name) || '—'}
+              </span>
+              <div className="flex h-4 overflow-hidden rounded bg-muted/40">
+                <span
+                  className="bg-sky-500"
+                  style={{ width: `${segmentWidthPct(active, maxTotal)}%` }}
+                />
+                <span
+                  className="bg-amber-500"
+                  style={{ width: `${segmentWidthPct(inputWait, maxTotal)}%` }}
+                />
+                <span
+                  className="bg-violet-500"
+                  style={{ width: `${segmentWidthPct(outputWait, maxTotal)}%` }}
+                />
+              </div>
+              <span className="text-[11px] tabular-nums text-muted-foreground">
+                {formatMicros(active + inputWait + outputWait)}
+              </span>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}
+
+function Legend() {
+  const items: [string, string][] = [
+    ['bg-sky-500', 'Active'],
+    ['bg-amber-500', 'Input wait'],
+    ['bg-violet-500', 'Output wait'],
+  ]
+  return (
+    <div className="flex items-center gap-3">
+      {items.map(([cls, label]) => (
+        <span
+          key={label}
+          className="flex items-center gap-1 text-[10px] text-muted-foreground"
+        >
+          <span className={cn('size-2 rounded-sm', cls)} />
+          {label}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+function StagesSkeleton() {
+  return (
+    <div className="rounded-xl border border-border bg-card p-4">
+      <Skeleton className="mb-3 h-3 w-24" />
+      <div className="space-y-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-4 w-full" />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function toStr(v: unknown): string {
+  return v == null ? '' : String(v)
+}

--- a/apps/dashboard/src/lib/query-config/index.ts
+++ b/apps/dashboard/src/lib/query-config/index.ts
@@ -69,6 +69,7 @@ import { queryCacheConfig } from './queries/query-cache'
 import { queryChildrenConfig } from './queries/query-children'
 import { queryConditionCacheConfig } from './queries/query-condition-cache'
 import { queryDetailConfig } from './queries/query-detail'
+import { queryProcessorsConfig } from './queries/query-processors'
 import { queryViewsLogConfig } from './queries/query-views-log'
 import { recentQueriesConfig } from './queries/recent-queries'
 import { runningQueriesConfig } from './queries/running-queries'
@@ -170,6 +171,7 @@ export const queries: Array<QueryConfig> = [
   queryViewsLogConfig,
   queryDetailConfig,
   queryChildrenConfig,
+  queryProcessorsConfig,
   runningQueriesConfig,
   historyQueriesConfig,
   recentQueriesConfig,

--- a/apps/dashboard/src/lib/query-config/queries/query-processors.ts
+++ b/apps/dashboard/src/lib/query-config/queries/query-processors.ts
@@ -1,0 +1,53 @@
+import type { QueryConfig } from '@/types/query-config'
+
+/**
+ * query-processors: per-processor timing for a single query, the closest
+ * available "where did the time go" breakdown for a stages view.
+ *
+ * Source: `system.processors_profile_log` (requires `log_processor_profiles=1`,
+ * on by default). Grouped by processor `name` so repeat invocations of the same
+ * processor roll up; ordered by self-time so the heaviest stages lead. The page
+ * renders this as a horizontal duration-proportional bar chart (active vs
+ * input-wait vs output-wait).
+ *
+ * Note: this is a duration-proportional breakdown, not a wall-clock Gantt —
+ * `processors_profile_log` carries aggregate elapsed per processor, not
+ * start/finish offsets. A true time-axis Gantt needs OpenTelemetry spans
+ * (`opentelemetry_span_log`), which require tracing enabled on the server.
+ *
+ * The table is optional; the page hides this section when it is empty.
+ */
+export const queryProcessorsConfig: QueryConfig = {
+  name: 'query-processors',
+  description:
+    'Per-processor timing breakdown for a query (processors_profile_log)',
+  docs: "The required table 'processors_profile_log' may be missing. See https://clickhouse.com/docs/en/operations/system-tables/processors_profile_log",
+  permission: { feature: 'queries' },
+  optional: true,
+  tableCheck: 'system.processors_profile_log',
+  sql: `
+    SELECT
+      name,
+      sum(elapsed_us) AS elapsed_us,
+      sum(input_wait_elapsed_us) AS input_wait_us,
+      sum(output_wait_elapsed_us) AS output_wait_us,
+      sum(input_rows) AS input_rows,
+      sum(output_rows) AS output_rows
+    FROM system.processors_profile_log
+    WHERE query_id = {query_id: String}
+    GROUP BY name
+    ORDER BY elapsed_us DESC
+    LIMIT 20
+  `,
+  columns: [
+    'name',
+    'elapsed_us',
+    'input_wait_us',
+    'output_wait_us',
+    'input_rows',
+    'output_rows',
+  ],
+  defaultParams: {
+    query_id: '',
+  },
+}

--- a/apps/dashboard/src/lib/query/format-micros.test.ts
+++ b/apps/dashboard/src/lib/query/format-micros.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test'
+
+import { formatMicros, segmentWidthPct } from './format-micros'
+
+describe('formatMicros', () => {
+  test('sub-millisecond values render as µs', () => {
+    expect(formatMicros(0)).toBe('0µs')
+    expect(formatMicros(1)).toBe('1µs')
+    expect(formatMicros(999)).toBe('999µs')
+  })
+
+  test('milliseconds render with adaptive precision', () => {
+    expect(formatMicros(1000)).toBe('1.00ms')
+    expect(formatMicros(9_999)).toBe('10.00ms')
+    expect(formatMicros(12_300)).toBe('12.3ms')
+  })
+
+  test('seconds and minutes', () => {
+    expect(formatMicros(1_200_000)).toBe('1.20s')
+    expect(formatMicros(59_900_000)).toBe('59.90s')
+    expect(formatMicros(125_000_000)).toBe('2m 5s')
+  })
+
+  test('non-finite / negative fall back to 0µs', () => {
+    expect(formatMicros(NaN)).toBe('0µs')
+    expect(formatMicros(-5)).toBe('0µs')
+  })
+})
+
+describe('segmentWidthPct', () => {
+  test('the max-total row spans 100%', () => {
+    expect(segmentWidthPct(100, 100)).toBe(100)
+  })
+
+  test('scales proportionally and never exceeds 100', () => {
+    expect(segmentWidthPct(25, 100)).toBe(25)
+    expect(segmentWidthPct(150, 100)).toBe(100)
+  })
+
+  test('zero / negative max is safe (no NaN)', () => {
+    expect(segmentWidthPct(50, 0)).toBe(0)
+    expect(segmentWidthPct(50, -1)).toBe(0)
+  })
+})

--- a/apps/dashboard/src/lib/query/format-micros.ts
+++ b/apps/dashboard/src/lib/query/format-micros.ts
@@ -1,0 +1,29 @@
+/**
+ * Format microseconds into a compact human duration for query-stage bars:
+ * `980µs`, `12.3ms`, `1.20s`, `2m 3s`. Pure — unit tested.
+ */
+export function formatMicros(us: number): string {
+  if (!Number.isFinite(us) || us <= 0) return '0µs'
+  if (us < 1000) return `${Math.round(us)}µs`
+  if (us < 1_000_000) {
+    // more precision when sub-10ms (small absolute differences matter there)
+    return `${(us / 1000).toFixed(us < 10_000 ? 2 : 1)}ms`
+  }
+  const s = us / 1_000_000
+  if (s < 60) return `${s.toFixed(2)}s`
+  const m = Math.floor(s / 60)
+  const rem = Math.round(s % 60)
+  return `${m}m ${rem}s`
+}
+
+/**
+ * Width (0..100) of a segment relative to the largest row's total, so the
+ * heaviest stage spans the full track and others scale against it. Floors at
+ * 0 when there is no max (avoids NaN / divide-by-zero).
+ */
+export function segmentWidthPct(segment: number, maxTotal: number): number {
+  if (maxTotal <= 0) return 0
+  const pct = (segment / maxTotal) * 100
+  if (!Number.isFinite(pct) || pct < 0) return 0
+  return pct > 100 ? 100 : pct
+}


### PR DESCRIPTION
## What
Adds a **Query stages** visualization to \`/query\`: a duration-proportional horizontal bar chart of the per-processor time breakdown (active vs input-wait vs output-wait) for the query, mounted under the SQL block.

## Why
Ask #2 (the "Gantt of query stages") from the /query enhancement group.

## Honest caveat
This is a **duration-proportional breakdown**, not a wall-clock Gantt. \`system.processors_profile_log\` carries aggregate \`elapsed_us\` per processor, not start/finish offsets — so a true time-axis Gantt isn't possible from this source. A literal Gantt needs OpenTelemetry spans (\`opentelemetry_span_log\`), which require tracing enabled on the ClickHouse server and are usually empty. The chart hides itself when the optional table is empty, so deployments without processor profiles see no change.

## Changes
- \`lib/query-config/queries/query-processors.ts\` — new optional config (filters \`processors_profile_log\` by \`query_id\`, grouped by processor name, top 20 by elapsed).
- \`lib/query/format-micros.ts\` (+ \`.test.ts\`) — pure helpers (\`formatMicros\`, \`segmentWidthPct\`), 7 unit tests.
- \`components/query-detail/query-stages-chart.tsx\` — the chart (bars + legend + skeleton + graceful empty).
- \`lib/query-config/index.ts\` — registers \`queryProcessorsConfig\`.
- \`components/query-detail/query-detail-view.tsx\` — mounts \`<QueryStagesChart>\` under the SQL block.

## Test
- \`bun test src/lib/query/format-micros.test.ts src/lib/query/query-insights.test.ts\` → 13 pass.
- \`pnpm run build\` (Vite + \`tsc --noEmit\`) → green.