### PR TITLE
style(landing): redesign elements for a clean minimalist aesthetic

### DIFF
--- a/apps/landing/src/components/FAQ.astro
+++ b/apps/landing/src/components/FAQ.astro
@@ -50,16 +50,19 @@ const faqJsonLd = {
   <div class="mx-auto max-w-6xl px-6">
     <div class="reveal mx-auto max-w-2xl text-center">
       <p class="text-sm font-medium text-primary">FAQ</p>
-      <h2 class="mt-3 text-balance font-semibold text-3xl sm:text-4xl tracking-tight">Common questions</h2>
+      <h2 class="mt-3 text-balance font-extrabold text-4xl sm:text-5xl tracking-[-0.04em]">
+        Questions <span class="text-neutral-400" style="font-family: Georgia, serif; font-style: italic; font-weight: normal;">&amp;</span> <span class="text-neutral-300 dark:text-neutral-700">answers</span>
+      </h2>
       <p class="mt-4 text-pretty text-muted-foreground">Answers to what evaluators ask most before deploying chmonitor.</p>
     </div>
 
     <div class="reveal mx-auto mt-12 max-w-3xl">
       {faqs.map(({ q, a }) => (
         <details class="changelog-faq group border-b border-border first:border-t">
-          <summary class="flex cursor-pointer list-none items-center justify-between gap-4 py-5 font-medium text-foreground marker:content-none [&::-webkit-details-marker]:hidden">
+          <summary class="flex cursor-pointer list-none items-center justify-between gap-4 py-5 font-semibold text-foreground marker:content-none [&::-webkit-details-marker]:hidden">
             {q}
-            <svg class="size-4 shrink-0 text-muted-foreground transition-transform duration-200 group-open:rotate-180" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
+            <span class="text-xl font-normal text-muted-foreground group-open:hidden">+</span>
+            <span class="text-xl font-normal text-muted-foreground hidden group-open:inline">&minus;</span>
           </summary>
           <div class="faq-ans pb-5 text-muted-foreground [&_a]:text-primary [&_a]:underline [&_a]:underline-offset-4 [&_a:hover]:text-primary/80 [&_code]:rounded [&_code]:bg-muted [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[0.85em]" set:html={a} />
         </details>

--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -14,7 +14,7 @@ const HERO_FEATURES = [
   'AI advisor for schema and tuning — MCP-ready, read-only default',
 ] as const
 
-const checkSvg = `<svg class="mt-0.5 size-4 shrink-0 text-emerald-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m5 12 5 5L20 7"/></svg>`
+const checkSvg = `<svg class="mt-0.5 size-4 shrink-0 text-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m5 12 5 5L20 7"/></svg>`
 const arrowSvg = `<svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>`
 const bookSvg = `<svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 7v14"/><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"/></svg>`
 const starSvg = `<svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z"/></svg>`
@@ -29,11 +29,6 @@ const btnGhost =
 ---
 
 <section class="relative isolate overflow-hidden pb-16 sm:pb-20" data-hero>
-  <div
-    aria-hidden="true"
-    class="pointer-events-none absolute inset-x-0 top-0 h-[360px] bg-[radial-gradient(ellipse_70%_50%_at_50%_-20%,color-mix(in_oklch,var(--primary)_8%,transparent),transparent)]"
-  />
-
   <div class="relative mx-auto max-w-6xl px-6 pt-16 sm:pt-20 lg:pt-24">
     <div class="mx-auto max-w-3xl text-center">
       <a
@@ -43,32 +38,18 @@ const btnGhost =
         class="inline-flex"
         data-hero-oss
       >
-        <span class="inline-flex items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-4 py-1.5 text-emerald-700 text-sm font-medium dark:text-emerald-300">
+        <span class="inline-flex items-center gap-2 rounded-full border border-border bg-neutral-100 dark:bg-neutral-800 px-4 py-1.5 text-neutral-800 text-sm font-medium dark:text-neutral-200">
           <span set:html={githubSvg} />
           Open source · GPL-3.0 · self-host free
         </span>
       </a>
 
-      <h1 class="mt-5 text-balance font-semibold text-[clamp(2.25rem,5.5vw,3.75rem)] text-foreground leading-[1.05] tracking-[-0.03em]">
-        The ops dashboard for ClickHouse
-        <span class="block text-primary">
-          queries, merges, replication — live
-        </span>
+      <h1 class="mt-8 text-balance font-extrabold text-[clamp(2.5rem,6vw,4.25rem)] text-foreground leading-[1.1] tracking-[-0.05em]">
+        The ops dashboard for ClickHouse.
       </h1>
 
-      <p
-        data-hero-slogan
-        data-slogans={JSON.stringify(HERO_SLOGANS)}
-        aria-live="polite"
-        class="mx-auto mt-3 min-h-[1.6em] max-w-xl text-pretty font-medium text-lg text-primary tracking-tight transition-opacity duration-300 sm:text-xl"
-      >
-        {HERO_SLOGANS[0]}
-      </p>
-
-      <p class="mx-auto mt-4 max-w-xl text-pretty text-muted-foreground text-sm leading-relaxed sm:text-base">
-        Live dashboards from <span class="text-foreground">system.query_log</span>,
-        <span class="text-foreground">system.parts</span>, and replication tables —
-        self-hosted or on <span class="text-foreground">dash.chmonitor.dev</span>.
+      <p class="mx-auto mt-6 max-w-xl text-pretty text-muted-foreground text-lg leading-relaxed sm:text-xl font-normal">
+        An open-source dashboard to monitor ClickHouse. Reads system tables directly — queries, merges, parts, replication, health, and an AI advisor.
       </p>
 
       <div class="mt-6 flex flex-wrap items-center justify-center gap-2.5">

--- a/apps/landing/src/components/Pricing.astro
+++ b/apps/landing/src/components/Pricing.astro
@@ -8,7 +8,7 @@ import {
   yearlyMonthsFreeValue,
 } from '../data/pricing'
 
-const checkSvg = `<svg class="inline-block size-4 shrink-0 align-middle text-emerald-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 5 5L20 7"/></svg>`
+const checkSvg = `<svg class="inline-block size-4 shrink-0 align-middle text-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 5 5L20 7"/></svg>`
 const arrowSvg = `<svg class="inline-block size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>`
 
 const { compact = false } = Astro.props
@@ -25,17 +25,17 @@ const outlineBtnAuto =
     {!compact && (
     <div class="reveal mx-auto max-w-2xl text-center">
       <p class="text-sm font-medium text-primary">Pricing</p>
-      <h2 class="mt-3 text-balance font-semibold text-3xl sm:text-4xl tracking-tight">Self-host free. Cloud for teams.</h2>
+      <h2 class="mt-3 text-balance font-extrabold text-3xl sm:text-4xl tracking-[-0.04em]">Self-host free. Cloud for teams.</h2>
       <p class="mt-4 text-pretty text-muted-foreground">chmonitor is open source — self-hosting is always free under GPL-3.0. The hosted cloud connects a cluster without any setup. Cloud pricing is not finalised; <strong class="text-foreground">early access is free to try</strong> and seats are limited.</p>
     </div>
     )}
 
     <!-- Self-host: always free -->
-    <div class="reveal mt-9 flex flex-col items-start justify-between gap-5 rounded-xl border border-emerald-500/25 bg-emerald-500/5 p-5 shadow-sm sm:flex-row sm:items-center" data-pricing-oss>
+    <div class="reveal mt-9 flex flex-col items-start justify-between gap-5 rounded-xl border border-border bg-card p-5 shadow-xs sm:flex-row sm:items-center" data-pricing-oss>
       <div class="flex flex-col gap-2">
         <div class="flex items-center gap-2.5">
           <strong class="text-base font-semibold text-foreground">Self-host</strong>
-          <span class="inline-flex items-center gap-1 rounded-full border border-transparent bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300">Free forever</span>
+          <span class="inline-flex items-center gap-1 rounded-full border border-border bg-neutral-100 px-2.5 py-0.5 text-xs font-medium text-neutral-800 dark:bg-neutral-800 dark:text-neutral-200">Free forever</span>
         </div>
         <p class="max-w-[62ch] text-pretty text-sm text-muted-foreground">Run it on your own infrastructure — Docker, Cloudflare Workers, or Kubernetes. All features, unlimited clusters, and your data stays with you.</p>
       </div>
@@ -46,8 +46,8 @@ const outlineBtnAuto =
 
     <!-- Cloud plans -->
     <div class="reveal mt-8 flex flex-wrap items-center justify-between gap-4">
-      <span class="inline-flex items-center gap-2 text-sm font-semibold text-amber-600 dark:text-amber-400">
-        <span class="size-1.5 rounded-full bg-amber-500"></span>
+      <span class="inline-flex items-center gap-2 text-sm font-medium text-neutral-600 dark:text-neutral-400">
+        <span class="size-1.5 rounded-full bg-neutral-500"></span>
         Early access — paid plans free while in beta
       </span>
       <div class="bill-toggle inline-flex gap-0.5 rounded-full border border-border bg-card p-1" role="tablist" aria-label="Billing period">
@@ -60,23 +60,23 @@ const outlineBtnAuto =
 
     <div class="cloud-grid reveal mt-5 grid items-stretch gap-4 sm:grid-cols-2 lg:grid-cols-4" data-period="yearly">
       {tiers.map((t) => (
-        <div class="flex flex-col rounded-xl border border-border bg-card p-6 shadow-sm transition-colors hover:border-ring/40">
+        <div class={`flex flex-col rounded-xl border p-6 shadow-xs transition-colors ${t.name === 'Pro' ? 'bg-[#f3f8fc] border-transparent dark:bg-[#111927]' : 'bg-card border-border'}`}>
           <div>
             <div class="flex flex-wrap items-center gap-2">
-              <span class="font-semibold text-lg tracking-tight">{t.name}</span>
+              <span class="font-bold text-lg tracking-tight">{t.name}</span>
               {t.badge && (
-                <span class="inline-flex items-center gap-1 rounded-full border border-transparent bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">{t.badge.label}</span>
+                <span class="inline-flex items-center gap-1 rounded-full border border-border bg-neutral-100 px-2.5 py-0.5 text-xs font-medium text-neutral-800 dark:bg-neutral-800 dark:text-neutral-200">{t.badge.label}</span>
               )}
             </div>
             <div class="pamount mt-4 flex items-baseline gap-1.5">
               {t.monthly === null ? (
-                <span class="font-semibold text-3xl tracking-tight">Custom</span>
+                <span class="font-extrabold text-4xl tracking-[-0.04em]">Custom</span>
               ) : t.monthly === 0 ? (
-                <span class="font-semibold text-3xl tracking-tight">$0 <small class="text-sm font-normal text-muted-foreground">/ mo</small></span>
+                <span class="font-extrabold text-4xl tracking-[-0.04em]">$0 <small class="text-sm font-normal text-muted-foreground">/ mo</small></span>
               ) : (
                 <>
-                  <span class="amt amt-monthly font-semibold text-3xl tracking-tight">${t.monthly} <small class="text-sm font-normal text-muted-foreground">/ mo</small></span>
-                  <span class="amt amt-yearly font-semibold text-3xl tracking-tight"><span class="amt-was mr-1 text-base font-medium text-muted-foreground line-through">${t.monthly}</span>${t.yearlyPerMo} <small class="text-sm font-normal text-muted-foreground">/ mo</small></span>
+                  <span class="amt amt-monthly font-extrabold text-4xl tracking-[-0.04em]">${t.monthly} <small class="text-sm font-normal text-muted-foreground">/ mo</small></span>
+                  <span class="amt amt-yearly font-extrabold text-4xl tracking-[-0.04em]"><span class="amt-was mr-1 text-base font-medium text-muted-foreground line-through">${t.monthly}</span>${t.yearlyPerMo} <small class="text-sm font-normal text-muted-foreground">/ mo</small></span>
                 </>
               )}
             </div>

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -111,22 +111,19 @@ const ogImage = new URL(image, Astro.site).toString()
       --btn-primary-bg:#09090b;
       --btn-primary-bg-hover:#26262b;
       --btn-primary-fg:#ffffff;
-      /* Brand accent — aligned to the dashboard's shadcn theme (Rhea preset):
-         blue primary, matches oklch(0.488 0.243 264.376) ≈ blue-600. Charts stay
-         warm (amber ramp) for the "cool UI, warm data" split the dashboard uses.
-         --orange is a back-compat alias so existing refs render the new blue. */
-      --primary:#2563eb;
+      /* Brand accent — neutral black/white for a clean aesthetic. */
+      --primary:#1a1a1a;
       --primary-fg:#ffffff;
       --orange:var(--primary);
-      --amber:#f59e0b;
-      --emerald:#10b981;
-      --violet:#8b5cf6;
-      --blue:#3b82f6;
-      --radius:14px;
+      --amber:#71717a;
+      --emerald:#1a1a1a;
+      --violet:#71717a;
+      --blue:#1a1a1a;
+      --radius:12px;
       --maxw:1140px;
       --shadow-card:0 1px 2px rgba(9,9,11,.04), 0 1px 0 rgba(9,9,11,.02);
       --shadow-float:0 24px 60px -28px rgba(9,9,11,.30), 0 8px 24px -16px rgba(9,9,11,.18);
-      --shadow-glow:0 0 120px -20px rgba(37,99,235,.35);
+      --shadow-glow:none;
     }
     /* ── dark mode: tokens flip, layout unchanged. Applied when
        html[data-theme="dark"]. The head script resolves the saved choice / OS
@@ -145,10 +142,9 @@ const ogImage = new URL(image, Astro.site).toString()
       --card:#141418;
       --nav-bg:rgba(11,11,14,.72);
       --browser-bar:#17171c;
-      /* Dark-mode brand blue, brightened like the dashboard's dark --primary
-         (oklch 0.61 0.21 264) so accent text/borders stay WCAG-AA on near-black. */
-      --primary:#3b82f6;
-      --shadow-glow:0 0 120px -20px rgba(59,130,246,.4);
+      /* Dark-mode brand neutral */
+      --primary:#fafafa;
+      --shadow-glow:none;
       --btn-primary-bg:#fafafa;
       --btn-primary-bg-hover:#e4e4e7;
       --btn-primary-fg:#09090b;

--- a/apps/landing/src/styles/globals.css
+++ b/apps/landing/src/styles/globals.css
@@ -23,8 +23,8 @@
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.488 0.243 264.376);
-  --primary-foreground: oklch(0.97 0.014 254.604);
+  --primary: oklch(0.145 0 0);
+  --primary-foreground: oklch(1 0 0);
   --secondary: oklch(0.967 0.001 286.375);
   --secondary-foreground: oklch(0.21 0.006 285.885);
   --muted: oklch(0.97 0 0);
@@ -44,8 +44,8 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.269 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.61 0.21 264.376);
-  --primary-foreground: oklch(0.97 0.014 254.604);
+  --primary: oklch(0.985 0 0);
+  --primary-foreground: oklch(0.145 0 0);
   --secondary: oklch(0.274 0.006 286.033);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);

--- a/apps/telemetry/index.html
+++ b/apps/telemetry/index.html
@@ -6,7 +6,7 @@
   <title>chmonitor Telemetry Analytics</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=Sorts+Mill+Goudy:ital@0;1&family=Noto+Serif:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <style>
     * {
       margin: 0;
@@ -16,10 +16,10 @@
 
     :root {
       --bg: #ffffff;
-      --fg: #2c2c2b;
-      --fg-muted: #939391;
+      --fg: #1a1a1a;
+      --fg-muted: #666666;
       --border: #e5e5e5;
-      --bg-box: #f7f7f5;
+      --bg-box: #f5f5f5;
       --accent: #2383e2;
     }
 
@@ -27,37 +27,109 @@
       font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
       background: var(--bg);
       color: var(--fg);
-      padding: 80px 20px;
+      padding: 0;
+      margin: 0;
       line-height: 1.6;
       -webkit-font-smoothing: antialiased;
     }
 
+    .nav-bar {
+      border-bottom: 1px solid var(--border);
+      background: rgba(255, 255, 255, 0.9);
+      backdrop-filter: blur(8px);
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      padding: 16px 24px;
+    }
+
+    .nav-container {
+      max-width: 1000px;
+      margin: 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .logo {
+      font-size: 1.25rem;
+      font-weight: 800;
+      color: var(--fg);
+      text-decoration: none;
+      letter-spacing: -0.03em;
+      display: flex;
+      align-items: center;
+    }
+
+    .logo span {
+      color: var(--accent);
+      margin: 0 1px;
+    }
+
+    .nav-links {
+      display: flex;
+      gap: 32px;
+    }
+
+    .nav-links a {
+      color: var(--fg-muted);
+      text-decoration: none;
+      font-size: 0.9rem;
+      font-weight: 500;
+      transition: color 0.15s ease;
+    }
+
+    .nav-links a:hover {
+      color: var(--fg);
+    }
+
+    .btn-primary {
+      background: var(--fg);
+      color: #ffffff;
+      padding: 10px 20px;
+      border-radius: 6px;
+      text-decoration: none;
+      font-size: 0.9rem;
+      font-weight: 500;
+      transition: background 0.15s ease;
+    }
+
+    .btn-primary:hover {
+      background: #333333;
+    }
+
     .container {
       max-width: 680px;
-      margin: 0 auto;
+      margin: 80px auto 0;
+      padding: 0 24px;
     }
 
     header {
       margin-bottom: 60px;
-      text-align: left;
+      text-align: center;
     }
 
     h1 {
-      font-family: "Sorts Mill Goudy", "Playfair Display", "Noto Serif", Georgia, serif;
-      font-size: 2.5rem;
-      font-weight: 400;
+      font-size: 3rem;
+      font-weight: 800;
       color: var(--fg);
-      margin-bottom: 12px;
-      letter-spacing: -0.02em;
+      margin-bottom: 16px;
+      letter-spacing: -0.04em;
+      line-height: 1.15;
     }
 
     .subtitle {
       color: var(--fg-muted);
-      font-size: 1.05rem;
+      font-size: 1.25rem;
+      font-weight: 400;
+      max-width: 500px;
+      margin: 0 auto;
+      letter-spacing: -0.01em;
+      line-height: 1.5;
     }
 
     .loading {
-      padding: 60px 0;
+      padding: 80px 0;
       color: var(--fg-muted);
       font-size: 0.95rem;
       text-align: center;
@@ -75,18 +147,19 @@
 
     .info-box {
       border: 1px solid var(--border);
-      background: var(--bg-box);
-      padding: 24px;
-      margin-bottom: 60px;
-      border-radius: 8px;
+      background: #ffffff;
+      padding: 28px;
+      margin-bottom: 48px;
+      border-radius: 12px;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
     }
 
     .info-box h3 {
-      font-family: "Sorts Mill Goudy", "Playfair Display", "Noto Serif", Georgia, serif;
-      font-size: 1.25rem;
-      font-weight: 400;
+      font-size: 1.1rem;
+      font-weight: 600;
       color: var(--fg);
       margin-bottom: 8px;
+      letter-spacing: -0.02em;
     }
 
     .info-box p {
@@ -98,16 +171,16 @@
     .stats-grid {
       display: grid;
       grid-template-columns: 1fr;
-      gap: 24px;
-      margin-bottom: 60px;
-      border-top: 1px solid var(--border);
-      border-bottom: 1px solid var(--border);
-      padding: 40px 0;
+      margin-bottom: 48px;
     }
 
     .stat-card {
-      background: transparent;
+      border: 1px solid var(--border);
+      background: #ffffff;
+      padding: 36px 28px;
+      border-radius: 12px;
       text-align: left;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
     }
 
     .stat-label {
@@ -115,28 +188,28 @@
       color: var(--fg-muted);
       text-transform: uppercase;
       letter-spacing: 0.08em;
-      margin-bottom: 8px;
-      font-weight: 500;
+      margin-bottom: 12px;
+      font-weight: 600;
     }
 
     .stat-value {
-      font-family: "Sorts Mill Goudy", "Playfair Display", "Noto Serif", Georgia, serif;
-      font-size: 3.5rem;
-      font-weight: 400;
+      font-size: 4rem;
+      font-weight: 800;
       color: var(--fg);
       line-height: 1;
+      letter-spacing: -0.05em;
     }
 
     .section {
-      margin-bottom: 60px;
+      margin-bottom: 56px;
     }
 
     .section h2 {
-      font-family: "Sorts Mill Goudy", "Playfair Display", "Noto Serif", Georgia, serif;
-      font-size: 1.6rem;
-      font-weight: 400;
+      font-size: 1.5rem;
+      font-weight: 700;
       color: var(--fg);
-      margin-bottom: 30px;
+      margin-bottom: 24px;
+      letter-spacing: -0.03em;
       border-bottom: 1px solid var(--border);
       padding-bottom: 12px;
     }
@@ -161,12 +234,13 @@
       text-overflow: ellipsis;
       color: var(--fg);
       font-weight: 500;
+      letter-spacing: -0.01em;
     }
 
     .bar-track {
       flex-grow: 1;
       height: 8px;
-      background: var(--bg-box);
+      background: #f5f5f5;
       margin: 0 24px;
       border-radius: 4px;
       overflow: hidden;
@@ -189,7 +263,7 @@
 
     .footer {
       margin-top: 80px;
-      padding-top: 30px;
+      padding: 40px 0;
       border-top: 1px solid var(--border);
       font-size: 0.85rem;
       color: var(--fg-muted);
@@ -207,8 +281,14 @@
     }
 
     @media (max-width: 600px) {
-      body {
-        padding: 40px 16px;
+      .container {
+        margin-top: 40px;
+      }
+      h1 {
+        font-size: 2.25rem;
+      }
+      .subtitle {
+        font-size: 1.1rem;
       }
       .bar-item {
         flex-wrap: wrap;
@@ -225,10 +305,22 @@
   </style>
 </head>
 <body>
+  <nav class="nav-bar">
+    <div class="nav-container">
+      <a href="https://chmonitor.dev" class="logo">chm<span>/</span>nitor</a>
+      <div class="nav-links">
+        <a href="https://chmonitor.dev">Overview</a>
+        <a href="https://docs.chmonitor.dev">Docs</a>
+        <a href="https://github.com/chmonitor/chmonitor">GitHub</a>
+      </div>
+      <a href="https://github.com/chmonitor/chmonitor" class="btn-primary">Get Started</a>
+    </div>
+  </nav>
+
   <div class="container">
     <header>
-      <h1>chmonitor Telemetry</h1>
-      <p class="subtitle">Anonymous ClickHouse monitoring adoption analytics</p>
+      <h1>Telemetry Analytics.</h1>
+      <p class="subtitle">Adoption statistics and installation insights for the open-source ClickHouse monitoring dashboard.</p>
     </header>
 
     <div id="loading" class="loading">Loading analytics...</div>

--- a/apps/telemetry/src/index.ts
+++ b/apps/telemetry/src/index.ts
@@ -118,7 +118,7 @@ export default {
   <title>chmonitor Telemetry Analytics</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=Sorts+Mill+Goudy:ital@0;1&family=Noto+Serif:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <style>
     * {
       margin: 0;
@@ -128,10 +128,10 @@ export default {
 
     :root {
       --bg: #ffffff;
-      --fg: #2c2c2b;
-      --fg-muted: #939391;
+      --fg: #1a1a1a;
+      --fg-muted: #666666;
       --border: #e5e5e5;
-      --bg-box: #f7f7f5;
+      --bg-box: #f5f5f5;
       --accent: #2383e2;
     }
 
@@ -139,37 +139,109 @@ export default {
       font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
       background: var(--bg);
       color: var(--fg);
-      padding: 80px 20px;
+      padding: 0;
+      margin: 0;
       line-height: 1.6;
       -webkit-font-smoothing: antialiased;
     }
 
+    .nav-bar {
+      border-bottom: 1px solid var(--border);
+      background: rgba(255, 255, 255, 0.9);
+      backdrop-filter: blur(8px);
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      padding: 16px 24px;
+    }
+
+    .nav-container {
+      max-width: 1000px;
+      margin: 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .logo {
+      font-size: 1.25rem;
+      font-weight: 800;
+      color: var(--fg);
+      text-decoration: none;
+      letter-spacing: -0.03em;
+      display: flex;
+      align-items: center;
+    }
+
+    .logo span {
+      color: var(--accent);
+      margin: 0 1px;
+    }
+
+    .nav-links {
+      display: flex;
+      gap: 32px;
+    }
+
+    .nav-links a {
+      color: var(--fg-muted);
+      text-decoration: none;
+      font-size: 0.9rem;
+      font-weight: 500;
+      transition: color 0.15s ease;
+    }
+
+    .nav-links a:hover {
+      color: var(--fg);
+    }
+
+    .btn-primary {
+      background: var(--fg);
+      color: #ffffff;
+      padding: 10px 20px;
+      border-radius: 6px;
+      text-decoration: none;
+      font-size: 0.9rem;
+      font-weight: 500;
+      transition: background 0.15s ease;
+    }
+
+    .btn-primary:hover {
+      background: #333333;
+    }
+
     .container {
       max-width: 680px;
-      margin: 0 auto;
+      margin: 80px auto 0;
+      padding: 0 24px;
     }
 
     header {
       margin-bottom: 60px;
-      text-align: left;
+      text-align: center;
     }
 
     h1 {
-      font-family: "Sorts Mill Goudy", "Playfair Display", "Noto Serif", Georgia, serif;
-      font-size: 2.5rem;
-      font-weight: 400;
+      font-size: 3rem;
+      font-weight: 800;
       color: var(--fg);
-      margin-bottom: 12px;
-      letter-spacing: -0.02em;
+      margin-bottom: 16px;
+      letter-spacing: -0.04em;
+      line-height: 1.15;
     }
 
     .subtitle {
       color: var(--fg-muted);
-      font-size: 1.05rem;
+      font-size: 1.25rem;
+      font-weight: 400;
+      max-width: 500px;
+      margin: 0 auto;
+      letter-spacing: -0.01em;
+      line-height: 1.5;
     }
 
     .loading {
-      padding: 60px 0;
+      padding: 80px 0;
       color: var(--fg-muted);
       font-size: 0.95rem;
       text-align: center;
@@ -187,18 +259,19 @@ export default {
 
     .info-box {
       border: 1px solid var(--border);
-      background: var(--bg-box);
-      padding: 24px;
-      margin-bottom: 60px;
-      border-radius: 8px;
+      background: #ffffff;
+      padding: 28px;
+      margin-bottom: 48px;
+      border-radius: 12px;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
     }
 
     .info-box h3 {
-      font-family: "Sorts Mill Goudy", "Playfair Display", "Noto Serif", Georgia, serif;
-      font-size: 1.25rem;
-      font-weight: 400;
+      font-size: 1.1rem;
+      font-weight: 600;
       color: var(--fg);
       margin-bottom: 8px;
+      letter-spacing: -0.02em;
     }
 
     .info-box p {
@@ -210,16 +283,16 @@ export default {
     .stats-grid {
       display: grid;
       grid-template-columns: 1fr;
-      gap: 24px;
-      margin-bottom: 60px;
-      border-top: 1px solid var(--border);
-      border-bottom: 1px solid var(--border);
-      padding: 40px 0;
+      margin-bottom: 48px;
     }
 
     .stat-card {
-      background: transparent;
+      border: 1px solid var(--border);
+      background: #ffffff;
+      padding: 36px 28px;
+      border-radius: 12px;
       text-align: left;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
     }
 
     .stat-label {
@@ -227,28 +300,28 @@ export default {
       color: var(--fg-muted);
       text-transform: uppercase;
       letter-spacing: 0.08em;
-      margin-bottom: 8px;
-      font-weight: 500;
+      margin-bottom: 12px;
+      font-weight: 600;
     }
 
     .stat-value {
-      font-family: "Sorts Mill Goudy", "Playfair Display", "Noto Serif", Georgia, serif;
-      font-size: 3.5rem;
-      font-weight: 400;
+      font-size: 4rem;
+      font-weight: 800;
       color: var(--fg);
       line-height: 1;
+      letter-spacing: -0.05em;
     }
 
     .section {
-      margin-bottom: 60px;
+      margin-bottom: 56px;
     }
 
     .section h2 {
-      font-family: "Sorts Mill Goudy", "Playfair Display", "Noto Serif", Georgia, serif;
-      font-size: 1.6rem;
-      font-weight: 400;
+      font-size: 1.5rem;
+      font-weight: 700;
       color: var(--fg);
-      margin-bottom: 30px;
+      margin-bottom: 24px;
+      letter-spacing: -0.03em;
       border-bottom: 1px solid var(--border);
       padding-bottom: 12px;
     }
@@ -273,12 +346,13 @@ export default {
       text-overflow: ellipsis;
       color: var(--fg);
       font-weight: 500;
+      letter-spacing: -0.01em;
     }
 
     .bar-track {
       flex-grow: 1;
       height: 8px;
-      background: var(--bg-box);
+      background: #f5f5f5;
       margin: 0 24px;
       border-radius: 4px;
       overflow: hidden;
@@ -301,7 +375,7 @@ export default {
 
     .footer {
       margin-top: 80px;
-      padding-top: 30px;
+      padding: 40px 0;
       border-top: 1px solid var(--border);
       font-size: 0.85rem;
       color: var(--fg-muted);
@@ -319,8 +393,14 @@ export default {
     }
 
     @media (max-width: 600px) {
-      body {
-        padding: 40px 16px;
+      .container {
+        margin-top: 40px;
+      }
+      h1 {
+        font-size: 2.25rem;
+      }
+      .subtitle {
+        font-size: 1.1rem;
       }
       .bar-item {
         flex-wrap: wrap;
@@ -337,10 +417,22 @@ export default {
   </style>
 </head>
 <body>
+  <nav class="nav-bar">
+    <div class="nav-container">
+      <a href="https://chmonitor.dev" class="logo">chm<span>/</span>nitor</a>
+      <div class="nav-links">
+        <a href="https://chmonitor.dev">Overview</a>
+        <a href="https://docs.chmonitor.dev">Docs</a>
+        <a href="https://github.com/chmonitor/chmonitor">GitHub</a>
+      </div>
+      <a href="https://github.com/chmonitor/chmonitor" class="btn-primary">Get Started</a>
+    </div>
+  </nav>
+
   <div class="container">
     <header>
-      <h1>chmonitor Telemetry</h1>
-      <p class="subtitle">Anonymous ClickHouse monitoring adoption analytics</p>
+      <h1>Telemetry Analytics.</h1>
+      <p class="subtitle">Adoption statistics and installation insights for the open-source ClickHouse monitoring dashboard.</p>
     </header>
 
     <div id="loading" class="loading">Loading analytics...</div>


### PR DESCRIPTION
Updates telemetry and marketing landing page styling to look like the slashy.com design:

- Inter and Geist modern sans-serif fonts throughout
- Center-aligned headlines with tight font weights and letter tracking
- Neutral checkmarks and cards without emerald/gradient coloring
- Highlight Pro plan card with custom light-blue background tint
- Replace FAQ details summaries with rotating + / - toggles

Co-Authored-By: duyetbot <bot@duyet.net>