### PR TITLE
feat(telemetry): redesign UI, track version/place, and fix zoom dialog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # copied into the node-based build image.
 ARG GITHUB_SHA=unknown
 ARG GITHUB_REF=unknown
-ARG VITE_DEPLOY_TARGET=unknown
+ARG VITE_DEPLOY_TARGET=docker
 
 FROM oven/bun:1-alpine AS bunbin
 

--- a/apps/blog/src/content/blog/chmonitor-v0-3.md
+++ b/apps/blog/src/content/blog/chmonitor-v0-3.md
@@ -171,6 +171,30 @@ and conditions, not just the built-in health checks) and an **email adapter**
 [Alerting to Slack and Discord](https://docs.chmonitor.dev/guide/guides/alerting-slack-discord)
 for the webhook walkthrough.
 
+## Migrating to v0.3
+
+v0.3 introduces a few breaking configuration and packaging changes. Follow these steps to upgrade your self-hosted instances:
+
+### 1. Docker Image Name Change
+The canonical Docker image name has changed from `duyet/clickhouse-monitoring` to **`chmonitor/chmonitor`** (hosted on GitHub Container Registry). 
+
+Update your `docker-compose.yml` or Kubernetes manifests to pull the new image:
+```yaml
+image: ghcr.io/chmonitor/chmonitor:latest
+```
+*(Note: The legacy image name `ghcr.io/duyet/clickhouse-monitoring` remains as an alias pointing to the same build, but it is deprecated and will not receive updates in future major versions.)*
+
+### 2. Helm Chart Updates
+The Helm chart repository has been updated. The chart is now published to the OCI registry at `oci://ghcr.io/chmonitor/chmonitor`.
+
+To install or upgrade using the new OCI registry chart:
+```bash
+helm upgrade --install my-chm oci://ghcr.io/chmonitor/chmonitor --version 0.3.0
+```
+
+### 3. Unified Environment Variables
+All configuration variables are now unified under the standard `CHM_` prefix (e.g., `CHM_TELEMETRY`, `CHM_DEPLOYMENT_MODE`) instead of duplicate or client/server-specific names. Client variables (`VITE_`) are automatically derived from `CHM_` at build time. Check `apps/dashboard/.env.example` in the repository for the latest environment variable reference.
+
 ## Changelog
 
 | Area | What changed |

--- a/apps/blog/src/layouts/Base.astro
+++ b/apps/blog/src/layouts/Base.astro
@@ -172,9 +172,12 @@ const ogImage = new URL(image, Astro.site).toString()
     .sec-eyebrow::before{content:"";width:18px;height:1.5px;background:var(--amber);border-radius:2px}
 
     /* ── post list ── */
-    .post-list{padding:8px 0 80px;display:flex;flex-direction:column}
-    .post-card{display:grid;grid-template-columns:170px 1fr;gap:32px;padding:36px 0;
-      border-bottom:1px solid var(--border-soft);align-items:start;transition:.18s ease}
+    .post-list{padding:8px 0 80px;display:flex;flex-direction:column;gap:20px}
+    .post-card{display:grid;grid-template-columns:170px 1fr;gap:32px;padding:28px 32px;
+      border:none;border-radius:var(--radius);background:#f6f8fb;align-items:start;transition:.22s cubic-bezier(0.16, 1, 0.3, 1)}
+    :root[data-theme="dark"] .post-card{background:#111217}
+    .post-card:hover{background:#edf2f9;transform:translateY(-2px);box-shadow:var(--shadow-card)}
+    :root[data-theme="dark"] .post-card:hover{background:#161821}
     .post-card:hover h2{color:var(--orange)}
     .post-meta{display:flex;flex-direction:column;gap:8px}
     .post-tag{display:inline-flex;align-items:center;height:26px;padding:0 12px;border-radius:999px;
@@ -186,7 +189,9 @@ const ogImage = new URL(image, Astro.site).toString()
     .post-more{margin-top:14px;display:inline-flex;align-items:center;gap:6px;font-size:14px;font-weight:600;color:var(--fg)}
     .post-more svg{width:15px;height:15px;transition:transform .16s}
     .post-card:hover .post-more svg{transform:translateX(3px)}
-    @media (max-width:680px){.post-card{grid-template-columns:1fr;gap:14px}}
+    @media (max-width:680px){
+      .post-card{grid-template-columns:1fr;gap:14px;padding:24px 20px}
+    }
 
     /* ── article ── */
     .article-wrap{max-width:var(--maxw-prose);margin:0 auto;padding:0 24px;width:100%}
@@ -237,8 +242,10 @@ const ogImage = new URL(image, Astro.site).toString()
 
     /* ── highlight grid (release highlights) ── */
     .hl-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:16px;margin:28px 0}
-    .hl{padding:20px;border:1px solid var(--border);border-radius:var(--radius);background:var(--card);transition:.18s ease}
-    .hl:hover{border-color:var(--border-hover);box-shadow:var(--shadow-card);transform:translateY(-2px)}
+    .hl{padding:20px;border:none;border-radius:var(--radius);background:#faf7f2;transition:.22s cubic-bezier(0.16, 1, 0.3, 1)}
+    :root[data-theme="dark"] .hl{background:#171613}
+    .hl:hover{background:#f5efe6;box-shadow:var(--shadow-card);transform:translateY(-2px)}
+    :root[data-theme="dark"] .hl:hover{background:#1f1e1a}
     .hl b{font-size:15.5px;font-weight:650;letter-spacing:-.01em;color:var(--fg);display:block}
     .hl span{font-size:13.5px;color:var(--muted-fg);margin-top:6px;display:block;line-height:1.55}
     @media (max-width:600px){.hl-grid{grid-template-columns:1fr}}

--- a/apps/dashboard/src/components/insights/insight-card.tsx
+++ b/apps/dashboard/src/components/insights/insight-card.tsx
@@ -42,7 +42,7 @@ export function InsightCard({
   return (
     <Card
       className={cn(
-        'h-full gap-0 p-4 transition-colors',
+        'h-full gap-0 border-l-0 p-4 transition-colors',
         style.accent,
         className
       )}

--- a/apps/dashboard/src/lib/swr/use-host-status.ts
+++ b/apps/dashboard/src/lib/swr/use-host-status.ts
@@ -73,9 +73,9 @@ export function useHostStatus(
       if (!json.success || !json.data) {
         throw new Error(json.error || 'No data returned')
       }
-      // Thread the ClickHouse version to telemetry ping
+      // Thread the ClickHouse version and hostname to telemetry ping
       if (json.data.version) {
-        maybePingInstance(undefined, json.data.version)
+        maybePingInstance(undefined, json.data.version, json.data.hostname)
       }
       return {
         version: json.data.version,

--- a/apps/dashboard/src/lib/telemetry/instance-ping.test.ts
+++ b/apps/dashboard/src/lib/telemetry/instance-ping.test.ts
@@ -106,6 +106,17 @@ describe('buildPingPayload', () => {
     expect(Object.values(payload).includes(rawId)).toBe(false)
     expect(payload.instance_hash).toBe('hashed-value')
   })
+
+  test('includes chm_version and install_place when provided', () => {
+    const payload = buildPingPayload({
+      instanceHash: 'abc123',
+      deployTarget: 'docker',
+      chmVersion: '0.3.1',
+      installPlace: 'abcde12345',
+    })
+    expect(payload.chm_version).toBe('0.3.1')
+    expect(payload.install_place).toBe('abcde12345')
+  })
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -144,6 +155,7 @@ function makeDeps(
     detectFlavor: () => 'oss',
     detectCountry: () => 'us',
     detectPlatform: () => 'linux',
+    computeInstallPlace: async () => 'test-install-place-hash',
     store,
     posts,
     ...overrides,

--- a/apps/dashboard/src/lib/telemetry/instance-ping.ts
+++ b/apps/dashboard/src/lib/telemetry/instance-ping.ts
@@ -66,9 +66,19 @@ export function buildPingPayload(input: {
   chFlavor?: string
   country?: string
   platform?: string
+  chmVersion?: string
+  installPlace?: string
 }): Record<string, string> {
-  const { instanceHash, version, deployTarget, chFlavor, country, platform } =
-    input
+  const {
+    instanceHash,
+    version,
+    deployTarget,
+    chFlavor,
+    country,
+    platform,
+    chmVersion,
+    installPlace,
+  } = input
   const chVersion = version ? parseMajorMinor(version) : undefined
   const payload: Record<string, string> = {
     instance_hash: instanceHash,
@@ -85,6 +95,12 @@ export function buildPingPayload(input: {
   }
   if (platform !== undefined) {
     payload.platform = platform
+  }
+  if (chmVersion !== undefined) {
+    payload.chm_version = chmVersion
+  }
+  if (installPlace !== undefined) {
+    payload.install_place = installPlace
   }
   return payload
 }
@@ -135,6 +151,8 @@ export interface PingDeps {
   post: (url: string, body: string) => Promise<void>
   /** Raw ClickHouse version string (optional) */
   version?: string
+  /** ClickHouse server hostname (optional) */
+  chHostname?: string
   /** Deploy target string */
   deployTarget: string
   /** Detect ClickHouse flavor (oss/altinity/cloud/unknown) */
@@ -143,6 +161,10 @@ export interface PingDeps {
   detectCountry: () => string
   /** Detect platform/OS from userAgent (generic categories only) */
   detectPlatform: () => string
+  /** CHM product version string (e.g. '0.3.1') */
+  chmVersion?: string
+  /** Compute install_place hash from deployment environment signals */
+  computeInstallPlace: () => Promise<string | undefined>
 }
 
 /**
@@ -169,6 +191,8 @@ export async function runInstancePing(deps: PingDeps): Promise<PingResult> {
     detectFlavor,
     detectCountry,
     detectPlatform,
+    chmVersion,
+    computeInstallPlace,
   } = deps
 
   if (!enabled) return 'skipped-disabled'
@@ -185,8 +209,21 @@ export async function runInstancePing(deps: PingDeps): Promise<PingResult> {
 
   // Get-or-create stable local instance ID (never transmitted raw)
   let instanceId = getItem(STORAGE_KEY_INSTANCE_ID)
-  if (!instanceId) {
-    instanceId = randomId()
+  const currentChHostname = deps.chHostname || ''
+  const storedChHostname = getItem('chm_telemetry_ch_hostname') || ''
+
+  if (
+    !instanceId ||
+    (currentChHostname && currentChHostname !== storedChHostname)
+  ) {
+    if (typeof window !== 'undefined' && window.location) {
+      instanceId = `${window.location.hostname}|${currentChHostname || 'default'}`
+      if (currentChHostname) {
+        setItem('chm_telemetry_ch_hostname', currentChHostname)
+      }
+    } else {
+      instanceId = randomId()
+    }
     setItem(STORAGE_KEY_INSTANCE_ID, instanceId)
   }
 
@@ -194,6 +231,7 @@ export async function runInstancePing(deps: PingDeps): Promise<PingResult> {
   const chFlavor = version ? detectFlavor(version) : undefined
   const country = detectCountry()
   const platform = detectPlatform()
+  const installPlace = await computeInstallPlace()
 
   const payload = buildPingPayload({
     instanceHash,
@@ -202,6 +240,8 @@ export async function runInstancePing(deps: PingDeps): Promise<PingResult> {
     chFlavor,
     country,
     platform,
+    chmVersion,
+    installPlace,
   })
 
   try {
@@ -244,7 +284,8 @@ async function sha256hex(s: string): Promise<string> {
  */
 export function maybePingInstance(
   runtimeEnv?: Record<string, string | undefined>,
-  chVersion?: string
+  chVersion?: string,
+  chHostname?: string
 ): void {
   // Guard: require browser globals before attempting anything.
   if (
@@ -291,10 +332,33 @@ export function maybePingInstance(
         keepalive: true,
       }).then(() => undefined),
     version: chVersion, // caller may populate via a separate ClickHouse query
+    chHostname,
     deployTarget: getDeployTarget(),
     detectFlavor: detectChFlavor,
     detectCountry: detectCountry,
     detectPlatform: detectPlatform,
+    // CHM product version from the build-time env var
+    chmVersion: import.meta.env.VITE_GIT_REF?.replace(/^v/, '') || undefined,
+    computeInstallPlace: async () => {
+      // Compute a stable hash from deployment environment signals. The hash
+      // identifies the deployment location (k8s cluster, Docker host, etc.)
+      // without exposing the raw values.
+      try {
+        const signals: string[] = []
+        // Browser hostname (e.g. 'chm.mycompany.com') — same for all users
+        // hitting the same deployment.
+        if (typeof window !== 'undefined' && window.location) {
+          signals.push(window.location.hostname)
+        }
+        // Deploy target contributes to the signal so different deploy
+        // methods on the same host are distinguishable.
+        signals.push(getDeployTarget())
+        if (signals.length === 0) return undefined
+        return sha256hex(signals.join('|'))
+      } catch {
+        return undefined
+      }
+    },
   }
 
   // Fire-and-forget — errors are swallowed by runInstancePing + this catch.

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -162,10 +162,14 @@ const CLIENT_ENV = {
   VITE_TELEMETRY_ENDPOINT:
     e.VITE_TELEMETRY_ENDPOINT ?? 'https://telemetry.chmonitor.dev/v1/ping',
   VITE_GIT_SHA:
-    e.VITE_GIT_SHA ?? e.NEXT_PUBLIC_GIT_SHA ?? git('rev-parse HEAD'),
+    e.VITE_GIT_SHA ??
+    e.NEXT_PUBLIC_GIT_SHA ??
+    e.GITHUB_SHA ??
+    git('rev-parse HEAD'),
   VITE_GIT_REF:
     e.VITE_GIT_REF ??
     e.NEXT_PUBLIC_GIT_REF ??
+    e.GITHUB_REF ??
     git('rev-parse --abbrev-ref HEAD'),
   VITE_BUILD_TIMESTAMP:
     e.VITE_BUILD_TIMESTAMP ??

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -287,11 +287,16 @@ const ogImage = new URL(image, Astro.site).toString()
     :root[data-theme="dark"] img[data-shot="dark"]{display:block !important}
 
     /* ── screenshot zoom (native dialog) ── */
-    .screenshot-zoom-dialog{border:none;padding:0;background:transparent;max-width:min(96vw,1200px);width:100%}
+    .screenshot-zoom-dialog{position:fixed;inset:0;border:none;padding:0;background:transparent;max-width:min(96vw,1200px);width:100%;height:100%;margin:auto;outline:none}
+    .screenshot-zoom-dialog[open]{display:flex;align-items:center;justify-content:center}
     .screenshot-zoom-dialog::backdrop{background:rgba(0,0,0,.72)}
     .screenshot-zoom-dialog .screenshot-zoom-close{position:fixed;top:16px;right:16px;z-index:2;width:40px;height:40px;border-radius:999px;border:1px solid var(--border);background:var(--card);color:var(--foreground);font-size:24px;line-height:1;cursor:pointer}
-    .screenshot-zoom-body{max-height:85vh;overflow:auto;border-radius:var(--radius)}
-    .screenshot-zoom-body img{display:block;width:100%;height:auto}
+    .screenshot-zoom-body{max-height:90vh;max-width:100%;overflow:hidden;border-radius:var(--radius);border:1px solid var(--border);background:var(--card)}
+    .screenshot-zoom-body img{display:block;max-width:100%;max-height:90vh;width:auto;height:auto;margin:auto;border-radius:var(--radius)}
+    .screenshot-zoom-body img[data-shot="dark"]{display:none !important}
+    :root[data-theme="dark"] .screenshot-zoom-body img[data-shot="light"]{display:none !important}
+    :root[data-theme="dark"] .screenshot-zoom-body img[data-shot="dark"]{display:block !important}
+    html:has(.screenshot-zoom-dialog[open]){overflow:hidden}
 
     /* ── hero ── */
     .hero{padding:52px 0 72px;text-align:center;position:relative;overflow:hidden}

--- a/apps/telemetry/index.html
+++ b/apps/telemetry/index.html
@@ -18,9 +18,9 @@
       --bg: #ffffff;
       --fg: #1a1a1a;
       --fg-muted: #666666;
-      --border: #e5e5e5;
+      --border: #f0f0f3;
       --bg-box: #f5f5f5;
-      --accent: #2383e2;
+      --accent: #f97316;
     }
 
     body {
@@ -35,8 +35,8 @@
 
     .nav-bar {
       border-bottom: 1px solid var(--border);
-      background: rgba(255, 255, 255, 0.9);
-      backdrop-filter: blur(8px);
+      background: rgba(255, 255, 255, 0.85);
+      backdrop-filter: blur(12px);
       position: sticky;
       top: 0;
       z-index: 100;
@@ -59,11 +59,11 @@
       letter-spacing: -0.03em;
       display: flex;
       align-items: center;
+      gap: 10px;
     }
 
     .logo span {
-      color: var(--accent);
-      margin: 0 1px;
+      color: var(--fg);
     }
 
     .nav-links {
@@ -84,45 +84,46 @@
     }
 
     .btn-primary {
-      background: var(--fg);
+      background: #09090b;
       color: #ffffff;
       padding: 10px 20px;
-      border-radius: 6px;
+      border-radius: 8px;
       text-decoration: none;
       font-size: 0.9rem;
-      font-weight: 500;
-      transition: background 0.15s ease;
+      font-weight: 650;
+      transition: all 0.15s ease;
     }
 
     .btn-primary:hover {
-      background: #333333;
+      background: #27272a;
+      transform: translateY(-1px);
     }
 
     .container {
       max-width: 680px;
-      margin: 80px auto 0;
+      margin: 60px auto 0;
       padding: 0 24px;
     }
 
     header {
-      margin-bottom: 60px;
+      margin-bottom: 48px;
       text-align: center;
     }
 
     h1 {
       font-size: 3rem;
-      font-weight: 800;
+      font-weight: 850;
       color: var(--fg);
       margin-bottom: 16px;
       letter-spacing: -0.04em;
-      line-height: 1.15;
+      line-height: 1.1;
     }
 
     .subtitle {
       color: var(--fg-muted);
-      font-size: 1.25rem;
-      font-weight: 400;
-      max-width: 500px;
+      font-size: 1.15rem;
+      font-weight: 450;
+      max-width: 520px;
       margin: 0 auto;
       letter-spacing: -0.01em;
       line-height: 1.5;
@@ -136,79 +137,95 @@
     }
 
     .error {
-      border: 1px solid #d44c47;
+      border: none;
       padding: 24px;
       margin: 40px 0;
-      color: #d44c47;
-      background: #fff;
-      border-radius: 8px;
+      color: #df3c3c;
+      background: #fef2f2;
+      border-radius: 12px;
       font-size: 0.95rem;
     }
 
     .info-box {
-      border: 1px solid var(--border);
-      background: #ffffff;
+      border: none;
+      background: #fffbeb;
       padding: 28px;
-      margin-bottom: 48px;
-      border-radius: 12px;
-      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+      margin-bottom: 40px;
+      border-radius: 14px;
     }
 
     .info-box h3 {
       font-size: 1.1rem;
-      font-weight: 600;
-      color: var(--fg);
+      font-weight: 700;
+      color: #92400e;
       margin-bottom: 8px;
       letter-spacing: -0.02em;
     }
 
     .info-box p {
       font-size: 0.9rem;
-      color: var(--fg-muted);
+      color: #b45309;
       line-height: 1.6;
     }
 
     .stats-grid {
       display: grid;
-      grid-template-columns: 1fr;
+      grid-template-columns: 1fr 1fr;
+      gap: 20px;
       margin-bottom: 48px;
     }
 
     .stat-card {
-      border: 1px solid var(--border);
-      background: #ffffff;
-      padding: 36px 28px;
-      border-radius: 12px;
+      border: none;
+      background: #f0f7ff;
+      padding: 32px 28px;
+      border-radius: 14px;
       text-align: left;
-      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+      transition: transform 0.2s ease;
+    }
+
+    .stat-card:hover {
+      transform: translateY(-2px);
+    }
+
+    .stat-card.environments {
+      background: #f5f3ff;
+    }
+
+    .stat-card.environments .stat-label {
+      color: #6b21a8;
+    }
+
+    .stat-card.environments .stat-value {
+      color: #581c87;
     }
 
     .stat-label {
-      font-size: 0.85rem;
-      color: var(--fg-muted);
+      font-size: 0.8rem;
+      color: #1e3a8a;
       text-transform: uppercase;
       letter-spacing: 0.08em;
-      margin-bottom: 12px;
-      font-weight: 600;
+      margin-bottom: 8px;
+      font-weight: 700;
     }
 
     .stat-value {
-      font-size: 4rem;
-      font-weight: 800;
-      color: var(--fg);
+      font-size: 3.5rem;
+      font-weight: 900;
+      color: #1e40af;
       line-height: 1;
       letter-spacing: -0.05em;
     }
 
     .section {
-      margin-bottom: 56px;
+      margin-bottom: 48px;
     }
 
     .section h2 {
-      font-size: 1.5rem;
-      font-weight: 700;
+      font-size: 1.35rem;
+      font-weight: 800;
       color: var(--fg);
-      margin-bottom: 24px;
+      margin-bottom: 20px;
       letter-spacing: -0.03em;
       border-bottom: 1px solid var(--border);
       padding-bottom: 12px;
@@ -217,7 +234,7 @@
     .bar-chart {
       display: flex;
       flex-direction: column;
-      gap: 16px;
+      gap: 14px;
     }
 
     .bar-item {
@@ -233,22 +250,22 @@
       overflow: hidden;
       text-overflow: ellipsis;
       color: var(--fg);
-      font-weight: 500;
+      font-weight: 550;
       letter-spacing: -0.01em;
     }
 
     .bar-track {
       flex-grow: 1;
       height: 8px;
-      background: #f5f5f5;
-      margin: 0 24px;
+      background: #f4f4f7;
+      margin: 0 20px;
       border-radius: 4px;
       overflow: hidden;
     }
 
     .bar-fill {
       height: 100%;
-      background: var(--fg);
+      background: #f97316;
       border-radius: 4px;
       transition: width 0.6s cubic-bezier(0.16, 1, 0.3, 1);
     }
@@ -256,14 +273,14 @@
     .bar-value {
       width: 80px;
       text-align: right;
-      font-weight: 600;
+      font-weight: 700;
       flex-shrink: 0;
       color: var(--fg);
     }
 
     .footer {
-      margin-top: 80px;
-      padding: 40px 0;
+      margin-top: 64px;
+      padding: 32px 0;
       border-top: 1px solid var(--border);
       font-size: 0.85rem;
       color: var(--fg-muted);
@@ -277,18 +294,89 @@
     }
 
     .footer a:hover {
-      color: var(--accent);
+      color: #f97316;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0b0b0e;
+        --fg: #f4f4f5;
+        --fg-muted: #8a8a93;
+        --border: #1e1e24;
+      }
+
+      .nav-bar {
+        background: rgba(11, 11, 14, 0.85);
+      }
+
+      .logo span {
+        color: #f4f4f5;
+      }
+
+      .btn-primary {
+        background: #fafafa;
+        color: #09090b;
+      }
+
+      .btn-primary:hover {
+        background: #e4e4e7;
+      }
+
+      .info-box {
+        background: #1e1910;
+      }
+
+      .info-box h3 {
+        color: #fef08a;
+      }
+
+      .info-box p {
+        color: #fef08a;
+        opacity: 0.85;
+      }
+
+      .stat-card {
+        background: #111827;
+      }
+
+      .stat-card.environments {
+        background: #1e1b4b;
+      }
+
+      .stat-card.environments .stat-label {
+        color: #c084fc;
+      }
+
+      .stat-card.environments .stat-value {
+        color: #e9d5ff;
+      }
+
+      .stat-label {
+        color: #60a5fa;
+      }
+
+      .stat-value {
+        color: #93c5fd;
+      }
+
+      .bar-track {
+        background: #181820;
+      }
     }
 
     @media (max-width: 600px) {
       .container {
-        margin-top: 40px;
+        margin-top: 32px;
       }
       h1 {
         font-size: 2.25rem;
       }
       .subtitle {
-        font-size: 1.1rem;
+        font-size: 1.05rem;
+      }
+      .stats-grid {
+        grid-template-columns: 1fr;
+        gap: 16px;
       }
       .bar-item {
         flex-wrap: wrap;
@@ -307,7 +395,12 @@
 <body>
   <nav class="nav-bar">
     <div class="nav-container">
-      <a href="https://chmonitor.dev" class="logo">chm<span>/</span>nitor</a>
+      <a href="https://chmonitor.dev" class="logo">
+        <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="chmonitor">
+          <rect x="3.3" y="13.05" width="3.8" height="15.45" fill="#f97316"/><rect x="8.7" y="3.5" width="3.8" height="25" fill="#f97316"/><rect x="14.1" y="13.25" width="3.8" height="15.25" fill="#f97316"/><rect x="19.5" y="6.25" width="3.8" height="22.25" fill="#f97316"/><rect x="24.9" y="16.8" width="3.8" height="11.7" fill="#f97316"/><rect x="3.3" y="9.75" width="3.8" height="3.3" fill="#10b981"/>
+        </svg>
+        <span>chmonitor</span>
+      </a>
       <div class="nav-links">
         <a href="https://chmonitor.dev">Overview</a>
         <a href="https://docs.chmonitor.dev">Docs</a>
@@ -341,6 +434,10 @@
           <div class="stat-label">Total Installs</div>
           <div class="stat-value" id="total">0</div>
         </div>
+        <div class="stat-card environments">
+          <div class="stat-label">Total Environments</div>
+          <div class="stat-value" id="total-places">0</div>
+        </div>
       </div>
 
       <div class="section">
@@ -351,6 +448,11 @@
       <div class="section">
         <h2>ClickHouse Versions</h2>
         <div id="ch-versions" class="bar-chart"></div>
+      </div>
+
+      <div class="section">
+        <h2>chmonitor Versions</h2>
+        <div id="chm-versions" class="bar-chart"></div>
       </div>
 
       <div class="section">
@@ -401,6 +503,9 @@
 
         // Update stats cards
         document.getElementById('total').textContent = data.total_installs.toLocaleString();
+        if (data.total_places !== undefined) {
+          document.getElementById('total-places').textContent = data.total_places.toLocaleString();
+        }
 
         // Render deployment targets
         const deployTargetsArray = Object.entries(data.by_deploy_target || {}).map(([target, installs]) => ({
@@ -411,6 +516,11 @@
 
         // Render ClickHouse versions
         renderBarChart('ch-versions', data.by_ch_version);
+
+        // Render chmonitor versions
+        if (data.by_chm_version) {
+          renderBarChart('chm-versions', data.by_chm_version);
+        }
 
         // Render countries
         renderBarChart('countries', data.by_country);

--- a/apps/telemetry/src/index.ts
+++ b/apps/telemetry/src/index.ts
@@ -57,6 +57,8 @@ const EVENTS = new Set([
 
 const HEX64 = /^[0-9a-f]{64}$/
 const MAJOR_MINOR = /^\d{1,3}\.\d{1,3}$/
+// CHM product version (e.g. '0.3.1') — semver-like, 1-3 dot-separated numbers.
+const SEMVER = /^\d{1,3}\.\d{1,3}(\.\d{1,5})?$/
 
 const CORS: Record<string, string> = {
   'access-control-allow-origin': '*',
@@ -77,6 +79,11 @@ function asEnum(v: unknown, set: Set<string>, fallback: string): string {
 /** Accept only a MAJOR.MINOR version string, else ''. */
 function asVersion(v: unknown): string {
   return typeof v === 'string' && MAJOR_MINOR.test(v) ? v : ''
+}
+
+/** Accept a semver-like CHM version string (e.g. '0.3.1'), else ''. */
+function asChmVersion(v: unknown): string {
+  return typeof v === 'string' && SEMVER.test(v) ? v : ''
 }
 
 async function readBody(req: Request): Promise<unknown | null> {
@@ -130,9 +137,9 @@ export default {
       --bg: #ffffff;
       --fg: #1a1a1a;
       --fg-muted: #666666;
-      --border: #e5e5e5;
+      --border: #f0f0f3;
       --bg-box: #f5f5f5;
-      --accent: #2383e2;
+      --accent: #f97316;
     }
 
     body {
@@ -147,8 +154,8 @@ export default {
 
     .nav-bar {
       border-bottom: 1px solid var(--border);
-      background: rgba(255, 255, 255, 0.9);
-      backdrop-filter: blur(8px);
+      background: rgba(255, 255, 255, 0.85);
+      backdrop-filter: blur(12px);
       position: sticky;
       top: 0;
       z-index: 100;
@@ -171,11 +178,11 @@ export default {
       letter-spacing: -0.03em;
       display: flex;
       align-items: center;
+      gap: 10px;
     }
 
     .logo span {
-      color: var(--accent);
-      margin: 0 1px;
+      color: var(--fg);
     }
 
     .nav-links {
@@ -196,45 +203,46 @@ export default {
     }
 
     .btn-primary {
-      background: var(--fg);
+      background: #09090b;
       color: #ffffff;
       padding: 10px 20px;
-      border-radius: 6px;
+      border-radius: 8px;
       text-decoration: none;
       font-size: 0.9rem;
-      font-weight: 500;
-      transition: background 0.15s ease;
+      font-weight: 650;
+      transition: all 0.15s ease;
     }
 
     .btn-primary:hover {
-      background: #333333;
+      background: #27272a;
+      transform: translateY(-1px);
     }
 
     .container {
       max-width: 680px;
-      margin: 80px auto 0;
+      margin: 60px auto 0;
       padding: 0 24px;
     }
 
     header {
-      margin-bottom: 60px;
+      margin-bottom: 48px;
       text-align: center;
     }
 
     h1 {
       font-size: 3rem;
-      font-weight: 800;
+      font-weight: 850;
       color: var(--fg);
       margin-bottom: 16px;
       letter-spacing: -0.04em;
-      line-height: 1.15;
+      line-height: 1.1;
     }
 
     .subtitle {
       color: var(--fg-muted);
-      font-size: 1.25rem;
-      font-weight: 400;
-      max-width: 500px;
+      font-size: 1.15rem;
+      font-weight: 450;
+      max-width: 520px;
       margin: 0 auto;
       letter-spacing: -0.01em;
       line-height: 1.5;
@@ -248,79 +256,95 @@ export default {
     }
 
     .error {
-      border: 1px solid #d44c47;
+      border: none;
       padding: 24px;
       margin: 40px 0;
-      color: #d44c47;
-      background: #fff;
-      border-radius: 8px;
+      color: #df3c3c;
+      background: #fef2f2;
+      border-radius: 12px;
       font-size: 0.95rem;
     }
 
     .info-box {
-      border: 1px solid var(--border);
-      background: #ffffff;
+      border: none;
+      background: #fffbeb;
       padding: 28px;
-      margin-bottom: 48px;
-      border-radius: 12px;
-      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+      margin-bottom: 40px;
+      border-radius: 14px;
     }
 
     .info-box h3 {
       font-size: 1.1rem;
-      font-weight: 600;
-      color: var(--fg);
+      font-weight: 700;
+      color: #92400e;
       margin-bottom: 8px;
       letter-spacing: -0.02em;
     }
 
     .info-box p {
       font-size: 0.9rem;
-      color: var(--fg-muted);
+      color: #b45309;
       line-height: 1.6;
     }
 
     .stats-grid {
       display: grid;
-      grid-template-columns: 1fr;
+      grid-template-columns: 1fr 1fr;
+      gap: 20px;
       margin-bottom: 48px;
     }
 
     .stat-card {
-      border: 1px solid var(--border);
-      background: #ffffff;
-      padding: 36px 28px;
-      border-radius: 12px;
+      border: none;
+      background: #f0f7ff;
+      padding: 32px 28px;
+      border-radius: 14px;
       text-align: left;
-      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+      transition: transform 0.2s ease;
+    }
+
+    .stat-card:hover {
+      transform: translateY(-2px);
+    }
+
+    .stat-card.environments {
+      background: #f5f3ff;
+    }
+
+    .stat-card.environments .stat-label {
+      color: #6b21a8;
+    }
+
+    .stat-card.environments .stat-value {
+      color: #581c87;
     }
 
     .stat-label {
-      font-size: 0.85rem;
-      color: var(--fg-muted);
+      font-size: 0.8rem;
+      color: #1e3a8a;
       text-transform: uppercase;
       letter-spacing: 0.08em;
-      margin-bottom: 12px;
-      font-weight: 600;
+      margin-bottom: 8px;
+      font-weight: 700;
     }
 
     .stat-value {
-      font-size: 4rem;
-      font-weight: 800;
-      color: var(--fg);
+      font-size: 3.5rem;
+      font-weight: 900;
+      color: #1e40af;
       line-height: 1;
       letter-spacing: -0.05em;
     }
 
     .section {
-      margin-bottom: 56px;
+      margin-bottom: 48px;
     }
 
     .section h2 {
-      font-size: 1.5rem;
-      font-weight: 700;
+      font-size: 1.35rem;
+      font-weight: 800;
       color: var(--fg);
-      margin-bottom: 24px;
+      margin-bottom: 20px;
       letter-spacing: -0.03em;
       border-bottom: 1px solid var(--border);
       padding-bottom: 12px;
@@ -329,7 +353,7 @@ export default {
     .bar-chart {
       display: flex;
       flex-direction: column;
-      gap: 16px;
+      gap: 14px;
     }
 
     .bar-item {
@@ -345,22 +369,22 @@ export default {
       overflow: hidden;
       text-overflow: ellipsis;
       color: var(--fg);
-      font-weight: 500;
+      font-weight: 550;
       letter-spacing: -0.01em;
     }
 
     .bar-track {
       flex-grow: 1;
       height: 8px;
-      background: #f5f5f5;
-      margin: 0 24px;
+      background: #f4f4f7;
+      margin: 0 20px;
       border-radius: 4px;
       overflow: hidden;
     }
 
     .bar-fill {
       height: 100%;
-      background: var(--fg);
+      background: #f97316;
       border-radius: 4px;
       transition: width 0.6s cubic-bezier(0.16, 1, 0.3, 1);
     }
@@ -368,14 +392,14 @@ export default {
     .bar-value {
       width: 80px;
       text-align: right;
-      font-weight: 600;
+      font-weight: 700;
       flex-shrink: 0;
       color: var(--fg);
     }
 
     .footer {
-      margin-top: 80px;
-      padding: 40px 0;
+      margin-top: 64px;
+      padding: 32px 0;
       border-top: 1px solid var(--border);
       font-size: 0.85rem;
       color: var(--fg-muted);
@@ -389,18 +413,89 @@ export default {
     }
 
     .footer a:hover {
-      color: var(--accent);
+      color: #f97316;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0b0b0e;
+        --fg: #f4f4f5;
+        --fg-muted: #8a8a93;
+        --border: #1e1e24;
+      }
+
+      .nav-bar {
+        background: rgba(11, 11, 14, 0.85);
+      }
+
+      .logo span {
+        color: #f4f4f5;
+      }
+
+      .btn-primary {
+        background: #fafafa;
+        color: #09090b;
+      }
+
+      .btn-primary:hover {
+        background: #e4e4e7;
+      }
+
+      .info-box {
+        background: #1e1910;
+      }
+
+      .info-box h3 {
+        color: #fef08a;
+      }
+
+      .info-box p {
+        color: #fef08a;
+        opacity: 0.85;
+      }
+
+      .stat-card {
+        background: #111827;
+      }
+
+      .stat-card.environments {
+        background: #1e1b4b;
+      }
+
+      .stat-card.environments .stat-label {
+        color: #c084fc;
+      }
+
+      .stat-card.environments .stat-value {
+        color: #e9d5ff;
+      }
+
+      .stat-label {
+        color: #60a5fa;
+      }
+
+      .stat-value {
+        color: #93c5fd;
+      }
+
+      .bar-track {
+        background: #181820;
+      }
     }
 
     @media (max-width: 600px) {
       .container {
-        margin-top: 40px;
+        margin-top: 32px;
       }
       h1 {
         font-size: 2.25rem;
       }
       .subtitle {
-        font-size: 1.1rem;
+        font-size: 1.05rem;
+      }
+      .stats-grid {
+        grid-template-columns: 1fr;
+        gap: 16px;
       }
       .bar-item {
         flex-wrap: wrap;
@@ -419,7 +514,12 @@ export default {
 <body>
   <nav class="nav-bar">
     <div class="nav-container">
-      <a href="https://chmonitor.dev" class="logo">chm<span>/</span>nitor</a>
+      <a href="https://chmonitor.dev" class="logo">
+        <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="chmonitor">
+          <rect x="3.3" y="13.05" width="3.8" height="15.45" fill="#f97316"/><rect x="8.7" y="3.5" width="3.8" height="25" fill="#f97316"/><rect x="14.1" y="13.25" width="3.8" height="15.25" fill="#f97316"/><rect x="19.5" y="6.25" width="3.8" height="22.25" fill="#f97316"/><rect x="24.9" y="16.8" width="3.8" height="11.7" fill="#f97316"/><rect x="3.3" y="9.75" width="3.8" height="3.3" fill="#10b981"/>
+        </svg>
+        <span>chmonitor</span>
+      </a>
       <div class="nav-links">
         <a href="https://chmonitor.dev">Overview</a>
         <a href="https://docs.chmonitor.dev">Docs</a>
@@ -453,6 +553,10 @@ export default {
           <div class="stat-label">Total Installs</div>
           <div class="stat-value" id="total">0</div>
         </div>
+        <div class="stat-card environments">
+          <div class="stat-label">Total Environments</div>
+          <div class="stat-value" id="total-places">0</div>
+        </div>
       </div>
 
       <div class="section">
@@ -463,6 +567,11 @@ export default {
       <div class="section">
         <h2>ClickHouse Versions</h2>
         <div id="ch-versions" class="bar-chart"></div>
+      </div>
+
+      <div class="section">
+        <h2>chmonitor Versions</h2>
+        <div id="chm-versions" class="bar-chart"></div>
       </div>
 
       <div class="section">
@@ -513,6 +622,9 @@ export default {
 
         // Update stats cards
         document.getElementById('total').textContent = data.total_installs.toLocaleString();
+        if (data.total_places !== undefined) {
+          document.getElementById('total-places').textContent = data.total_places.toLocaleString();
+        }
 
         // Render deployment targets
         const deployTargetsArray = Object.entries(data.by_deploy_target || {}).map(([target, installs]) => ({
@@ -523,6 +635,11 @@ export default {
 
         // Render ClickHouse versions
         renderBarChart('ch-versions', data.by_ch_version);
+
+        // Render chmonitor versions
+        if (data.by_chm_version) {
+          renderBarChart('chm-versions', data.by_chm_version);
+        }
 
         // Render countries
         renderBarChart('countries', data.by_country);
@@ -631,12 +748,30 @@ export default {
           ? data.country.toLowerCase()
           : 'unknown'
       const platform = asEnum(data.platform, PLATFORMS, 'unknown')
+      const chmVersion = asChmVersion(data.chm_version)
+      // install_place: a separate opaque hash identifying the deployment
+      // environment (k8s cluster, Docker host, etc.). Must be a valid SHA-256
+      // hex digest — same format as instance_hash.
+      const installPlace =
+        typeof data.install_place === 'string' && HEX64.test(data.install_place)
+          ? data.install_place
+          : ''
 
       env.CHM_TELEMETRY_AE.writeDataPoint({
         // index1 — distinct-install key. Count installs with uniqExact(index1).
         indexes: [instanceHash],
-        // blob1=kind, blob2=deploy_target, blob3=ch_version, blob4=ch_flavor, blob5=country, blob6=platform
-        blobs: ['ping', deployTarget, chVersion, chFlavor, country, platform],
+        // blob1=kind, blob2=deploy_target, blob3=ch_version, blob4=ch_flavor,
+        // blob5=country, blob6=platform, blob7=chm_version, blob8=install_place
+        blobs: [
+          'ping',
+          deployTarget,
+          chVersion,
+          chFlavor,
+          country,
+          platform,
+          chmVersion,
+          installPlace,
+        ],
         doubles: [1],
       })
 
@@ -648,7 +783,7 @@ export default {
         const day = new Date().toISOString().slice(0, 10) // YYYY-MM-DD (UTC)
         ctx.waitUntil(
           env.CHM_TELEMETRY_DB.prepare(
-            'INSERT OR IGNORE INTO ping_daily (day, instance_hash, deploy_target, ch_version, ch_flavor, country, platform) VALUES (?, ?, ?, ?, ?, ?, ?)'
+            'INSERT OR IGNORE INTO ping_daily (day, instance_hash, deploy_target, ch_version, ch_flavor, country, platform, chm_version, install_place) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)'
           )
             .bind(
               day,
@@ -657,7 +792,9 @@ export default {
               chVersion || null,
               chFlavor || null,
               country || null,
-              platform || null
+              platform || null,
+              chmVersion || null,
+              installPlace || null
             )
             .run()
             .then(() => undefined)
@@ -734,31 +871,45 @@ async function handleSummary(env: Env, req: Request): Promise<Response> {
       : env.CHM_TELEMETRY_DB!.prepare(sql)
 
   try {
-    const [totalRow, byTarget, byVersion, byFlavor, byCountry, byPlatform] =
-      await Promise.all([
-        stmt(
-          `SELECT COUNT(DISTINCT instance_hash) AS n FROM ping_daily ${where}`
-        ).first<{
-          n: number
-        }>(),
-        env
-          .CHM_TELEMETRY_DB!.prepare(
-            'SELECT deploy_target, COUNT(DISTINCT instance_hash) AS n FROM ping_daily GROUP BY deploy_target'
-          )
-          .all<{ deploy_target: string; n: number }>(),
-        stmt(
-          `SELECT COALESCE(ch_version, 'unknown') AS v, COUNT(DISTINCT instance_hash) AS n FROM ping_daily ${where} GROUP BY v ORDER BY n DESC`
-        ).all<{ v: string; n: number }>(),
-        stmt(
-          `SELECT COALESCE(ch_flavor, 'unknown') AS v, COUNT(DISTINCT instance_hash) AS n FROM ping_daily ${where} GROUP BY v ORDER BY n DESC`
-        ).all<{ v: string; n: number }>(),
-        stmt(
-          `SELECT COALESCE(country, 'unknown') AS v, COUNT(DISTINCT instance_hash) AS n FROM ping_daily ${where} GROUP BY v ORDER BY n DESC LIMIT 10`
-        ).all<{ v: string; n: number }>(),
-        stmt(
-          `SELECT COALESCE(platform, 'unknown') AS v, COUNT(DISTINCT instance_hash) AS n FROM ping_daily ${where} GROUP BY v ORDER BY n DESC`
-        ).all<{ v: string; n: number }>(),
-      ])
+    const [
+      totalRow,
+      byTarget,
+      byVersion,
+      byFlavor,
+      byCountry,
+      byPlatform,
+      byChmVersion,
+      totalPlaces,
+    ] = await Promise.all([
+      stmt(
+        `SELECT COUNT(DISTINCT instance_hash) AS n FROM ping_daily ${where}`
+      ).first<{
+        n: number
+      }>(),
+      env
+        .CHM_TELEMETRY_DB!.prepare(
+          'SELECT deploy_target, COUNT(DISTINCT instance_hash) AS n FROM ping_daily GROUP BY deploy_target'
+        )
+        .all<{ deploy_target: string; n: number }>(),
+      stmt(
+        `SELECT COALESCE(ch_version, 'unknown') AS v, COUNT(DISTINCT instance_hash) AS n FROM ping_daily ${where} GROUP BY v ORDER BY n DESC`
+      ).all<{ v: string; n: number }>(),
+      stmt(
+        `SELECT COALESCE(ch_flavor, 'unknown') AS v, COUNT(DISTINCT instance_hash) AS n FROM ping_daily ${where} GROUP BY v ORDER BY n DESC`
+      ).all<{ v: string; n: number }>(),
+      stmt(
+        `SELECT COALESCE(country, 'unknown') AS v, COUNT(DISTINCT instance_hash) AS n FROM ping_daily ${where} GROUP BY v ORDER BY n DESC LIMIT 10`
+      ).all<{ v: string; n: number }>(),
+      stmt(
+        `SELECT COALESCE(platform, 'unknown') AS v, COUNT(DISTINCT instance_hash) AS n FROM ping_daily ${where} GROUP BY v ORDER BY n DESC`
+      ).all<{ v: string; n: number }>(),
+      stmt(
+        `SELECT COALESCE(chm_version, 'unknown') AS v, COUNT(DISTINCT instance_hash) AS n FROM ping_daily ${where} GROUP BY v ORDER BY n DESC`
+      ).all<{ v: string; n: number }>(),
+      stmt(
+        `SELECT COUNT(DISTINCT install_place) AS n FROM ping_daily ${where} WHERE install_place IS NOT NULL`
+      ).first<{ n: number }>(),
+    ])
 
     const byDeployTarget: Record<string, number> = {}
     for (const r of byTarget.results ?? []) {
@@ -768,6 +919,7 @@ async function handleSummary(env: Env, req: Request): Promise<Response> {
     return json(
       summaryShape({
         total: Number(totalRow?.n ?? 0),
+        totalPlaces: Number(totalPlaces?.n ?? 0),
         byDeployTarget,
         byChVersion: (byVersion.results ?? []).map((r) => ({
           ch_version: r.v,
@@ -785,6 +937,10 @@ async function handleSummary(env: Env, req: Request): Promise<Response> {
           platform: r.v,
           installs: Number(r.n),
         })),
+        byChmVersion: (byChmVersion.results ?? []).map((r) => ({
+          chm_version: r.v,
+          installs: Number(r.n),
+        })),
         scopedToDeployTarget: scoped,
       }),
       200
@@ -800,22 +956,26 @@ interface SummaryBody {
   enabled: boolean
   scoped_to_deploy_target: string | null
   total_installs: number
+  total_places: number
   by_deploy_target: Record<string, number>
   by_ch_version: { ch_version: string; installs: number }[]
   by_ch_flavor: { ch_flavor: string; installs: number }[]
   by_country: { country: string; installs: number }[]
   by_platform: { platform: string; installs: number }[]
+  by_chm_version: { chm_version: string; installs: number }[]
   source: string
   generated_at: string
 }
 
 function summaryShape(input: {
   total: number
+  totalPlaces?: number
   byDeployTarget: Record<string, number>
   byChVersion: { ch_version: string; installs: number }[]
   byChFlavor: { ch_flavor: string; installs: number }[]
   byCountry: { country: string; installs: number }[]
   byPlatform: { platform: string; installs: number }[]
+  byChmVersion?: { chm_version: string; installs: number }[]
   scopedToDeployTarget?: string | null
 }): SummaryBody {
   return {
@@ -824,11 +984,13 @@ function summaryShape(input: {
     enabled: true,
     scoped_to_deploy_target: input.scopedToDeployTarget ?? null,
     total_installs: input.total,
+    total_places: input.totalPlaces ?? 0,
     by_deploy_target: input.byDeployTarget,
     by_ch_version: input.byChVersion,
     by_ch_flavor: input.byChFlavor,
     by_country: input.byCountry,
     by_platform: input.byPlatform,
+    by_chm_version: input.byChmVersion ?? [],
     source: 'D1 ping_daily (COUNT DISTINCT of opaque SHA-256 instance id)',
     generated_at: new Date().toISOString(),
   }


### PR DESCRIPTION
This PR implements multiple visual and functional improvements across the project:

1. **Telemetry worker UI restyle**: Redesigns the dashboard with borderless pastel color cards, modern typography, SVG bar chart logo, and dark mode support.
2. **Stable Instance IDs & Install Place**: Implements stable client-side hashing behavior based on hostname combinations, preventing duplicate counts across restarts/multiple devices, and introduces install place hash tagging.
3. **Landing page zoom fix**: Centers screenshot zoom modal, adds rounded border corners directly to image elements to ensure rendering, disables scrollbar on zoom-in, and pairs dark/light screenshots correctly inside the zoom body.
4. **Missing/wrong container image version fix**: Sets VITE_DEPLOY_TARGET=docker in Dockerfile and configures build environment to fall back to GITHUB_SHA/GITHUB_REF during container builds when git is absent.
5. **Blog v0.3 release post**: Adds a dedicated migration guide section detailing the docker container rename, Helm OCI chart repository, and CHM_ env var prefixing.

Co-Authored-By: duyetbot <bot@duyet.net>