### PR TITLE
feat(insights): add percentile selector for average query duration

### DIFF
--- a/apps/dashboard/src/components/insights/insight-card.tsx
+++ b/apps/dashboard/src/components/insights/insight-card.tsx
@@ -42,7 +42,7 @@ export function InsightCard({
   return (
     <Card
       className={cn(
-        'h-full gap-0 p-4 transition-colors',
+        'h-full gap-0 border-l-0 p-4 transition-colors',
         style.accent,
         className
       )}

--- a/apps/dashboard/src/lib/api/charts/insight-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/insight-charts.ts
@@ -192,13 +192,18 @@ export const insightCharts: Record<string, ChartQueryBuilder> = {
     }
   },
 
-  // Average query duration
+  // Query duration percentile (p95/p99/p100) — default p99
   'insight-avg-duration': (params) => {
     const timeFilter = buildTimeFilter(params.lastHours)
+    const percentile = (params.params?.percentile as string) || 'p99'
+    const durationExpr =
+      percentile === 'p100'
+        ? 'max(query_duration_ms)'
+        : `quantile(${percentile === 'p95' ? '0.95' : '0.99'})(query_duration_ms)`
     return {
       query: `
         SELECT
-          avg(query_duration_ms) as avg_duration_ms,
+          ${durationExpr} as avg_duration_ms,
           count() as query_count
         FROM system.query_log
         WHERE type = 'QueryFinish' AND is_initial_query = 1 ${timeFilter ? `AND ${timeFilter}` : ''}

--- a/apps/dashboard/src/routes/(dashboard)/-insights/stats-grid.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/-insights/stats-grid.tsx
@@ -25,7 +25,9 @@ import {
   BusiestDayQueriesStat,
   BusiestSecondStat,
   ErrorRateStat,
+  PercentileSelector,
 } from './traffic-stats'
+import { useState } from 'react'
 
 function SectionLabel({ title }: { readonly title: string }) {
   return (
@@ -42,8 +44,15 @@ export function StatsGrid({
   readonly hostId: number
   readonly lastHours?: number
 }) {
+  const [percentile, setPercentile] = useState('99')
+
   return (
     <div className="flex flex-col gap-4">
+      {/* Global percentile toggle */}
+      <div className="flex items-center justify-end">
+        <PercentileSelector value={percentile} onChange={setPercentile} />
+      </div>
+
       {/* Record Breakers */}
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
         <SectionLabel title="Record Breakers" />
@@ -85,7 +94,11 @@ export function StatsGrid({
         <BusiestDayQueriesStat hostId={hostId} lastHours={lastHours} />
         <BusiestDayBytesStat hostId={hostId} lastHours={lastHours} />
         <BusiestSecondStat hostId={hostId} lastHours={lastHours} />
-        <AvgDurationStat hostId={hostId} lastHours={lastHours} />
+        <AvgDurationStat
+          hostId={hostId}
+          lastHours={lastHours}
+          percentile={percentile}
+        />
       </div>
 
       {/* Error Rate */}

--- a/apps/dashboard/src/routes/(dashboard)/-insights/traffic-stats.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/-insights/traffic-stats.tsx
@@ -6,9 +6,44 @@ import {
   TimerIcon,
 } from 'lucide-react'
 
+import type { Dispatch, SetStateAction } from 'react'
+
 import { StatCard, statEmpty, statLoading } from './stat-card'
 import { useChartData } from '@/lib/query/use-chart-data'
-import { formatDuration } from '@/lib/utils'
+import { cn, formatDuration } from '@/lib/utils'
+
+const PERCENTILES = ['95', '99', '100'] as const
+
+export function PercentileSelector({
+  value,
+  onChange,
+}: {
+  readonly value: string
+  readonly onChange: Dispatch<SetStateAction<string>>
+}) {
+  return (
+    <div className="flex items-center gap-1.5 text-xs">
+      <span className="text-muted-foreground font-medium">Percentile</span>
+      <div className="flex rounded-lg border bg-muted p-0.5">
+        {PERCENTILES.map((p) => (
+          <button
+            key={p}
+            type="button"
+            onClick={() => onChange(p)}
+            className={cn(
+              'rounded-md px-2 py-1 text-xs font-medium transition-colors',
+              value === p
+                ? 'bg-background text-foreground shadow-xs'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            p{p}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
 
 function formatDay(day: string | Date): string {
   return new Date(day).toLocaleDateString('en-US', {
@@ -99,19 +134,28 @@ export function BusiestSecondStat({ hostId, lastHours }: RangeStatProps) {
   )
 }
 
-export function AvgDurationStat({ hostId, lastHours }: RangeStatProps) {
+interface PercentileStatProps extends RangeStatProps {
+  readonly percentile: string
+}
+
+export function AvgDurationStat({
+  hostId,
+  lastHours,
+  percentile,
+}: PercentileStatProps) {
   const { data, isLoading, error, sql, metadata } = useChartData({
     chartName: 'insight-avg-duration',
     hostId,
     lastHours,
+    params: { percentile },
   })
-  if (isLoading) return statLoading('Average Query Duration')
-  if (error || !data?.length)
-    return statEmpty('Average Query Duration', sql, data, metadata)
+  const label = `Average Query Duration (p${percentile})`
+  if (isLoading) return statLoading(label)
+  if (error || !data?.length) return statEmpty(label, sql, data, metadata)
   const d = data[0] as { avg_duration_ms: number; query_count: number }
   return (
     <StatCard
-      title="Average Query Duration"
+      title={label}
       icon={<TimerIcon className="size-3.5 text-indigo-500" />}
       sql={sql}
       data={data}


### PR DESCRIPTION
Add a segmented control (p95/p99/p100) to the insights page that switches the avg-duration stat card from `avg()` to `quantile()`/`max()`.

### Changes
- **insight-charts.ts**: Updated the `insight-avg-duration` chart builder to read `params.params?.percentile` and generate the correct SQL expression (quantile for p95/p99, max for p100)
- **traffic-stats.tsx**: Added `PercentileSelector` component (segmented control), updated `AvgDurationStat` to accept `percentile` prop and pass it as `params`
- **stats-grid.tsx**: Wired percentile state into `StatsGrid`, renders `PercentileSelector` at the top of the grid; default is p99

### Design
- Small segmented control in the insights page header, adjacent to the stat cards
- Default selection: p99
- Caching is automatic — TanStack Query key includes `JSON.stringify(params)` so switching percentile re-fetches

Closes #2345