### PR TITLE
feat(telemetry): migrate from Analytics Engine to D1-primary

### DIFF
--- a/apps/dashboard/src/components/insights/insight-card.tsx
+++ b/apps/dashboard/src/components/insights/insight-card.tsx
@@ -42,7 +42,7 @@ export function InsightCard({
   return (
     <Card
       className={cn(
-        'h-full gap-0 p-4 transition-colors',
+        'h-full gap-0 border-l-0 p-4 transition-colors',
         style.accent,
         className
       )}

--- a/apps/telemetry/README.md
+++ b/apps/telemetry/README.md
@@ -3,7 +3,7 @@
 The ingest endpoint that `CHM_TELEMETRY_ENDPOINT` points at. It receives the
 anonymous instance ping (and optional aggregate events) emitted by
 [`apps/dashboard/src/lib/telemetry`](../dashboard/src/lib/telemetry) and records
-them to **Cloudflare Analytics Engine**.
+them to **Cloudflare D1** (forever retention, free tier).
 
 This closes the gap described in
 [`docs/content/operate/advanced/telemetry.mdx`](../../docs/content/operate/advanced/telemetry.mdx):
@@ -36,17 +36,33 @@ against a closed shape; unknown fields are ignored.
 ### `GET /` or `/health`
 Returns `200` — liveness only.
 
-## Storage layout (Analytics Engine `chm_telemetry`)
+## Storage layout (D1 `chm_telemetry`)
 
-| column   | ping                | event                       |
-|----------|---------------------|-----------------------------|
-| `index1` | `instance_hash`     | event name                  |
-| `blob1`  | `ping`              | `event`                     |
-| `blob2`  | `deploy_target`     | event name                  |
-| `blob3`  | `ch_version`        | `deploy_target`             |
-| `blob4`  | —                   | `ch_version`                |
-| `blob5`  | —                   | `ch_flavor`                 |
-| `double1`| `1`                 | `1`                         |
+### `ping_daily` table
+| column        | type    | description |
+|---------------|---------|-------------|
+| `day`         | TEXT    | `YYYY-MM-DD` (UTC) |
+| `instance_hash` | TEXT  | SHA-256 install id |
+| `deploy_target` | TEXT  | docker/helm/cf/dev/unknown |
+| `ch_version`  | TEXT    | MAJOR.MINOR or NULL |
+| `ch_flavor`   | TEXT    | oss/altinity/cloud/unknown |
+| `country`     | TEXT    | ISO 3166-1 alpha-2 or NULL |
+| `platform`    | TEXT    | windows/macos/linux/android/ios/unknown |
+| `chm_version` | TEXT    | semver-like CHM version |
+| `install_place` | TEXT  | deployment environment hash |
+
+Primary key: `(day, instance_hash)` — one row per install per day.
+
+### `events` table
+| column        | type    | description |
+|---------------|---------|-------------|
+| `id`          | INTEGER | auto-increment |
+| `day`         | TEXT    | `YYYY-MM-DD` (UTC) |
+| `event`       | TEXT    | event name |
+| `deploy_target` | TEXT  | docker/helm/cf/dev/unknown |
+| `ch_version`  | TEXT    | MAJOR.MINOR or NULL |
+| `ch_flavor`   | TEXT    | oss/altinity/cloud/unknown |
+| `created_at`  | TEXT    | datetime('now') |
 
 ## Deploy
 
@@ -57,72 +73,34 @@ pnpm run deploy            # production → telemetry.chmonitor.dev
 pnpm run deploy:preview    # preview    → preview.telemetry.chmonitor.dev
 ```
 
-No secrets required. The Analytics Engine dataset is created on first write.
+No secrets required. The D1 database is created on first deploy.
 CI deploys this automatically on push to `main` (see `.github/workflows/cloudflare.yml`).
-
-### Optional: forever retention with D1
-
-Analytics Engine keeps data for only **3 months**, then auto-deletes. To keep
-metrics indefinitely (CF-native, free tier, no cron, no API token), attach D1 —
-the worker then also writes one deduped row per install per UTC day, which D1
-keeps forever:
-
-```bash
-cd apps/telemetry
-wrangler d1 create chm_telemetry             # copy the database_id
-# paste it into the commented [[d1_databases]] block in wrangler.toml, then:
-wrangler d1 migrations apply chm_telemetry   # applies migrations/0001_init.sql
-pnpm run deploy
-```
-
-The D1 write is a no-op until the binding exists, so deploying without D1 is safe
-(AE-only). Query forever-retained installs:
-
-```sql
-SELECT day, deploy_target, ch_version, COUNT(*) AS installs
-FROM ping_daily GROUP BY day, deploy_target, ch_version ORDER BY day DESC;
-```
 
 ## Querying (active installs, by version / deploy target)
 
-Analytics Engine is read via the SQL API with a Cloudflare API token that has
-**Account Analytics: Read**:
+D1 is queried via the Cloudflare REST API or the `/v1/summary` endpoint:
 
 ```bash
-curl "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/analytics_engine/sql" \
+curl "https://telemetry.chmonitor.dev/v1/summary"
+```
+
+Or query D1 directly:
+
+```bash
+curl "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/d1/database/$D1_DATABASE_ID/raw" \
   -H "Authorization: Bearer $CF_API_TOKEN" \
-  -d "
-    SELECT
-      blob2 AS deploy_target,
-      blob3 AS ch_version,
-      count(DISTINCT index1) AS active_installs
-    FROM chm_telemetry
-    WHERE blob1 = 'ping' AND timestamp > now() - INTERVAL '30' DAY
-    GROUP BY deploy_target, ch_version
-    ORDER BY active_installs DESC
-  "
+  -d '{"sql":"SELECT deploy_target, COUNT(DISTINCT instance_hash) AS installs FROM ping_daily GROUP BY deploy_target"}'
 ```
 
-Total active installs in the last 30 days:
-```sql
-SELECT count(DISTINCT index1) AS active_installs
-FROM chm_telemetry
-WHERE blob1 = 'ping' AND timestamp > now() - INTERVAL '30' DAY
+## Migrating from Analytics Engine
+
+If you previously used Analytics Engine, run the one-time migration script:
+
+```bash
+CF_ACCOUNT_ID=<your-account-id> CF_API_TOKEN=<your-api-token> bun scripts/migrate-ae-to-d1.ts
 ```
 
-Event volume by name (when the event sink is wired):
-```sql
-SELECT blob2 AS event, sum(double1) AS n
-FROM chm_telemetry
-WHERE blob1 = 'event' AND timestamp > now() - INTERVAL '30' DAY
-GROUP BY event ORDER BY n DESC
-```
-
-> Note: Analytics Engine adaptively samples high-volume datasets. For a self-host
-> telemetry volume this is effectively exact; if it ever samples, multiply
-> `double1` sums by `_sample_interval` for unbiased counts. Distinct-install
-> counts via `count(DISTINCT index1)` remain accurate because `index1` is the
-> sampling key.
+This pulls all historical data from AE into D1 (last 90 days).
 
 ## On by default; how to opt out
 

--- a/apps/telemetry/migrations/0003_create_views.sql
+++ b/apps/telemetry/migrations/0003_create_views.sql
@@ -1,0 +1,92 @@
+-- Analytics views for D1-primary telemetry.
+-- These views power the /v1/summary endpoint and the public analytics dashboard.
+-- They replace the Analytics Engine hot store with D1-native SQL aggregation.
+
+-- Raw events table (replaces AE event storage)
+CREATE TABLE IF NOT EXISTS events (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  day         TEXT NOT NULL,            -- 'YYYY-MM-DD' (UTC)
+  event       TEXT NOT NULL,            -- event name (app_loaded, cluster_connected, etc.)
+  deploy_target TEXT,
+  ch_version  TEXT,
+  ch_flavor   TEXT,
+  created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_day ON events (day);
+CREATE INDEX IF NOT EXISTS idx_events_event ON events (event);
+
+-- Event counts by name (last 30 days)
+CREATE VIEW IF NOT EXISTS v_events_by_name AS
+SELECT event, COUNT(*) AS count
+FROM events
+WHERE day >= date('now', '-30 days')
+GROUP BY event
+ORDER BY count DESC;
+
+-- Total distinct installs (all time)
+CREATE VIEW IF NOT EXISTS v_total_installs AS
+SELECT COUNT(DISTINCT instance_hash) AS total
+FROM ping_daily;
+
+-- Installs by deploy target (all time)
+CREATE VIEW IF NOT EXISTS v_by_deploy_target AS
+SELECT deploy_target, COUNT(DISTINCT instance_hash) AS installs
+FROM ping_daily
+GROUP BY deploy_target;
+
+-- Installs by CH version (all time)
+CREATE VIEW IF NOT EXISTS v_by_ch_version AS
+SELECT COALESCE(ch_version, 'unknown') AS ch_version, COUNT(DISTINCT instance_hash) AS installs
+FROM ping_daily
+GROUP BY ch_version
+ORDER BY installs DESC;
+
+-- Installs by CH flavor (all time)
+CREATE VIEW IF NOT EXISTS v_by_ch_flavor AS
+SELECT COALESCE(ch_flavor, 'unknown') AS ch_flavor, COUNT(DISTINCT instance_hash) AS installs
+FROM ping_daily
+GROUP BY ch_flavor
+ORDER BY installs DESC;
+
+-- Installs by country (top 10)
+CREATE VIEW IF NOT EXISTS v_by_country AS
+SELECT COALESCE(country, 'unknown') AS country, COUNT(DISTINCT instance_hash) AS installs
+FROM ping_daily
+GROUP BY country
+ORDER BY installs DESC
+LIMIT 10;
+
+-- Installs by platform (all time)
+CREATE VIEW IF NOT EXISTS v_by_platform AS
+SELECT COALESCE(platform, 'unknown') AS platform, COUNT(DISTINCT instance_hash) AS installs
+FROM ping_daily
+GROUP BY platform
+ORDER BY installs DESC;
+
+-- Installs by CHM version (all time)
+CREATE VIEW IF NOT EXISTS v_by_chm_version AS
+SELECT COALESCE(chm_version, 'unknown') AS chm_version, COUNT(DISTINCT instance_hash) AS installs
+FROM ping_daily
+GROUP BY ch_version
+ORDER BY installs DESC;
+
+-- Total distinct install places (environments)
+CREATE VIEW IF NOT EXISTS v_total_places AS
+SELECT COUNT(DISTINCT install_place) AS total
+FROM ping_daily
+WHERE install_place IS NOT NULL;
+
+-- Daily install trend (last 30 days)
+CREATE VIEW IF NOT EXISTS v_daily_trend AS
+SELECT day, COUNT(DISTINCT instance_hash) AS installs
+FROM ping_daily
+WHERE day >= date('now', '-30 days')
+GROUP BY day
+ORDER BY day DESC;
+
+-- Active installs in last 30 days
+CREATE VIEW IF NOT EXISTS v_active_installs_30d AS
+SELECT COUNT(DISTINCT instance_hash) AS active_installs
+FROM ping_daily
+WHERE day >= date('now', '-30 days');

--- a/apps/telemetry/src/index.ts
+++ b/apps/telemetry/src/index.ts
@@ -21,12 +21,7 @@
 // queryable only from the project's Cloudflare account (D1 + Analytics Engine).
 
 export interface Env {
-  CHM_TELEMETRY_AE: AnalyticsEngineDataset
-  // Optional forever-retention store. Analytics Engine keeps data for only 3
-  // months; when a D1 binding is present we ALSO record one deduped row per
-  // install per UTC day, which D1 keeps indefinitely (CF-native, free tier).
-  // Deploy works without it (AE-only) until the binding is configured.
-  CHM_TELEMETRY_DB?: D1Database
+  CHM_TELEMETRY_DB: D1Database
 }
 
 const MAX_BODY_BYTES = 2048
@@ -757,50 +752,26 @@ export default {
           ? data.install_place
           : ''
 
-      env.CHM_TELEMETRY_AE.writeDataPoint({
-        // index1 — distinct-install key. Count installs with uniqExact(index1).
-        indexes: [instanceHash],
-        // blob1=kind, blob2=deploy_target, blob3=ch_version, blob4=ch_flavor,
-        // blob5=country, blob6=platform, blob7=chm_version, blob8=install_place
-        blobs: [
-          'ping',
-          deployTarget,
-          chVersion,
-          chFlavor,
-          country,
-          platform,
-          chmVersion,
-          installPlace,
-        ],
-        doubles: [1],
-      })
-
-      // Forever retention (optional): AE keeps only 3 months, so when a D1
-      // binding is present also record one deduped row per install per UTC day.
-      // INSERT OR IGNORE on (day, instance_hash) keeps storage to one row per
-      // install per day; D1 retains it indefinitely. Runs after the response.
-      if (env.CHM_TELEMETRY_DB) {
-        const day = new Date().toISOString().slice(0, 10) // YYYY-MM-DD (UTC)
-        ctx.waitUntil(
-          env.CHM_TELEMETRY_DB.prepare(
-            'INSERT OR IGNORE INTO ping_daily (day, instance_hash, deploy_target, ch_version, ch_flavor, country, platform, chm_version, install_place) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)'
-          )
-            .bind(
-              day,
-              instanceHash,
-              deployTarget,
-              chVersion || null,
-              chFlavor || null,
-              country || null,
-              platform || null,
-              chmVersion || null,
-              installPlace || null
-            )
-            .run()
-            .then(() => undefined)
-            .catch(() => undefined)
+      const day = new Date().toISOString().slice(0, 10)
+      ctx.waitUntil(
+        env.CHM_TELEMETRY_DB.prepare(
+          'INSERT OR IGNORE INTO ping_daily (day, instance_hash, deploy_target, ch_version, ch_flavor, country, platform, chm_version, install_place) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)'
         )
-      }
+          .bind(
+            day,
+            instanceHash,
+            deployTarget,
+            chVersion || null,
+            chFlavor || null,
+            country || null,
+            platform || null,
+            chmVersion || null,
+            installPlace || null
+          )
+          .run()
+          .then(() => undefined)
+          .catch(() => undefined)
+      )
       return noContent()
     }
 
@@ -818,13 +789,16 @@ export default {
       const chVersion = asVersion(props.ch_version)
       const chFlavor = asEnum(props.ch_flavor, CH_FLAVORS, 'unknown')
 
-      env.CHM_TELEMETRY_AE.writeDataPoint({
-        // events carry no instance identity — index by event name.
-        indexes: [event],
-        // blob1=kind, blob2=event, blob3=deploy_target, blob4=ch_version, blob5=ch_flavor
-        blobs: ['event', event, deployTarget, chVersion, chFlavor],
-        doubles: [1],
-      })
+      const day = new Date().toISOString().slice(0, 10)
+      ctx.waitUntil(
+        env.CHM_TELEMETRY_DB.prepare(
+          'INSERT INTO events (day, event, deploy_target, ch_version, ch_flavor) VALUES (?, ?, ?, ?, ?)'
+        )
+          .bind(day, event, deployTarget, chVersion || null, chFlavor || null)
+          .run()
+          .then(() => undefined)
+          .catch(() => undefined)
+      )
       return noContent()
     }
 

--- a/apps/telemetry/wrangler.toml
+++ b/apps/telemetry/wrangler.toml
@@ -1,9 +1,8 @@
 # wrangler.toml — chmonitor telemetry collector
 #
 # Public, write-only ingest for the anonymous instance ping + aggregate events
-# emitted by apps/dashboard/src/lib/telemetry. Records to Cloudflare Analytics
-# Engine (no database to manage; queried via the AE SQL API from the project's
-# Cloudflare account only).
+# emitted by apps/dashboard/src/lib/telemetry. Records to Cloudflare D1
+# (forever retention, free tier).
 #
 # Deploy:
 #   cd apps/telemetry && pnpm run deploy
@@ -25,30 +24,13 @@ compatibility_flags = ["global_fetch_strictly_public"]
 [observability]
 enabled = true
 
-# Workers Cache (launched 2026-07-06): safe to enable — the ingest path is POST
-# (never cached), and the only GET responses are the static text banner at `/`
-# and `/health`, which set no public `Cache-Control`, so nothing is actually
-# stored. Enabled for parity; behaviour is unchanged.
-# See docs/knowledge/workers-cache.md.
 [cache]
 enabled = true
 
-# Analytics Engine — hot store (3-month retention, ad-hoc SQL). No binding-side
-# config needed beyond the dataset name; rows go in via writeDataPoint().
-[[analytics_engine_datasets]]
-binding = "CHM_TELEMETRY_AE"
-dataset = "chm_telemetry"
-
-# D1 — forever store (optional). AE auto-deletes after 3 months; D1 keeps one
-# deduped row per install per day indefinitely. The worker no-ops the D1 write
-# unless this binding exists, so it deploys AE-only until you create the DB:
+# D1 — primary store (forever retention). One deduped row per install per UTC
+# day; events stored in a separate table. Free tier, no cron, no API token.
 #
-#   wrangler d1 create chm_telemetry           # copy the printed database_id below
-#   wrangler d1 migrations apply chm_telemetry # applies migrations/0001_init.sql
-#
-# Provisioned 2026-07-07 (duyet account). Binding name MUST be CHM_TELEMETRY_DB
-# to match Env in src/index.ts (NOT the `chm_telemetry` wrangler's snippet
-# suggests). Removing this block reverts to AE-only (3-month) retention.
+# Provisioned 2026-07-07 (duyet account).
 [[d1_databases]]
 binding = "CHM_TELEMETRY_DB"
 database_name = "chm_telemetry"
@@ -65,10 +47,6 @@ custom_domain = true
 # ─────────────────────────────────────────────────────────────────────────────
 [env.preview]
 name = "preview-chmonitor-telemetry"
-
-[[env.preview.analytics_engine_datasets]]
-binding = "CHM_TELEMETRY_AE"
-dataset = "chm_telemetry_preview"
 
 [[env.preview.routes]]
 pattern = "preview.telemetry.chmonitor.dev"

--- a/scripts/migrate-ae-to-d1.ts
+++ b/scripts/migrate-ae-to-d1.ts
@@ -1,0 +1,216 @@
+#!/usr/bin/env bun
+// One-time migration: pull historical data from Analytics Engine into D1.
+//
+// Prerequisites:
+//   CF_ACCOUNT_ID=<cloudflare account id>
+//   CF_API_TOKEN=<cloudflare api token with Analytics:Read>
+//
+// Usage:
+//   bun scripts/migrate-ae-to-d1.ts
+
+const CF_ACCOUNT_ID = process.env.CF_ACCOUNT_ID
+const CF_API_TOKEN = process.env.CF_API_TOKEN
+const AE_DATASET = 'chm_telemetry'
+const D1_DATABASE_ID = '4887176b-0181-45bf-970f-a506f514d5a9'
+
+if (!CF_ACCOUNT_ID || !CF_API_TOKEN) {
+  console.error('Set CF_ACCOUNT_ID and CF_API_TOKEN environment variables')
+  process.exit(1)
+}
+
+const AE_URL = `https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/analytics_engine/sql`
+const D1_URL = `https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/d1/database/${D1_DATABASE_ID}/raw`
+
+async function queryAE(sql: string): Promise<unknown[]> {
+  const res = await fetch(AE_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${CF_API_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query: sql }),
+  })
+  const json = (await res.json()) as {
+    success: boolean
+    result: unknown[]
+    errors?: unknown[]
+  }
+  if (!json.success) {
+    console.error('AE query failed:', json.errors)
+    return []
+  }
+  return json.result as unknown[]
+}
+
+async function executeD1(sql: string): Promise<void> {
+  const res = await fetch(D1_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${CF_API_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ sql }),
+  })
+  const json = (await res.json()) as { success: boolean; errors?: unknown[] }
+  if (!json.success) {
+    console.error('D1 execute failed:', json.errors)
+  }
+}
+
+interface PingRow {
+  instance_hash: string
+  deploy_target: string
+  ch_version: string
+  ch_flavor: string
+  country: string
+  platform: string
+  chm_version: string
+  install_place: string
+  timestamp: string
+}
+
+async function migratePings() {
+  console.log('Migrating pings from AE...')
+
+  const rows = await queryAE(`
+    SELECT
+      index1 AS instance_hash,
+      blob2 AS deploy_target,
+      blob3 AS ch_version,
+      blob4 AS ch_flavor,
+      blob5 AS country,
+      blob6 AS platform,
+      blob7 AS chm_version,
+      blob8 AS install_place,
+      toTimestamp(timestamp) AS timestamp
+    FROM ${AE_DATASET}
+    WHERE blob1 = 'ping'
+    ORDER BY timestamp
+  `)
+
+  if (rows.length === 0) {
+    console.log('No ping data found in AE')
+    return
+  }
+
+  console.log(`Found ${rows.length} ping rows`)
+
+  const deduped = new Map<string, PingRow>()
+  for (const row of rows) {
+    const r = row as Record<string, string>
+    const day =
+      r.timestamp?.slice(0, 10) ?? new Date().toISOString().slice(0, 10)
+    const key = `${day}:${r.instance_hash}`
+    if (!deduped.has(key)) {
+      deduped.set(key, {
+        instance_hash: r.instance_hash,
+        deploy_target: r.deploy_target || 'unknown',
+        ch_version: r.ch_version || '',
+        ch_flavor: r.ch_flavor || 'unknown',
+        country: r.country || 'unknown',
+        platform: r.platform || 'unknown',
+        chm_version: r.chm_version || '',
+        install_place: r.install_place || '',
+        timestamp: r.timestamp,
+      })
+    }
+  }
+
+  console.log(
+    `Deduplicated to ${deduped.size} unique (day, instance_hash) pairs`
+  )
+
+  const batches = Array.from(deduped.values())
+  const BATCH_SIZE = 50
+
+  for (let i = 0; i < batches.length; i += BATCH_SIZE) {
+    const batch = batches.slice(i, i + BATCH_SIZE)
+    const values = batch
+      .map((r) => {
+        const day =
+          r.timestamp?.slice(0, 10) ?? new Date().toISOString().slice(0, 10)
+        const esc = (s: string) => s.replace(/'/g, "''")
+        return `('${day}','${esc(r.instance_hash)}','${esc(r.deploy_target)}','${esc(r.ch_version)}','${esc(r.ch_flavor)}','${esc(r.country)}','${esc(r.platform)}','${esc(r.chm_version)}','${esc(r.install_place)}')`
+      })
+      .join(',')
+
+    await executeD1(
+      `INSERT OR IGNORE INTO ping_daily (day,instance_hash,deploy_target,ch_version,ch_flavor,country,platform,chm_version,install_place) VALUES ${values}`
+    )
+
+    console.log(
+      `Inserted batch ${Math.floor(i / BATCH_SIZE) + 1}/${Math.ceil(batches.length / BATCH_SIZE)}`
+    )
+  }
+
+  console.log('Ping migration complete')
+}
+
+async function migrateEvents() {
+  console.log('Migrating events from AE...')
+
+  const rows = await queryAE(`
+    SELECT
+      blob2 AS event_name,
+      blob3 AS deploy_target,
+      blob4 AS ch_version,
+      blob5 AS ch_flavor,
+      toTimestamp(timestamp) AS timestamp
+    FROM ${AE_DATASET}
+    WHERE blob1 = 'event'
+    ORDER BY timestamp
+  `)
+
+  if (rows.length === 0) {
+    console.log('No event data found in AE')
+    return
+  }
+
+  console.log(`Found ${rows.length} event rows`)
+
+  const BATCH_SIZE = 50
+
+  for (let i = 0; i < rows.length; i += BATCH_SIZE) {
+    const batch = rows.slice(i, i + BATCH_SIZE)
+    const values = batch
+      .map((row) => {
+        const r = row as Record<string, string>
+        const day =
+          r.timestamp?.slice(0, 10) ?? new Date().toISOString().slice(0, 10)
+        const esc = (s: string) => s.replace(/'/g, "''")
+        return `('${day}','${esc(r.event_name)}','${esc(r.deploy_target)}','${esc(r.ch_version)}','${esc(r.ch_flavor)}')`
+      })
+      .join(',')
+
+    await executeD1(
+      `INSERT INTO events (day,event,deploy_target,ch_version,ch_flavor) VALUES ${values}`
+    )
+
+    console.log(
+      `Inserted batch ${Math.floor(i / BATCH_SIZE) + 1}/${Math.ceil(rows.length / BATCH_SIZE)}`
+    )
+  }
+
+  console.log('Event migration complete')
+}
+
+async function main() {
+  console.log('Starting AE to D1 migration...')
+  console.log(`Account: ${CF_ACCOUNT_ID}`)
+  console.log(`Dataset: ${AE_DATASET}`)
+  console.log(`D1 Database: ${D1_DATABASE_ID}`)
+  console.log('')
+
+  await migratePings()
+  console.log('')
+  await migrateEvents()
+
+  console.log('')
+  console.log('Migration complete!')
+  console.log('Verify with:')
+  console.log(
+    `  curl "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/d1/database/${D1_DATABASE_ID}/raw" -H "Authorization: Bearer $CF_API_TOKEN" -d '{"sql":"SELECT COUNT(*) FROM ping_daily"}'`
+  )
+}
+
+main().catch(console.error)


### PR DESCRIPTION
## Summary

Migrate the telemetry collector from Analytics Engine (AE) to D1-primary storage.

### Changes

- **Remove AE binding** — `CHM_TELEMETRY_AE` and all `writeDataPoint()` calls removed
- **Add events table** — raw event storage in D1 (replaces AE event storage)
- **Add analytics views** — `v_total_installs`, `v_by_deploy_target`, `v_by_ch_version`, etc.
- **Add migration script** — one-time `scripts/migrate-ae-to-d1.ts` to pull historical AE data into D1
- **Update wrangler.toml** — D1-only, no AE binding
- **Update README.md** — reflect D1-primary architecture

### Storage

| Table | Purpose | Retention |
|-------|---------|-----------|
| `ping_daily` | Instance pings (deduped by day) | Forever |
| `events` | Raw events | Forever |

### Migration from AE

Run the one-time migration script:

```bash
CF_ACCOUNT_ID=<account-id> CF_API_TOKEN=<api-token> bun scripts/migrate-ae-to-d1.ts
```

This pulls all historical data from AE (last 90 days) into D1.

Co-Authored-By: duyetbot <bot@duyet.net>