### PR TITLE
style(insights): remove left border from AI insight cards

### DIFF
--- a/apps/dashboard/src/components/insights/insight-card.tsx
+++ b/apps/dashboard/src/components/insights/insight-card.tsx
@@ -42,7 +42,7 @@ export function InsightCard({
   return (
     <Card
       className={cn(
-        'h-full gap-0 p-4 transition-colors',
+        'h-full gap-0 border-l-0 p-4 transition-colors',
         style.accent,
         className
       )}


### PR DESCRIPTION
Remove the left border from AI Insights > Anomalies cards for cleaner design.

**What changed**
- Added  class to  component to override the left border
- Keeps top, right, and bottom borders for card definition
- Maintains severity-specific accent colors (rose/amber for critical/warning)

**Why**
- Cleaner visual design without the colored left stripe
- Better visual consistency with other card components in the dashboard