### PR TITLE
style(landing): unify button size to Geist medium (40px)

### DIFF
--- a/apps/landing/src/components/FinalCta.astro
+++ b/apps/landing/src/components/FinalCta.astro
@@ -1,3 +1,6 @@
+---
+import { btnOnDarkOutline, btnOnDarkPrimary } from '../lib/button-classes'
+---
 <section class="pt-6 pb-20 sm:pb-28">
   <div class="mx-auto max-w-[1200px] px-6">
     <!-- Fixed pure-black CTA (x.ai field) — monochrome, no brand accent color. -->
@@ -19,7 +22,7 @@
         </p>
         <div class="mt-8 flex flex-wrap items-center justify-center gap-2.5">
           <a
-            class="inline-flex items-center justify-center gap-2 rounded-md bg-white px-5 h-10 text-sm font-medium text-black transition-colors hover:bg-white/90 active:scale-[.98]"
+            class={btnOnDarkPrimary}
             href="https://dash.chmonitor.dev"
             target="_blank"
             rel="noopener"
@@ -29,7 +32,7 @@
             <svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
           </a>
           <a
-            class="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/5 px-5 h-10 text-sm font-medium text-white transition-colors hover:bg-white/10 active:scale-[.98]"
+            class={btnOnDarkOutline}
             href="https://docs.chmonitor.dev"
             target="_blank"
             rel="noopener"
@@ -37,7 +40,7 @@
             Read the Docs
           </a>
           <a
-            class="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/5 px-5 h-10 text-sm font-medium text-white transition-colors hover:bg-white/10 active:scale-[.98]"
+            class={btnOnDarkOutline}
             href="https://github.com/chmonitor/chmonitor"
             target="_blank"
             rel="noopener"

--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -1,4 +1,9 @@
 ---
+import {
+  btnGhost,
+  btnOutline,
+  btnPrimary,
+} from '../lib/button-classes'
 import { formatCount, getGitHubStats } from '../lib/github-stars'
 
 const { stars } = await getGitHubStats()
@@ -18,14 +23,6 @@ const arrowSvg = `<svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="cu
 const bookSvg = `<svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 7v14"/><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"/></svg>`
 const starSvg = `<svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z"/></svg>`
 const githubSvg = `<svg class="size-3.5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49l-.01-1.9c-2.78.62-3.37-1.2-3.37-1.2-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.36-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.4 9.4 0 0 1 5 0c1.91-1.32 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.35 4.8-4.58 5.06.36.32.68.94.68 1.9l-.01 2.82c0 .27.18.6.69.49A10.03 10.03 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"/></svg>`
-
-/* shadcn Button classes (Geist: 40px, 6px radius, medium weight) */
-const btnPrimary =
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-primary px-5 h-10 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 active:scale-[.98] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50'
-const btnOutline =
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md border border-input bg-background px-5 h-10 text-sm font-medium transition-colors hover:bg-accent active:scale-[.98] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50'
-const btnGhost =
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md px-4 h-10 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground active:scale-[.98] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50'
 ---
 
 <section class="relative isolate overflow-hidden pb-20 sm:pb-28" data-hero>

--- a/apps/landing/src/components/Nav.astro
+++ b/apps/landing/src/components/Nav.astro
@@ -1,3 +1,6 @@
+---
+import { btnOutline, btnOutlineBlock, btnPrimary, btnPrimaryBlock } from '../lib/button-classes'
+---
   <header class="nav">
     <div class="wrap nav-row">
       <a class="brand" href="/">
@@ -44,11 +47,11 @@
           <svg class="i-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
           <svg class="i-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>
         </button>
-        <a class="inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-input bg-background px-3 h-8 text-sm font-medium shadow-xs transition-all hover:bg-accent active:scale-[.98]" href="https://github.com/chmonitor/chmonitor" target="_blank" rel="noopener">
+        <a class={btnOutline} href="https://github.com/chmonitor/chmonitor" target="_blank" rel="noopener">
           <svg class="size-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49l-.01-1.9c-2.78.62-3.37-1.2-3.37-1.2-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.36-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.4 9.4 0 0 1 5 0c1.91-1.32 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.35 4.8-4.58 5.06.36.32.68.94.68 1.9l-.01 2.82c0 .27.18.6.69.49A10.03 10.03 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"/></svg>
           Star
         </a>
-        <a class="inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md bg-primary px-3 h-8 text-sm font-medium text-primary-foreground shadow-xs transition-all hover:bg-primary/90 active:scale-[.98]" href="https://dash.chmonitor.dev" target="_blank" rel="noopener">
+        <a class={btnPrimary} href="https://dash.chmonitor.dev" target="_blank" rel="noopener">
           Dashboard
           <svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
         </a>
@@ -98,11 +101,11 @@
             <svg class="i-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>
           </button>
         </div>
-        <a class="inline-flex w-full items-center justify-center gap-2 rounded-md border border-input bg-background px-6 h-10 text-sm font-medium shadow-xs transition-all hover:bg-accent active:scale-[.98]" href="https://github.com/chmonitor/chmonitor" target="_blank" rel="noopener">
+        <a class={btnOutlineBlock} href="https://github.com/chmonitor/chmonitor" target="_blank" rel="noopener">
           <svg class="size-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49l-.01-1.9c-2.78.62-3.37-1.2-3.37-1.2-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.36-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.4 9.4 0 0 1 5 0c1.91-1.32 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.35 4.8-4.58 5.06.36.32.68.94.68 1.9l-.01 2.82c0 .27.18.6.69.49A10.03 10.03 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"/></svg>
           Star on GitHub
         </a>
-        <a class="inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary px-6 h-10 text-sm font-medium text-primary-foreground shadow-xs transition-all hover:bg-primary/90 active:scale-[.98]" href="https://dash.chmonitor.dev" target="_blank" rel="noopener">
+        <a class={btnPrimaryBlock} href="https://dash.chmonitor.dev" target="_blank" rel="noopener">
           Dashboard
           <svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
         </a>

--- a/apps/landing/src/components/Pricing.astro
+++ b/apps/landing/src/components/Pricing.astro
@@ -8,17 +8,20 @@ import {
   yearlyMonthsFreeValue,
 } from '../data/pricing'
 
+import {
+  btnOutline,
+  btnOutlineBlock,
+  btnPrimaryBlock,
+} from '../lib/button-classes'
+
 const checkSvg = `<svg class="inline-block size-4 shrink-0 align-middle text-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 5 5L20 7"/></svg>`
 const arrowSvg = `<svg class="inline-block size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>`
 
 const { compact = false } = Astro.props
 
-const primaryBtn =
-  'inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary px-6 h-10 text-sm font-medium text-primary-foreground shadow-xs transition-all hover:bg-primary/90 active:scale-[.98] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50'
-const outlineBtn =
-  'inline-flex w-full items-center justify-center gap-2 rounded-md border border-input bg-background px-6 h-10 text-sm font-medium shadow-xs transition-all hover:bg-accent active:scale-[.98] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50'
-const outlineBtnAuto =
-  'inline-flex items-center justify-center gap-2 rounded-md border border-input bg-background px-6 h-10 text-sm font-medium shadow-xs transition-all hover:bg-accent active:scale-[.98] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50'
+const primaryBtn = btnPrimaryBlock
+const outlineBtn = btnOutlineBlock
+const outlineBtnAuto = btnOutline
 
 const cardColors = [
   'bg-[#f3f4f6]/70 border-transparent dark:bg-neutral-900/40', // Free

--- a/apps/landing/src/components/SocialProof.astro
+++ b/apps/landing/src/components/SocialProof.astro
@@ -2,6 +2,7 @@
 // GitHub stats fetched once at build time via the shared helper (also used by
 // the hero star badge) so the static build makes a single API call. Fails open:
 // chips render without counts when the API is unreachable — never a fake number.
+import { btnOutline, btnPrimary } from '../lib/button-classes'
 import { GITHUB_REPO as REPO, formatCount as fmt, getGitHubStats } from '../lib/github-stars'
 
 const { stars, forks, updated } = await getGitHubStats()
@@ -35,11 +36,11 @@ const commitIcon = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" s
       </div>
 
       <div class="flex flex-wrap justify-center gap-2.5">
-        <a class="inline-flex items-center justify-center gap-2 rounded-md bg-primary px-6 h-10 text-sm font-medium text-primary-foreground shadow-xs transition-all hover:bg-primary/90 active:scale-[.98]" href="https://github.com/chmonitor/chmonitor" target="_blank" rel="noopener">
+        <a class={btnPrimary} href="https://github.com/chmonitor/chmonitor" target="_blank" rel="noopener">
           <svg class="size-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49l-.01-1.9c-2.78.62-3.37-1.2-3.37-1.2-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.36-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.4 9.4 0 0 1 5 0c1.91-1.32 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.35 4.8-4.58 5.06.36.32.68.94.68 1.9l-.01 2.82c0 .27.18.6.69.49A10.03 10.03 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"/></svg>
           View on GitHub
         </a>
-        <a class="inline-flex items-center justify-center gap-2 rounded-md border border-input bg-background px-6 h-10 text-sm font-medium shadow-xs transition-all hover:bg-accent active:scale-[.98]" href="https://github.com/chmonitor/chmonitor/discussions" target="_blank" rel="noopener">
+        <a class={btnOutline} href="https://github.com/chmonitor/chmonitor/discussions" target="_blank" rel="noopener">
           Join the discussion
         </a>
       </div>

--- a/apps/landing/src/components/ui/button.tsx
+++ b/apps/landing/src/components/ui/button.tsx
@@ -19,10 +19,11 @@ const buttonVariants = cva(
         link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
+        // Geist medium (40px) — default matches landing CTAs
+        default: 'h-10 px-4 has-[>svg]:px-4',
         sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
-        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
-        icon: 'size-9',
+        lg: 'h-10 rounded-md px-4 has-[>svg]:px-4',
+        icon: 'size-10',
       },
     },
     defaultVariants: {

--- a/apps/landing/src/lib/button-classes.ts
+++ b/apps/landing/src/lib/button-classes.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared landing button classes — one size everywhere (Geist medium: 40px).
+ * Keep padding/height identical across hero, nav, pricing, and final CTA.
+ */
+
+const size =
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md h-10 px-4 text-sm font-medium transition-colors active:scale-[.98] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50'
+
+export const btnPrimary = `${size} bg-primary text-primary-foreground hover:bg-primary/90`
+
+export const btnOutline = `${size} border border-input bg-background hover:bg-accent`
+
+export const btnGhost = `${size} text-muted-foreground hover:bg-accent hover:text-accent-foreground`
+
+/** Full-width variant (pricing cards, mobile drawer). */
+export const btnPrimaryBlock = `${btnPrimary} w-full`
+
+export const btnOutlineBlock = `${btnOutline} w-full`
+
+/** Final CTA on pure-black band (fixed light-on-dark). */
+export const btnOnDarkPrimary = `${size} bg-white text-black hover:bg-white/90`
+
+export const btnOnDarkOutline = `${size} border border-white/15 bg-white/5 text-white hover:bg-white/10`


### PR DESCRIPTION
## Summary
- Single shared button size: **h-10 / px-4** (Geist medium 40px)
- Wired hero, nav (desktop + mobile), pricing, final CTA, social proof through `lib/button-classes.ts`
- shadcn `Button` default size matches landing CTAs

## Test plan
- [x] `pnpm run build` in apps/landing
- [ ] Homepage: hero + nav CTAs same height
- [ ] Pricing cards + final CTA same height