### PR TITLE
fix(menu): hide Billing & Organization in OSS; cleaner insight card border

### DIFF
--- a/apps/dashboard/src/components/app-sidebar.tsx
+++ b/apps/dashboard/src/components/app-sidebar.tsx
@@ -1,5 +1,4 @@
 import { BookOpenIcon } from 'lucide-react'
-import { menuItemsConfig } from '@/menu'
 
 import { HostSwitcher } from '@/components/host/host-switcher'
 import { SampleClusterBanner } from '@/components/host/sample-cluster-banner'
@@ -15,21 +14,15 @@ import {
   SidebarMenuItem,
 } from '@/components/ui/sidebar'
 import { GUEST_USER } from '@/lib/clerk/guest-user'
-import { isCloudModeClient } from '@/lib/cloud/cloud-mode'
 import { DOCS_SITE_URL } from '@/lib/docs-site'
 import { useFeaturePermissions } from '@/lib/feature-permissions/context'
-import { filterMenuItemsByPermissions } from '@/lib/feature-permissions/menu'
+import { getVisibleMenuItems } from '@/lib/menu/visible-items'
 
 export function AppSidebar() {
   const { config } = useFeaturePermissions()
-  const cloudMode = isCloudModeClient()
-  // Billing + Organization are cloud-only surfaces — self-hosting is free
-  // forever and has no orgs, so these would only confuse self-hosters.
-  const cloudOnlyHrefs = new Set(['/billing', '/organization'])
-  const menuItems = filterMenuItemsByPermissions(
-    menuItemsConfig,
-    config
-  ).filter((item) => cloudMode || !cloudOnlyHrefs.has(item.href))
+  // Feature-permission + cloud-only (Billing/Organization) gates resolved in
+  // one place — see lib/menu/visible-items.ts.
+  const menuItems = getVisibleMenuItems(config)
 
   return (
     <Sidebar collapsible="icon" variant="inset">

--- a/apps/dashboard/src/components/controls/command-palette.tsx
+++ b/apps/dashboard/src/components/controls/command-palette.tsx
@@ -8,7 +8,6 @@ import {
   Table,
   TextSearch,
 } from 'lucide-react'
-import { menuItemsConfig } from '@/menu'
 
 import { detectQuickNav, parseTableName } from './command-palette-utils'
 import * as React from 'react'
@@ -24,7 +23,7 @@ import {
 } from '@/components/ui/command'
 import { IconButton } from '@/components/ui/icon-button'
 import { useFeaturePermissions } from '@/lib/feature-permissions/context'
-import { filterMenuItemsByPermissions } from '@/lib/feature-permissions/menu'
+import { getVisibleMenuItems } from '@/lib/menu/visible-items'
 import { useRouter, useSearchParams } from '@/lib/next-compat'
 import { buildUrl } from '@/lib/url/url-builder'
 import { cn } from '@/lib/utils'
@@ -77,7 +76,7 @@ export const CommandPalette = function CommandPalette({
   const [internalOpen, setInternalOpen] = React.useState(false)
   const [inputValue, setInputValue] = useState('')
   const { config } = useFeaturePermissions()
-  const menuItems = filterMenuItemsByPermissions(menuItemsConfig, config)
+  const menuItems = getVisibleMenuItems(config)
 
   const open = controlledOpen ?? internalOpen
   const setOpen = onOpenChange ?? setInternalOpen

--- a/apps/dashboard/src/components/insights/insight-card.tsx
+++ b/apps/dashboard/src/components/insights/insight-card.tsx
@@ -42,7 +42,7 @@ export function InsightCard({
   return (
     <Card
       className={cn(
-        'h-full gap-0 border-l-2 p-4 transition-colors',
+        'h-full gap-0 p-4 transition-colors',
         style.accent,
         className
       )}

--- a/apps/dashboard/src/components/insights/severity-meta.ts
+++ b/apps/dashboard/src/components/insights/severity-meta.ts
@@ -22,7 +22,7 @@ export interface SeverityMeta {
   readonly iconColor: string
   /** Tinted outline-badge classes (also used for header count badges). */
   readonly badge: string
-  /** Left-border accent color (paired with `border-l-2`) to surface severity. */
+  /** Full-border accent color for the card (all four sides), by severity. */
   readonly accent: string
 }
 
@@ -34,7 +34,7 @@ export const SEVERITY_META: Record<InsightSeverity, SeverityMeta> = {
     iconColor: 'text-rose-600 dark:text-rose-400',
     badge:
       'border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-800/60 dark:bg-rose-950/40 dark:text-rose-400',
-    accent: 'border-l-rose-400 dark:border-l-rose-500',
+    accent: 'border-rose-300 dark:border-rose-700/60',
   },
   warning: {
     label: 'Warning',
@@ -43,7 +43,7 @@ export const SEVERITY_META: Record<InsightSeverity, SeverityMeta> = {
     iconColor: 'text-amber-600 dark:text-amber-400',
     badge:
       'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800/60 dark:bg-amber-950/40 dark:text-amber-400',
-    accent: 'border-l-amber-400 dark:border-l-amber-500',
+    accent: 'border-amber-300 dark:border-amber-700/60',
   },
   info: {
     label: 'Notice',
@@ -52,7 +52,7 @@ export const SEVERITY_META: Record<InsightSeverity, SeverityMeta> = {
     iconColor: 'text-muted-foreground',
     badge:
       'border-border bg-muted/50 text-muted-foreground dark:bg-muted/30 dark:text-muted-foreground',
-    accent: 'border-l-border',
+    accent: 'border-border',
   },
 }
 

--- a/apps/dashboard/src/components/menu/types.ts
+++ b/apps/dashboard/src/components/menu/types.ts
@@ -25,4 +25,12 @@ export interface MenuItem {
   permission?: FeaturePermission
   /** ClickHouse system table name(s) to check for availability/muting */
   tableCheck?: string | string[]
+  /**
+   * Cloud (SaaS)-only surface — hidden in self-host / OSS. Set on items that
+   * make sense only in the cloud product (e.g. Billing, Organization). Filtered
+   * centrally by `getVisibleMenuItems` (lib/menu/visible-items.ts) against
+   * `isCloudModeClient()`, so every nav surface (sidebar, command palette, …)
+   * honors it without each one re-implementing the gate.
+   */
+  cloudOnly?: boolean
 }

--- a/apps/dashboard/src/lib/menu/__tests__/visible-items.test.ts
+++ b/apps/dashboard/src/lib/menu/__tests__/visible-items.test.ts
@@ -1,0 +1,106 @@
+import { menuItemsConfig } from '@/menu'
+
+import type { MenuItem } from '@/components/menu/types'
+
+import { describe, expect, test } from 'bun:test'
+import { filterCloudOnly } from '@/lib/menu/visible-items'
+
+const leaf = (overrides: Partial<MenuItem> = {}): MenuItem => ({
+  title: overrides.title ?? 'Item',
+  href: overrides.href ?? '/item',
+  ...overrides,
+})
+
+describe('filterCloudOnly', () => {
+  test('drops a cloudOnly leaf in self-host / OSS (the reported bug)', () => {
+    const items = [
+      leaf({ title: 'Overview', href: '/overview' }),
+      leaf({ title: 'Billing', href: '/billing', cloudOnly: true }),
+      leaf({ title: 'Organization', href: '/organization', cloudOnly: true }),
+    ]
+
+    expect(filterCloudOnly(items, false).map((i) => i.title)).toEqual([
+      'Overview',
+    ])
+  })
+
+  test('keeps cloudOnly items in cloud mode', () => {
+    const items = [
+      leaf({ title: 'Overview', href: '/overview' }),
+      leaf({ title: 'Billing', href: '/billing', cloudOnly: true }),
+    ]
+
+    expect(filterCloudOnly(items, true).map((i) => i.title)).toEqual([
+      'Overview',
+      'Billing',
+    ])
+  })
+
+  test('removes a parent group whose only children are cloudOnly in OSS', () => {
+    const items: MenuItem[] = [
+      {
+        title: 'Cloud',
+        href: '',
+        items: [
+          leaf({ title: 'Billing', href: '/billing', cloudOnly: true }),
+          leaf({
+            title: 'Organization',
+            href: '/organization',
+            cloudOnly: true,
+          }),
+        ],
+      },
+    ]
+
+    expect(filterCloudOnly(items, false)).toEqual([])
+  })
+
+  test('keeps a parent group when some non-cloud children survive', () => {
+    const items: MenuItem[] = [
+      {
+        title: 'Mixed',
+        href: '',
+        items: [
+          leaf({ title: 'Overview', href: '/overview' }),
+          leaf({ title: 'Billing', href: '/billing', cloudOnly: true }),
+        ],
+      },
+    ]
+
+    const result = filterCloudOnly(items, false)
+    expect(result).toHaveLength(1)
+    expect(result[0].items?.map((i) => i.title)).toEqual(['Overview'])
+  })
+
+  test('non-cloudOnly items are untouched in either mode', () => {
+    const items = [leaf({ title: 'Health', href: '/health' })]
+
+    expect(filterCloudOnly(items, false).map((i) => i.title)).toEqual([
+      'Health',
+    ])
+    expect(filterCloudOnly(items, true).map((i) => i.title)).toEqual(['Health'])
+  })
+})
+
+// Intent guard: Billing + Organization MUST be marked cloudOnly so every nav
+// surface (sidebar, command palette, …) hides them in self-host / OSS. If this
+// fails, someone added a cloud surface without the flag and self-hosters will
+// see non-functional SaaS menu items again.
+describe('menu config cloud-only contract', () => {
+  const find = (href: string) =>
+    menuItemsConfig.find((item) => item.href === href)
+
+  test('Billing is cloud-only', () => {
+    expect(find('/billing')?.cloudOnly).toBe(true)
+  })
+
+  test('Organization is cloud-only', () => {
+    expect(find('/organization')?.cloudOnly).toBe(true)
+  })
+
+  test('Billing + Organization are hidden when filtering the real config in OSS', () => {
+    const titles = filterCloudOnly(menuItemsConfig, false).map((i) => i.title)
+    expect(titles).not.toContain('Billing')
+    expect(titles).not.toContain('Organization')
+  })
+})

--- a/apps/dashboard/src/lib/menu/visible-items.ts
+++ b/apps/dashboard/src/lib/menu/visible-items.ts
@@ -1,0 +1,56 @@
+// Central menu-visibility resolver. A menu item is shown when it passes TWO
+// independent gates, applied in one place so every nav surface (sidebar,
+// command palette, future ones) stays consistent:
+//
+//   1. Feature permission  — `filterMenuItemsByPermissions` (auth/deployment)
+//   2. Cloud-only          — drop `cloudOnly` items when not in cloud mode
+//
+// Previously the cloud-only rule lived as inline logic in app-sidebar.tsx and
+// clerk-nav.tsx but was missing from the command palette, so ⌘K leaked
+// Billing/Organization in self-host / OSS. Encoding the rule as data on the
+// item (`cloudOnly: true`) and resolving it here removes that fragility.
+
+import { menuItemsConfig } from '@/menu'
+
+import type { MenuItem } from '@/components/menu/types'
+import type { PublicFeaturePermissionConfig } from '@/lib/feature-permissions/types'
+
+import { isCloudModeClient } from '@/lib/cloud/cloud-mode'
+import { filterMenuItemsByPermissions } from '@/lib/feature-permissions/menu'
+
+/**
+ * Drop `cloudOnly` items (and any parent left empty by their removal) when the
+ * deployment is not the cloud product. Recursive so a `cloudOnly` child inside
+ * a group is hidden too. Mirrors `filterMenuItemsByPermissions`' empty-parent
+ * semantics: a group whose children all vanish is removed rather than rendered
+ * childless.
+ */
+export function filterCloudOnly(
+  items: readonly MenuItem[],
+  cloudMode: boolean
+): MenuItem[] {
+  return items.flatMap((item) => {
+    if (item.cloudOnly && !cloudMode) return []
+
+    if (!item.items) return [{ ...item }]
+
+    const childItems = filterCloudOnly(item.items, cloudMode)
+    if (childItems.length === 0) return []
+
+    return [{ ...item, items: childItems }]
+  })
+}
+
+/**
+ * The single source of truth for what a CLIENT nav surface may render:
+ * `menuItemsConfig` with feature-permission and cloud-only gates applied.
+ * `isCloudModeClient()` is resolved at build time, so this is cheap and stable
+ * across renders.
+ */
+export function getVisibleMenuItems(
+  config: PublicFeaturePermissionConfig
+): MenuItem[] {
+  const cloudMode = isCloudModeClient()
+  const byPermission = filterMenuItemsByPermissions(menuItemsConfig, config)
+  return filterCloudOnly(byPermission, cloudMode)
+}

--- a/apps/dashboard/src/menu.ts
+++ b/apps/dashboard/src/menu.ts
@@ -790,22 +790,25 @@ export const menuItemsConfig: MenuItem[] = [
     ],
   },
   {
-    // Cloud (SaaS) plan + host limits. Hidden in self-host (filtered by cloud
-    // mode in app-sidebar.tsx) since self-hosting is free forever.
+    // Cloud (SaaS) plan + host limits. Self-hosting is free forever, so this
+    // only makes sense in the cloud product — `cloudOnly` hides it in OSS
+    // across every nav surface (see getVisibleMenuItems).
     title: 'Billing',
     href: '/billing',
     icon: CircleDollarSignIcon,
     section: 'others',
     permission: { feature: 'billing' },
+    cloudOnly: true,
   },
   {
     // Cloud (SaaS) team management — members, roles, invitations. Cloud-only
-    // (filtered in app-sidebar.tsx). Org is created on a paid upgrade.
+    // (an org is created on a paid upgrade); `cloudOnly` hides it in OSS.
     title: 'Organization',
     href: '/organization',
     icon: UsersIcon,
     section: 'others',
     permission: { feature: 'billing' },
+    cloudOnly: true,
   },
   {
     title: 'System',


### PR DESCRIPTION
## What

Two small, independent fixes from the OSS deploy at `clickhouse.sg.afsouth1ctcld.net`.

### 1. Hide Billing & Organization menu items in OSS (`fa62906c`)
The cloud-only gate for **Billing** and **Organization** lived as inline logic in `app-sidebar.tsx` and `clerk-nav.tsx` but was **missing from the command palette**, so ⌘K leaked them in self-host / OSS.

Fix: encode the rule as **data** — a `cloudOnly` flag on `MenuItem` — and resolve it once in `getVisibleMenuItems` (`lib/menu/visible-items.ts`). The sidebar and command palette now both honor it without each re-implementing the gate.

- `components/menu/types.ts` — add `cloudOnly?: boolean`
- `menu.ts` — mark Billing + Organization `cloudOnly: true`
- `lib/menu/visible-items.ts` — new helper (feature-permission + cloud-only filter)
- `app-sidebar.tsx`, `controls/command-palette.tsx` — use the helper
- `lib/menu/__tests__/visible-items.test.ts` — intent tests (OSS hides billing/org)

### 2. Insight card: full colored border, no bold left stripe (`abe21e66`)
The AI Insights card used a 2px left accent stripe (`border-l-2` + `border-l-{color}`). Replaced with a subtle 1px **severity-tinted border on all four sides**: critical=rose, warning=amber, info=default border. Cleaner, less templated.

- `components/insights/severity-meta.ts` — `accent` tokens: `border-l-*` → `border-*`
- `components/insights/insight-card.tsx` — drop `border-l-2`

## Verify
- `bun test src/lib/menu/__tests__/visible-items.test.ts` → 8 pass
- `pnpm run type-check` → exit 0
- `pnpm exec biome check` (changed files) → clean

Co-Authored-By: duyetbot <bot@duyet.net>