### PR TITLE
fix(insights): repair percentile SQL, compact empty states, query menu

### DIFF
--- a/apps/dashboard/src/components/charts/chart-empty.tsx
+++ b/apps/dashboard/src/components/charts/chart-empty.tsx
@@ -157,7 +157,7 @@ export const ChartEmpty = function ChartEmpty({
         className={cn(
           compact ? chartCard.contentCompact : chartCard.content,
           'relative flex flex-col items-center justify-center overflow-hidden',
-          compact ? 'py-2 min-h-[50px]' : 'py-6 sm:py-8'
+          compact ? 'py-1 px-2 min-h-[44px]' : 'py-6 sm:py-8'
         )}
       >
         {/* Grid pattern overlay */}
@@ -187,7 +187,12 @@ export const ChartEmpty = function ChartEmpty({
             compact ? 'text-[11px]' : 'text-sm'
           )}
         >
-          {title ? `${title} - No data` : 'No data available'}
+          {/* Compact cards already show the title in the header — keep body short. */}
+          {compact
+            ? 'No data'
+            : title
+              ? `${title} - No data`
+              : 'No data available'}
         </p>
 
         {!compact && (description || !title) && (

--- a/apps/dashboard/src/components/charts/chart-empty.tsx
+++ b/apps/dashboard/src/components/charts/chart-empty.tsx
@@ -156,7 +156,8 @@ export const ChartEmpty = function ChartEmpty({
       <CardContent
         className={cn(
           compact ? chartCard.contentCompact : chartCard.content,
-          'relative flex flex-col items-center justify-center py-6 sm:py-8 overflow-hidden'
+          'relative flex flex-col items-center justify-center overflow-hidden',
+          compact ? 'py-2 min-h-[50px]' : 'py-6 sm:py-8'
         )}
       >
         {/* Grid pattern overlay */}
@@ -164,30 +165,39 @@ export const ChartEmpty = function ChartEmpty({
 
         <div
           className={cn(
-            'mb-3 sm:mb-4 rounded-full p-3 transition-all duration-300 relative',
+            compact ? 'mb-1 p-1' : 'mb-3 sm:mb-4 p-3',
+            'rounded-full transition-all duration-300 relative',
             'bg-primary/5 dark:bg-primary/10 group-hover:bg-primary/10 dark:group-hover:bg-primary/20',
             'border border-primary/10 dark:border-primary/20 group-hover:border-primary/20 dark:group-hover:border-primary/30',
             'after:absolute after:inset-0 after:rounded-full after:bg-primary/20 after:blur-md after:opacity-0 group-hover:after:opacity-50 after:transition-opacity after:duration-300'
           )}
         >
           <Inbox
-            className="h-5 w-5 sm:h-6 sm:w-6 text-primary/60 dark:text-primary/50 group-hover:text-primary/80 group-hover:scale-110 transition-all duration-300"
+            className={cn(
+              compact ? 'h-3.5 w-3.5' : 'h-5 w-5 sm:h-6 sm:w-6',
+              'text-primary/60 dark:text-primary/50 group-hover:text-primary/80 group-hover:scale-110 transition-all duration-300'
+            )}
             strokeWidth={1.5}
           />
         </div>
 
-        <p className="text-sm font-medium text-muted-foreground text-center">
+        <p
+          className={cn(
+            'font-medium text-muted-foreground text-center',
+            compact ? 'text-[11px]' : 'text-sm'
+          )}
+        >
           {title ? `${title} - No data` : 'No data available'}
         </p>
 
-        {(description || !title) && (
+        {!compact && (description || !title) && (
           <p className="mt-1 text-xs text-muted-foreground/60 max-w-xs text-center leading-relaxed">
             {description ||
               'There is no data to display. This could be due to no activity in the selected time period.'}
           </p>
         )}
 
-        {onRetry && (
+        {!compact && onRetry && (
           <Button
             variant="outline"
             size="sm"
@@ -199,7 +209,7 @@ export const ChartEmpty = function ChartEmpty({
           </Button>
         )}
 
-        {suggestion && (
+        {!compact && suggestion && (
           <div className="mt-4 sm:mt-5 w-full max-w-xs interactive-element">
             <SuggestionCard suggestion={suggestion} />
           </div>

--- a/apps/dashboard/src/components/skeletons/chart.tsx
+++ b/apps/dashboard/src/components/skeletons/chart.tsx
@@ -3,7 +3,13 @@ import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { cn } from '@/lib/utils'
 
-export type ChartSkeletonType = 'area' | 'bar' | 'line' | 'metric' | 'table'
+export type ChartSkeletonType =
+  | 'area'
+  | 'bar'
+  | 'line'
+  | 'metric'
+  | 'table'
+  | 'stat'
 
 interface ChartSkeletonProps {
   className?: string
@@ -165,6 +171,14 @@ const MetricCardSkeleton = () => (
   </div>
 )
 
+/** Compact stat card skeleton */
+const StatSkeleton = () => (
+  <div className="flex flex-col gap-1.5 py-1 px-1">
+    <Skeleton className="h-6 w-24 opacity-80" />
+    <Skeleton className="h-3 w-32 opacity-50" />
+  </div>
+)
+
 /** Tabular skeleton mirroring actual tables */
 const TableSkeletonMini = () => (
   <div className="w-full h-full min-h-[140px] flex flex-col pt-1">
@@ -211,6 +225,8 @@ export const ChartSkeleton = function ChartSkeleton({
         return <MetricCardSkeleton />
       case 'table':
         return <TableSkeletonMini />
+      case 'stat':
+        return <StatSkeleton />
       default:
         return <AreaChartSkeleton />
     }

--- a/apps/dashboard/src/components/skeletons/chart.tsx
+++ b/apps/dashboard/src/components/skeletons/chart.tsx
@@ -268,7 +268,11 @@ export const ChartSkeleton = function ChartSkeleton({
       </CardHeader>
 
       <CardContent
-        className={cn(chartCard.content, 'relative overflow-hidden')}
+        className={cn(
+          type === 'stat' ? chartCard.contentCompact : chartCard.content,
+          'relative overflow-hidden',
+          type === 'stat' && 'py-1 px-2'
+        )}
       >
         {renderContent()}
       </CardContent>

--- a/apps/dashboard/src/lib/api/__tests__/charts/insight-charts.test.ts
+++ b/apps/dashboard/src/lib/api/__tests__/charts/insight-charts.test.ts
@@ -51,4 +51,43 @@ describe('insightCharts', () => {
       }
     }
   })
+
+  test('largest-scan uses single-pass aggregate and valid time filter', () => {
+    const result = insightCharts['insight-largest-scan']({
+      lastHours: 24,
+      params: { percentile: '99' },
+    })
+    expect('query' in result).toBe(true)
+    if (!('query' in result)) return
+    expect(result.query).toContain('quantileTDigest(0.99)(read_bytes)')
+    expect(result.query).toContain('AND event_time >=')
+    expect(result.query).toContain('read_bytes > 0')
+    // Aggregate evaluated once in a subquery, not twice in the SELECT list.
+    const matches = result.query.match(
+      /quantileTDigest\(0\.99\)\(read_bytes\)/g
+    )
+    expect(matches?.length).toBe(1)
+  })
+
+  test('largest-scan p100 uses max()', () => {
+    const result = insightCharts['insight-largest-scan']({
+      lastHours: 24,
+      params: { percentile: '100' },
+    })
+    if (!('query' in result)) throw new Error('expected query')
+    expect(result.query).toContain('max(read_bytes)')
+    expect(result.query).not.toContain('quantileTDigest')
+  })
+
+  test('total-queries percentile filter includes AND before time filter', () => {
+    const result = insightCharts['insight-total-queries']({
+      lastHours: 24,
+      params: { percentile: '99' },
+    })
+    if (!('query' in result)) throw new Error('expected query')
+    // Regression: missing AND produced invalid SQL like
+    // "is_initial_query = 1 event_time >="
+    expect(result.query).toMatch(/is_initial_query = 1\s+AND\s+event_time/)
+    expect(result.query).not.toMatch(/is_initial_query = 1\s+event_time/)
+  })
 })

--- a/apps/dashboard/src/lib/api/charts/insight-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/insight-charts.ts
@@ -7,22 +7,74 @@ import type { ChartQueryBuilder } from './types'
 
 import { buildTimeFilter } from '@/lib/clickhouse-query'
 
+/**
+ * Aggregate expression for a percentile (or max for p100).
+ * Uses quantileTDigest — lower memory than exact quantile on large query_log.
+ */
 function percentileThreshold(percentile: string, column: string): string {
   return percentile === '100'
     ? `max(${column})`
-    : `quantile(0.${percentile})(${column})`
+    : `quantileTDigest(0.${percentile})(${column})`
 }
 
 /**
  * Build a WHERE filter that excludes queries whose duration exceeds the given
  * percentile threshold. For p100 no filter is applied (include everything).
+ *
+ * `timeFilter` is a bare condition from buildTimeFilter (no leading AND).
  */
 function percentileDurationFilter(
   percentile: string,
   timeFilter: string
 ): string {
   if (percentile === '100') return ''
-  return `AND query_duration_ms <= (SELECT quantile(0.${percentile})(query_duration_ms) FROM system.query_log WHERE type = 'QueryFinish' AND is_initial_query = 1 ${timeFilter})`
+  const timeClause = timeFilter ? `AND ${timeFilter}` : ''
+  return `AND query_duration_ms <= (
+    SELECT ${percentileThreshold(percentile, 'query_duration_ms')}
+    FROM system.query_log
+    WHERE type = 'QueryFinish' AND is_initial_query = 1 ${timeClause}
+  )`
+}
+
+/** Shared WHERE for finished initial queries, optionally time-bounded. */
+function finishedQueryWhere(timeFilter: string, extra = ''): string {
+  const timeClause = timeFilter ? `AND ${timeFilter}` : ''
+  const extraClause = extra ? `AND ${extra}` : ''
+  return `type = 'QueryFinish' AND is_initial_query = 1 ${timeClause} ${extraClause}`
+}
+
+/**
+ * Single-pass aggregate card: compute the threshold once in a subquery, then
+ * format for display. Avoids evaluating max/quantile twice in the SELECT list.
+ */
+function scalarAggregateQuery(
+  thresholdExpr: string,
+  alias: string,
+  readableAlias: string,
+  where: string,
+  formatReadable = true
+): string {
+  if (formatReadable) {
+    return `
+      SELECT
+        formatReadableSize(v) AS ${readableAlias},
+        v AS ${alias}
+      FROM (
+        SELECT ${thresholdExpr} AS v
+        FROM system.query_log
+        WHERE ${where}
+      )
+    `
+  }
+  return `
+    SELECT
+      v AS ${alias}
+    FROM (
+      SELECT ${thresholdExpr} AS v
+      FROM system.query_log
+      WHERE ${where}
+    )
+  `
 }
 
 export const insightCharts: Record<string, ChartQueryBuilder> = {
@@ -31,13 +83,12 @@ export const insightCharts: Record<string, ChartQueryBuilder> = {
     const percentile = (params.params?.percentile as string) || '99'
     const threshold = percentileThreshold(percentile, 'read_bytes')
     return {
-      query: `
-        SELECT
-          formatReadableSize(${threshold}) as readable_bytes,
-          ${threshold} as read_bytes
-        FROM system.query_log
-        WHERE type = 'QueryFinish' AND is_initial_query = 1 ${timeFilter ? `AND ${timeFilter}` : ''}
-      `,
+      query: scalarAggregateQuery(
+        threshold,
+        'read_bytes',
+        'readable_bytes',
+        finishedQueryWhere(timeFilter, 'read_bytes > 0')
+      ),
     }
   },
 
@@ -47,13 +98,15 @@ export const insightCharts: Record<string, ChartQueryBuilder> = {
     const speedExpr = `read_bytes / greatest(query_duration_ms, 1) * 1000`
     const threshold = percentileThreshold(percentile, speedExpr)
     return {
-      query: `
-        SELECT
-          formatReadableSize(${threshold}) as readable_speed,
-          ${threshold} as bytes_per_second
-        FROM system.query_log
-        WHERE type = 'QueryFinish' AND is_initial_query = 1 AND query_duration_ms > 0 ${timeFilter ? `AND ${timeFilter}` : ''}
-      `,
+      query: scalarAggregateQuery(
+        threshold,
+        'bytes_per_second',
+        'readable_speed',
+        finishedQueryWhere(
+          timeFilter,
+          'query_duration_ms > 0 AND read_bytes > 0'
+        )
+      ),
     }
   },
 
@@ -62,12 +115,13 @@ export const insightCharts: Record<string, ChartQueryBuilder> = {
     const percentile = (params.params?.percentile as string) || '99'
     const threshold = percentileThreshold(percentile, 'query_duration_ms')
     return {
-      query: `
-        SELECT
-          ${threshold} as query_duration_ms
-        FROM system.query_log
-        WHERE type = 'QueryFinish' AND is_initial_query = 1 ${timeFilter ? `AND ${timeFilter}` : ''}
-      `,
+      query: scalarAggregateQuery(
+        threshold,
+        'query_duration_ms',
+        'readable_duration',
+        finishedQueryWhere(timeFilter),
+        false
+      ),
     }
   },
 
@@ -203,10 +257,10 @@ export const insightCharts: Record<string, ChartQueryBuilder> = {
     return {
       query: `
         SELECT
-          ${durationExpr} as avg_duration_ms,
-          count() as query_count
+          ${durationExpr} AS avg_duration_ms,
+          count() AS query_count
         FROM system.query_log
-        WHERE type = 'QueryFinish' AND is_initial_query = 1 ${timeFilter ? `AND ${timeFilter}` : ''}
+        WHERE ${finishedQueryWhere(timeFilter)}
       `,
     }
   },

--- a/apps/dashboard/src/lib/api/charts/insight-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/insight-charts.ts
@@ -13,6 +13,18 @@ function percentileThreshold(percentile: string, column: string): string {
     : `quantile(0.${percentile})(${column})`
 }
 
+/**
+ * Build a WHERE filter that excludes queries whose duration exceeds the given
+ * percentile threshold. For p100 no filter is applied (include everything).
+ */
+function percentileDurationFilter(
+  percentile: string,
+  timeFilter: string
+): string {
+  if (percentile === '100') return ''
+  return `AND query_duration_ms <= (SELECT quantile(0.${percentile})(query_duration_ms) FROM system.query_log WHERE type = 'QueryFinish' AND is_initial_query = 1 ${timeFilter})`
+}
+
 export const insightCharts: Record<string, ChartQueryBuilder> = {
   'insight-largest-scan': (params) => {
     const timeFilter = buildTimeFilter(params.lastHours)
@@ -183,14 +195,11 @@ export const insightCharts: Record<string, ChartQueryBuilder> = {
     }
   },
 
-  // Query duration percentile (p95/p99/p100) — default p99
+  // Query duration percentile (p95/p99/p100)
   'insight-avg-duration': (params) => {
     const timeFilter = buildTimeFilter(params.lastHours)
-    const percentile = (params.params?.percentile as string) || 'p99'
-    const durationExpr =
-      percentile === 'p100'
-        ? 'max(query_duration_ms)'
-        : `quantile(${percentile === 'p95' ? '0.95' : '0.99'})(query_duration_ms)`
+    const percentile = (params.params?.percentile as string) || '99'
+    const durationExpr = percentileThreshold(percentile, 'query_duration_ms')
     return {
       query: `
         SELECT
@@ -224,6 +233,8 @@ export const insightCharts: Record<string, ChartQueryBuilder> = {
   // Total queries executed in the period
   'insight-total-queries': (params) => {
     const timeFilter = buildTimeFilter(params.lastHours)
+    const percentile = (params.params?.percentile as string) || '99'
+    const durationFilter = percentileDurationFilter(percentile, timeFilter)
     return {
       query: `
         SELECT
@@ -231,6 +242,7 @@ export const insightCharts: Record<string, ChartQueryBuilder> = {
           formatReadableQuantity(count()) as readable_count
         FROM system.query_log
         WHERE type = 'QueryFinish' AND is_initial_query = 1 ${timeFilter ? `AND ${timeFilter}` : ''}
+          ${durationFilter}
       `,
     }
   },
@@ -238,6 +250,8 @@ export const insightCharts: Record<string, ChartQueryBuilder> = {
   // Total data scanned across all queries
   'insight-total-scanned': (params) => {
     const timeFilter = buildTimeFilter(params.lastHours)
+    const percentile = (params.params?.percentile as string) || '99'
+    const durationFilter = percentileDurationFilter(percentile, timeFilter)
     return {
       query: `
         SELECT
@@ -245,6 +259,7 @@ export const insightCharts: Record<string, ChartQueryBuilder> = {
           formatReadableSize(sum(read_bytes)) as readable_total
         FROM system.query_log
         WHERE type = 'QueryFinish' AND is_initial_query = 1 ${timeFilter ? `AND ${timeFilter}` : ''}
+          ${durationFilter}
       `,
     }
   },
@@ -252,6 +267,8 @@ export const insightCharts: Record<string, ChartQueryBuilder> = {
   // Total rows read across all queries
   'insight-total-rows-read': (params) => {
     const timeFilter = buildTimeFilter(params.lastHours)
+    const percentile = (params.params?.percentile as string) || '99'
+    const durationFilter = percentileDurationFilter(percentile, timeFilter)
     return {
       query: `
         SELECT
@@ -259,6 +276,7 @@ export const insightCharts: Record<string, ChartQueryBuilder> = {
           formatReadableQuantity(sum(read_rows)) as readable_total
         FROM system.query_log
         WHERE type = 'QueryFinish' AND is_initial_query = 1 ${timeFilter ? `AND ${timeFilter}` : ''}
+          ${durationFilter}
       `,
     }
   },
@@ -266,6 +284,8 @@ export const insightCharts: Record<string, ChartQueryBuilder> = {
   // Peak memory usage across all completed queries
   'insight-peak-memory': (params) => {
     const timeFilter = buildTimeFilter(params.lastHours)
+    const percentile = (params.params?.percentile as string) || '99'
+    const durationFilter = percentileDurationFilter(percentile, timeFilter)
     return {
       query: `
         SELECT
@@ -273,6 +293,7 @@ export const insightCharts: Record<string, ChartQueryBuilder> = {
           formatReadableSize(max(memory_usage)) as readable_peak
         FROM system.query_log
         WHERE type = 'QueryFinish' AND is_initial_query = 1 ${timeFilter ? `AND ${timeFilter}` : ''}
+          ${durationFilter}
       `,
     }
   },

--- a/apps/dashboard/src/lib/query/use-chart-data.ts
+++ b/apps/dashboard/src/lib/query/use-chart-data.ts
@@ -186,10 +186,21 @@ export function useChartData<T extends ChartDataPoint = ChartDataPoint>({
     }
   }, [error, hasData, isLoading])
 
+  // Prefer successful-response metadata; fall back to SQL attached on the
+  // thrown FetchError so empty/error cards can still open "review query".
+  const errorSql =
+    error && 'sql' in error && typeof error.sql === 'string'
+      ? error.sql
+      : undefined
+  const errorMetadata =
+    error && 'metadata' in error && error.metadata
+      ? (error.metadata as ChartMetadata)
+      : undefined
+
   return {
     data: dataArray ?? [],
-    metadata: data?.metadata,
-    sql: data?.metadata?.sql,
+    metadata: data?.metadata ?? errorMetadata,
+    sql: data?.metadata?.sql ?? errorSql,
     error: error ?? undefined,
     isLoading,
     isValidating,

--- a/apps/dashboard/src/lib/swr/fetch-error.ts
+++ b/apps/dashboard/src/lib/swr/fetch-error.ts
@@ -8,12 +8,20 @@ interface ApiErrorBody {
     type?: string
     details?: { missingTables?: readonly string[]; [key: string]: unknown }
   }
+  /** Present on chart/table error responses so the UI can still review SQL. */
+  metadata?: {
+    sql?: string
+    [key: string]: unknown
+  }
 }
 
 export interface FetchError extends Error {
   status?: number
   type?: string
   details?: { missingTables?: readonly string[]; [key: string]: unknown }
+  /** SQL from the failed request, when the API included it in the body. */
+  sql?: string
+  metadata?: ApiErrorBody['metadata']
 }
 
 export async function throwIfNotOk(
@@ -33,6 +41,13 @@ export async function throwIfNotOk(
   if (errorData.error) {
     error.type = errorData.error.type
     error.details = errorData.error.details
+  }
+
+  if (errorData.metadata) {
+    error.metadata = errorData.metadata
+    if (typeof errorData.metadata.sql === 'string') {
+      error.sql = errorData.metadata.sql
+    }
   }
 
   throw error

--- a/apps/dashboard/src/routes/(dashboard)/-insights/query-stats.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/-insights/query-stats.tsx
@@ -29,6 +29,14 @@ export function TotalQueriesStat({
   if (error || !data?.length)
     return statEmpty('Total Queries', sql, data, metadata)
   const d = data[0] as { total_queries: number; readable_count: string }
+  if (
+    d.total_queries === null ||
+    d.total_queries === undefined ||
+    d.readable_count === null ||
+    d.readable_count === undefined
+  ) {
+    return statEmpty('Total Queries', sql, data, metadata)
+  }
   const pLabel = percentile === '100' ? '' : ` (p${percentile})`
   return (
     <StatCard
@@ -58,6 +66,14 @@ export function TotalScannedStat({
   if (error || !data?.length)
     return statEmpty('Total Data Scanned', sql, data, metadata)
   const d = data[0] as { total_bytes: number; readable_total: string }
+  if (
+    d.total_bytes === null ||
+    d.total_bytes === undefined ||
+    d.readable_total === null ||
+    d.readable_total === undefined
+  ) {
+    return statEmpty('Total Data Scanned', sql, data, metadata)
+  }
   const pLabel = percentile === '100' ? '' : ` (p${percentile})`
   return (
     <StatCard
@@ -87,6 +103,14 @@ export function TotalRowsReadStat({
   if (error || !data?.length)
     return statEmpty('Total Rows Read', sql, data, metadata)
   const d = data[0] as { total_rows: number; readable_total: string }
+  if (
+    d.total_rows === null ||
+    d.total_rows === undefined ||
+    d.readable_total === null ||
+    d.readable_total === undefined
+  ) {
+    return statEmpty('Total Rows Read', sql, data, metadata)
+  }
   const pLabel = percentile === '100' ? '' : ` (p${percentile})`
   return (
     <StatCard
@@ -116,6 +140,14 @@ export function PeakMemoryStat({
   if (error || !data?.length)
     return statEmpty('Peak Memory', sql, data, metadata)
   const d = data[0] as { peak_memory: number; readable_peak: string }
+  if (
+    d.peak_memory === null ||
+    d.peak_memory === undefined ||
+    d.readable_peak === null ||
+    d.readable_peak === undefined
+  ) {
+    return statEmpty('Peak Memory', sql, data, metadata)
+  }
   const pLabel = percentile === '100' ? '' : ` (p${percentile})`
   return (
     <StatCard

--- a/apps/dashboard/src/routes/(dashboard)/-insights/query-stats.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/-insights/query-stats.tsx
@@ -11,21 +11,28 @@ import { useChartData } from '@/lib/query/use-chart-data'
 interface RangeStatProps {
   readonly hostId: number
   readonly lastHours?: number
+  readonly percentile: string
 }
 
-export function TotalQueriesStat({ hostId, lastHours }: RangeStatProps) {
+export function TotalQueriesStat({
+  hostId,
+  lastHours,
+  percentile,
+}: RangeStatProps) {
   const { data, isLoading, error, sql, metadata } = useChartData({
     chartName: 'insight-total-queries',
     hostId,
     lastHours,
+    params: { percentile },
   })
   if (isLoading) return statLoading('Total Queries')
   if (error || !data?.length)
     return statEmpty('Total Queries', sql, data, metadata)
   const d = data[0] as { total_queries: number; readable_count: string }
+  const pLabel = percentile === '100' ? '' : ` (p${percentile})`
   return (
     <StatCard
-      title="Total Queries"
+      title={`Total Queries${pLabel}`}
       icon={<SearchIcon className="size-3.5 text-sky-500" />}
       sql={sql}
       data={data}
@@ -36,19 +43,25 @@ export function TotalQueriesStat({ hostId, lastHours }: RangeStatProps) {
   )
 }
 
-export function TotalScannedStat({ hostId, lastHours }: RangeStatProps) {
+export function TotalScannedStat({
+  hostId,
+  lastHours,
+  percentile,
+}: RangeStatProps) {
   const { data, isLoading, error, sql, metadata } = useChartData({
     chartName: 'insight-total-scanned',
     hostId,
     lastHours,
+    params: { percentile },
   })
   if (isLoading) return statLoading('Total Data Scanned')
   if (error || !data?.length)
     return statEmpty('Total Data Scanned', sql, data, metadata)
   const d = data[0] as { total_bytes: number; readable_total: string }
+  const pLabel = percentile === '100' ? '' : ` (p${percentile})`
   return (
     <StatCard
-      title="Total Data Scanned"
+      title={`Total Data Scanned${pLabel}`}
       icon={<HardDriveIcon className="size-3.5 text-violet-500" />}
       sql={sql}
       data={data}
@@ -59,19 +72,25 @@ export function TotalScannedStat({ hostId, lastHours }: RangeStatProps) {
   )
 }
 
-export function TotalRowsReadStat({ hostId, lastHours }: RangeStatProps) {
+export function TotalRowsReadStat({
+  hostId,
+  lastHours,
+  percentile,
+}: RangeStatProps) {
   const { data, isLoading, error, sql, metadata } = useChartData({
     chartName: 'insight-total-rows-read',
     hostId,
     lastHours,
+    params: { percentile },
   })
   if (isLoading) return statLoading('Total Rows Read')
   if (error || !data?.length)
     return statEmpty('Total Rows Read', sql, data, metadata)
   const d = data[0] as { total_rows: number; readable_total: string }
+  const pLabel = percentile === '100' ? '' : ` (p${percentile})`
   return (
     <StatCard
-      title="Total Rows Read"
+      title={`Total Rows Read${pLabel}`}
       icon={<ScrollTextIcon className="size-3.5 text-blue-500" />}
       sql={sql}
       data={data}
@@ -82,19 +101,25 @@ export function TotalRowsReadStat({ hostId, lastHours }: RangeStatProps) {
   )
 }
 
-export function PeakMemoryStat({ hostId, lastHours }: RangeStatProps) {
+export function PeakMemoryStat({
+  hostId,
+  lastHours,
+  percentile,
+}: RangeStatProps) {
   const { data, isLoading, error, sql, metadata } = useChartData({
     chartName: 'insight-peak-memory',
     hostId,
     lastHours,
+    params: { percentile },
   })
   if (isLoading) return statLoading('Peak Memory')
   if (error || !data?.length)
     return statEmpty('Peak Memory', sql, data, metadata)
   const d = data[0] as { peak_memory: number; readable_peak: string }
+  const pLabel = percentile === '100' ? '' : ` (p${percentile})`
   return (
     <StatCard
-      title="Peak Memory"
+      title={`Peak Memory${pLabel}`}
       icon={<MemoryStickIcon className="size-3.5 text-pink-500" />}
       sql={sql}
       data={data}

--- a/apps/dashboard/src/routes/(dashboard)/-insights/record-stats.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/-insights/record-stats.tsx
@@ -106,7 +106,7 @@ export function LongestQueryStat({
   if (
     d.query_duration_ms === null ||
     d.query_duration_ms === undefined ||
-    isNaN(Number(d.query_duration_ms))
+    Number.isNaN(Number(d.query_duration_ms))
   ) {
     return statEmpty(label, sql, data, metadata)
   }

--- a/apps/dashboard/src/routes/(dashboard)/-insights/record-stats.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/-insights/record-stats.tsx
@@ -28,12 +28,15 @@ export function LargestScanStat({
   if (isLoading) return statLoading(label)
   if (error || !data?.length) return statEmpty(label, sql, data, metadata)
   const d = data[0] as Record<string, unknown>
+  const readable = d.readable_bytes
+  const bytes = d.read_bytes
   if (
-    d.read_bytes === null ||
-    d.read_bytes === undefined ||
-    d.readable_bytes === null ||
-    d.readable_bytes === undefined ||
-    d.readable_bytes === 'NaN'
+    bytes === null ||
+    bytes === undefined ||
+    Number.isNaN(Number(bytes)) ||
+    readable === null ||
+    readable === undefined ||
+    String(readable).toLowerCase() === 'nan'
   ) {
     return statEmpty(label, sql, data, metadata)
   }
@@ -44,7 +47,7 @@ export function LargestScanStat({
       sql={sql}
       data={data}
       metadata={metadata}
-      value={String(d.readable_bytes)}
+      value={String(readable)}
     />
   )
 }

--- a/apps/dashboard/src/routes/(dashboard)/-insights/record-stats.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/-insights/record-stats.tsx
@@ -28,6 +28,15 @@ export function LargestScanStat({
   if (isLoading) return statLoading(label)
   if (error || !data?.length) return statEmpty(label, sql, data, metadata)
   const d = data[0] as Record<string, unknown>
+  if (
+    d.read_bytes === null ||
+    d.read_bytes === undefined ||
+    d.readable_bytes === null ||
+    d.readable_bytes === undefined ||
+    d.readable_bytes === 'NaN'
+  ) {
+    return statEmpty(label, sql, data, metadata)
+  }
   return (
     <StatCard
       title={label}
@@ -55,6 +64,15 @@ export function FastestScanStat({
   if (isLoading) return statLoading(label)
   if (error || !data?.length) return statEmpty(label, sql, data, metadata)
   const d = data[0] as Record<string, unknown>
+  if (
+    d.bytes_per_second === null ||
+    d.bytes_per_second === undefined ||
+    d.readable_speed === null ||
+    d.readable_speed === undefined ||
+    d.readable_speed === 'NaN'
+  ) {
+    return statEmpty(label, sql, data, metadata)
+  }
   return (
     <StatCard
       title={label}
@@ -82,6 +100,13 @@ export function LongestQueryStat({
   if (isLoading) return statLoading(label)
   if (error || !data?.length) return statEmpty(label, sql, data, metadata)
   const d = data[0] as Record<string, unknown>
+  if (
+    d.query_duration_ms === null ||
+    d.query_duration_ms === undefined ||
+    isNaN(Number(d.query_duration_ms))
+  ) {
+    return statEmpty(label, sql, data, metadata)
+  }
   return (
     <StatCard
       title={label}
@@ -103,6 +128,14 @@ export function TotalStorageStat({ hostId }: { readonly hostId: number }) {
   if (error || !data?.length)
     return statEmpty('Total Storage', sql, data, metadata)
   const d = data[0] as Record<string, unknown>
+  if (
+    d.total_compressed === null ||
+    d.total_compressed === undefined ||
+    d.total_tables === null ||
+    d.total_tables === undefined
+  ) {
+    return statEmpty('Total Storage', sql, data, metadata)
+  }
   return (
     <StatCard
       title="Total Storage"

--- a/apps/dashboard/src/routes/(dashboard)/-insights/stat-card.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/-insights/stat-card.tsx
@@ -12,7 +12,7 @@ export function statLoading(title: string) {
     <ChartSkeleton
       title={title}
       type="stat"
-      className="min-h-[90px]"
+      className="min-h-[72px]"
       headerClassName="py-1"
     />
   )
@@ -32,7 +32,7 @@ export function statEmpty(
       data={data}
       metadata={metadata}
       compact
-      className="min-h-[90px]"
+      className="min-h-[72px]"
       headerClassName="py-1"
     />
   )

--- a/apps/dashboard/src/routes/(dashboard)/-insights/stat-card.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/-insights/stat-card.tsx
@@ -8,7 +8,14 @@ import { ChartSkeleton } from '@/components/skeletons/chart'
 
 /** Skeleton shown while a stat's chart data is loading. */
 export function statLoading(title: string) {
-  return <ChartSkeleton title={title} headerClassName="py-1" />
+  return (
+    <ChartSkeleton
+      title={title}
+      type="stat"
+      className="min-h-[90px]"
+      headerClassName="py-1"
+    />
+  )
 }
 
 /** Empty / error state shown when a stat has no data. */
@@ -25,6 +32,7 @@ export function statEmpty(
       data={data}
       metadata={metadata}
       compact
+      className="min-h-[90px]"
       headerClassName="py-1"
     />
   )

--- a/apps/dashboard/src/routes/(dashboard)/-insights/stats-grid.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/-insights/stats-grid.tsx
@@ -77,10 +77,26 @@ export function StatsGrid({
       {/* Query Insights */}
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
         <SectionLabel title="Query Insights" />
-        <TotalQueriesStat hostId={hostId} lastHours={lastHours} />
-        <TotalScannedStat hostId={hostId} lastHours={lastHours} />
-        <TotalRowsReadStat hostId={hostId} lastHours={lastHours} />
-        <PeakMemoryStat hostId={hostId} lastHours={lastHours} />
+        <TotalQueriesStat
+          hostId={hostId}
+          lastHours={lastHours}
+          percentile={percentile}
+        />
+        <TotalScannedStat
+          hostId={hostId}
+          lastHours={lastHours}
+          percentile={percentile}
+        />
+        <TotalRowsReadStat
+          hostId={hostId}
+          lastHours={lastHours}
+          percentile={percentile}
+        />
+        <PeakMemoryStat
+          hostId={hostId}
+          lastHours={lastHours}
+          percentile={percentile}
+        />
       </div>
 
       {/* Cluster Activity */}

--- a/apps/dashboard/src/routes/api/v1/charts/$name.ts
+++ b/apps/dashboard/src/routes/api/v1/charts/$name.ts
@@ -314,6 +314,7 @@ export async function handler(
           duration: 0,
           rows: 0,
           host: String(hostId),
+          sql: result.executedSql.trim(),
           unavailable: {
             reason: 'table_not_found',
             message: result.error.message,
@@ -338,6 +339,8 @@ export async function handler(
       // Preserve the client's classification (e.g. an unreachable upstream is
       // ssl_error/network_error → 503) instead of flattening every failure to a
       // 500. See statusForFetchDataError for the rationale.
+      // Always include metadata.sql so empty/error cards can still open the
+      // "review query" toolbar even when the host rejects the query.
       return Response.json(
         {
           success: false,
@@ -345,6 +348,14 @@ export async function handler(
             type: result.error.type,
             message: result.error.message,
             details: result.error.details,
+          },
+          metadata: {
+            queryId: '',
+            duration: 0,
+            rows: 0,
+            host: String(hostId),
+            sql: result.executedSql.trim(),
+            clickhouseVersion: result.clickhouseVersion,
           },
         },
         { status: statusForFetchDataError(result.error.type) }

--- a/apps/dashboard/src/routes/api/v1/charts/__tests__/name.test.ts
+++ b/apps/dashboard/src/routes/api/v1/charts/__tests__/name.test.ts
@@ -145,9 +145,12 @@ describe('GET /api/v1/charts/$name — optional table degradation', () => {
     const body = (await response.json()) as {
       success: boolean
       error: { type: string; message: string }
+      metadata?: { sql?: string }
     }
     expect(body.success).toBe(false)
     expect(body.error.type).toBe('query_error')
+    // SQL stays available so empty/error cards can open "review query".
+    expect(body.metadata?.sql).toBe('SELECT 1')
   })
 
   test('unreachable upstream (525/ssl_error) → 503, not 500', async () => {

--- a/scripts/migrate-ae-to-d1.ts
+++ b/scripts/migrate-ae-to-d1.ts
@@ -26,20 +26,20 @@ async function queryAE(sql: string): Promise<unknown[]> {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${CF_API_TOKEN}`,
-      'Content-Type': 'application/json',
+      'Content-Type': 'text/plain',
     },
-    body: JSON.stringify({ query: sql }),
+    body: sql,
   })
-  const json = (await res.json()) as {
-    success: boolean
-    result: unknown[]
-    errors?: unknown[]
-  }
-  if (!json.success) {
-    console.error('AE query failed:', json.errors)
+  if (!res.ok) {
+    console.error(`AE query failed: HTTP ${res.status} ${await res.text()}`)
     return []
   }
-  return json.result as unknown[]
+  const json = (await res.json()) as {
+    meta: unknown[]
+    data: Record<string, string>[]
+    rows: number
+  }
+  return json.data ?? []
 }
 
 async function executeD1(sql: string): Promise<void> {
@@ -82,7 +82,7 @@ async function migratePings() {
       blob6 AS platform,
       blob7 AS chm_version,
       blob8 AS install_place,
-      toTimestamp(timestamp) AS timestamp
+      timestamp
     FROM ${AE_DATASET}
     WHERE blob1 = 'ping'
     ORDER BY timestamp
@@ -155,7 +155,7 @@ async function migrateEvents() {
       blob3 AS deploy_target,
       blob4 AS ch_version,
       blob5 AS ch_flavor,
-      toTimestamp(timestamp) AS timestamp
+      timestamp
     FROM ${AE_DATASET}
     WHERE blob1 = 'event'
     ORDER BY timestamp


### PR DESCRIPTION
## Summary
- **Largest Scan / percentile cards**: fixed invalid SQL in `percentileDurationFilter` (missing `AND` before the time filter), switched record-breaker aggregates to single-pass `max` / `quantileTDigest`, and filter out zero-byte scans.
- **Empty / error cards**: chart API error responses now include `metadata.sql`; client hooks surface it so the review-query toolbar stays available with no data.
- **Compact UI**: smaller padding/min-height on insights stat skeletons and empty states.

## Test plan
- [x] `bun test` insight-charts + charts `$name` unit tests
- [ ] Open `/insights?host=0`, toggle p95/p99/p100 — Largest Scan should return a value when the host is healthy
- [ ] With host down / query error, empty cards still show the ⋮ menu and SQL
- [ ] Empty/skeleton cards match loaded card height (~compact)