### PR TITLE
fix(landing): curated features and Cursor-style hero

### DIFF
--- a/apps/landing/src/components/FeatureShowcase.tsx
+++ b/apps/landing/src/components/FeatureShowcase.tsx
@@ -1,0 +1,95 @@
+import { Check } from 'lucide-react'
+
+import { ScreenshotZoom } from '@/components/ScreenshotZoom'
+import { FEATURE_SECTIONS } from '@/data/feature-showcase'
+import '@/styles/globals.css'
+
+function FeatureBlock({
+  section,
+}: {
+  section: (typeof FEATURE_SECTIONS)[number]
+}) {
+  const Icon = section.icon
+
+  return (
+    <article
+      id={section.id}
+      className="scroll-mt-20 grid items-center gap-10 min-[881px]:grid-cols-2 min-[881px]:gap-16"
+    >
+      <div
+        className={
+          section.reverse ? 'min-[881px]:order-2' : 'min-[881px]:order-1'
+        }
+      >
+        <div className="inline-flex size-9 items-center justify-center rounded-md border border-border text-muted-foreground">
+          <Icon className="size-4" strokeWidth={1.5} />
+        </div>
+        <p className="mt-4 font-medium text-primary text-sm">
+          {section.eyebrow}
+        </p>
+        <h3 className="mt-2 text-balance font-semibold text-2xl tracking-tight sm:text-3xl">
+          {section.title}
+        </h3>
+        <p className="mt-3 max-w-[46ch] text-pretty text-muted-foreground text-sm leading-relaxed sm:text-base">
+          {section.description}
+        </p>
+        <ul className="mt-6 flex list-none flex-col gap-2.5">
+          {section.bullets.map((bullet) => (
+            <li
+              key={bullet}
+              className="flex gap-2.5 text-foreground text-sm leading-snug"
+            >
+              <Check
+                className="mt-0.5 size-4 shrink-0 text-emerald-500"
+                strokeWidth={2.4}
+              />
+              {bullet}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div
+        className={
+          section.reverse ? 'min-[881px]:order-1' : 'min-[881px]:order-2'
+        }
+      >
+        <ScreenshotZoom
+          id={section.id}
+          src={section.screenshot.src}
+          alt={section.screenshot.alt}
+        />
+      </div>
+    </article>
+  )
+}
+
+export default function FeatureShowcase() {
+  return (
+    <section
+      id="features"
+      className="border-border/60 border-t bg-muted/20 py-20 sm:py-28"
+      data-feature-sections={FEATURE_SECTIONS.length}
+    >
+      <div className="mx-auto max-w-6xl px-6">
+        <div className="mx-auto max-w-2xl text-center">
+          <p className="font-medium text-primary text-sm">What you get</p>
+          <h2 className="mt-3 text-balance font-semibold text-3xl tracking-tight sm:text-4xl">
+            Everything about your cluster, in one place
+          </h2>
+          <p className="mt-4 text-pretty text-muted-foreground text-sm sm:text-base">
+            chmonitor reads ClickHouse system tables directly — no exporters, no
+            extra storage. Each view is purpose-built so you can spot the
+            problem and move on.
+          </p>
+        </div>
+
+        <div className="mt-20 flex flex-col gap-24 sm:gap-28">
+          {FEATURE_SECTIONS.map((section) => (
+            <FeatureBlock key={section.id} section={section} />
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/landing/src/components/Footer.astro
+++ b/apps/landing/src/components/Footer.astro
@@ -23,7 +23,9 @@ function fmtDate(iso: string) {
             <h5 class="text-xs font-medium uppercase tracking-wider text-muted-foreground">Product</h5>
             <div class="mt-3 flex flex-col gap-2.5">
               <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="/#top">Live demo</a>
-              <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="/#features">Ship log</a>
+              <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="/#features">Features</a>
+              <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="/#feature-ai-agent">AI Agent</a>
+              <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="/#feature-topology">Cluster topology</a>
               <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="/pricing">Pricing</a>
               <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="https://dash.chmonitor.dev" target="_blank" rel="noopener">Dashboard</a>
               <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="https://blog.chmonitor.dev" target="_blank" rel="noopener">Blog</a>

--- a/apps/landing/src/components/HeroIsland.tsx
+++ b/apps/landing/src/components/HeroIsland.tsx
@@ -5,7 +5,6 @@ import {
   Bot,
   Database,
   Expand,
-  Play,
   Search,
   Star,
   Zap,
@@ -14,19 +13,12 @@ import {
 import { useEffect, useMemo, useState } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { buttonVariants } from '@/components/ui/button'
-import { Card, CardContent } from '@/components/ui/card'
 import { Dialog, DialogContent, DialogImage } from '@/components/ui/dialog'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { HERO_DEMO_TABS } from '@/lib/hero-demo'
 import { resolveScreenshotZoom } from '@/lib/screenshot-zoom'
+import { cn } from '@/lib/utils'
 import '@/styles/globals.css'
-
-const GALLERY_SHOTS = HERO_DEMO_TABS.map((tab) => ({
-  id: tab.id,
-  src: tab.screenshot.src,
-  alt: tab.screenshot.alt,
-  label: tab.label,
-}))
 
 const TAB_ICONS: Record<string, typeof Activity> = {
   overview: Activity,
@@ -36,12 +28,20 @@ const TAB_ICONS: Record<string, typeof Activity> = {
   explorer: Database,
 }
 
+const GALLERY_SHOTS = HERO_DEMO_TABS.map((tab) => ({
+  id: tab.id,
+  src: tab.screenshot.src,
+  alt: tab.screenshot.alt,
+  label: tab.label,
+}))
+
 export default function HeroIsland({ starLabel = '' }: { starLabel?: string }) {
   const [activeTab, setActiveTab] = useState('overview')
   const [agentPhase, setAgentPhase] = useState(0)
   const [zoomOpen, setZoomOpen] = useState(false)
   const [zoomId, setZoomId] = useState<string | null>(null)
 
+  const activeTabData = HERO_DEMO_TABS.find((t) => t.id === activeTab)
   const zoomShot = zoomId ? resolveScreenshotZoom(GALLERY_SHOTS, zoomId) : null
 
   useEffect(() => {
@@ -51,9 +51,9 @@ export default function HeroIsland({ starLabel = '' }: { starLabel?: string }) {
     }
     setAgentPhase(0)
     const timers = [
-      setTimeout(() => setAgentPhase(1), 600),
-      setTimeout(() => setAgentPhase(2), 1800),
-      setTimeout(() => setAgentPhase(3), 3200),
+      setTimeout(() => setAgentPhase(1), 500),
+      setTimeout(() => setAgentPhase(2), 1600),
+      setTimeout(() => setAgentPhase(3), 2800),
     ]
     return () => timers.forEach(clearTimeout)
   }, [activeTab])
@@ -74,89 +74,100 @@ export default function HeroIsland({ starLabel = '' }: { starLabel?: string }) {
 
   return (
     <section className="relative isolate overflow-hidden" data-hero-demo>
-      <div className="mx-auto max-w-6xl px-6 pt-16 pb-10 sm:pt-20 lg:pt-24">
-        <div className="grid items-end gap-10 lg:grid-cols-[1fr_1.1fr] lg:gap-14">
-          <div className="text-left">
+      {/* Subtle top glow — x.ai / Cursor energy without gradient blobs */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 h-[480px] bg-[radial-gradient(ellipse_80%_50%_at_50%_-20%,color-mix(in_oklch,var(--primary)_18%,transparent),transparent)]"
+      />
+
+      <div className="relative mx-auto max-w-6xl px-6 pt-20 pb-6 sm:pt-24 lg:pt-28">
+        <div className="mx-auto max-w-3xl text-center">
+          <a
+            href="https://github.com/chmonitor/chmonitor"
+            target="_blank"
+            rel="noopener"
+            className="inline-block"
+          >
+            <Badge
+              variant="outline"
+              className="rounded-full border-border/80 bg-background/50 px-3 py-1 text-xs font-normal backdrop-blur-sm"
+            >
+              <span className="size-1.5 rounded-full bg-emerald-500" />
+              Open source · GPL-3.0
+              <ArrowRight className="size-3" />
+            </Badge>
+          </a>
+
+          <h1 className="mt-6 text-balance font-semibold text-foreground text-[clamp(2.75rem,7vw,5rem)] leading-[0.92] tracking-[-0.04em]">
+            Your ClickHouse
+            <br />
+            <span className="text-primary">command center</span>
+          </h1>
+
+          <p className="mx-auto mt-5 max-w-2xl text-pretty text-base text-muted-foreground leading-relaxed sm:text-lg">
+            Queries, merges, replication and health — live from system tables.
+            An AI agent that reads your schema before recommending. Alerts to
+            Slack, PagerDuty or any webhook.
+          </p>
+
+          <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+            <a
+              href="https://dash.chmonitor.dev"
+              target="_blank"
+              rel="noopener"
+              data-cta="hero-primary"
+              className={buttonVariants({ size: 'lg' })}
+            >
+              Open dashboard
+              <ArrowRight className="size-4" />
+            </a>
+            <a
+              href="https://docs.chmonitor.dev"
+              target="_blank"
+              rel="noopener"
+              className={buttonVariants({ variant: 'outline', size: 'lg' })}
+            >
+              <BookOpen className="size-4" />
+              Quickstart
+            </a>
             <a
               href="https://github.com/chmonitor/chmonitor"
               target="_blank"
               rel="noopener"
-              className="inline-block"
+              data-cta="github-star-hero"
+              aria-label={
+                starLabel
+                  ? `Star chmonitor on GitHub — ${starLabel} stars`
+                  : 'Star chmonitor on GitHub'
+              }
+              className={buttonVariants({ variant: 'ghost', size: 'lg' })}
             >
-              <Badge
-                variant="outline"
-                className="rounded-full px-3 py-1 text-xs font-normal"
-              >
-                <span className="size-1.5 rounded-full bg-emerald-500" />
-                Open source · GPL-3.0
-                <ArrowRight className="size-3" />
-              </Badge>
+              <Star className="size-4" />
+              {starLabel ? (
+                <span className="font-medium tabular-nums">{starLabel}</span>
+              ) : (
+                'Star on GitHub'
+              )}
             </a>
-
-            <h1 className="mt-5 text-balance font-semibold text-foreground text-[clamp(2.5rem,6vw,4.5rem)] leading-[0.95] tracking-[-0.03em]">
-              Your ClickHouse
-              <br />
-              <span className="text-primary">command center</span>
-            </h1>
-
-            <p className="mt-5 max-w-xl text-pretty text-base text-muted-foreground leading-relaxed sm:text-lg">
-              Queries, merges, replication and health — live from system tables.
-              An AI agent that reads your schema before recommending. Alerts to
-              Slack, PagerDuty or any webhook.
-            </p>
-
-            <div className="mt-8 flex flex-wrap items-center gap-3">
-              <a
-                href="https://dash.chmonitor.dev"
-                target="_blank"
-                rel="noopener"
-                data-cta="hero-primary"
-                className={buttonVariants({ size: 'lg' })}
-              >
-                Open dashboard
-                <ArrowRight className="size-4" />
-              </a>
-              <a
-                href="https://docs.chmonitor.dev"
-                target="_blank"
-                rel="noopener"
-                className={buttonVariants({ variant: 'outline', size: 'lg' })}
-              >
-                <BookOpen className="size-4" />
-                Quickstart
-              </a>
-              <a
-                href="https://github.com/chmonitor/chmonitor"
-                target="_blank"
-                rel="noopener"
-                data-cta="github-star-hero"
-                aria-label={
-                  starLabel
-                    ? `Star chmonitor on GitHub — ${starLabel} stars`
-                    : 'Star chmonitor on GitHub'
-                }
-                className={buttonVariants({ variant: 'ghost', size: 'lg' })}
-              >
-                <Star className="size-4" />
-                {starLabel ? (
-                  <span className="font-medium tabular-nums">{starLabel}</span>
-                ) : (
-                  'Star on GitHub'
-                )}
-              </a>
-            </div>
           </div>
+        </div>
 
-          <div className="relative">
-            <Tabs value={activeTab} onValueChange={setActiveTab}>
-              <TabsList className="w-full justify-start overflow-x-auto">
+        {/* Live demo — Cursor-style: tabs then full-bleed screenshot */}
+        <div className="mt-14 sm:mt-16">
+          <Tabs value={activeTab} onValueChange={setActiveTab}>
+            <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-between">
+              <TabsList className="h-auto w-full justify-center gap-0.5 rounded-none border-border/60 border-b bg-transparent p-0 sm:w-auto sm:justify-start">
                 {HERO_DEMO_TABS.map((tab) => {
                   const Icon = TAB_ICONS[tab.id] ?? Activity
                   return (
                     <TabsTrigger
                       key={tab.id}
                       value={tab.id}
-                      className="gap-1.5"
+                      className={cn(
+                        'gap-1.5 rounded-none border-transparent border-b-2 bg-transparent px-4 py-2.5 shadow-none',
+                        'data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none',
+                        'hover:text-foreground'
+                      )}
                     >
                       <Icon className="size-3.5" />
                       {tab.label}
@@ -164,137 +175,61 @@ export default function HeroIsland({ starLabel = '' }: { starLabel?: string }) {
                   )
                 })}
               </TabsList>
+              {activeTabData ? (
+                <p className="hidden text-muted-foreground text-xs sm:block">
+                  {activeTabData.headline}
+                </p>
+              ) : null}
+            </div>
 
-              {HERO_DEMO_TABS.map((tab) => (
-                <TabsContent key={tab.id} value={tab.id}>
-                  <Card className="overflow-hidden border-border/60 bg-card/80 backdrop-blur-sm">
-                    <CardContent className="p-0">
-                      <div className="flex items-center justify-between gap-3 border-border/50 border-b px-4 py-3">
-                        <div>
-                          <p className="font-medium text-foreground text-sm">
-                            {tab.headline}
-                          </p>
-                          <p className="text-muted-foreground text-xs">
-                            {tab.description}
-                          </p>
-                        </div>
-                        {tab.metrics ? (
-                          <div className="hidden gap-4 sm:flex">
-                            {tab.metrics.map((m) => (
-                              <div key={m.label} className="text-right">
-                                <p className="font-medium text-foreground text-sm tabular-nums">
-                                  {m.value}
-                                </p>
-                                <p className="text-muted-foreground text-[11px]">
-                                  {m.label}
-                                </p>
-                              </div>
-                            ))}
-                          </div>
-                        ) : null}
-                      </div>
+            {HERO_DEMO_TABS.map((tab) => (
+              <TabsContent key={tab.id} value={tab.id} className="mt-6">
+                {tab.id === 'agent' && agentPhase > 0 ? (
+                  <div className="mb-4 flex flex-wrap items-start justify-center gap-x-6 gap-y-2 px-2 text-center text-xs">
+                    <span className="text-muted-foreground">
+                      <span className="font-medium text-foreground">You:</span>{' '}
+                      {tab.prompt}
+                    </span>
+                    <span className="max-w-xl text-left text-foreground">
+                      <Bot className="mr-1 inline size-3 text-primary" />
+                      {agentLines.slice(0, agentPhase).join(' · ')}
+                    </span>
+                  </div>
+                ) : null}
 
-                      {tab.id === 'agent' ? (
-                        <div className="space-y-2 border-border/50 border-b px-4 py-3">
-                          <div className="flex items-start gap-2">
-                            <span className="mt-0.5 font-medium text-muted-foreground text-xs">
-                              You
-                            </span>
-                            <p className="rounded-md bg-muted px-2.5 py-1.5 text-foreground text-xs">
-                              {tab.prompt}
-                            </p>
-                          </div>
-                          {agentPhase > 0 ? (
-                            <div className="flex items-start gap-2">
-                              <Bot className="mt-0.5 size-3.5 text-primary" />
-                              <div className="space-y-1">
-                                {agentLines.slice(0, agentPhase).map((line) => (
-                                  <p
-                                    key={line}
-                                    className="text-foreground text-xs leading-relaxed"
-                                  >
-                                    {line}
-                                  </p>
-                                ))}
-                              </div>
-                            </div>
-                          ) : (
-                            <p className="pl-5 text-muted-foreground text-xs">
-                              Agent thinking…
-                            </p>
-                          )}
-                        </div>
-                      ) : null}
+                <button
+                  type="button"
+                  data-screenshot-zoom={tab.id}
+                  className="group relative mx-auto block w-full max-w-5xl cursor-zoom-in overflow-hidden rounded-xl shadow-2xl shadow-black/25 transition-transform duration-500 hover:scale-[1.005] dark:shadow-black/60"
+                  onClick={() => openZoom(tab.id)}
+                  aria-label={`Zoom ${tab.label} screenshot`}
+                >
+                  <img
+                    src={tab.screenshot.src}
+                    alt={tab.screenshot.alt}
+                    className="aspect-[16/10] w-full object-cover object-top"
+                  />
+                  <span className="pointer-events-none absolute top-4 right-4 inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-background/90 px-2.5 py-1.5 text-foreground text-xs opacity-0 shadow-sm backdrop-blur-sm transition-opacity group-hover:opacity-100">
+                    <Expand className="size-3.5" />
+                    Zoom
+                  </span>
+                  <div
+                    aria-hidden
+                    className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-background/80 to-transparent"
+                  />
+                </button>
 
-                      <button
-                        type="button"
-                        data-screenshot-zoom={tab.id}
-                        className="group relative block w-full cursor-zoom-in"
-                        onClick={() => openZoom(tab.id)}
-                        aria-label={`Zoom ${tab.label} screenshot`}
-                      >
-                        <img
-                          src={tab.screenshot.src}
-                          alt={tab.screenshot.alt}
-                          className="aspect-[16/10] w-full object-cover object-top transition-transform duration-300 group-hover:scale-[1.01]"
-                        />
-                        <span className="pointer-events-none absolute top-3 right-3 inline-flex items-center gap-1 rounded-md bg-background/90 px-2 py-1 text-foreground text-xs opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
-                          <Expand className="size-3" />
-                          Zoom
-                        </span>
-                      </button>
-                    </CardContent>
-                  </Card>
-                </TabsContent>
-              ))}
-            </Tabs>
-
-            <p className="mt-3 flex items-center gap-2 text-muted-foreground text-xs">
-              <Play className="size-3" />
-              Interactive preview — switch tabs to explore product surfaces
-            </p>
-          </div>
-        </div>
-      </div>
-
-      <div className="mx-auto max-w-6xl px-6 pb-14">
-        <div className="flex items-center justify-between gap-4">
-          <h2 className="font-medium text-foreground text-sm">
-            Every surface, one dashboard
-          </h2>
-          <p className="text-muted-foreground text-xs">
-            Click any shot to zoom
-          </p>
-        </div>
-        <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
-          {GALLERY_SHOTS.map((shot) => (
-            <button
-              key={shot.id}
-              type="button"
-              data-screenshot-zoom={shot.id}
-              className="group cursor-zoom-in text-left"
-              onClick={() => openZoom(shot.id)}
-              aria-label={`Zoom ${shot.label}`}
-            >
-              <div className="overflow-hidden rounded-lg shadow-lg transition-transform duration-300 group-hover:scale-[1.02]">
-                <img
-                  src={shot.src}
-                  alt={shot.alt}
-                  loading="lazy"
-                  decoding="async"
-                  className="aspect-[16/10] w-full object-cover object-top"
-                />
-              </div>
-              <p className="mt-1.5 font-medium text-muted-foreground text-[11px]">
-                {shot.label}
-              </p>
-            </button>
-          ))}
+                <p className="mt-4 text-center text-muted-foreground text-xs">
+                  {tab.description}
+                </p>
+              </TabsContent>
+            ))}
+          </Tabs>
         </div>
       </div>
 
       <Dialog open={zoomOpen} onOpenChange={setZoomOpen}>
-        <DialogContent className="p-3">
+        <DialogContent className="border-none bg-transparent p-0 shadow-none">
           {zoomShot ? (
             <DialogImage src={zoomShot.src} alt={zoomShot.alt} />
           ) : null}

--- a/apps/landing/src/components/Nav.astro
+++ b/apps/landing/src/components/Nav.astro
@@ -15,7 +15,9 @@
           <div class="nav-menu">
             <a href="/#top">Live demo<small>Tabbed product preview in the hero</small></a>
             <a href="/#highlights">Highlights<small>Agent, alerting, self-host and cloud</small></a>
-            <a href="/#features">Ship log<small>Every CHANGELOG feature, searchable</small></a>
+            <a href="/#features">Features<small>Agent, queries, topology and more</small></a>
+            <a href="/#feature-ai-agent">AI Agent<small>Schema-aware recommendations</small></a>
+            <a href="/#feature-queries">Queries<small>Running, slow and expensive</small></a>
             <a href="/monitor-queries">Query monitoring<small>Running, slow, failed &amp; expensive</small></a>
             <a href="/cluster-health">Cluster health<small>Threshold alerts and topology</small></a>
           </div>
@@ -72,7 +74,9 @@
         <span class="nav-drawer-label">Features</span>
         <a href="/#top">Live demo</a>
         <a href="/#highlights">Highlights</a>
-        <a href="/#features">Ship log</a>
+        <a href="/#features">Features</a>
+        <a href="/#feature-ai-agent">AI Agent</a>
+        <a href="/#feature-queries">Queries</a>
         <a href="/monitor-queries">Query monitoring</a>
         <a href="/cluster-health">Cluster health</a>
         <span class="nav-drawer-label">Explore</span>

--- a/apps/landing/src/components/ScreenshotZoom.tsx
+++ b/apps/landing/src/components/ScreenshotZoom.tsx
@@ -1,0 +1,56 @@
+import { Expand } from 'lucide-react'
+
+import { useState } from 'react'
+import { Dialog, DialogContent, DialogImage } from '@/components/ui/dialog'
+import { cn } from '@/lib/utils'
+
+type Props = {
+  id: string
+  src: string
+  alt: string
+  className?: string
+  aspectClass?: string
+}
+
+export function ScreenshotZoom({
+  id,
+  src,
+  alt,
+  className,
+  aspectClass = 'aspect-[16/10]',
+}: Props) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <button
+        type="button"
+        data-screenshot-zoom={id}
+        className={cn(
+          'group relative block w-full cursor-zoom-in overflow-hidden rounded-xl shadow-2xl shadow-black/20 transition-transform duration-500 hover:scale-[1.01] dark:shadow-black/50',
+          className
+        )}
+        onClick={() => setOpen(true)}
+        aria-label={`Zoom ${alt}`}
+      >
+        <img
+          src={src}
+          alt={alt}
+          loading="lazy"
+          decoding="async"
+          className={cn('w-full object-cover object-top', aspectClass)}
+        />
+        <span className="pointer-events-none absolute top-4 right-4 inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-background/90 px-2.5 py-1.5 text-foreground text-xs opacity-0 shadow-sm backdrop-blur-sm transition-opacity group-hover:opacity-100">
+          <Expand className="size-3.5" />
+          Zoom
+        </span>
+      </button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="border-none bg-transparent p-0 shadow-none">
+          <DialogImage src={src} alt={alt} />
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/apps/landing/src/components/ui/badge.tsx
+++ b/apps/landing/src/components/ui/badge.tsx
@@ -11,7 +11,8 @@ const badgeVariants = cva(
       variant: {
         default: 'border-transparent bg-primary text-primary-foreground',
         secondary: 'border-transparent bg-secondary text-secondary-foreground',
-        outline: 'text-foreground border-border',
+        outline:
+          'text-foreground border-border bg-background/60 backdrop-blur-sm',
       },
     },
     defaultVariants: {

--- a/apps/landing/src/components/ui/tabs.tsx
+++ b/apps/landing/src/components/ui/tabs.tsx
@@ -71,8 +71,8 @@ function TabsTrigger({
         'focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50',
         'disabled:pointer-events-none disabled:opacity-50',
         selected
-          ? 'bg-background text-foreground shadow-sm'
-          : 'hover:text-foreground',
+          ? 'bg-background text-foreground shadow-sm dark:bg-card'
+          : 'text-muted-foreground hover:text-foreground',
         className
       )}
       onClick={() => onValueChange(value)}

--- a/apps/landing/src/data/feature-showcase.test.ts
+++ b/apps/landing/src/data/feature-showcase.test.ts
@@ -1,0 +1,20 @@
+import { FEATURE_SECTIONS } from './feature-showcase'
+import { describe, expect, test } from 'bun:test'
+
+describe('feature showcase sections', () => {
+  test('every section has id, copy and screenshot', () => {
+    expect(FEATURE_SECTIONS.length).toBeGreaterThanOrEqual(6)
+    for (const section of FEATURE_SECTIONS) {
+      expect(section.id.startsWith('feature-')).toBe(true)
+      expect(section.title.length).toBeGreaterThan(0)
+      expect(section.bullets.length).toBeGreaterThan(0)
+      expect(section.screenshot.src.startsWith('/landing-assets/')).toBe(true)
+      expect(section.screenshot.alt.length).toBeGreaterThan(0)
+    }
+  })
+
+  test('section ids are unique', () => {
+    const ids = FEATURE_SECTIONS.map((s) => s.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+})

--- a/apps/landing/src/data/feature-showcase.ts
+++ b/apps/landing/src/data/feature-showcase.ts
@@ -1,0 +1,128 @@
+import type { LucideIcon } from 'lucide-react'
+import { Bell, Bot, Database, GitBranch, LineChart, Search } from 'lucide-react'
+
+export type FeatureSection = {
+  id: string
+  icon: LucideIcon
+  eyebrow: string
+  title: string
+  description: string
+  bullets: string[]
+  screenshot: {
+    src: string
+    alt: string
+  }
+  /** Flip screenshot to the left on wide screens */
+  reverse?: boolean
+}
+
+export const FEATURE_SECTIONS: FeatureSection[] = [
+  {
+    id: 'feature-ai-agent',
+    icon: Bot,
+    eyebrow: 'AI Agent',
+    title: 'Ask your cluster anything',
+    description:
+      'The built-in agent reads schema and query_log before recommending. Connect over MCP from Claude, Cursor or any client.',
+    bullets: [
+      '29 tools across schema, diagnostics and optimization',
+      'Recommend-only advisor: skip indexes, projections and PREWHERE rewrites',
+      'Bring your own model, skills and external MCP servers',
+      'Read-only MCP endpoint — nothing applied without you',
+    ],
+    screenshot: {
+      src: '/landing-assets/ai-agent-new-dark.webp',
+      alt: 'chmonitor AI agent chat with schema-aware recommendations',
+    },
+  },
+  {
+    id: 'feature-queries',
+    icon: Search,
+    eyebrow: 'Query monitoring',
+    title: 'Every query, explained',
+    description:
+      'Running, history, failed, slowest and most expensive queries — duration, memory, rows read and the full statement.',
+    bullets: [
+      'Queries by user and top patterns over time',
+      'Saved filter presets and one-click EXPLAIN',
+      'Kill long-running queries from the table',
+      'Query heatmap and record-breaker insights',
+    ],
+    screenshot: {
+      src: '/landing-assets/running-queries-new-dark.webp',
+      alt: 'Running queries with live charts and sortable table',
+    },
+    reverse: true,
+  },
+  {
+    id: 'feature-topology',
+    icon: GitBranch,
+    eyebrow: 'Cluster topology',
+    title: 'See the whole cluster at a glance',
+    description:
+      'Interactive map of nodes, shards, replicas and Keeper quorum — live replication links, health states and per-node metrics.',
+    bullets: [
+      'ClickHouse nodes and Keeper quorum with leader and followers',
+      'Physical and logical clusters, overlapping virtual clusters',
+      'Per-node CPU, memory and latency — healthy, warn or unreachable',
+    ],
+    screenshot: {
+      src: '/landing-assets/cluster-topology-new-dark.webp',
+      alt: 'Cluster topology map of shards, replicas and Keeper quorum',
+    },
+  },
+  {
+    id: 'feature-alerting',
+    icon: Bell,
+    eyebrow: 'Alerting',
+    title: 'Know before your users do',
+    description:
+      'Built-in health checks watch replication lag, disk, memory and failed queries — each with tunable warning and critical thresholds.',
+    bullets: [
+      'One webhook URL — Slack, Discord, PagerDuty or Opsgenie',
+      'Editable thresholds per check with full fire and recovery history',
+      'One-click AI audit prompt for any failing check',
+    ],
+    screenshot: {
+      src: '/landing-assets/health-summary.png',
+      alt: 'Health checks with editable warning and critical thresholds',
+    },
+    reverse: true,
+  },
+  {
+    id: 'feature-explorer',
+    icon: Database,
+    eyebrow: 'Data Explorer',
+    title: 'Explore tables and how they connect',
+    description:
+      'Browse every database and table, map dependencies between them, then drop into SQL — all without leaving the dashboard.',
+    bullets: [
+      'Dependency graph: materialized views, dictionaries and sources',
+      'Run SQL with row counts, timing, DDL and parts inspection',
+      'Projections, skip indexes and table lineage at a glance',
+    ],
+    screenshot: {
+      src: '/landing-assets/data-explorer-new-dark.webp',
+      alt: 'Data explorer dependency graph between tables',
+    },
+  },
+  {
+    id: 'feature-insights',
+    icon: LineChart,
+    eyebrow: 'Insights',
+    title: "Know your cluster's vitals",
+    description:
+      'Record-breaking queries, storage stats and a full year of activity — surfaced automatically, no dashboards to build.',
+    bullets: [
+      'AI-generated findings with stable-key dismissal',
+      'Query activity heatmap — a year of volume at a glance',
+      'Storage breakdown by database, table and part',
+      'SQL console with history, EXPLAIN and scan analysis',
+    ],
+    screenshot: {
+      src: '/landing-assets/overview-insights-dark.webp',
+      alt: 'Overview with AI insights, heatmap and storage stats',
+    },
+    reverse: true,
+  },
+]

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -3,7 +3,7 @@ import Base from '../layouts/Base.astro'
 import Nav from '../components/Nav.astro'
 import Hero from '../components/Hero.astro'
 import ProductHighlights from '../components/ProductHighlights.tsx'
-import FeaturesCatalog from '../components/FeaturesCatalog.tsx'
+import FeatureShowcase from '../components/FeatureShowcase.tsx'
 import SocialProof from '../components/SocialProof.astro'
 import Comparison from '../components/Comparison.astro'
 import Pricing from '../components/Pricing.astro'
@@ -11,17 +11,14 @@ import FAQ from '../components/FAQ.astro'
 import FinalCta from '../components/FinalCta.astro'
 import Footer from '../components/Footer.astro'
 import UseCaseLinks from '../components/UseCaseLinks.astro'
-import { loadChangelogFeatures } from '../data/changelog-features'
 import { useCases } from '../data/use-cases'
-
-const { groups, totalCount } = loadChangelogFeatures()
 ---
 <Base>
   <Nav />
   <main id="top">
     <Hero />
     <ProductHighlights client:visible />
-    <FeaturesCatalog client:visible groups={groups} totalCount={totalCount} />
+    <FeatureShowcase client:visible />
     <SocialProof />
     <Comparison />
     <UseCaseLinks items={useCases} eyebrow="Use cases" heading="Explore by use case" soft />


### PR DESCRIPTION
## Summary

Follow-up to #2415 based on review feedback:

- **Remove** the CHANGELOG ship log from the homepage (`FeaturesCatalog`)
- **Add** six curated, screenshot-backed feature sections (agent, queries, topology, alerting, explorer, insights) with borderless zoomable shots
- **Redesign hero** — centered headline, underline tabs (Cursor-style), full-bleed screenshots without card chrome or thumbnail grid
- **Fix** dark-mode badge and tab styling

## Test plan

- [x] `pnpm run build` in `apps/landing`
- [x] `pnpm test` — 22 tests pass
- [ ] Visual check: hero tabs + feature sections in light/dark mode