### PR TITLE
feat(alerting): maintenance windows / alert suppression (plan 28)

### DIFF
--- a/apps/dashboard/src/components/health/health-settings-dialog.tsx
+++ b/apps/dashboard/src/components/health/health-settings-dialog.tsx
@@ -2,6 +2,7 @@ import { Settings } from 'lucide-react'
 import { toast } from 'sonner'
 
 import { HEALTH_CHECKS } from './health-checks'
+import { MaintenanceWindowsPanel } from './maintenance-windows-panel'
 import { RecentAlertsCard } from './recent-alerts-card'
 import { WebhookSubscriptionsPanel } from './webhook-subscriptions-panel'
 import { useEffect, useState } from 'react'
@@ -181,6 +182,7 @@ export function HealthSettingsDialog() {
             <TabsTrigger value="alerts">Alerts</TabsTrigger>
             <TabsTrigger value="history">History</TabsTrigger>
             <TabsTrigger value="webhooks">Webhooks</TabsTrigger>
+            <TabsTrigger value="maintenance">Maintenance</TabsTrigger>
           </TabsList>
 
           <TabsContent value="thresholds">
@@ -371,6 +373,12 @@ export function HealthSettingsDialog() {
           <TabsContent value="webhooks">
             <ScrollArea className="h-[420px] pr-3">
               <WebhookSubscriptionsPanel />
+            </ScrollArea>
+          </TabsContent>
+
+          <TabsContent value="maintenance">
+            <ScrollArea className="h-[420px] pr-3">
+              <MaintenanceWindowsPanel />
             </ScrollArea>
           </TabsContent>
         </Tabs>

--- a/apps/dashboard/src/components/health/maintenance-windows-panel.tsx
+++ b/apps/dashboard/src/components/health/maintenance-windows-panel.tsx
@@ -1,0 +1,244 @@
+/**
+ * Maintenance windows panel (plan 28).
+ *
+ * Lets an operator declare a maintenance window (one host or all hosts) so
+ * the health sweep suppresses outbound alerts while `now` falls inside it —
+ * the finding is still recorded, this only gates the notification. Lives as
+ * a tab in `HealthSettingsDialog` alongside Webhooks/History; every action
+ * here is an immediate server call (create/delete), same pattern as
+ * `WebhookSubscriptionsPanel`. Free/OSS feature: no Clerk sign-in required,
+ * the server falls back to a single-tenant owner when Clerk isn't configured.
+ */
+
+import { toast } from 'sonner'
+
+import type { MaintenanceWindowInfo } from '@/lib/hooks/use-maintenance-windows'
+
+import { useState } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  useMaintenanceWindows,
+  useMaintenanceWindowsMutations,
+} from '@/lib/hooks/use-maintenance-windows'
+import { useHosts } from '@/lib/swr/use-hosts'
+import { cn } from '@/lib/utils'
+
+const ALL_HOSTS_VALUE = '__all__'
+
+function windowStatus(w: MaintenanceWindowInfo): {
+  label: string
+  variant: 'default' | 'secondary' | 'outline'
+} {
+  const now = Date.now()
+  if (now < w.startsAt) return { label: 'Upcoming', variant: 'outline' }
+  if (now >= w.endsAt) return { label: 'Ended', variant: 'secondary' }
+  return { label: 'Active', variant: 'default' }
+}
+
+/** `datetime-local` uses the browser's local timezone with no offset suffix. */
+function toDatetimeLocalValue(ms: number): string {
+  const d = new Date(ms)
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+function fromDatetimeLocalValue(value: string): number | null {
+  if (!value) return null
+  const ms = new Date(value).getTime()
+  return Number.isFinite(ms) ? ms : null
+}
+
+function WindowRow({
+  window,
+  hostName,
+  onDeleted,
+}: {
+  window: MaintenanceWindowInfo
+  hostName: string
+  onDeleted: () => void
+}) {
+  const [busy, setBusy] = useState(false)
+  const { deleteWindow } = useMaintenanceWindowsMutations()
+  const status = windowStatus(window)
+
+  const handleDelete = async () => {
+    setBusy(true)
+    try {
+      await deleteWindow(window.id)
+      onDeleted()
+    } catch {
+      toast.error('Failed to delete maintenance window')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-2 rounded-md border p-3">
+      <div className="flex min-w-0 flex-col gap-1">
+        <div className="flex items-center gap-2">
+          <Badge variant={status.variant}>{status.label}</Badge>
+          <span className="truncate text-sm font-medium">{hostName}</span>
+        </div>
+        <span className="truncate text-xs text-muted-foreground">
+          {window.reason || 'No reason given'} ·{' '}
+          {new Date(window.startsAt).toLocaleString()} →{' '}
+          {new Date(window.endsAt).toLocaleString()}
+        </span>
+      </div>
+      <Button variant="ghost" size="sm" disabled={busy} onClick={handleDelete}>
+        Delete
+      </Button>
+    </div>
+  )
+}
+
+function AddWindowForm({ onCreated }: { onCreated: () => void }) {
+  const { hosts } = useHosts()
+  const [hostValue, setHostValue] = useState<string>(ALL_HOSTS_VALUE)
+  const [reason, setReason] = useState('')
+  const [startsAt, setStartsAt] = useState(() =>
+    toDatetimeLocalValue(Date.now())
+  )
+  const [endsAt, setEndsAt] = useState(() =>
+    toDatetimeLocalValue(Date.now() + 60 * 60 * 1000)
+  )
+  const [busy, setBusy] = useState(false)
+  const { createWindow } = useMaintenanceWindowsMutations()
+
+  const handleSubmit = async () => {
+    const startMs = fromDatetimeLocalValue(startsAt)
+    const endMs = fromDatetimeLocalValue(endsAt)
+    if (startMs === null || endMs === null) {
+      toast.error('Enter a valid start and end time')
+      return
+    }
+    if (endMs <= startMs) {
+      toast.error('End time must be after start time')
+      return
+    }
+    setBusy(true)
+    try {
+      await createWindow({
+        hostId: hostValue === ALL_HOSTS_VALUE ? null : Number(hostValue),
+        reason: reason.trim(),
+        startsAt: startMs,
+        endsAt: endMs,
+      })
+      toast.success('Maintenance window created')
+      setReason('')
+      onCreated()
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : 'Failed to create window'
+      )
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md border p-3">
+      <Label className="text-sm font-medium">Add maintenance window</Label>
+      <div className="grid grid-cols-2 gap-2">
+        <div className="flex flex-col gap-1">
+          <Label className="text-xs text-muted-foreground">Host</Label>
+          <Select value={hostValue} onValueChange={setHostValue}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL_HOSTS_VALUE}>All hosts</SelectItem>
+              {hosts.map((h) => (
+                <SelectItem key={h.id} value={String(h.id)}>
+                  {h.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label className="text-xs text-muted-foreground">Reason</Label>
+          <Input
+            placeholder="Deploy, backup, …"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label className="text-xs text-muted-foreground">Starts</Label>
+          <Input
+            type="datetime-local"
+            value={startsAt}
+            onChange={(e) => setStartsAt(e.target.value)}
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label className="text-xs text-muted-foreground">Ends</Label>
+          <Input
+            type="datetime-local"
+            value={endsAt}
+            onChange={(e) => setEndsAt(e.target.value)}
+          />
+        </div>
+      </div>
+      <Button
+        size="sm"
+        className="self-start"
+        disabled={busy}
+        onClick={handleSubmit}
+      >
+        Add
+      </Button>
+    </div>
+  )
+}
+
+export function MaintenanceWindowsPanel({ className }: { className?: string }) {
+  const { windows, isLoading, refetch } = useMaintenanceWindows()
+  const { hosts } = useHosts()
+
+  const hostName = (hostId: number | null): string => {
+    if (hostId === null) return 'All hosts'
+    return hosts.find((h) => h.id === hostId)?.name ?? `Host ${hostId}`
+  }
+
+  return (
+    <div className={cn('flex flex-col gap-3', className)}>
+      <p className="text-xs text-muted-foreground">
+        While a window is active, the health sweep still runs every check and
+        records findings — it only suppresses the outbound alert notification
+        for the covered host(s).
+      </p>
+
+      {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+
+      {!isLoading && windows.length === 0 && (
+        <p className="text-sm text-muted-foreground">No maintenance windows.</p>
+      )}
+
+      <div className="flex flex-col gap-2">
+        {windows.map((w) => (
+          <WindowRow
+            key={w.id}
+            window={w}
+            hostName={hostName(w.hostId)}
+            onDeleted={refetch}
+          />
+        ))}
+      </div>
+
+      <AddWindowForm onCreated={refetch} />
+    </div>
+  )
+}

--- a/apps/dashboard/src/db/conversations-migrations/0014_maintenance_windows.sql
+++ b/apps/dashboard/src/db/conversations-migrations/0014_maintenance_windows.sql
@@ -1,0 +1,20 @@
+-- Maintenance windows (alert suppression) — plan 28.
+--
+-- Lets an operator declare a planned-work window (one host or all hosts) so
+-- the health sweep suppresses outbound notifications while `now` falls
+-- inside it. The rule still runs and the finding is still reported — this
+-- gates dispatch only, not data collection. See lib/health/maintenance-windows.ts.
+
+CREATE TABLE IF NOT EXISTS maintenance_windows (
+  id         TEXT    NOT NULL PRIMARY KEY,   -- uuid
+  owner_id   TEXT    NOT NULL,               -- billing-owner id (Clerk user_*/org_*); '' for OSS single-tenant
+  host_id    INTEGER,                        -- NULL => applies to ALL hosts
+  reason     TEXT    NOT NULL DEFAULT '',
+  starts_at  INTEGER NOT NULL,               -- unix ms
+  ends_at    INTEGER NOT NULL,               -- unix ms
+  created_by TEXT    NOT NULL DEFAULT '',
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_maint_windows_active
+  ON maintenance_windows (owner_id, ends_at);

--- a/apps/dashboard/src/lib/health/maintenance-windows.test.ts
+++ b/apps/dashboard/src/lib/health/maintenance-windows.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Tests for maintenance windows (plan 28).
+ *
+ * Two layers, mirroring server-sweep.test.ts / deployments/d1-store.test.ts:
+ *  1. `isSuppressed` — the pure suppression rule, unit-tested directly (no D1)
+ *     covering in-window / out-of-window / all-hosts / per-host boundaries —
+ *     this is the logic the sweep's dispatch gate depends on.
+ *  2. The D1-backed store (`listWindows`/`createWindow`/`deleteWindow`) via a
+ *     behavioral fake of D1Database, exercising the real SQL, owner scoping,
+ *     `endsAt > startsAt` validation, and the fail-open degrade when no
+ *     binding is present.
+ */
+
+import type { MaintenanceWindow } from './maintenance-windows'
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// --- behavioral D1 fake ------------------------------------------------------
+interface FakeRow {
+  id: string
+  owner_id: string
+  host_id: number | null
+  reason: string
+  starts_at: number
+  ends_at: number
+  created_by: string
+  created_at: number
+}
+
+function makeFakeD1() {
+  const rows: FakeRow[] = []
+
+  function prepare(sql: string) {
+    const isInsert = /^\s*INSERT INTO/i.test(sql)
+    const isDelete = /^\s*DELETE FROM/i.test(sql)
+    const isSelect = /^\s*SELECT/i.test(sql)
+
+    return {
+      bind(...args: unknown[]) {
+        return {
+          async run(): Promise<{ meta: { changes: number } }> {
+            if (isInsert) {
+              const [
+                id,
+                ownerId,
+                hostId,
+                reason,
+                startsAt,
+                endsAt,
+                createdBy,
+                createdAt,
+              ] = args as [
+                string,
+                string,
+                number | null,
+                string,
+                number,
+                number,
+                string,
+                number,
+              ]
+              rows.push({
+                id,
+                owner_id: ownerId,
+                host_id: hostId,
+                reason,
+                starts_at: startsAt,
+                ends_at: endsAt,
+                created_by: createdBy,
+                created_at: createdAt,
+              })
+              return { meta: { changes: 1 } }
+            }
+            if (isDelete) {
+              const [id, ownerId] = args as [string, string]
+              const idx = rows.findIndex(
+                (r) => r.id === id && r.owner_id === ownerId
+              )
+              if (idx >= 0) rows.splice(idx, 1)
+              return { meta: { changes: idx >= 0 ? 1 : 0 } }
+            }
+            throw new Error(`fake D1: run() called on unexpected SQL: ${sql}`)
+          },
+          async all<T>(): Promise<{ results: T[] }> {
+            if (!isSelect)
+              throw new Error(`fake D1: all() called on non-SELECT: ${sql}`)
+            const [ownerId] = args as [string]
+            const filtered = rows
+              .filter((r) => r.owner_id === ownerId)
+              .sort((a, b) => b.starts_at - a.starts_at)
+            return { results: filtered as unknown as T[] }
+          },
+        }
+      },
+    }
+  }
+
+  return {
+    rows,
+    prepare,
+    batch: async (stmts: unknown[]) =>
+      stmts.map(() => ({ meta: { changes: 0 } })),
+  }
+}
+
+let fakeDb: ReturnType<typeof makeFakeD1> | null
+
+mock.module('@chm/platform', () => ({
+  getPlatformBindings: () => ({
+    getD1Database: () => fakeDb,
+  }),
+}))
+
+const { isSuppressed, listWindows, createWindow, deleteWindow } = await import(
+  './maintenance-windows'
+)
+
+function window(over: Partial<MaintenanceWindow> = {}): MaintenanceWindow {
+  return {
+    id: 'w1',
+    ownerId: 'owner-a',
+    hostId: null,
+    reason: 'deploy',
+    startsAt: 1000,
+    endsAt: 2000,
+    createdBy: 'user_1',
+    createdAt: 500,
+    ...over,
+  }
+}
+
+beforeEach(() => {
+  fakeDb = makeFakeD1()
+})
+
+// ---------------------------------------------------------------------------
+// isSuppressed — pure rule
+// ---------------------------------------------------------------------------
+describe('isSuppressed', () => {
+  test('true when now is inside a per-host window targeting the finding host', () => {
+    const windows = [window({ hostId: 3, startsAt: 1000, endsAt: 2000 })]
+    expect(isSuppressed(windows, 3, 1500)).toBe(true)
+  })
+
+  test('false when now is inside the window but the window targets a different host', () => {
+    const windows = [window({ hostId: 3, startsAt: 1000, endsAt: 2000 })]
+    expect(isSuppressed(windows, 4, 1500)).toBe(false)
+  })
+
+  test('true when the window is host_id=null (applies to ALL hosts)', () => {
+    const windows = [window({ hostId: null, startsAt: 1000, endsAt: 2000 })]
+    expect(isSuppressed(windows, 42, 1500)).toBe(true)
+  })
+
+  test('false when now is before startsAt or at/after endsAt (end is exclusive)', () => {
+    const windows = [window({ hostId: null, startsAt: 1000, endsAt: 2000 })]
+    expect(isSuppressed(windows, 1, 999)).toBe(false)
+    expect(isSuppressed(windows, 1, 2000)).toBe(false)
+    expect(isSuppressed(windows, 1, 1000)).toBe(true)
+    expect(isSuppressed(windows, 1, 1999)).toBe(true)
+  })
+
+  test('false for an empty window list', () => {
+    expect(isSuppressed([], 1, 1500)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// D1-backed store
+// ---------------------------------------------------------------------------
+describe('maintenance-windows d1 store', () => {
+  // Each test uses a distinct owner id: `listWindows` keeps a best-effort
+  // in-memory cache keyed by owner (module-level, not reset between tests),
+  // so reusing an owner id across tests could read a stale cached result
+  // from an earlier test instead of exercising the fake D1 fresh.
+
+  test('create then list round-trips every field', async () => {
+    const created = await createWindow({
+      ownerId: 'owner-roundtrip',
+      hostId: 2,
+      reason: 'backup',
+      startsAt: 1000,
+      endsAt: 2000,
+      createdBy: 'user_1',
+    })
+
+    const listed = await listWindows('owner-roundtrip')
+    expect(listed).toEqual([created])
+  })
+
+  test('createWindow rejects endsAt <= startsAt', async () => {
+    await expect(
+      createWindow({
+        ownerId: 'owner-invalid-range',
+        hostId: null,
+        reason: 'bad',
+        startsAt: 2000,
+        endsAt: 1000,
+        createdBy: 'user_1',
+      })
+    ).rejects.toThrow()
+  })
+
+  test('listWindows only returns rows for the requested owner', async () => {
+    await createWindow({
+      ownerId: 'owner-scope-a',
+      hostId: null,
+      reason: 'a',
+      startsAt: 1000,
+      endsAt: 2000,
+      createdBy: 'user_1',
+    })
+    await createWindow({
+      ownerId: 'owner-scope-b',
+      hostId: null,
+      reason: 'b',
+      startsAt: 1000,
+      endsAt: 2000,
+      createdBy: 'user_2',
+    })
+
+    expect((await listWindows('owner-scope-a')).map((w) => w.reason)).toEqual([
+      'a',
+    ])
+    expect((await listWindows('owner-scope-b')).map((w) => w.reason)).toEqual([
+      'b',
+    ])
+  })
+
+  test("deleteWindow is owner-scoped: cannot delete another owner's window", async () => {
+    const created = await createWindow({
+      ownerId: 'owner-delete-a',
+      hostId: null,
+      reason: 'a',
+      startsAt: 1000,
+      endsAt: 2000,
+      createdBy: 'user_1',
+    })
+
+    await deleteWindow('owner-delete-b', created.id)
+    expect((await listWindows('owner-delete-a')).map((w) => w.id)).toEqual([
+      created.id,
+    ])
+
+    await deleteWindow('owner-delete-a', created.id)
+    expect(await listWindows('owner-delete-a')).toEqual([])
+  })
+
+  test('degrades to [] / throws-on-create (never crashes the caller) when no D1 binding is present', async () => {
+    fakeDb = null
+
+    expect(await listWindows('owner-no-binding')).toEqual([])
+    await expect(
+      createWindow({
+        ownerId: 'owner-no-binding',
+        hostId: null,
+        reason: 'x',
+        startsAt: 1000,
+        endsAt: 2000,
+        createdBy: 'user_1',
+      })
+    ).rejects.toThrow()
+    // delete swallows the failure rather than throwing (fail-open).
+    await expect(
+      deleteWindow('owner-no-binding', 'missing')
+    ).resolves.toBeUndefined()
+  })
+})

--- a/apps/dashboard/src/lib/health/maintenance-windows.ts
+++ b/apps/dashboard/src/lib/health/maintenance-windows.ts
@@ -1,0 +1,273 @@
+/**
+ * Maintenance windows — passive alert-dispatch suppression (plan 28).
+ *
+ * Lets an operator declare "planned work" (a deploy, a backup, …) for one
+ * host or every host, with a start/end time and a reason. While `now` falls
+ * inside a matching window, `server-sweep.ts` skips the outbound webhook for
+ * an otherwise-notify-worthy finding — the rule still runs and the finding is
+ * still reported in the sweep summary; this is a dispatch-time gate, not a
+ * data-collection gate, and it must never change dedup semantics
+ * (`alert-state-store.ts`'s `decideNotification` is untouched).
+ *
+ * Storage mirrors `insights/store/d1-store.ts`: a dedicated `MAINTENANCE_D1`
+ * binding takes precedence, falling back to the shared `CHM_CLOUD_D1`
+ * binding used by the rest of the cloud-mode D1 backends. The table is
+ * migrated lazily (single-flight) on first use. Every failure is caught,
+ * logged, and swallowed — a missing/misconfigured binding degrades to "no
+ * windows" (self-hosted/OSS default) rather than throwing into the sweep or
+ * the CRUD route.
+ *
+ * `isSuppressed` is the pure, D1-free core so the suppression rule itself is
+ * fully unit-testable without mocking D1.
+ */
+
+import { ErrorLogger } from '@chm/logger'
+import { getPlatformBindings } from '@chm/platform'
+
+const COMPONENT = 'maintenance-windows'
+const warn = (msg: string) =>
+  ErrorLogger.logWarning(`[maintenance-windows] ${msg}`, {
+    component: COMPONENT,
+  })
+
+/** Preferred dedicated binding, then the shared cloud-mode D1 binding. */
+const D1_BINDING_NAMES = ['MAINTENANCE_D1', 'CHM_CLOUD_D1'] as const
+
+const TABLE = 'maintenance_windows'
+
+const MIGRATION_SQL = `
+  CREATE TABLE IF NOT EXISTS ${TABLE} (
+    id TEXT NOT NULL PRIMARY KEY,
+    owner_id TEXT NOT NULL,
+    host_id INTEGER,
+    reason TEXT NOT NULL DEFAULT '',
+    starts_at INTEGER NOT NULL,
+    ends_at INTEGER NOT NULL,
+    created_by TEXT NOT NULL DEFAULT '',
+    created_at INTEGER NOT NULL
+  )
+`
+const INDEX_SQL = `
+  CREATE INDEX IF NOT EXISTS idx_maint_windows_active
+    ON ${TABLE} (owner_id, ends_at)
+`
+
+export interface MaintenanceWindow {
+  id: string
+  ownerId: string
+  /** null => applies to ALL hosts for this owner. */
+  hostId: number | null
+  reason: string
+  /** unix ms */
+  startsAt: number
+  /** unix ms */
+  endsAt: number
+  createdBy: string
+  /** unix ms */
+  createdAt: number
+}
+
+export interface CreateMaintenanceWindowInput {
+  ownerId: string
+  hostId: number | null
+  reason: string
+  startsAt: number
+  endsAt: number
+  createdBy: string
+}
+
+/** D1 row shape (snake_case columns). */
+interface D1WindowRow {
+  id: string
+  owner_id: string
+  host_id: number | null
+  reason: string
+  starts_at: number
+  ends_at: number
+  created_by: string
+  created_at: number
+}
+
+function rowToWindow(row: D1WindowRow): MaintenanceWindow {
+  return {
+    id: row.id,
+    ownerId: row.owner_id,
+    hostId: row.host_id,
+    reason: row.reason,
+    startsAt: row.starts_at,
+    endsAt: row.ends_at,
+    createdBy: row.created_by,
+    createdAt: row.created_at,
+  }
+}
+
+function getDb(): D1Database | null {
+  const bindings = getPlatformBindings()
+  for (const name of D1_BINDING_NAMES) {
+    const db = bindings.getD1Database(name)
+    if (db) return db
+  }
+  return null
+}
+
+// Single-flight migration: concurrent first calls share one promise so the
+// idempotent DDL runs at most once; a failure clears it so the next call retries.
+let migration: Promise<void> | null = null
+
+function ensureMigrated(db: D1Database): Promise<void> {
+  if (!migration) {
+    migration = (async () => {
+      try {
+        await db.batch([db.prepare(MIGRATION_SQL), db.prepare(INDEX_SQL)])
+      } catch (err) {
+        migration = null
+        throw err
+      }
+    })()
+  }
+  return migration
+}
+
+// ---------------------------------------------------------------------------
+// Best-effort 30s in-memory cache of active windows per owner, so a health
+// sweep tick doesn't pay a D1 read for every host/rule combination. Cleared
+// implicitly by TTL; a create/delete invalidates the affected owner's entry
+// so the UI + sweep never observe stale data for more than the TTL.
+// ---------------------------------------------------------------------------
+const CACHE_TTL_MS = 30_000
+const cache = new Map<
+  string,
+  { windows: MaintenanceWindow[]; expiresAt: number }
+>()
+
+function invalidateCache(ownerId: string): void {
+  cache.delete(ownerId)
+}
+
+/**
+ * Pure suppression check — true iff any window targets this host (or ALL
+ * hosts, `hostId === null`) and `now` falls within `[startsAt, endsAt)`.
+ * No I/O, no D1 — exercised directly by unit tests.
+ */
+export function isSuppressed(
+  windows: MaintenanceWindow[],
+  hostId: number,
+  now: number
+): boolean {
+  return windows.some(
+    (w) =>
+      (w.hostId === null || w.hostId === hostId) &&
+      w.startsAt <= now &&
+      now < w.endsAt
+  )
+}
+
+/**
+ * List every maintenance window for an owner (past, current, and upcoming —
+ * callers filter to "active" via `isSuppressed`). Best-effort: degrades to
+ * `[]` when no D1 binding resolves or the read fails.
+ */
+export async function listWindows(
+  ownerId: string
+): Promise<MaintenanceWindow[]> {
+  const cached = cache.get(ownerId)
+  if (cached && cached.expiresAt > Date.now()) return cached.windows
+
+  try {
+    const db = getDb()
+    if (!db) return []
+    await ensureMigrated(db)
+
+    const result = await db
+      .prepare(
+        `SELECT id, owner_id, host_id, reason, starts_at, ends_at, created_by, created_at
+         FROM ${TABLE}
+         WHERE owner_id = ?1
+         ORDER BY starts_at DESC`
+      )
+      .bind(ownerId)
+      .all<D1WindowRow>()
+
+    const windows = (result.results ?? []).map(rowToWindow)
+    cache.set(ownerId, { windows, expiresAt: Date.now() + CACHE_TTL_MS })
+    return windows
+  } catch (err) {
+    warn(`failed to list windows for owner ${ownerId}: ${err}`)
+    return []
+  }
+}
+
+/**
+ * Create a maintenance window. Validates `endsAt > startsAt`. Throws on
+ * invalid input (caller's problem to surface as a 400); a D1/binding failure
+ * also throws so the CRUD route can report the write didn't happen (unlike
+ * the read/suppression paths, a create failure must not look like success).
+ */
+export async function createWindow(
+  input: CreateMaintenanceWindowInput
+): Promise<MaintenanceWindow> {
+  if (input.endsAt <= input.startsAt) {
+    throw new Error('endsAt must be after startsAt')
+  }
+
+  const db = getDb()
+  if (!db) {
+    throw new Error('No D1 binding (MAINTENANCE_D1 / CHM_CLOUD_D1) found')
+  }
+  await ensureMigrated(db)
+
+  const window: MaintenanceWindow = {
+    id: crypto.randomUUID(),
+    ownerId: input.ownerId,
+    hostId: input.hostId,
+    reason: input.reason,
+    startsAt: input.startsAt,
+    endsAt: input.endsAt,
+    createdBy: input.createdBy,
+    createdAt: Date.now(),
+  }
+
+  await db
+    .prepare(
+      `INSERT INTO ${TABLE}
+         (id, owner_id, host_id, reason, starts_at, ends_at, created_by, created_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)`
+    )
+    .bind(
+      window.id,
+      window.ownerId,
+      window.hostId,
+      window.reason,
+      window.startsAt,
+      window.endsAt,
+      window.createdBy,
+      window.createdAt
+    )
+    .run()
+
+  invalidateCache(input.ownerId)
+  return window
+}
+
+/**
+ * Delete a maintenance window, scoped to its owner (an owner can never delete
+ * another owner's window even by guessing an id). Best-effort: a D1 failure
+ * is swallowed (logged) rather than thrown, matching the rest of this store's
+ * fail-open posture — the window simply persists until the next attempt.
+ */
+export async function deleteWindow(ownerId: string, id: string): Promise<void> {
+  try {
+    const db = getDb()
+    if (!db) return
+    await ensureMigrated(db)
+
+    await db
+      .prepare(`DELETE FROM ${TABLE} WHERE id = ?1 AND owner_id = ?2`)
+      .bind(id, ownerId)
+      .run()
+
+    invalidateCache(ownerId)
+  } catch (err) {
+    warn(`failed to delete window ${id} for owner ${ownerId}: ${err}`)
+  }
+}

--- a/apps/dashboard/src/lib/health/server-sweep.test.ts
+++ b/apps/dashboard/src/lib/health/server-sweep.test.ts
@@ -131,6 +131,29 @@ mock.module('@/lib/insights/generate-insights', () => ({
   generateInsights: async () => [],
 }))
 
+// --- maintenance windows stub ------------------------------------------------
+// Mocked at the module boundary (like generate-insights above) rather than
+// routed through the shared fake D1: the sweep only depends on
+// `listWindows`/`isSuppressed`'s CONTRACT here, not the D1 storage details
+// already covered by maintenance-windows.test.ts.
+interface MockWindow {
+  hostId: number | null
+  startsAt: number
+  endsAt: number
+}
+let mockWindows: MockWindow[] = []
+
+mock.module('@/lib/health/maintenance-windows', () => ({
+  listWindows: async (_ownerId: string) => mockWindows,
+  isSuppressed: (windows: MockWindow[], hostId: number, now: number) =>
+    windows.some(
+      (w) =>
+        (w.hostId === null || w.hostId === hostId) &&
+        w.startsAt <= now &&
+        now < w.endsAt
+    ),
+}))
+
 const { alertStateStore } = await import('./alert-state-store')
 const { ruleRegistry } = await import('@/lib/alerting/rule-registry')
 const { buildAlertEventRecord, runHealthSweep } = await import('./server-sweep')
@@ -165,6 +188,7 @@ beforeEach(() => {
   fakeDb = makeFakeD1()
   testValue = 50
   fetchCalls = []
+  mockWindows = []
 })
 
 afterEach(() => {
@@ -337,6 +361,75 @@ describe('runHealthSweep — alert-history hook', () => {
 
     const summary = await runHealthSweep()
 
+    expect(summary.alertsDispatched).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// runHealthSweep — maintenance-window suppression (plan 28)
+// ---------------------------------------------------------------------------
+describe('runHealthSweep — maintenance window suppression', () => {
+  test('an active ALL-hosts window suppresses dispatch and records decisionKind=maintenance', async () => {
+    mockWindows = [{ hostId: null, startsAt: 0, endsAt: Date.now() + 60_000 }]
+
+    globalThis.fetch = mock(
+      async () => new Response(null, { status: 200 })
+    ) as unknown as typeof fetch
+
+    const summary = await runHealthSweep()
+
+    // Suppressed, not dispatched — no webhook call at all.
+    expect(summary.alertsDispatched).toBe(0)
+    expect(summary.maintenanceSuppressed).toBe(1)
+    expect(summary.alertsSuppressed).toBe(1)
+    // The finding itself is still reported (data collection unaffected).
+    expect(summary.totalFindings).toBe(1)
+    expect(fakeDb.rows).toHaveLength(1)
+    expect(fakeDb.rows[0]?.decision_kind).toBe('maintenance')
+    expect(fakeDb.rows[0]?.delivered).toBe(0)
+  })
+
+  test("an active window on a DIFFERENT host does not suppress this host's dispatch", async () => {
+    mockWindows = [{ hostId: 999, startsAt: 0, endsAt: Date.now() + 60_000 }]
+
+    globalThis.fetch = mock(
+      async () => new Response(null, { status: 200 })
+    ) as unknown as typeof fetch
+
+    const summary = await runHealthSweep()
+
+    expect(summary.alertsDispatched).toBe(1)
+    expect(summary.maintenanceSuppressed).toBe(0)
+  })
+
+  test('a window outside its time range does not suppress', async () => {
+    // Window already ended.
+    mockWindows = [{ hostId: null, startsAt: 0, endsAt: Date.now() - 60_000 }]
+
+    globalThis.fetch = mock(
+      async () => new Response(null, { status: 200 })
+    ) as unknown as typeof fetch
+
+    const summary = await runHealthSweep()
+
+    expect(summary.alertsDispatched).toBe(1)
+    expect(summary.maintenanceSuppressed).toBe(0)
+  })
+
+  test('suppression does not commit dedup state: the condition stays "new" on the next sweep', async () => {
+    mockWindows = [{ hostId: null, startsAt: 0, endsAt: Date.now() + 60_000 }]
+    globalThis.fetch = mock(
+      async () => new Response(null, { status: 200 })
+    ) as unknown as typeof fetch
+
+    await runHealthSweep()
+    // Nothing committed to the dedup store for the suppressed condition.
+    expect(alertStateStore.get('0:test-sweep-rule')).toBeUndefined()
+
+    // Window closes; the same condition should notify normally now, as if
+    // suppression never happened (no stale cooldown/escalation state).
+    mockWindows = []
+    const summary = await runHealthSweep()
     expect(summary.alertsDispatched).toBe(1)
   })
 })

--- a/apps/dashboard/src/lib/health/server-sweep.ts
+++ b/apps/dashboard/src/lib/health/server-sweep.ts
@@ -9,6 +9,7 @@ import type { AlertDecision } from './alert-state-store'
 import { detectAdapter } from './adapters'
 import { recordAlertEvent } from './alert-history-store'
 import { alertStateStore, evaluateAlert } from './alert-state-store'
+import { isSuppressed, listWindows } from './maintenance-windows'
 import {
   getServerAlertConfig,
   getServerAlertCooldownMs,
@@ -64,6 +65,8 @@ export interface SweepSummary {
   alertsDispatched: number
   /** Alerts suppressed by the dedup state store (already-firing conditions). */
   alertsSuppressed: number
+  /** Of `alertsSuppressed`, how many were gated by an active maintenance window. */
+  maintenanceSuppressed: number
   /** Recovery notifications sent for conditions that returned to ok. */
   recoveries: number
   /** Total AI insights generated and persisted across all hosts. */
@@ -254,11 +257,19 @@ export async function runHealthSweep(): Promise<SweepSummary> {
 
   const configs = getClickHouseConfigs()
 
+  // Maintenance windows: loaded once per sweep, best-effort (never throws —
+  // listWindows() already degrades to [] on any D1/binding failure).
+  // (verify) The sweep runs from a cron context with no signed-in session, so
+  // there is no per-tenant owner to resolve here yet — OSS single-tenant
+  // ('') is correct today; multi-tenant sweep scoping is a follow-up.
+  const windows = await listWindows('')
+
   const hosts: SweepHostSummary[] = []
   const findings: SweepFinding[] = []
   let insightsGenerated = 0
   let alertsDispatched = 0
   let alertsSuppressed = 0
+  let maintenanceSuppressed = 0
   let recoveries = 0
 
   for (const config of configs) {
@@ -308,6 +319,47 @@ export async function runHealthSweep(): Promise<SweepSummary> {
             severity: effective,
             cooldownMs,
           })
+          if (decision.notify && isSuppressed(windows, config.id, Date.now())) {
+            // A maintenance window covers this host right now — suppress the
+            // dispatch only. The finding above was already pushed to
+            // `findings` and the rule already ran, so nothing about data
+            // collection changes. Deliberately do NOT call `commit()`: the
+            // dedup state store must stay exactly as it was (still "unknown"
+            // for a brand-new condition, or still at its last-committed
+            // severity for a persisting one) so the cooldown/escalation
+            // semantics are unaffected once the window ends — the very next
+            // sweep after the window closes re-evaluates fresh and notifies
+            // normally if the condition still holds.
+            alertsSuppressed++
+            maintenanceSuppressed++
+            try {
+              await recordAlertEvent({
+                eventTime: new Date().toISOString(),
+                hostId: config.id,
+                hostLabel: name,
+                rule: rule.id,
+                severity:
+                  decision.kind === 'recovery'
+                    ? 'recovery'
+                    : (decision.severity as 'warning' | 'critical'),
+                prevSeverity:
+                  decision.previousSeverity === 'ok'
+                    ? null
+                    : decision.previousSeverity,
+                decisionKind: 'maintenance',
+                delivered: false,
+                value,
+                channel: detectAdapter(settings.webhookUrl).id,
+              })
+            } catch (err) {
+              debug(
+                `[health-sweep] alert-history record failed for host ${config.id} rule ${rule.id}`,
+                err instanceof Error ? err.message : String(err)
+              )
+            }
+            continue
+          }
+
           if (decision.notify) {
             const label = rule.formatLabel
               ? rule.formatLabel(value)
@@ -401,6 +453,7 @@ export async function runHealthSweep(): Promise<SweepSummary> {
     totalFindings: findings.length,
     alertsDispatched,
     alertsSuppressed,
+    maintenanceSuppressed,
     recoveries,
     insightsGenerated,
     hosts,

--- a/apps/dashboard/src/lib/hooks/use-maintenance-windows.ts
+++ b/apps/dashboard/src/lib/hooks/use-maintenance-windows.ts
@@ -1,0 +1,90 @@
+/**
+ * Maintenance windows (plan 28) — client hook for the /api/v1/health/maint-windows
+ * CRUD endpoint. Unlike webhook subscriptions, this feature is free/OSS and
+ * does NOT require Clerk sign-in: the server resolves the caller's owner
+ * (Clerk org/user when signed in, `''` OSS single-tenant otherwise) and the
+ * global /api/v1 middleware already gates the request per the deployment's
+ * auth posture — this hook just calls the endpoint and surfaces the result.
+ */
+
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { apiFetch } from '@/lib/swr/api-fetch'
+import { throwIfNotOk } from '@/lib/swr/fetch-error'
+
+export interface MaintenanceWindowInfo {
+  id: string
+  ownerId: string
+  hostId: number | null
+  reason: string
+  startsAt: number
+  endsAt: number
+  createdBy: string
+  createdAt: number
+}
+
+export const MAINTENANCE_WINDOWS_QUERY_KEY = [
+  '/api/v1/health/maint-windows',
+] as const
+
+export function useMaintenanceWindows(enabled = true) {
+  const query = useQuery({
+    queryKey: MAINTENANCE_WINDOWS_QUERY_KEY,
+    queryFn: async () => {
+      const response = await apiFetch('/api/v1/health/maint-windows')
+      await throwIfNotOk(response, 'Failed to load maintenance windows')
+      const json = (await response.json()) as {
+        success: boolean
+        windows: MaintenanceWindowInfo[]
+      }
+      return json.windows ?? []
+    },
+    enabled,
+    staleTime: 15_000,
+  })
+
+  return {
+    windows: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
+  }
+}
+
+export function useMaintenanceWindowsMutations() {
+  const queryClient = useQueryClient()
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: MAINTENANCE_WINDOWS_QUERY_KEY })
+
+  const createWindow = async (input: {
+    hostId: number | null
+    reason: string
+    startsAt: number
+    endsAt: number
+  }): Promise<MaintenanceWindowInfo> => {
+    const response = await apiFetch('/api/v1/health/maint-windows', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    })
+    await throwIfNotOk(response, 'Failed to create maintenance window')
+    invalidate()
+    const json = (await response.json()) as {
+      success: boolean
+      window: MaintenanceWindowInfo
+    }
+    return json.window
+  }
+
+  const deleteWindow = async (id: string): Promise<void> => {
+    const response = await apiFetch(
+      `/api/v1/health/maint-windows?id=${encodeURIComponent(id)}`,
+      { method: 'DELETE' }
+    )
+    await throwIfNotOk(response, 'Failed to delete maintenance window')
+    invalidate()
+  }
+
+  return { createWindow, deleteWindow, invalidate }
+}

--- a/apps/dashboard/src/routes/api/v1/health/maint-windows.ts
+++ b/apps/dashboard/src/routes/api/v1/health/maint-windows.ts
@@ -1,0 +1,143 @@
+/**
+ * Maintenance windows CRUD (plan 28)
+ * GET    /api/v1/health/maint-windows        — list windows for the caller's owner
+ * POST   /api/v1/health/maint-windows        — create a window
+ * DELETE /api/v1/health/maint-windows?id=... — delete a window
+ *
+ * Auth: GET is covered by the global /api/v1 middleware auth gate (same as
+ * the sibling checks.ts/snapshot.ts/history.ts routes). POST/DELETE
+ * self-enforce a write gate (`authorizeFeatureRequest`, feature 'settings')
+ * because that global middleware is a public passthrough under
+ * provider='none' / CHM_CLERK_PUBLIC_READ — mirrors webhook.ts's write gate.
+ *
+ * Owner resolution: `resolveBillingOwnerId()` reads the current Clerk session
+ * (org if active, else user). It throws when Clerk isn't configured — this
+ * route treats that as the OSS single-tenant owner (`''`) rather than
+ * failing the request, per the plan's fail-open invariant (self-hosted with
+ * no Clerk still gets a working, single-tenant maintenance-windows feature).
+ */
+
+import { z } from 'zod'
+import { createFileRoute } from '@tanstack/react-router'
+
+import { resolveBillingOwnerId } from '@/lib/billing/billing-owner'
+import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
+import {
+  createWindow,
+  deleteWindow,
+  listWindows,
+} from '@/lib/health/maintenance-windows'
+
+/** OSS single-tenant fallback when Clerk is not configured / no session. */
+async function resolveOwnerId(): Promise<string> {
+  try {
+    return await resolveBillingOwnerId()
+  } catch {
+    return ''
+  }
+}
+
+function jsonError(message: string, status: number): Response {
+  return Response.json(
+    { success: false, error: { type: 'validation', message } },
+    { status }
+  )
+}
+
+const CreateWindowSchema = z.object({
+  hostId: z.number().int().nonnegative().nullable(),
+  reason: z.string().max(500).optional().default(''),
+  startsAt: z.number().int().nonnegative(),
+  endsAt: z.number().int().nonnegative(),
+})
+
+async function handleGet(): Promise<Response> {
+  const ownerId = await resolveOwnerId()
+  const windows = await listWindows(ownerId)
+  return Response.json(
+    { success: true, windows },
+    {
+      headers: {
+        'Cache-Control': 'public, s-maxage=5, stale-while-revalidate=15',
+      },
+    }
+  )
+}
+
+async function handlePost(request: Request): Promise<Response> {
+  const permissionResponse = await authorizeFeatureRequest(
+    { feature: 'settings', defaultAccess: 'authenticated', operation: 'write' },
+    request,
+    { allowAgentBearerToken: true }
+  )
+  if (permissionResponse) return permissionResponse
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return jsonError('Request body must be valid JSON', 400)
+  }
+
+  const parsed = CreateWindowSchema.safeParse(body)
+  if (!parsed.success) {
+    return jsonError(
+      `Invalid request body: ${parsed.error.issues.map((i) => i.message).join(', ')}`,
+      400
+    )
+  }
+  const { hostId, reason, startsAt, endsAt } = parsed.data
+
+  if (endsAt <= startsAt) {
+    return jsonError('"endsAt" must be after "startsAt"', 400)
+  }
+
+  const ownerId = await resolveOwnerId()
+  try {
+    const window = await createWindow({
+      ownerId,
+      hostId,
+      reason,
+      startsAt,
+      endsAt,
+      createdBy: ownerId,
+    })
+    return Response.json({ success: true, window }, { status: 201 })
+  } catch (err) {
+    return jsonError(
+      err instanceof Error
+        ? err.message
+        : 'Failed to create maintenance window',
+      500
+    )
+  }
+}
+
+async function handleDelete(request: Request): Promise<Response> {
+  const permissionResponse = await authorizeFeatureRequest(
+    { feature: 'settings', defaultAccess: 'authenticated', operation: 'write' },
+    request,
+    { allowAgentBearerToken: true }
+  )
+  if (permissionResponse) return permissionResponse
+
+  const { searchParams } = new URL(request.url)
+  const id = searchParams.get('id')
+  if (!id) {
+    return jsonError('Missing "id" query parameter', 400)
+  }
+
+  const ownerId = await resolveOwnerId()
+  await deleteWindow(ownerId, id)
+  return Response.json({ success: true })
+}
+
+export const Route = createFileRoute('/api/v1/health/maint-windows')({
+  server: {
+    handlers: {
+      GET: async () => handleGet(),
+      POST: async ({ request }) => handlePost(request),
+      DELETE: async ({ request }) => handleDelete(request),
+    },
+  },
+})


### PR DESCRIPTION
Implements advisor plan 28: maintenance windows for alert suppression.

**Features:**
- Maintenance window scheduling
- Alert suppression during maintenance periods
- Time-based muting rules
- UI for managing maintenance windows

**Technical Implementation:**
- Maintenance window schema and storage
- Alert filtering logic
- Time range validation
- Integration with alert sweep

**Commits:**
```
  cee506057 feat(alerting): maintenance windows / alert suppression (plan 28)
```

**Advisor Plan:** #28