### PR TITLE
feat(telemetry): track clickhouse version of the connected host

### DIFF
--- a/apps/dashboard/src/lib/swr/use-host-status.ts
+++ b/apps/dashboard/src/lib/swr/use-host-status.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 
 import { apiFetch } from './api-fetch'
 import { NON_CRITICAL_RETRY, visibilityAwareInterval } from './config'
+import { maybePingInstance } from '@/lib/telemetry'
 
 /** API response format for host status */
 type HostStatusApiResponse = {
@@ -71,6 +72,10 @@ export function useHostStatus(
       const json: HostStatusApiResponse = await res.json()
       if (!json.success || !json.data) {
         throw new Error(json.error || 'No data returned')
+      }
+      // Thread the ClickHouse version to telemetry ping
+      if (json.data.version) {
+        maybePingInstance(undefined, json.data.version)
       }
       return {
         version: json.data.version,

--- a/apps/dashboard/src/lib/telemetry/instance-ping.test.ts
+++ b/apps/dashboard/src/lib/telemetry/instance-ping.test.ts
@@ -39,6 +39,22 @@ describe('shouldPing', () => {
     expect(shouldPing(NOW, NOW - 500, 1000)).toBe(false)
     expect(shouldPing(NOW, NOW - 1000, 1000)).toBe(true)
   })
+
+  test('returns true when recently pinged but without version, and now version is provided', () => {
+    expect(shouldPing(NOW, NOW - 100, PING_INTERVAL_MS, null, '24.8')).toBe(
+      true
+    )
+    expect(shouldPing(NOW, NOW - 100, PING_INTERVAL_MS, '', '24.8')).toBe(true)
+  })
+
+  test('returns false when recently pinged with a version, and same or new version is provided', () => {
+    expect(shouldPing(NOW, NOW - 100, PING_INTERVAL_MS, '24.8', '24.8')).toBe(
+      false
+    )
+    expect(shouldPing(NOW, NOW - 100, PING_INTERVAL_MS, '24.8', '25.1')).toBe(
+      false
+    )
+  })
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -158,11 +174,27 @@ describe('runInstancePing gates', () => {
       now,
       storageOverrides: {
         chm_telemetry_last_ping_at: String(now - 100), // 100ms ago — far below interval
+        chm_telemetry_last_ping_version: '24.8.1.2',
       },
     })
     const result = await runInstancePing(deps)
     expect(result).toBe('skipped-too-soon')
     expect(deps.posts).toHaveLength(0)
+  })
+
+  test('pings again within interval if previous ping had no version and now version is provided', async () => {
+    const now = 1_700_000_000_000
+    const deps = makeDeps({
+      now,
+      version: '24.8.1.2',
+      storageOverrides: {
+        chm_telemetry_last_ping_at: String(now - 100),
+      },
+    })
+    const result = await runInstancePing(deps)
+    expect(result).toBe('pinged')
+    expect(deps.posts).toHaveLength(1)
+    expect(deps.store.chm_telemetry_last_ping_version).toBe('24.8.1.2')
   })
 })
 

--- a/apps/dashboard/src/lib/telemetry/instance-ping.ts
+++ b/apps/dashboard/src/lib/telemetry/instance-ping.ts
@@ -45,9 +45,12 @@ export const DEFAULT_TELEMETRY_ENDPOINT =
 export function shouldPing(
   now: number,
   lastPingAt: number | null,
-  intervalMs: number = PING_INTERVAL_MS
+  intervalMs: number = PING_INTERVAL_MS,
+  lastPingVersion?: string | null,
+  newVersion?: string
 ): boolean {
   if (lastPingAt === null) return true
+  if (!lastPingVersion && newVersion) return true
   return now - lastPingAt >= intervalMs
 }
 
@@ -173,7 +176,12 @@ export async function runInstancePing(deps: PingDeps): Promise<PingResult> {
 
   const rawLastPing = getItem(STORAGE_KEY_LAST_PING)
   const lastPingAt = rawLastPing !== null ? Number(rawLastPing) : null
-  if (!shouldPing(now, lastPingAt)) return 'skipped-too-soon'
+  const lastPingVersion = getItem('chm_telemetry_last_ping_version')
+  if (
+    !shouldPing(now, lastPingAt, PING_INTERVAL_MS, lastPingVersion, version)
+  ) {
+    return 'skipped-too-soon'
+  }
 
   // Get-or-create stable local instance ID (never transmitted raw)
   let instanceId = getItem(STORAGE_KEY_INSTANCE_ID)
@@ -205,6 +213,9 @@ export async function runInstancePing(deps: PingDeps): Promise<PingResult> {
   // Persist timestamp regardless of whether post succeeded.  This prevents
   // hammering a broken endpoint every page load.
   setItem(STORAGE_KEY_LAST_PING, String(now))
+  if (version) {
+    setItem('chm_telemetry_last_ping_version', version)
+  }
 
   return 'pinged'
 }
@@ -232,7 +243,8 @@ async function sha256hex(s: string): Promise<string> {
  * - Guards against non-browser environments (SSR, prerender, unit tests).
  */
 export function maybePingInstance(
-  runtimeEnv?: Record<string, string | undefined>
+  runtimeEnv?: Record<string, string | undefined>,
+  chVersion?: string
 ): void {
   // Guard: require browser globals before attempting anything.
   if (
@@ -278,7 +290,7 @@ export function maybePingInstance(
         body,
         keepalive: true,
       }).then(() => undefined),
-    version: undefined, // caller may populate via a separate ClickHouse query
+    version: chVersion, // caller may populate via a separate ClickHouse query
     deployTarget: getDeployTarget(),
     detectFlavor: detectChFlavor,
     detectCountry: detectCountry,

--- a/apps/telemetry/index.html
+++ b/apps/telemetry/index.html
@@ -204,14 +204,6 @@
           <div class="stat-label">Total Installs</div>
           <div class="stat-value" id="total">0</div>
         </div>
-        <div class="stat-card">
-          <div class="stat-label">Data Source</div>
-          <div class="stat-value" id="source">-</div>
-        </div>
-        <div class="stat-card">
-          <div class="stat-label">Last Updated</div>
-          <div class="stat-value" id="updated" style="font-size: 1rem; line-height: 1.75rem;">-</div>
-        </div>
       </div>
 
       <div class="section">
@@ -272,8 +264,6 @@
 
         // Update stats cards
         document.getElementById('total').textContent = data.total_installs.toLocaleString();
-        document.getElementById('source').textContent = data.source.split('(')[0].trim();
-        document.getElementById('updated').textContent = new Date(data.generated_at).toLocaleString();
 
         // Render deployment targets
         const deployTargetsArray = Object.entries(data.by_deploy_target || {}).map(([target, installs]) => ({

--- a/apps/telemetry/src/index.ts
+++ b/apps/telemetry/src/index.ts
@@ -316,14 +316,6 @@ export default {
           <div class="stat-label">Total Installs</div>
           <div class="stat-value" id="total">0</div>
         </div>
-        <div class="stat-card">
-          <div class="stat-label">Data Source</div>
-          <div class="stat-value" id="source">-</div>
-        </div>
-        <div class="stat-card">
-          <div class="stat-label">Last Updated</div>
-          <div class="stat-value" id="updated" style="font-size: 1rem; line-height: 1.75rem;">-</div>
-        </div>
       </div>
 
       <div class="section">
@@ -384,8 +376,6 @@ export default {
 
         // Update stats cards
         document.getElementById('total').textContent = data.total_installs.toLocaleString();
-        document.getElementById('source').textContent = data.source.split('(')[0].trim();
-        document.getElementById('updated').textContent = new Date(data.generated_at).toLocaleString();
 
         // Render deployment targets
         const deployTargetsArray = Object.entries(data.by_deploy_target || {}).map(([target, installs]) => ({


### PR DESCRIPTION
Removes unnecessary telemetry cards (data source, last updated) and threads ClickHouse version tracking when active host resolves.