### PR TITLE
style(landing): Geist tokens + x.ai monochrome hero

### DIFF
--- a/apps/landing/src/components/FinalCta.astro
+++ b/apps/landing/src/components/FinalCta.astro
@@ -1,29 +1,47 @@
-<section class="pt-6 pb-20 sm:pb-24">
-  <div class="mx-auto max-w-6xl px-6">
-    <!-- Deliberately dark in BOTH themes: a spotlight CTA band anchored by the
-         dark hero image. Colors are fixed (not theme tokens) so light mode keeps
-         the same dark look. -->
-    <div class="reveal relative isolate overflow-hidden rounded-xl bg-neutral-950 shadow-sm">
-      <div class="absolute inset-0 -z-10" aria-hidden="true">
-        <img src="/landing-assets/hero-cmyk-3.jpg" alt="" width="2752" height="1536" loading="lazy" decoding="async" class="h-full w-full object-cover object-center" />
-      </div>
-      <div aria-hidden="true" class="absolute inset-0 -z-10 bg-gradient-to-b from-black/70 via-black/40 to-black/80"></div>
+<section class="pt-6 pb-20 sm:pb-28">
+  <div class="mx-auto max-w-[1200px] px-6">
+    <!-- Fixed pure-black CTA (x.ai field) — monochrome, no brand accent color. -->
+    <div class="reveal relative isolate overflow-hidden rounded-2xl border border-white/10 bg-black">
+      <div
+        class="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(ellipse_60%_50%_at_50%_0%,rgba(255,255,255,0.08),transparent_70%)]"
+        aria-hidden="true"
+      ></div>
 
-      <div class="relative mx-auto max-w-2xl px-6 py-16 text-center sm:py-22">
-        <span class="mb-5 flex justify-center" aria-hidden="true">
-          <img src="/brand/logo-mark.svg" alt="chmonitor" class="size-10" />
+      <div class="relative mx-auto max-w-2xl px-6 py-16 text-center sm:py-20">
+        <span class="mb-6 flex justify-center" aria-hidden="true">
+          <img src="/brand/logo-mark.svg" alt="" class="size-9 opacity-90" />
         </span>
-        <h2 class="text-balance font-semibold text-3xl text-white tracking-tight sm:text-4xl">Start monitoring — with an <span class="text-[#3b82f6]">advisor</span> and <span class="text-[#3b82f6]">alerts</span> built in</h2>
-        <p class="mt-4 text-pretty text-white/70">Open the hosted dashboard and connect a cluster, or self-host with Docker, Kubernetes, or from source. Self-hosting is always free.</p>
-        <div class="mt-8 flex flex-wrap items-center justify-center gap-3">
-          <a class="inline-flex items-center justify-center gap-2 rounded-md bg-primary px-6 h-10 text-sm font-medium text-primary-foreground shadow-xs transition-all hover:bg-primary/90 active:scale-[.98]" href="https://dash.chmonitor.dev" target="_blank" rel="noopener" data-cta="final-primary">
-            Open dashboard
+        <h2 class="text-balance font-semibold text-3xl text-white tracking-[-0.04em] sm:text-4xl">
+          Start monitoring — advisor and alerts built in
+        </h2>
+        <p class="mt-4 text-pretty text-white/55 text-base leading-relaxed">
+          Open the hosted dashboard and connect a cluster, or self-host with Docker, Kubernetes, or from source. Self-hosting is always free.
+        </p>
+        <div class="mt-8 flex flex-wrap items-center justify-center gap-2.5">
+          <a
+            class="inline-flex items-center justify-center gap-2 rounded-md bg-white px-5 h-10 text-sm font-medium text-black transition-colors hover:bg-white/90 active:scale-[.98]"
+            href="https://dash.chmonitor.dev"
+            target="_blank"
+            rel="noopener"
+            data-cta="final-primary"
+          >
+            Open Dashboard
             <svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
           </a>
-          <a class="inline-flex items-center justify-center gap-2 rounded-md border border-white/20 bg-white/10 px-6 h-10 text-sm font-medium text-white shadow-xs backdrop-blur-sm transition-all hover:bg-white/20 active:scale-[.98]" href="https://docs.chmonitor.dev" target="_blank" rel="noopener">
-            Read the docs
+          <a
+            class="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/5 px-5 h-10 text-sm font-medium text-white transition-colors hover:bg-white/10 active:scale-[.98]"
+            href="https://docs.chmonitor.dev"
+            target="_blank"
+            rel="noopener"
+          >
+            Read the Docs
           </a>
-          <a class="inline-flex items-center justify-center gap-2 rounded-md border border-white/20 bg-white/10 px-6 h-10 text-sm font-medium text-white shadow-xs backdrop-blur-sm transition-all hover:bg-white/20 active:scale-[.98]" href="https://github.com/chmonitor/chmonitor" target="_blank" rel="noopener">
+          <a
+            class="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/5 px-5 h-10 text-sm font-medium text-white transition-colors hover:bg-white/10 active:scale-[.98]"
+            href="https://github.com/chmonitor/chmonitor"
+            target="_blank"
+            rel="noopener"
+          >
             <svg class="size-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49l-.01-1.9c-2.78.62-3.37-1.2-3.37-1.2-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.36-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.4 9.4 0 0 1 5 0c1.91-1.32 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.35 4.8-4.58 5.06.36.32.68.94.68 1.9l-.01 2.82c0 .27.18.6.69.49A10.03 10.03 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"/></svg>
             GitHub
           </a>

--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -1,5 +1,4 @@
 ---
-import { HERO_SLOGANS } from '../lib/hero-slogans'
 import { formatCount, getGitHubStats } from '../lib/github-stars'
 
 const { stars } = await getGitHubStats()
@@ -14,22 +13,32 @@ const HERO_FEATURES = [
   'AI advisor for schema and tuning — MCP-ready, read-only default',
 ] as const
 
-const checkSvg = `<svg class="mt-0.5 size-4 shrink-0 text-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m5 12 5 5L20 7"/></svg>`
+const checkSvg = `<svg class="mt-0.5 size-3.5 shrink-0 text-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m5 12 5 5L20 7"/></svg>`
 const arrowSvg = `<svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>`
 const bookSvg = `<svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 7v14"/><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"/></svg>`
 const starSvg = `<svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z"/></svg>`
-const githubSvg = `<svg class="size-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49l-.01-1.9c-2.78.62-3.37-1.2-3.37-1.2-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.36-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.4 9.4 0 0 1 5 0c1.91-1.32 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.35 4.8-4.58 5.06.36.32.68.94.68 1.9l-.01 2.82c0 .27.18.6.69.49A10.03 10.03 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"/></svg>`
+const githubSvg = `<svg class="size-3.5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49l-.01-1.9c-2.78.62-3.37-1.2-3.37-1.2-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.36-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.4 9.4 0 0 1 5 0c1.91-1.32 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.35 4.8-4.58 5.06.36.32.68.94.68 1.9l-.01 2.82c0 .27.18.6.69.49A10.03 10.03 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"/></svg>`
 
+/* shadcn Button classes (Geist: 40px, 6px radius, medium weight) */
 const btnPrimary =
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-primary px-6 h-10 text-sm font-medium text-primary-foreground shadow-xs transition-all hover:bg-primary/90 active:scale-[.98] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50'
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-primary px-5 h-10 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 active:scale-[.98] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50'
 const btnOutline =
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md border border-input bg-background px-6 h-10 text-sm font-medium shadow-xs transition-all hover:bg-accent active:scale-[.98] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50'
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md border border-input bg-background px-5 h-10 text-sm font-medium transition-colors hover:bg-accent active:scale-[.98] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50'
 const btnGhost =
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md px-6 h-10 text-sm font-medium transition-all hover:bg-accent hover:text-accent-foreground active:scale-[.98] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50'
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md px-4 h-10 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground active:scale-[.98] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50'
 ---
 
-<section class="relative isolate overflow-hidden pb-16 sm:pb-20" data-hero>
-  <div class="relative mx-auto max-w-6xl px-6 pt-16 sm:pt-20 lg:pt-24">
+<section class="relative isolate overflow-hidden pb-20 sm:pb-28" data-hero>
+  <!-- x.ai-style ambient field: faint radial + grid, no color noise -->
+  <div
+    class="pointer-events-none absolute inset-0 -z-10"
+    aria-hidden="true"
+  >
+    <div class="absolute inset-0 bg-[radial-gradient(ellipse_80%_50%_at_50%_-20%,rgba(120,120,120,0.12),transparent_60%)] dark:bg-[radial-gradient(ellipse_70%_45%_at_50%_-10%,rgba(255,255,255,0.08),transparent_55%)]"></div>
+    <div class="absolute inset-0 opacity-[0.35] dark:opacity-[0.2] [background-image:linear-gradient(to_right,rgba(128,128,128,0.06)_1px,transparent_1px),linear-gradient(to_bottom,rgb(128,128,128,0.06)_1px,transparent_1px)] [background-size:64px_64px] [mask-image:radial-gradient(ellipse_70%_60%_at_50%_0%,#000_40%,transparent_100%)]"></div>
+  </div>
+
+  <div class="relative mx-auto max-w-[1200px] px-6 pt-20 sm:pt-28 lg:pt-32">
     <div class="mx-auto max-w-3xl text-center">
       <a
         href="https://github.com/chmonitor/chmonitor"
@@ -38,21 +47,21 @@ const btnGhost =
         class="inline-flex"
         data-hero-oss
       >
-        <span class="inline-flex items-center gap-2 rounded-full border border-border bg-neutral-100 dark:bg-neutral-800 px-4 py-1.5 text-neutral-800 text-sm font-medium dark:text-neutral-200">
-          <span class="inline-flex items-center justify-center size-4 shrink-0" set:html={githubSvg} />
+        <span class="inline-flex items-center gap-2 rounded-full border border-border bg-background/80 px-3 py-1 text-muted-foreground text-xs font-medium tracking-wide backdrop-blur-sm transition-colors hover:border-foreground/20 hover:text-foreground">
+          <span class="inline-flex items-center justify-center size-3.5 shrink-0" set:html={githubSvg} />
           Open source · GPL-3.0 · self-host free
         </span>
       </a>
 
-      <h1 class="mt-8 text-balance font-extrabold text-[clamp(2.5rem,6vw,4.25rem)] text-foreground leading-[1.1] tracking-[-0.05em]">
-        The ops dashboard for ClickHouse.
+      <h1 class="mt-10 text-balance font-semibold text-[clamp(2.75rem,7vw,4.5rem)] text-foreground leading-[0.98] tracking-[-0.06em]">
+        The ops dashboard<br class="hidden sm:block" /> for ClickHouse.
       </h1>
 
-      <p class="mx-auto mt-6 max-w-xl text-pretty text-muted-foreground text-lg leading-relaxed sm:text-xl font-normal">
-        An open-source dashboard to monitor ClickHouse. Reads system tables directly — queries, merges, parts, replication, health, and an AI advisor.
+      <p class="mx-auto mt-7 max-w-xl text-pretty text-muted-foreground text-base leading-relaxed sm:text-lg font-normal">
+        Monitor queries, merges, parts, replication, and health. An AI advisor on top — open source, self-host free.
       </p>
 
-      <div class="mt-6 flex flex-wrap items-center justify-center gap-2.5">
+      <div class="mt-8 flex flex-wrap items-center justify-center gap-2.5">
         <a
           href="https://dash.chmonitor.dev"
           target="_blank"
@@ -60,7 +69,7 @@ const btnGhost =
           data-cta="hero-primary"
           class={btnPrimary}
         >
-          Start free
+          Start Free
           <span class="inline-flex items-center justify-center size-4 shrink-0" set:html={arrowSvg} />
         </a>
         <a
@@ -71,7 +80,7 @@ const btnGhost =
           class={btnOutline}
         >
           <span class="inline-flex items-center justify-center size-4 shrink-0" set:html={bookSvg} />
-          Self-host
+          Self-Host
         </a>
         {
           starLabel ? (
@@ -91,14 +100,14 @@ const btnGhost =
     </div>
 
     <ul
-      class="mx-auto mt-12 grid max-w-3xl list-none gap-x-8 gap-y-3 sm:grid-cols-2"
+      class="mx-auto mt-16 grid max-w-3xl list-none gap-x-10 gap-y-3.5 sm:grid-cols-2 border-t border-border pt-10"
       data-hero-features
     >
       {
         HERO_FEATURES.map((feature) => (
-          <li class="flex gap-2.5 text-left text-foreground text-sm leading-snug">
+          <li class="flex gap-2.5 text-left text-muted-foreground text-sm leading-snug">
             <span set:html={checkSvg} />
-            {feature}
+            <span class="text-foreground/90">{feature}</span>
           </li>
         ))
       }

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -33,7 +33,7 @@ const ogImage = new URL(image, Astro.site).toString()
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
   <link rel="manifest" href="/site.webmanifest" />
-  <meta name="theme-color" content="#2563eb" />
+  <meta name="theme-color" content="#000000" />
   <meta name="twitter:site" content="@chmonitor" />
   <script type="application/ld+json" set:html={JSON.stringify({
     "@context": "https://schema.org",
@@ -93,68 +93,64 @@ const ogImage = new URL(image, Astro.site).toString()
        `a{color:inherit}` beat EVERY Tailwind margin/padding/text-color utility
        (unlayered rules win over any layered rule), breaking the shadcn sections. */
     @layer base {
+    /* Geist (vercel.com/design.md) + x.ai monochrome field.
+       Light: white / gray-1000. Dark: pure black, white type. */
     :root{
       --bg:#ffffff;
       --bg-soft:#fafafa;
-      --fg:#09090b;
-      --fg-soft:#3f3f46;
-      --muted-fg:#71717a;
-      --border:#e7e7ea;
-      --border-soft:#f1f1f3;
-      --border-hover:#dcdce0;
-      --muted:#f4f4f5;
-      /* card/elevated surface — flips dark in the dark-mode block below */
+      --fg:#171717;
+      --fg-soft:#4d4d4d;
+      --muted-fg:#666666;
+      --border:#eaeaea;
+      --border-soft:#f2f2f2;
+      --border-hover:#c9c9c9;
+      --muted:#f2f2f2;
       --card:#ffffff;
-      --nav-bg:rgba(255,255,255,.78);
-      --browser-bar:#fbfbfc;
-      /* primary button is a token PAIR so it never inverts to light-on-light */
-      --btn-primary-bg:#09090b;
-      --btn-primary-bg-hover:#26262b;
+      --nav-bg:rgba(255,255,255,.80);
+      --browser-bar:#fafafa;
+      --btn-primary-bg:#171717;
+      --btn-primary-bg-hover:#000000;
       --btn-primary-fg:#ffffff;
-      /* Brand accent — neutral black/white for a clean aesthetic. */
-      --primary:#1a1a1a;
+      --primary:#171717;
       --primary-fg:#ffffff;
       --orange:var(--primary);
-      --amber:#71717a;
-      --emerald:#1a1a1a;
-      --violet:#71717a;
-      --blue:#1a1a1a;
-      --radius:12px;
-      --maxw:1140px;
-      --shadow-card:0 1px 2px rgba(9,9,11,.04), 0 1px 0 rgba(9,9,11,.02);
-      --shadow-float:0 24px 60px -28px rgba(9,9,11,.30), 0 8px 24px -16px rgba(9,9,11,.18);
+      --amber:#666666;
+      --emerald:#171717;
+      --violet:#666666;
+      --blue:#171717;
+      /* Geist everyday radius */
+      --radius:6px;
+      --maxw:1200px;
+      --shadow-card:0 2px 2px rgba(0,0,0,.04);
+      --shadow-float:0 1px 1px rgba(0,0,0,.02), 0 4px 8px -4px rgba(0,0,0,.04), 0 16px 24px -8px rgba(0,0,0,.06);
       --shadow-glow:none;
     }
-    /* ── dark mode: tokens flip, layout unchanged. Applied when
-       html[data-theme="dark"]. The head script resolves the saved choice / OS
-       preference to a concrete data-theme before paint; the nav toggle flips it.
-       Single token block — no duplication. Off-black (no pure #000), cool-gray. ── */
     :root[data-theme="dark"]{
-      --bg:#0b0b0e;
-      --bg-soft:#101014;
-      --fg:#f4f4f5;
-      --fg-soft:#c4c4cb;
-      --muted-fg:#8a8a93;
-      --border:#26262c;
-      --border-soft:#1c1c21;
-      --border-hover:#34343c;
-      --muted:#1a1a1f;
-      --card:#141418;
-      --nav-bg:rgba(11,11,14,.72);
-      --browser-bar:#17171c;
-      /* Dark-mode brand neutral */
-      --primary:#fafafa;
+      /* x.ai-style pure black canvas */
+      --bg:#000000;
+      --bg-soft:#0a0a0a;
+      --fg:#ededed;
+      --fg-soft:#a1a1a1;
+      --muted-fg:#888888;
+      --border:#1a1a1a;
+      --border-soft:#111111;
+      --border-hover:#2a2a2a;
+      --muted:#111111;
+      --card:#0a0a0a;
+      --nav-bg:rgba(0,0,0,.72);
+      --browser-bar:#0a0a0a;
+      --primary:#ededed;
       --shadow-glow:none;
-      --btn-primary-bg:#fafafa;
-      --btn-primary-bg-hover:#e4e4e7;
-      --btn-primary-fg:#09090b;
-      --shadow-card:0 1px 2px rgba(0,0,0,.4), 0 1px 0 rgba(0,0,0,.3);
-      --shadow-float:0 24px 60px -28px rgba(0,0,0,.7), 0 8px 24px -16px rgba(0,0,0,.5);
+      --btn-primary-bg:#ededed;
+      --btn-primary-bg-hover:#ffffff;
+      --btn-primary-fg:#0a0a0a;
+      --shadow-card:0 2px 2px rgba(0,0,0,.4);
+      --shadow-float:0 1px 1px rgba(0,0,0,.2), 0 4px 8px -4px rgba(0,0,0,.4), 0 16px 24px -8px rgba(0,0,0,.5);
     }
     *{margin:0;padding:0;box-sizing:border-box}
     html{scroll-behavior:smooth}
-    /* keep in-page jump targets clear of the sticky 64px nav */
-    :target{scroll-margin-top:84px}
+    /* keep in-page jump targets clear of the sticky nav */
+    :target{scroll-margin-top:72px}
     body{
       background:var(--bg);
       color:var(--fg);
@@ -169,15 +165,15 @@ const ogImage = new URL(image, Astro.site).toString()
     .wrap{max-width:var(--maxw);margin:0 auto;padding:0 24px}
     .eyebrow{font-size:12px;font-weight:600;letter-spacing:.10em;text-transform:uppercase;color:var(--muted-fg)}
 
-    /* ── buttons ── */
-    .btn{display:inline-flex;align-items:center;gap:8px;height:42px;padding:0 18px;border-radius:10px;
-      font-size:14.5px;font-weight:560;font-weight:600;white-space:nowrap;transition:.16s ease;border:1px solid transparent;cursor:pointer}
+    /* ── buttons (Geist: 40px height, 6px radius, no lift) ── */
+    .btn{display:inline-flex;align-items:center;gap:8px;height:40px;padding:0 14px;border-radius:var(--radius);
+      font-size:14px;font-weight:500;white-space:nowrap;transition:background .15s ease,border-color .15s ease,color .15s ease;border:1px solid transparent;cursor:pointer}
     .btn svg{width:16px;height:16px}
     .btn-primary{background:var(--btn-primary-bg);color:var(--btn-primary-fg)}
-    .btn-primary:hover{background:var(--btn-primary-bg-hover);transform:translateY(-1px)}
+    .btn-primary:hover{background:var(--btn-primary-bg-hover)}
     .btn-ghost{background:var(--card);color:var(--fg);border-color:var(--border)}
     .btn-ghost:hover{background:var(--muted);border-color:var(--border-hover)}
-    .btn-sm{height:36px;padding:0 14px;font-size:13.5px;border-radius:9px}
+    .btn-sm{height:32px;padding:0 10px;font-size:13px;border-radius:var(--radius)}
 
     /* ── logo mark ── */
     .mark{width:30px;height:30px;display:flex;align-items:center;justify-content:center;flex:0 0 auto}
@@ -195,8 +191,8 @@ const ogImage = new URL(image, Astro.site).toString()
       transition:border-color .2s ease}
     /* Only draw the divider once the page has scrolled off the very top. */
     header.nav.is-scrolled{border-bottom-color:var(--border-soft)}
-    .nav-row{display:flex;align-items:center;justify-content:space-between;gap:28px;height:64px}
-    .brand{display:flex;align-items:center;gap:10px;flex:0 0 auto;font-weight:650;font-weight:600;font-size:16px;letter-spacing:-.01em}
+    .nav-row{display:flex;align-items:center;justify-content:space-between;gap:24px;height:56px}
+    .brand{display:flex;align-items:center;gap:10px;flex:0 0 auto;font-weight:600;font-size:15px;letter-spacing:-.02em}
     .nav-links{display:flex;align-items:center;gap:22px}
     .nav-links a{font-size:14px;color:var(--muted-fg);font-weight:500;white-space:nowrap;transition:color .15s}
     .nav-links a:hover{color:var(--fg)}

--- a/apps/landing/src/styles/globals.css
+++ b/apps/landing/src/styles/globals.css
@@ -13,49 +13,50 @@
    so the shadcn `dark:` variant must key off that attribute. */
 @custom-variant dark (&:is([data-theme='dark'] *));
 
-/* shadcn tokens — aligned to the dashboard's theme (Rhea): blue primary, neutral
-   stone surfaces. Kept in sync with apps/dashboard/src/styles.css. */
+/* shadcn tokens — Geist (Vercel design.md) + x.ai monochrome. Light: near-white
+   surfaces, gray-1000 primary. Dark: pure black field, white primary (x.ai). */
 :root {
-  --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.145 0 0);
-  --primary-foreground: oklch(1 0 0);
-  --secondary: oklch(0.967 0.001 286.375);
-  --secondary-foreground: oklch(0.21 0.006 285.885);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  /* Geist shape: 6px everyday radius */
+  --radius: 0.375rem;
+  --background: #ffffff;
+  --foreground: #171717;
+  --card: #ffffff;
+  --card-foreground: #171717;
+  --popover: #ffffff;
+  --popover-foreground: #171717;
+  --primary: #171717;
+  --primary-foreground: #ffffff;
+  --secondary: #fafafa;
+  --secondary-foreground: #171717;
+  --muted: #f2f2f2;
+  --muted-foreground: #666666;
+  --accent: #fafafa;
+  --accent-foreground: #171717;
+  --destructive: #ea001d;
+  --border: #eaeaea;
+  --input: #eaeaea;
+  --ring: #006bff;
 }
 
 [data-theme='dark'] {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.269 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.985 0 0);
-  --primary-foreground: oklch(0.145 0 0);
-  --secondary: oklch(0.274 0.006 286.033);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
+  --background: #000000;
+  --foreground: #ededed;
+  --card: #0a0a0a;
+  --card-foreground: #ededed;
+  --popover: #0a0a0a;
+  --popover-foreground: #ededed;
+  --primary: #ededed;
+  --primary-foreground: #0a0a0a;
+  --secondary: #111111;
+  --secondary-foreground: #ededed;
+  --muted: #111111;
+  --muted-foreground: #a1a1a1;
+  --accent: #111111;
+  --accent-foreground: #ededed;
+  --destructive: #ff676d;
+  --border: #ffffff1a;
+  --input: #ffffff26;
+  --ring: #48aeff;
 }
 
 img {


### PR DESCRIPTION
## Summary
- Align landing tokens with **Vercel Geist** (`design.md`): 6px radius, gray-1000 primary, subtle elevation, 40px buttons.
- **x.ai-style** dark field: pure black canvas, sparse hero with radial + grid, monochrome final CTA (no blue accents).
- Hero/CTA use shadcn button utility classes only; nav slightly tighter.

## Test plan
- [x] `pnpm run build` in `apps/landing`
- [ ] Visit homepage light + dark — hero spacing, CTAs, final band
- [ ] Confirm no blue accent left on final CTA
- [ ] Nav height / sticky scroll still works