### PR TITLE
fix(landing): monitoring hero, changelog chips, and dark-mode polish

### DIFF
--- a/apps/landing/scripts/verify-landing-structure.ts
+++ b/apps/landing/scripts/verify-landing-structure.ts
@@ -11,16 +11,20 @@ const html = readFileSync(distIndex, 'utf8')
 const required = [
   'data-hero',
   'data-hero-features',
-  'AI ops agent for ClickHouse',
+  'data-feature-index-promo',
+  'UI monitoring for ClickHouse',
+  'data-hero-slogan',
+  '/changelog#ship-log',
 ] as const
 
 const forbidden = [
   'Ship log',
-  'features shipped',
   'Open source, built in public',
   'data-hero-demo-input',
   'data-hero-prompt-input',
   'Ask the agent a question',
+  'Live demo',
+  'Tabbed product preview',
 ] as const
 
 let failed = false
@@ -66,6 +70,14 @@ while ((zoomTag = zoomTagRe.exec(html)) !== null) {
 }
 if (borderedZoom === 0 && zoomCount > 0) {
   console.log('OK: screenshot zoom wrappers are borderless')
+}
+
+const homeFeatureCount = html.match(/data-feature-count="(\d+)"/)
+if (!homeFeatureCount) {
+  console.error('MISSING data-feature-count on homepage (feature index promo)')
+  failed = true
+} else {
+  console.log(`OK: homepage feature index promo count=${homeFeatureCount[1]}`)
 }
 
 const distChangelog = join(process.cwd(), 'dist/changelog/index.html')

--- a/apps/landing/src/components/FAQ.astro
+++ b/apps/landing/src/components/FAQ.astro
@@ -56,10 +56,10 @@ const faqJsonLd = {
 
     <div class="reveal mx-auto mt-12 max-w-3xl">
       {faqs.map(({ q, a }) => (
-        <details class="faq-item group border-b border-border first:border-t">
-          <summary class="flex cursor-pointer list-none items-center justify-between gap-4 py-5 font-medium text-foreground [&::-webkit-details-marker]:hidden">
+        <details class="changelog-faq group border-b border-border first:border-t">
+          <summary class="flex cursor-pointer list-none items-center justify-between gap-4 py-5 font-medium text-foreground marker:content-none [&::-webkit-details-marker]:hidden">
             {q}
-            <svg class="size-4 shrink-0 text-muted-foreground transition-transform duration-200 group-open:rotate-180" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+            <svg class="size-4 shrink-0 text-muted-foreground transition-transform duration-200 group-open:rotate-180" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
           </summary>
           <div class="faq-ans pb-5 text-muted-foreground [&_a]:text-primary [&_a]:underline [&_a]:underline-offset-4 [&_a:hover]:text-primary/80 [&_code]:rounded [&_code]:bg-muted [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[0.85em]" set:html={a} />
         </details>

--- a/apps/landing/src/components/FeatureIndexPromo.tsx
+++ b/apps/landing/src/components/FeatureIndexPromo.tsx
@@ -1,0 +1,60 @@
+import { ArrowRight, List } from 'lucide-react'
+
+import { buttonVariants } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+
+type Props = {
+  totalCount: number
+  scopeCount: number
+}
+
+export function FeatureIndexPromo({ totalCount, scopeCount }: Props) {
+  return (
+    <section
+      id="feature-index"
+      className="border-border/60 border-t py-16 sm:py-20"
+      data-feature-index-promo
+      data-feature-count={totalCount}
+    >
+      <div className="mx-auto max-w-6xl px-6">
+        <Card className="border-border/70 bg-muted/30">
+          <CardContent className="flex flex-col items-start gap-4 p-6 sm:flex-row sm:items-center sm:justify-between sm:p-8">
+            <div className="flex gap-4">
+              <List
+                className="mt-0.5 size-5 shrink-0 text-muted-foreground"
+                strokeWidth={1.5}
+                aria-hidden
+              />
+              <div>
+                <p className="font-medium text-primary text-sm">
+                  Complete feature list
+                </p>
+                <h2 className="mt-1 text-balance font-semibold text-xl tracking-tight sm:text-2xl">
+                  Every CHANGELOG feature, searchable
+                </h2>
+                <p className="mt-2 max-w-xl text-pretty text-muted-foreground text-sm leading-relaxed">
+                  <span className="tabular-nums font-medium text-foreground">
+                    {totalCount}
+                  </span>{' '}
+                  monitoring, agent, and alerting features across{' '}
+                  <span className="tabular-nums font-medium text-foreground">
+                    {scopeCount}
+                  </span>{' '}
+                  areas — searchable by scope or keyword.
+                </p>
+              </div>
+            </div>
+            <a
+              href="/changelog#ship-log"
+              className={buttonVariants({ variant: 'outline', size: 'lg' })}
+              data-cta="feature-index"
+            >
+              Browse feature index
+              <ArrowRight className="size-4" />
+            </a>
+          </CardContent>
+        </Card>
+      </div>
+    </section>
+  )
+}

--- a/apps/landing/src/components/FeatureShowcase.tsx
+++ b/apps/landing/src/components/FeatureShowcase.tsx
@@ -21,9 +21,7 @@ function FeatureBlock({
           section.reverse ? 'min-[881px]:order-2' : 'min-[881px]:order-1'
         }
       >
-        <div className="inline-flex size-9 items-center justify-center rounded-md border border-border text-muted-foreground">
-          <Icon className="size-4" strokeWidth={1.5} />
-        </div>
+        <Icon className="size-5 text-muted-foreground" strokeWidth={1.5} aria-hidden />
         <p className="mt-4 font-medium text-primary text-sm">
           {section.eyebrow}
         </p>
@@ -78,9 +76,8 @@ export default function FeatureShowcase() {
             Everything about your cluster, in one place
           </h2>
           <p className="mt-4 text-pretty text-muted-foreground text-sm sm:text-base">
-            chmonitor reads ClickHouse system tables directly — no exporters, no
-            extra storage. Each view is purpose-built so you can spot the
-            problem and move on.
+            Purpose-built views over ClickHouse system tables — queries,
+            replication, storage, and health. No exporters, no extra storage.
           </p>
         </div>
 

--- a/apps/landing/src/components/FeaturesCatalog.tsx
+++ b/apps/landing/src/components/FeaturesCatalog.tsx
@@ -1,6 +1,7 @@
 import { Search } from 'lucide-react'
 
 import type { ChangelogFeatureGroup } from '@/lib/parse-changelog-features'
+import { scopeChipLabel } from '@/lib/parse-changelog-features'
 
 import { useMemo, useState } from 'react'
 import { Badge } from '@/components/ui/badge'
@@ -8,11 +9,52 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Separator } from '@/components/ui/separator'
+import { cn } from '@/lib/utils'
 import '@/styles/globals.css'
 
 type Props = {
   groups: ChangelogFeatureGroup[]
   totalCount: number
+}
+
+function ScopeChip({
+  active,
+  label,
+  title,
+  count,
+  onClick,
+}: {
+  active: boolean
+  label: string
+  title: string
+  count?: number
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      title={title}
+      onClick={onClick}
+      className={cn(
+        'inline-flex h-7 max-w-[9.5rem] shrink-0 items-center gap-1.5 rounded-full px-2.5 text-xs font-medium transition-colors',
+        active
+          ? 'bg-primary text-primary-foreground'
+          : 'bg-muted/80 text-muted-foreground hover:bg-muted hover:text-foreground'
+      )}
+    >
+      <span className="truncate">{label}</span>
+      {count !== undefined ? (
+        <span
+          className={cn(
+            'tabular-nums text-[10px]',
+            active ? 'text-primary-foreground/80' : 'text-muted-foreground/80'
+          )}
+        >
+          {count}
+        </span>
+      ) : null}
+    </button>
+  )
 }
 
 export default function FeaturesCatalog({ groups, totalCount }: Props) {
@@ -75,30 +117,33 @@ export default function FeaturesCatalog({ groups, totalCount }: Props) {
           </p>
         </div>
 
-        <div className="mt-4 flex flex-wrap gap-2">
-          <button
-            type="button"
+        <div
+          className="mt-4 -mx-1 flex gap-1.5 overflow-x-auto px-1 pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          role="toolbar"
+          aria-label="Filter by scope"
+        >
+          <ScopeChip
+            active={activeScope === null}
+            label="All"
+            title="All scopes"
+            count={totalCount}
             onClick={() => setActiveScope(null)}
-            className="rounded-full"
-          >
-            <Badge variant={activeScope === null ? 'default' : 'outline'}>
-              All scopes
-            </Badge>
-          </button>
-          {scopes.map((scope) => (
-            <button
-              key={scope}
-              type="button"
-              onClick={() =>
-                setActiveScope(activeScope === scope ? null : scope)
-              }
-              className="rounded-full"
-            >
-              <Badge variant={activeScope === scope ? 'default' : 'outline'}>
-                {scope}
-              </Badge>
-            </button>
-          ))}
+          />
+          {scopes.map((scope) => {
+            const group = groups.find((g) => g.scope === scope)
+            return (
+              <ScopeChip
+                key={scope}
+                active={activeScope === scope}
+                label={scopeChipLabel(scope)}
+                title={scope}
+                count={group?.features.length}
+                onClick={() =>
+                  setActiveScope(activeScope === scope ? null : scope)
+                }
+              />
+            )
+          })}
         </div>
 
         <ScrollArea className="mt-8 max-h-[70vh] pr-2">
@@ -106,9 +151,13 @@ export default function FeaturesCatalog({ groups, totalCount }: Props) {
             {filtered.map((group) => (
               <Card key={group.scope}>
                 <CardHeader className="pb-3">
-                  <CardTitle className="flex items-center justify-between text-base">
-                    <span>{group.scope}</span>
-                    <Badge variant="secondary">{group.features.length}</Badge>
+                  <CardTitle className="flex items-center justify-between gap-2 text-base">
+                    <span className="truncate font-mono text-sm">
+                      {group.scope}
+                    </span>
+                    <Badge variant="secondary" className="shrink-0 tabular-nums">
+                      {group.features.length}
+                    </Badge>
                   </CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-0 pb-4">

--- a/apps/landing/src/components/FinalCta.astro
+++ b/apps/landing/src/components/FinalCta.astro
@@ -3,7 +3,7 @@
     <!-- Deliberately dark in BOTH themes: a spotlight CTA band anchored by the
          dark hero image. Colors are fixed (not theme tokens) so light mode keeps
          the same dark look. -->
-    <div class="reveal relative isolate overflow-hidden rounded-xl border border-white/10 bg-neutral-950 shadow-sm">
+    <div class="reveal relative isolate overflow-hidden rounded-xl bg-neutral-950 shadow-sm">
       <div class="absolute inset-0 -z-10" aria-hidden="true">
         <img src="/landing-assets/hero-cmyk-3.jpg" alt="" width="2752" height="1536" loading="lazy" decoding="async" class="h-full w-full object-cover object-center" />
       </div>

--- a/apps/landing/src/components/Footer.astro
+++ b/apps/landing/src/components/Footer.astro
@@ -22,7 +22,7 @@ function fmtDate(iso: string) {
           <div class="min-w-36">
             <h5 class="text-xs font-medium uppercase tracking-wider text-muted-foreground">Product</h5>
             <div class="mt-3 flex flex-col gap-2.5">
-              <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="/#top">Live demo</a>
+              <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="/#top">Overview</a>
               <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="/#features">Features</a>
               <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="/#feature-ai-agent">AI Agent</a>
               <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="/#feature-topology">Cluster topology</a>

--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -7,4 +7,4 @@ const { stars } = await getGitHubStats()
 const starLabel = formatCount(stars)
 ---
 
-<HeroContent starLabel={starLabel} />
+<HeroContent client:load starLabel={starLabel} />

--- a/apps/landing/src/components/HeroContent.tsx
+++ b/apps/landing/src/components/HeroContent.tsx
@@ -2,15 +2,16 @@ import { ArrowRight, BookOpen, Check, Star } from 'lucide-react'
 
 import { Badge } from '@/components/ui/badge'
 import { buttonVariants } from '@/components/ui/button'
+import { HeroRotatingSlogan } from '@/components/HeroRotatingSlogan'
 import { cn } from '@/lib/utils'
 
 const HERO_FEATURES = [
   'Real-time queries, merges and replication from system tables',
-  'Slow-query patterns, EXPLAIN and memory-heavy workload ranking',
-  'Cluster topology, replica lag and Keeper health in one view',
-  'AI agent with schema, diagnostics and tuning tools — MCP-ready',
+  'Running, slow and expensive query views with EXPLAIN',
+  'Cluster topology, replica lag and Keeper health',
+  'Disk, memory and merge backlog on one overview',
   'Threshold alerts to Slack, Opsgenie, PagerDuty and webhooks',
-  'Self-host on Docker, Kubernetes or Workers — or start on cloud',
+  'AI advisor for schema and tuning — MCP-ready, read-only default',
 ] as const
 
 type Props = {
@@ -26,7 +27,7 @@ export function HeroContent({ starLabel = '', className }: Props) {
     >
       <div
         aria-hidden
-        className="pointer-events-none absolute inset-x-0 top-0 h-[380px] bg-[radial-gradient(ellipse_70%_50%_at_50%_-20%,color-mix(in_oklch,var(--primary)_10%,transparent),transparent)]"
+        className="pointer-events-none absolute inset-x-0 top-0 h-[360px] bg-[radial-gradient(ellipse_70%_50%_at_50%_-20%,color-mix(in_oklch,var(--primary)_8%,transparent),transparent)]"
       />
 
       <div className="relative mx-auto max-w-6xl px-6 pt-16 sm:pt-20 lg:pt-24">
@@ -46,15 +47,18 @@ export function HeroContent({ starLabel = '', className }: Props) {
             </Badge>
           </a>
 
-          <h1 className="mt-5 text-balance font-semibold text-[clamp(2.25rem,5.5vw,3.75rem)] text-foreground leading-[1.05] tracking-[-0.03em]">
-            The AI ops agent for ClickHouse
-            <span className="block text-primary">— everywhere it runs</span>
+          <h1 className="mt-5 text-balance font-semibold text-[clamp(2rem,5vw,3.5rem)] text-foreground leading-[1.08] tracking-[-0.03em]">
+            UI monitoring for ClickHouse
           </h1>
 
+          <HeroRotatingSlogan />
+
           <p className="mx-auto mt-4 max-w-xl text-pretty text-muted-foreground text-sm leading-relaxed sm:text-base">
-            Monitor slow queries, merges and replication lag from live system
-            tables — with an advisor that recommends what to change, not just
-            charts.
+            Live dashboards from{' '}
+            <span className="text-foreground">system.query_log</span>,{' '}
+            <span className="text-foreground">system.parts</span>, and
+            replication tables — self-hosted or on{' '}
+            <span className="text-foreground">dash.chmonitor.dev</span>.
           </p>
 
           <div className="mt-6 flex flex-wrap items-center justify-center gap-2.5">

--- a/apps/landing/src/components/HeroRotatingSlogan.tsx
+++ b/apps/landing/src/components/HeroRotatingSlogan.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react'
+
+import { HERO_SLOGANS } from '@/lib/hero-slogans'
+import { cn } from '@/lib/utils'
+
+const INTERVAL_MS = 4500
+const FADE_MS = 280
+
+export function HeroRotatingSlogan() {
+  const [index, setIndex] = useState(0)
+  const [visible, setVisible] = useState(true)
+  const [motionOk, setMotionOk] = useState(true)
+
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const sync = () => setMotionOk(!mq.matches)
+    sync()
+    mq.addEventListener('change', sync)
+    return () => mq.removeEventListener('change', sync)
+  }, [])
+
+  useEffect(() => {
+    if (!motionOk || HERO_SLOGANS.length < 2) return
+    let swap: ReturnType<typeof setTimeout> | undefined
+    const tick = setInterval(() => {
+      setVisible(false)
+      swap = setTimeout(() => {
+        setIndex((i) => (i + 1) % HERO_SLOGANS.length)
+        setVisible(true)
+      }, FADE_MS)
+    }, INTERVAL_MS)
+    return () => {
+      clearInterval(tick)
+      if (swap) clearTimeout(swap)
+    }
+  }, [motionOk])
+
+  return (
+    <p
+      data-hero-slogan
+      aria-live={motionOk ? 'polite' : 'off'}
+      className={cn(
+        'mx-auto mt-3 min-h-[1.6em] max-w-xl text-pretty font-medium text-lg text-primary tracking-tight transition-opacity duration-300 sm:text-xl',
+        visible ? 'opacity-100' : 'opacity-0'
+      )}
+    >
+      {HERO_SLOGANS[index]}
+    </p>
+  )
+}

--- a/apps/landing/src/components/Nav.astro
+++ b/apps/landing/src/components/Nav.astro
@@ -13,9 +13,9 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
           </button>
           <div class="nav-menu">
-            <a href="/#top">Live demo<small>Tabbed product preview in the hero</small></a>
-            <a href="/#highlights">Highlights<small>Agent, alerting, self-host and cloud</small></a>
+            <a href="/#top">Overview<small>Product positioning and capabilities</small></a>
             <a href="/#features">Features<small>Agent, queries, topology and more</small></a>
+            <a href="/#feature-index">Feature index<small>Every CHANGELOG.md feature</small></a>
             <a href="/#feature-ai-agent">AI Agent<small>Schema-aware recommendations</small></a>
             <a href="/#feature-queries">Queries<small>Running, slow and expensive</small></a>
             <a href="/monitor-queries">Query monitoring<small>Running, slow, failed &amp; expensive</small></a>
@@ -73,9 +73,9 @@
       </div>
       <div class="nav-drawer-body">
         <span class="nav-drawer-label">Features</span>
-        <a href="/#top">Live demo</a>
-        <a href="/#highlights">Highlights</a>
+        <a href="/#top">Overview</a>
         <a href="/#features">Features</a>
+        <a href="/#feature-index">Feature index</a>
         <a href="/#feature-ai-agent">AI Agent</a>
         <a href="/#feature-queries">Queries</a>
         <a href="/monitor-queries">Query monitoring</a>

--- a/apps/landing/src/components/Pricing.astro
+++ b/apps/landing/src/components/Pricing.astro
@@ -52,15 +52,15 @@ const outlineBtnAuto =
       </span>
       <div class="bill-toggle inline-flex gap-0.5 rounded-full border border-border bg-card p-1" role="tablist" aria-label="Billing period">
         <button type="button" data-period="monthly" role="tab" aria-selected="false" class="billing-toggle-btn inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground active:scale-[.98] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50">Monthly</button>
-        <button type="button" data-period="yearly" role="tab" aria-selected="true" class="billing-toggle-btn active inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground active:scale-[.98] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50">
-          Yearly <span class="save text-xs font-semibold text-emerald-600 dark:text-emerald-400">{monthsFreeText(yearlyMonthsFreeValue)} free</span>
+        <button type="button" data-period="yearly" role="tab" aria-selected="true" class="billing-toggle-btn active inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm font-medium transition-colors active:scale-[.98] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50">
+          Yearly <span class="save text-xs font-semibold">{monthsFreeText(yearlyMonthsFreeValue)} free</span>
         </button>
       </div>
     </div>
 
     <div class="cloud-grid reveal mt-5 grid items-stretch gap-4 sm:grid-cols-2 lg:grid-cols-4" data-period="yearly">
       {tiers.map((t) => (
-        <div class={`flex flex-col rounded-xl border bg-card p-6 shadow-sm transition-colors hover:border-ring/40 ${t.highlight ? 'border-primary' : 'border-border'}`}>
+        <div class={`flex flex-col rounded-xl border bg-card p-6 shadow-sm transition-colors hover:border-ring/40 ${t.highlight ? 'border-primary/60 ring-1 ring-primary/20' : 'border-border'}`}>
           <div>
             <div class="flex flex-wrap items-center gap-2">
               <span class="font-semibold text-lg tracking-tight">{t.name}</span>
@@ -134,7 +134,19 @@ const outlineBtnAuto =
     /* Billing toggle: active-pill contrast flips with theme (same tokens as
        the rest of the page — .active fills with the foreground color, so
        text must invert to the background color to stay readable). */
-    .billing-toggle-btn.active { background: var(--foreground); color: var(--background); }
+    .billing-toggle-btn.active {
+      background: var(--primary);
+      color: var(--primary-foreground);
+    }
+    .billing-toggle-btn.active .save {
+      color: color-mix(in oklch, var(--primary-foreground) 85%, transparent);
+    }
+    .billing-toggle-btn:not(.active) .save {
+      color: oklch(0.55 0.14 155);
+    }
+    [data-theme='dark'] .billing-toggle-btn:not(.active) .save {
+      color: oklch(0.72 0.17 155);
+    }
 
     /* Monthly/yearly amount + billed-note swap, driven by the toggle above. */
     .cloud-grid .amt { display: none; }

--- a/apps/landing/src/lib/hero-slogans.test.ts
+++ b/apps/landing/src/lib/hero-slogans.test.ts
@@ -1,0 +1,15 @@
+import { HERO_SLOGANS, heroSloganAt } from './hero-slogans'
+import { describe, expect, test } from 'bun:test'
+
+describe('hero slogans', () => {
+  test('has multiple rotating lines', () => {
+    expect(HERO_SLOGANS.length).toBeGreaterThanOrEqual(3)
+  })
+
+  test('heroSloganAt wraps indices', () => {
+    const last = HERO_SLOGANS.length - 1
+    expect(heroSloganAt(0)).toBe(HERO_SLOGANS[0])
+    expect(heroSloganAt(last + 1)).toBe(HERO_SLOGANS[0])
+    expect(heroSloganAt(-1)).toBe(HERO_SLOGANS[last])
+  })
+})

--- a/apps/landing/src/lib/hero-slogans.ts
+++ b/apps/landing/src/lib/hero-slogans.ts
@@ -1,0 +1,15 @@
+/** Rotating hero taglines — monitoring-first, AI as one angle among several. */
+export const HERO_SLOGANS = [
+  'Slow queries, caught before users complain.',
+  'Replication lag on a live cluster map.',
+  'System tables — no exporters, no sidecars.',
+  'Merges, mutations and disk — one overview.',
+  'An advisor when you need a second opinion.',
+  'Self-hosted, Kubernetes, or cloud — same UI.',
+] as const
+
+export function heroSloganAt(index: number): string {
+  const n = HERO_SLOGANS.length
+  if (n === 0) return ''
+  return HERO_SLOGANS[((index % n) + n) % n]
+}

--- a/apps/landing/src/lib/parse-changelog-features.test.ts
+++ b/apps/landing/src/lib/parse-changelog-features.test.ts
@@ -2,6 +2,7 @@ import {
   countFeatureBulletsInMarkdown,
   groupChangelogFeatures,
   parseChangelogFeatures,
+  scopeChipLabel,
 } from './parse-changelog-features'
 import { describe, expect, test } from 'bun:test'
 import { readFileSync } from 'node:fs'
@@ -19,6 +20,13 @@ describe('parseChangelogFeatures', () => {
     const regexCount = countFeatureBulletsInMarkdown(markdown)
     expect(parsed.length).toBe(regexCount)
     expect(parsed.length).toBeGreaterThan(100)
+  })
+
+  test('scopeChipLabel shortens long scope ids', () => {
+    expect(scopeChipLabel('agent')).toBe('agent')
+    expect(scopeChipLabel('ch-capabilities')).toBe('capabilities')
+    expect(scopeChipLabel('billing,config')).toBe('billing·config')
+    expect(scopeChipLabel('expensive-queries').length).toBeLessThanOrEqual(16)
   })
 
   test('exposes every scope group with at least one feature', () => {

--- a/apps/landing/src/lib/parse-changelog-features.ts
+++ b/apps/landing/src/lib/parse-changelog-features.ts
@@ -78,6 +78,13 @@ export function groupChangelogFeatures(
     .map(([scope, groupFeatures]) => ({ scope, features: groupFeatures }))
 }
 
+/** Compact label for scope filter chips (full id stays in title/tooltip). */
+export function scopeChipLabel(scope: string, maxLen = 16): string {
+  const normalized = scope.replace(/^ch-/, '').replace(/,/g, '·')
+  if (normalized.length <= maxLen) return normalized
+  return `${normalized.slice(0, maxLen - 1)}…`
+}
+
 /** Count ✨ Features bullets — used by tests to prove parser completeness. */
 export function countFeatureBulletsInMarkdown(markdown: string): number {
   const lines = markdown.split('\n')

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -3,6 +3,8 @@ import Base from '../layouts/Base.astro'
 import Nav from '../components/Nav.astro'
 import Hero from '../components/Hero.astro'
 import FeatureShowcase from '../components/FeatureShowcase.tsx'
+import { FeatureIndexPromo } from '../components/FeatureIndexPromo.tsx'
+import { loadChangelogFeatures } from '../data/changelog-features'
 import Comparison from '../components/Comparison.astro'
 import Pricing from '../components/Pricing.astro'
 import FAQ from '../components/FAQ.astro'
@@ -10,12 +12,15 @@ import FinalCta from '../components/FinalCta.astro'
 import Footer from '../components/Footer.astro'
 import UseCaseLinks from '../components/UseCaseLinks.astro'
 import { useCases } from '../data/use-cases'
+
+const { totalCount, groups } = loadChangelogFeatures()
 ---
 <Base>
   <Nav />
   <main id="top">
     <Hero />
     <FeatureShowcase client:visible />
+    <FeatureIndexPromo totalCount={totalCount} scopeCount={groups.length} />
     <Comparison />
     <UseCaseLinks items={useCases} eyebrow="Use cases" heading="Explore by use case" soft />
     <Pricing compact />


### PR DESCRIPTION
## Summary

- **Hero**: stable H1 "UI monitoring for ClickHouse" + rotating slogans (6 lines, respects reduced motion)
- **Changelog** (`/changelog#ship-log`): scope filters are horizontal scroll chips with truncated labels (`ch-capabilities` → `capabilities`), counts, and full scope in tooltip — fixes overflowing badge row
- **Dark mode**: billing toggle uses primary fill (readable "2 months free" on active pill); Pro card uses softer `border-primary/60`
- **FAQ**: single chevron (removed Base.astro `faq-item` double-marker clash)
- **FinalCta**: removed outer `border` per design request
- **Nav/footer**: stale "Live demo" → Overview; homepage `FeatureIndexPromo` links to full catalog

## Test plan

- [x] `pnpm run build`
- [x] `pnpm test` — 23 tests
- [x] `bun scripts/verify-landing-structure.ts`