### PR TITLE
fix(insights): apply percentile to Query Insights total cards and fix avg-duration p95 mapping

### DIFF
--- a/apps/dashboard/src/lib/api/charts/insight-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/insight-charts.ts
@@ -13,6 +13,18 @@ function percentileThreshold(percentile: string, column: string): string {
     : `quantile(0.${percentile})(${column})`
 }
 
+/**
+ * Build a WHERE filter that excludes queries whose duration exceeds the given
+ * percentile threshold. For p100 no filter is applied (include everything).
+ */
+function percentileDurationFilter(
+  percentile: string,
+  timeFilter: string
+): string {
+  if (percentile === '100') return ''
+  return `AND query_duration_ms <= (SELECT quantile(0.${percentile})(query_duration_ms) FROM system.query_log WHERE type = 'QueryFinish' AND is_initial_query = 1 ${timeFilter})`
+}
+
 export const insightCharts: Record<string, ChartQueryBuilder> = {
   'insight-largest-scan': (params) => {
     const timeFilter = buildTimeFilter(params.lastHours)
@@ -183,14 +195,11 @@ export const insightCharts: Record<string, ChartQueryBuilder> = {
     }
   },
 
-  // Query duration percentile (p95/p99/p100) — default p99
+  // Query duration percentile (p95/p99/p100)
   'insight-avg-duration': (params) => {
     const timeFilter = buildTimeFilter(params.lastHours)
-    const percentile = (params.params?.percentile as string) || 'p99'
-    const durationExpr =
-      percentile === 'p100'
-        ? 'max(query_duration_ms)'
-        : `quantile(${percentile === 'p95' ? '0.95' : '0.99'})(query_duration_ms)`
+    const percentile = (params.params?.percentile as string) || '99'
+    const durationExpr = percentileThreshold(percentile, 'query_duration_ms')
     return {
       query: `
         SELECT
@@ -224,6 +233,8 @@ export const insightCharts: Record<string, ChartQueryBuilder> = {
   // Total queries executed in the period
   'insight-total-queries': (params) => {
     const timeFilter = buildTimeFilter(params.lastHours)
+    const percentile = (params.params?.percentile as string) || '99'
+    const durationFilter = percentileDurationFilter(percentile, timeFilter)
     return {
       query: `
         SELECT
@@ -231,6 +242,7 @@ export const insightCharts: Record<string, ChartQueryBuilder> = {
           formatReadableQuantity(count()) as readable_count
         FROM system.query_log
         WHERE type = 'QueryFinish' AND is_initial_query = 1 ${timeFilter ? `AND ${timeFilter}` : ''}
+          ${durationFilter}
       `,
     }
   },
@@ -238,6 +250,8 @@ export const insightCharts: Record<string, ChartQueryBuilder> = {
   // Total data scanned across all queries
   'insight-total-scanned': (params) => {
     const timeFilter = buildTimeFilter(params.lastHours)
+    const percentile = (params.params?.percentile as string) || '99'
+    const durationFilter = percentileDurationFilter(percentile, timeFilter)
     return {
       query: `
         SELECT
@@ -245,6 +259,7 @@ export const insightCharts: Record<string, ChartQueryBuilder> = {
           formatReadableSize(sum(read_bytes)) as readable_total
         FROM system.query_log
         WHERE type = 'QueryFinish' AND is_initial_query = 1 ${timeFilter ? `AND ${timeFilter}` : ''}
+          ${durationFilter}
       `,
     }
   },
@@ -252,6 +267,8 @@ export const insightCharts: Record<string, ChartQueryBuilder> = {
   // Total rows read across all queries
   'insight-total-rows-read': (params) => {
     const timeFilter = buildTimeFilter(params.lastHours)
+    const percentile = (params.params?.percentile as string) || '99'
+    const durationFilter = percentileDurationFilter(percentile, timeFilter)
     return {
       query: `
         SELECT
@@ -259,6 +276,7 @@ export const insightCharts: Record<string, ChartQueryBuilder> = {
           formatReadableQuantity(sum(read_rows)) as readable_total
         FROM system.query_log
         WHERE type = 'QueryFinish' AND is_initial_query = 1 ${timeFilter ? `AND ${timeFilter}` : ''}
+          ${durationFilter}
       `,
     }
   },
@@ -266,6 +284,8 @@ export const insightCharts: Record<string, ChartQueryBuilder> = {
   // Peak memory usage across all completed queries
   'insight-peak-memory': (params) => {
     const timeFilter = buildTimeFilter(params.lastHours)
+    const percentile = (params.params?.percentile as string) || '99'
+    const durationFilter = percentileDurationFilter(percentile, timeFilter)
     return {
       query: `
         SELECT
@@ -273,6 +293,7 @@ export const insightCharts: Record<string, ChartQueryBuilder> = {
           formatReadableSize(max(memory_usage)) as readable_peak
         FROM system.query_log
         WHERE type = 'QueryFinish' AND is_initial_query = 1 ${timeFilter ? `AND ${timeFilter}` : ''}
+          ${durationFilter}
       `,
     }
   },

--- a/apps/dashboard/src/routes/(dashboard)/-insights/query-stats.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/-insights/query-stats.tsx
@@ -11,21 +11,28 @@ import { useChartData } from '@/lib/query/use-chart-data'
 interface RangeStatProps {
   readonly hostId: number
   readonly lastHours?: number
+  readonly percentile: string
 }
 
-export function TotalQueriesStat({ hostId, lastHours }: RangeStatProps) {
+export function TotalQueriesStat({
+  hostId,
+  lastHours,
+  percentile,
+}: RangeStatProps) {
   const { data, isLoading, error, sql, metadata } = useChartData({
     chartName: 'insight-total-queries',
     hostId,
     lastHours,
+    params: { percentile },
   })
   if (isLoading) return statLoading('Total Queries')
   if (error || !data?.length)
     return statEmpty('Total Queries', sql, data, metadata)
   const d = data[0] as { total_queries: number; readable_count: string }
+  const pLabel = percentile === '100' ? '' : ` (p${percentile})`
   return (
     <StatCard
-      title="Total Queries"
+      title={`Total Queries${pLabel}`}
       icon={<SearchIcon className="size-3.5 text-sky-500" />}
       sql={sql}
       data={data}
@@ -36,19 +43,25 @@ export function TotalQueriesStat({ hostId, lastHours }: RangeStatProps) {
   )
 }
 
-export function TotalScannedStat({ hostId, lastHours }: RangeStatProps) {
+export function TotalScannedStat({
+  hostId,
+  lastHours,
+  percentile,
+}: RangeStatProps) {
   const { data, isLoading, error, sql, metadata } = useChartData({
     chartName: 'insight-total-scanned',
     hostId,
     lastHours,
+    params: { percentile },
   })
   if (isLoading) return statLoading('Total Data Scanned')
   if (error || !data?.length)
     return statEmpty('Total Data Scanned', sql, data, metadata)
   const d = data[0] as { total_bytes: number; readable_total: string }
+  const pLabel = percentile === '100' ? '' : ` (p${percentile})`
   return (
     <StatCard
-      title="Total Data Scanned"
+      title={`Total Data Scanned${pLabel}`}
       icon={<HardDriveIcon className="size-3.5 text-violet-500" />}
       sql={sql}
       data={data}
@@ -59,19 +72,25 @@ export function TotalScannedStat({ hostId, lastHours }: RangeStatProps) {
   )
 }
 
-export function TotalRowsReadStat({ hostId, lastHours }: RangeStatProps) {
+export function TotalRowsReadStat({
+  hostId,
+  lastHours,
+  percentile,
+}: RangeStatProps) {
   const { data, isLoading, error, sql, metadata } = useChartData({
     chartName: 'insight-total-rows-read',
     hostId,
     lastHours,
+    params: { percentile },
   })
   if (isLoading) return statLoading('Total Rows Read')
   if (error || !data?.length)
     return statEmpty('Total Rows Read', sql, data, metadata)
   const d = data[0] as { total_rows: number; readable_total: string }
+  const pLabel = percentile === '100' ? '' : ` (p${percentile})`
   return (
     <StatCard
-      title="Total Rows Read"
+      title={`Total Rows Read${pLabel}`}
       icon={<ScrollTextIcon className="size-3.5 text-blue-500" />}
       sql={sql}
       data={data}
@@ -82,19 +101,25 @@ export function TotalRowsReadStat({ hostId, lastHours }: RangeStatProps) {
   )
 }
 
-export function PeakMemoryStat({ hostId, lastHours }: RangeStatProps) {
+export function PeakMemoryStat({
+  hostId,
+  lastHours,
+  percentile,
+}: RangeStatProps) {
   const { data, isLoading, error, sql, metadata } = useChartData({
     chartName: 'insight-peak-memory',
     hostId,
     lastHours,
+    params: { percentile },
   })
   if (isLoading) return statLoading('Peak Memory')
   if (error || !data?.length)
     return statEmpty('Peak Memory', sql, data, metadata)
   const d = data[0] as { peak_memory: number; readable_peak: string }
+  const pLabel = percentile === '100' ? '' : ` (p${percentile})`
   return (
     <StatCard
-      title="Peak Memory"
+      title={`Peak Memory${pLabel}`}
       icon={<MemoryStickIcon className="size-3.5 text-pink-500" />}
       sql={sql}
       data={data}

--- a/apps/dashboard/src/routes/(dashboard)/-insights/stats-grid.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/-insights/stats-grid.tsx
@@ -77,10 +77,26 @@ export function StatsGrid({
       {/* Query Insights */}
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
         <SectionLabel title="Query Insights" />
-        <TotalQueriesStat hostId={hostId} lastHours={lastHours} />
-        <TotalScannedStat hostId={hostId} lastHours={lastHours} />
-        <TotalRowsReadStat hostId={hostId} lastHours={lastHours} />
-        <PeakMemoryStat hostId={hostId} lastHours={lastHours} />
+        <TotalQueriesStat
+          hostId={hostId}
+          lastHours={lastHours}
+          percentile={percentile}
+        />
+        <TotalScannedStat
+          hostId={hostId}
+          lastHours={lastHours}
+          percentile={percentile}
+        />
+        <TotalRowsReadStat
+          hostId={hostId}
+          lastHours={lastHours}
+          percentile={percentile}
+        />
+        <PeakMemoryStat
+          hostId={hostId}
+          lastHours={lastHours}
+          percentile={percentile}
+        />
       </div>
 
       {/* Cluster Activity */}


### PR DESCRIPTION
## Summary

Extends the percentile selector to the four **Query Insights** cards (Total Queries, Total Data Scanned, Total Rows Read, Peak Memory) — previously only the Record Breaker cards considered the selected p95/p99/p100.

Also fixes a bug in  where it checked for `'p95'`/`'p99'` strings but `PercentileSelector` emits raw `'95'`/`'99'`, so p95 silently fell back to p99.

## Changes

1. **`insight-charts.ts`**: Added `percentileDurationFilter()` helper that excludes outlier queries beyond the selected percentile threshold. Applied it to all four Query Insights charts. Fixed `insight-avg-duration` to use the shared `percentileThreshold()` helper instead of the broken `'p95'`/`'p99'` check.

2. **`query-stats.tsx`**: Added `percentile` prop to all four components (`TotalQueriesStat`, `TotalScannedStat`, `TotalRowsReadStat`, `PeakMemoryStat`). Shows `(p95)`/`(p99)` label in the card title. P100 shows no label (includes all data).

3. **`stats-grid.tsx`**: Passes `percentile` state down to the Query Insights section.

## Testing

- Build passes (Vite build + tsc)
- All 906 tests pass