### PR TITLE
fix(landing): point nav feature index to changelog

### DIFF
--- a/apps/landing/scripts/verify-landing-structure.ts
+++ b/apps/landing/scripts/verify-landing-structure.ts
@@ -27,6 +27,7 @@ const forbidden = [
   'Live demo',
   'Tabbed product preview',
   'UI monitoring for ClickHouse',
+  '/#feature-index',
 ] as const
 
 let failed = false

--- a/apps/landing/src/components/Nav.astro
+++ b/apps/landing/src/components/Nav.astro
@@ -15,7 +15,7 @@
           <div class="nav-menu">
             <a href="/#top">Overview<small>Product positioning and capabilities</small></a>
             <a href="/#features">Features<small>Agent, queries, topology and more</small></a>
-            <a href="/#feature-index">Feature index<small>Every CHANGELOG.md feature</small></a>
+            <a href="/changelog#ship-log">Feature index<small>Shipped features by scope</small></a>
             <a href="/#feature-ai-agent">AI Agent<small>Schema-aware recommendations</small></a>
             <a href="/#feature-queries">Queries<small>Running, slow and expensive</small></a>
             <a href="/monitor-queries">Query monitoring<small>Running, slow, failed &amp; expensive</small></a>
@@ -75,7 +75,7 @@
         <span class="nav-drawer-label">Features</span>
         <a href="/#top">Overview</a>
         <a href="/#features">Features</a>
-        <a href="/#feature-index">Feature index</a>
+        <a href="/changelog#ship-log">Feature index</a>
         <a href="/#feature-ai-agent">AI Agent</a>
         <a href="/#feature-queries">Queries</a>
         <a href="/monitor-queries">Query monitoring</a>


### PR DESCRIPTION
## Summary
- Nav "Feature index" links now go to `/changelog#ship-log` (homepage promo section was removed in #2421)
- `verify-landing-structure.ts` forbids stale `/#feature-index` on homepage HTML

Co-Authored-By: duyetbot <bot@duyet.net>