### PR TITLE
fix(landing): restore mobile nav and tighten responsive layout

### DIFF
--- a/apps/landing/src/components/Comparison.astro
+++ b/apps/landing/src/components/Comparison.astro
@@ -3,16 +3,20 @@ const checkSvg = `<svg class="inline-block size-[18px] shrink-0 align-middle tex
 const crossSvg = `<svg class="inline-block size-[18px] shrink-0 align-middle text-rose-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m18 6-12 12M6 6l12 12"/></svg>`
 const partialSvg = `<svg class="inline-block size-[18px] shrink-0 align-middle text-amber-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/></svg>`
 ---
-<section id="comparison" class="bg-muted/30 py-20 sm:py-24">
-  <div class="mx-auto max-w-6xl px-6">
+<section id="comparison" class="bg-muted/30 py-14 sm:py-20 md:py-24">
+  <div class="mx-auto max-w-6xl px-4 sm:px-6">
     <div class="reveal mx-auto max-w-2xl text-center">
       <p class="text-sm font-medium text-primary">Why chmonitor</p>
-      <h2 class="mt-3 text-balance font-semibold text-3xl sm:text-4xl tracking-tight">Purpose-built for ClickHouse</h2>
-      <p class="mt-4 text-pretty text-muted-foreground">General-purpose tools treat ClickHouse as one data source among many. chmonitor reads its system tables directly and tracks nothing else. Here's how it stacks up against the most common alternatives.</p>
+      <h2 class="mt-3 text-balance font-semibold text-2xl sm:text-3xl md:text-4xl tracking-tight">Purpose-built for ClickHouse</h2>
+      <p class="mt-4 text-pretty text-sm sm:text-base text-muted-foreground">General-purpose tools treat ClickHouse as one data source among many. chmonitor reads its system tables directly and tracks nothing else. Here's how it stacks up against the most common alternatives.</p>
     </div>
 
-    <div class="reveal mt-10 overflow-hidden rounded-xl border border-border shadow-sm">
-      <div class="overflow-x-auto">
+    <div class="reveal mt-8 sm:mt-10 overflow-hidden rounded-xl border border-border shadow-sm">
+      <!-- Scroll hint for narrow viewports — table is wider than phone screens -->
+      <p class="sm:hidden border-b border-border bg-muted/50 px-4 py-2 text-center text-[11px] text-muted-foreground">
+        Swipe to compare →
+      </p>
+      <div class="overflow-x-auto overscroll-x-contain [-webkit-overflow-scrolling:touch]">
         <table class="w-full min-w-[640px] border-collapse text-sm">
           <thead>
             <tr class="bg-muted">

--- a/apps/landing/src/components/FAQ.astro
+++ b/apps/landing/src/components/FAQ.astro
@@ -46,23 +46,23 @@ const faqJsonLd = {
 ---
 <script type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />
 
-<section id="faq" class="py-20 sm:py-24">
-  <div class="mx-auto max-w-6xl px-6">
+<section id="faq" class="py-14 sm:py-20 md:py-24">
+  <div class="mx-auto max-w-6xl px-4 sm:px-6">
     <div class="reveal mx-auto max-w-2xl text-center">
       <p class="text-sm font-medium text-primary">FAQ</p>
-      <h2 class="mt-3 text-balance font-extrabold text-4xl sm:text-5xl tracking-[-0.04em]">
+      <h2 class="mt-3 text-balance font-extrabold text-2xl sm:text-4xl md:text-5xl tracking-[-0.04em]">
         Questions &amp; answers
       </h2>
-      <p class="mt-4 text-pretty text-muted-foreground">Answers to what evaluators ask most before deploying chmonitor.</p>
+      <p class="mt-4 text-pretty text-sm sm:text-base text-muted-foreground">Answers to what evaluators ask most before deploying chmonitor.</p>
     </div>
 
-    <div class="reveal mx-auto mt-12 max-w-3xl">
+    <div class="reveal mx-auto mt-8 sm:mt-12 max-w-3xl">
       {faqs.map(({ q, a }) => (
         <details class="changelog-faq group border-b border-border first:border-t">
-          <summary class="flex cursor-pointer list-none items-center justify-between gap-4 py-5 font-semibold text-foreground marker:content-none [&::-webkit-details-marker]:hidden">
-            {q}
-            <span class="text-xl font-normal text-muted-foreground group-open:hidden">+</span>
-            <span class="text-xl font-normal text-muted-foreground hidden group-open:inline">&minus;</span>
+          <summary class="flex min-h-12 cursor-pointer list-none items-center justify-between gap-3 sm:gap-4 py-4 sm:py-5 text-left text-sm sm:text-base font-semibold text-foreground marker:content-none [&::-webkit-details-marker]:hidden">
+            <span class="min-w-0 flex-1 text-pretty">{q}</span>
+            <span class="shrink-0 text-xl font-normal text-muted-foreground group-open:hidden" aria-hidden="true">+</span>
+            <span class="shrink-0 text-xl font-normal text-muted-foreground hidden group-open:inline" aria-hidden="true">&minus;</span>
           </summary>
           <div class="faq-ans pb-5 text-muted-foreground [&_a]:text-primary [&_a]:underline [&_a]:underline-offset-4 [&_a:hover]:text-primary/80 [&_code]:rounded [&_code]:bg-muted [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[0.85em]" set:html={a} />
         </details>

--- a/apps/landing/src/components/FeatureShowcase.astro
+++ b/apps/landing/src/components/FeatureShowcase.astro
@@ -16,13 +16,13 @@ const icons: Record<string, string> = {
 
 <section
   id="features"
-  class="border-border/60 border-t bg-muted/20 py-20 sm:py-28"
+  class="border-border/60 border-t bg-muted/20 py-14 sm:py-20 md:py-28"
   data-feature-sections={FEATURE_SECTIONS.length}
 >
-  <div class="mx-auto max-w-6xl px-6">
+  <div class="mx-auto max-w-6xl px-4 sm:px-6">
     <div class="mx-auto max-w-2xl text-center">
       <p class="font-medium text-primary text-sm">What you get</p>
-      <h2 class="mt-3 text-balance font-semibold text-3xl tracking-tight sm:text-4xl">
+      <h2 class="mt-3 text-balance font-semibold text-2xl sm:text-3xl tracking-tight md:text-4xl">
         Everything about your cluster, in one place
       </h2>
       <p class="mt-4 text-pretty text-muted-foreground text-sm sm:text-base">
@@ -31,12 +31,12 @@ const icons: Record<string, string> = {
       </p>
     </div>
 
-    <div class="mt-20 flex flex-col gap-24 sm:gap-28">
+    <div class="mt-12 sm:mt-16 md:mt-20 flex flex-col gap-16 sm:gap-24 md:gap-28">
       {
         FEATURE_SECTIONS.map((section) => (
           <article
             id={section.id}
-            class="scroll-mt-20 grid items-center gap-10 min-[881px]:grid-cols-2 min-[881px]:gap-16"
+            class="scroll-mt-20 grid items-center gap-8 sm:gap-10 min-[881px]:grid-cols-2 min-[881px]:gap-16"
           >
             <div
               class={

--- a/apps/landing/src/components/FinalCta.astro
+++ b/apps/landing/src/components/FinalCta.astro
@@ -1,28 +1,28 @@
 ---
 import { btnOnDarkOutline, btnOnDarkPrimary } from '../lib/button-classes'
 ---
-<section class="pt-6 pb-20 sm:pb-28">
-  <div class="mx-auto max-w-[1200px] px-6">
+<section class="pt-4 sm:pt-6 pb-14 sm:pb-20 md:pb-28">
+  <div class="mx-auto max-w-[1200px] px-4 sm:px-6">
     <!-- Fixed pure-black CTA (x.ai field) — monochrome, no brand accent color. -->
-    <div class="reveal relative isolate overflow-hidden rounded-2xl border border-white/10 bg-black">
+    <div class="reveal relative isolate overflow-hidden rounded-xl sm:rounded-2xl border border-white/10 bg-black">
       <div
         class="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(ellipse_60%_50%_at_50%_0%,rgba(255,255,255,0.08),transparent_70%)]"
         aria-hidden="true"
       ></div>
 
-      <div class="relative mx-auto max-w-2xl px-6 py-16 text-center sm:py-20">
-        <span class="mb-6 flex justify-center" aria-hidden="true">
-          <img src="/brand/logo-mark.svg" alt="" class="size-9 opacity-90" />
+      <div class="relative mx-auto max-w-2xl px-4 sm:px-6 py-12 text-center sm:py-20">
+        <span class="mb-5 sm:mb-6 flex justify-center" aria-hidden="true">
+          <img src="/brand/logo-mark.svg" alt="" class="size-8 sm:size-9 opacity-90" />
         </span>
-        <h2 class="text-balance font-semibold text-3xl text-white tracking-[-0.04em] sm:text-4xl">
+        <h2 class="text-balance font-semibold text-2xl text-white tracking-[-0.04em] sm:text-4xl">
           Start monitoring — advisor and alerts built in
         </h2>
-        <p class="mt-4 text-pretty text-white/55 text-base leading-relaxed">
+        <p class="mt-3 sm:mt-4 text-pretty text-white/55 text-sm sm:text-base leading-relaxed">
           Open the hosted dashboard and connect a cluster, or self-host with Docker, Kubernetes, or from source. Self-hosting is always free.
         </p>
-        <div class="mt-8 flex flex-wrap items-center justify-center gap-2.5">
+        <div class="mt-7 sm:mt-8 flex w-full max-w-sm sm:max-w-none mx-auto flex-col sm:flex-row flex-wrap items-stretch sm:items-center justify-center gap-2.5">
           <a
-            class={btnOnDarkPrimary}
+            class={`${btnOnDarkPrimary} w-full sm:w-auto`}
             href="https://dash.chmonitor.dev"
             target="_blank"
             rel="noopener"
@@ -32,7 +32,7 @@ import { btnOnDarkOutline, btnOnDarkPrimary } from '../lib/button-classes'
             <svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
           </a>
           <a
-            class={btnOnDarkOutline}
+            class={`${btnOnDarkOutline} w-full sm:w-auto`}
             href="https://docs.chmonitor.dev"
             target="_blank"
             rel="noopener"
@@ -40,7 +40,7 @@ import { btnOnDarkOutline, btnOnDarkPrimary } from '../lib/button-classes'
             Read the Docs
           </a>
           <a
-            class={btnOnDarkOutline}
+            class={`${btnOnDarkOutline} w-full sm:w-auto`}
             href="https://github.com/chmonitor/chmonitor"
             target="_blank"
             rel="noopener"

--- a/apps/landing/src/components/Footer.astro
+++ b/apps/landing/src/components/Footer.astro
@@ -7,8 +7,8 @@ function fmtDate(iso: string) {
 }
 ---
   <footer class="border-t border-border">
-    <div class="mx-auto max-w-6xl px-6 py-16">
-      <div class="flex flex-col gap-12 lg:flex-row lg:justify-between">
+    <div class="mx-auto max-w-6xl px-4 sm:px-6 py-12 sm:py-16">
+      <div class="flex flex-col gap-10 sm:gap-12 lg:flex-row lg:justify-between">
         <div class="max-w-xs">
           <a class="brand flex items-center gap-2.5 text-base font-semibold tracking-tight" href="/">
             <span class="mark" aria-hidden="true">
@@ -18,8 +18,8 @@ function fmtDate(iso: string) {
           </a>
           <p class="mt-4 text-pretty text-sm text-muted-foreground">chmonitor reads your cluster's system tables and turns them into views your whole team can act on, no more memorising table names or hand-writing diagnostic SQL.</p>
         </div>
-        <div class="flex flex-wrap gap-x-12 gap-y-10">
-          <div class="min-w-36">
+        <div class="grid grid-cols-2 gap-x-8 gap-y-10 sm:flex sm:flex-wrap sm:gap-x-12">
+          <div class="min-w-0 sm:min-w-36">
             <h5 class="text-xs font-medium uppercase tracking-wider text-muted-foreground">Product</h5>
             <div class="mt-3 flex flex-col gap-2.5">
               <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="/#top">Overview</a>
@@ -33,7 +33,7 @@ function fmtDate(iso: string) {
               <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="/changelog#ship-log">Feature index</a>
             </div>
           </div>
-          <div class="min-w-36">
+          <div class="min-w-0 sm:min-w-36">
             <h5 class="text-xs font-medium uppercase tracking-wider text-muted-foreground">Use cases</h5>
             <div class="mt-3 flex flex-col gap-2.5">
               {useCases.map((u) => (
@@ -41,7 +41,7 @@ function fmtDate(iso: string) {
               ))}
             </div>
           </div>
-          <div class="min-w-36">
+          <div class="min-w-0 sm:min-w-36">
             <h5 class="text-xs font-medium uppercase tracking-wider text-muted-foreground">Open source</h5>
             <div class="mt-3 flex flex-col gap-2.5">
               <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="https://github.com/chmonitor/chmonitor" target="_blank" rel="noopener">GitHub</a>
@@ -50,7 +50,7 @@ function fmtDate(iso: string) {
               <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="https://github.com/chmonitor/chmonitor/releases" target="_blank" rel="noopener">Releases</a>
             </div>
           </div>
-          <div class="min-w-36">
+          <div class="min-w-0 sm:min-w-36">
             <h5 class="text-xs font-medium uppercase tracking-wider text-muted-foreground">Legal &amp; trust</h5>
             <div class="mt-3 flex flex-col gap-2.5">
               <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="https://github.com/chmonitor/chmonitor/blob/main/LICENSE" target="_blank" rel="noopener">License (GPL-3.0)</a>
@@ -59,7 +59,7 @@ function fmtDate(iso: string) {
             </div>
           </div>
           {latestPosts.length > 0 && (
-            <div class="min-w-44 max-w-52">
+            <div class="col-span-2 min-w-0 sm:col-span-1 sm:min-w-44 sm:max-w-52">
               <h5 class="text-xs font-medium uppercase tracking-wider text-muted-foreground">Latest from the blog</h5>
               <div class="mt-3 flex flex-col gap-3">
                 {latestPosts.map((post) => (
@@ -74,7 +74,7 @@ function fmtDate(iso: string) {
           )}
         </div>
       </div>
-      <div class="mt-12 flex flex-wrap items-center justify-between gap-3 border-t border-border pt-6 text-sm text-muted-foreground">
+      <div class="mt-10 sm:mt-12 flex flex-col sm:flex-row sm:flex-wrap items-start sm:items-center justify-between gap-2 sm:gap-3 border-t border-border pt-6 text-sm text-muted-foreground">
         <span>© 2026 chmonitor · Open source (GPL-3.0)</span>
         <span class="font-mono text-xs">Not affiliated with ClickHouse, Inc.</span>
       </div>

--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -25,46 +25,46 @@ const starSvg = `<svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="cur
 const githubSvg = `<svg class="size-3.5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49l-.01-1.9c-2.78.62-3.37-1.2-3.37-1.2-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.36-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.4 9.4 0 0 1 5 0c1.91-1.32 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.35 4.8-4.58 5.06.36.32.68.94.68 1.9l-.01 2.82c0 .27.18.6.69.49A10.03 10.03 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"/></svg>`
 ---
 
-<section class="relative isolate overflow-hidden pb-20 sm:pb-28" data-hero>
+<section class="relative isolate overflow-hidden pb-14 sm:pb-20 md:pb-28" data-hero>
   <!-- x.ai-style ambient field: faint radial + grid, no color noise -->
   <div
     class="pointer-events-none absolute inset-0 -z-10"
     aria-hidden="true"
   >
     <div class="absolute inset-0 bg-[radial-gradient(ellipse_80%_50%_at_50%_-20%,rgba(120,120,120,0.12),transparent_60%)] dark:bg-[radial-gradient(ellipse_70%_45%_at_50%_-10%,rgba(255,255,255,0.08),transparent_55%)]"></div>
-    <div class="absolute inset-0 opacity-[0.35] dark:opacity-[0.2] [background-image:linear-gradient(to_right,rgba(128,128,128,0.06)_1px,transparent_1px),linear-gradient(to_bottom,rgb(128,128,128,0.06)_1px,transparent_1px)] [background-size:64px_64px] [mask-image:radial-gradient(ellipse_70%_60%_at_50%_0%,#000_40%,transparent_100%)]"></div>
+    <div class="absolute inset-0 opacity-[0.35] dark:opacity-[0.2] [background-image:linear-gradient(to_right,rgb(128,128,128,0.06)_1px,transparent_1px),linear-gradient(to_bottom,rgb(128,128,128,0.06)_1px,transparent_1px)] [background-size:64px_64px] [mask-image:radial-gradient(ellipse_70%_60%_at_50%_0%,#000_40%,transparent_100%)]"></div>
   </div>
 
-  <div class="relative mx-auto max-w-[1200px] px-6 pt-20 sm:pt-28 lg:pt-32">
+  <div class="relative mx-auto max-w-[1200px] px-4 sm:px-6 pt-14 sm:pt-24 lg:pt-32">
     <div class="mx-auto max-w-3xl text-center">
       <a
         href="https://github.com/chmonitor/chmonitor"
         target="_blank"
         rel="noopener"
-        class="inline-flex"
+        class="inline-flex max-w-full"
         data-hero-oss
       >
-        <span class="inline-flex items-center gap-2 rounded-full border border-border bg-background/80 px-3 py-1 text-muted-foreground text-xs font-medium tracking-wide backdrop-blur-sm transition-colors hover:border-foreground/20 hover:text-foreground">
+        <span class="inline-flex max-w-full items-center gap-2 rounded-full border border-border bg-background/80 px-3 py-1 text-muted-foreground text-[11px] sm:text-xs font-medium tracking-wide backdrop-blur-sm transition-colors hover:border-foreground/20 hover:text-foreground">
           <span class="inline-flex items-center justify-center size-3.5 shrink-0" set:html={githubSvg} />
-          Open source · GPL-3.0 · self-host free
+          <span class="truncate">Open source · GPL-3.0 · self-host free</span>
         </span>
       </a>
 
-      <h1 class="mt-10 text-balance font-semibold text-[clamp(2.75rem,7vw,4.5rem)] text-foreground leading-[0.98] tracking-[-0.06em]">
+      <h1 class="mt-6 sm:mt-10 text-balance font-semibold text-[clamp(2.125rem,8.5vw,4.5rem)] text-foreground leading-[1.05] sm:leading-[0.98] tracking-[-0.05em] sm:tracking-[-0.06em]">
         The ops dashboard<br class="hidden sm:block" /> for ClickHouse.
       </h1>
 
-      <p class="mx-auto mt-7 max-w-xl text-pretty text-muted-foreground text-base leading-relaxed sm:text-lg font-normal">
+      <p class="mx-auto mt-5 sm:mt-7 max-w-xl text-pretty text-muted-foreground text-[15px] leading-relaxed sm:text-lg font-normal">
         Monitor queries, merges, parts, replication, and health. An AI advisor on top — open source, self-host free.
       </p>
 
-      <div class="mt-8 flex flex-wrap items-center justify-center gap-2.5">
+      <div class="mt-7 sm:mt-8 flex w-full max-w-md sm:max-w-none mx-auto flex-col sm:flex-row flex-wrap items-stretch sm:items-center justify-center gap-2.5">
         <a
           href="https://dash.chmonitor.dev"
           target="_blank"
           rel="noopener"
           data-cta="hero-primary"
-          class={btnPrimary}
+          class={`${btnPrimary} w-full sm:w-auto`}
         >
           Start Free
           <span class="inline-flex items-center justify-center size-4 shrink-0" set:html={arrowSvg} />
@@ -74,7 +74,7 @@ const githubSvg = `<svg class="size-3.5" viewBox="0 0 24 24" fill="currentColor"
           target="_blank"
           rel="noopener"
           data-cta="hero-self-host"
-          class={btnOutline}
+          class={`${btnOutline} w-full sm:w-auto`}
         >
           <span class="inline-flex items-center justify-center size-4 shrink-0" set:html={bookSvg} />
           Self-Host
@@ -86,7 +86,7 @@ const githubSvg = `<svg class="size-3.5" viewBox="0 0 24 24" fill="currentColor"
               target="_blank"
               rel="noopener"
               data-cta="github-star-hero"
-              class={btnGhost}
+              class={`${btnGhost} w-full sm:w-auto`}
             >
               <span class="inline-flex items-center justify-center size-4 shrink-0" set:html={starSvg} />
               <span class="tabular-nums">{starLabel}</span>
@@ -97,7 +97,7 @@ const githubSvg = `<svg class="size-3.5" viewBox="0 0 24 24" fill="currentColor"
     </div>
 
     <ul
-      class="mx-auto mt-16 grid max-w-3xl list-none gap-x-10 gap-y-3.5 sm:grid-cols-2 border-t border-border pt-10"
+      class="mx-auto mt-10 sm:mt-16 grid max-w-3xl list-none gap-x-10 gap-y-3 sm:gap-y-3.5 sm:grid-cols-2 border-t border-border pt-8 sm:pt-10"
       data-hero-features
     >
       {

--- a/apps/landing/src/components/Pricing.astro
+++ b/apps/landing/src/components/Pricing.astro
@@ -30,43 +30,43 @@ const cardColors = [
   'bg-[#fffbeb]/90 border-transparent dark:bg-amber-950/20',   // Enterprise
 ]
 ---
-<section id="pricing" class="py-20 sm:py-24">
-  <div class="mx-auto max-w-6xl px-6">
+<section id="pricing" class="py-14 sm:py-20 md:py-24">
+  <div class="mx-auto max-w-6xl px-4 sm:px-6">
     {!compact && (
     <div class="reveal mx-auto max-w-2xl text-center">
       <p class="text-sm font-medium text-primary">Pricing</p>
-      <h2 class="mt-3 text-balance font-extrabold text-3xl sm:text-4xl tracking-[-0.04em]">Self-host free. Cloud for teams.</h2>
-      <p class="mt-4 text-pretty text-muted-foreground">chmonitor is open source — self-hosting is always free under GPL-3.0, with every feature and unlimited clusters. The hosted cloud connects a cluster in minutes when you'd rather not run anything yourself.</p>
+      <h2 class="mt-3 text-balance font-extrabold text-2xl sm:text-3xl md:text-4xl tracking-[-0.04em]">Self-host free. Cloud for teams.</h2>
+      <p class="mt-4 text-pretty text-sm sm:text-base text-muted-foreground">chmonitor is open source — self-hosting is always free under GPL-3.0, with every feature and unlimited clusters. The hosted cloud connects a cluster in minutes when you'd rather not run anything yourself.</p>
     </div>
     )}
 
     <!-- Self-host: always free -->
-    <div class="reveal mt-9 flex flex-col items-start justify-between gap-5 rounded-xl border border-border bg-card p-5 shadow-xs sm:flex-row sm:items-center" data-pricing-oss>
-      <div class="flex flex-col gap-2">
-        <div class="flex items-center gap-2.5">
+    <div class="reveal mt-8 sm:mt-9 flex flex-col items-stretch justify-between gap-4 sm:gap-5 rounded-xl border border-border bg-card p-4 sm:p-5 shadow-xs sm:flex-row sm:items-center" data-pricing-oss>
+      <div class="flex flex-col gap-2 min-w-0">
+        <div class="flex flex-wrap items-center gap-2.5">
           <strong class="text-base font-semibold text-foreground">Self-host</strong>
           <span class="inline-flex items-center gap-1 rounded-full border border-border bg-neutral-100 px-2.5 py-0.5 text-xs font-medium text-neutral-800 dark:bg-neutral-800 dark:text-neutral-200">Free forever</span>
         </div>
         <p class="max-w-[62ch] text-pretty text-sm text-muted-foreground">Run it on your own infrastructure — Docker, Cloudflare Workers, or Kubernetes. All features, unlimited clusters, and your data stays with you.</p>
       </div>
-      <a class={outlineBtnAuto} href="https://docs.chmonitor.dev" target="_blank" rel="noopener">
+      <a class={`${outlineBtnAuto} w-full sm:w-auto shrink-0`} href="https://docs.chmonitor.dev" target="_blank" rel="noopener">
         Read the quickstart <span class="inline-flex items-center justify-center size-4 shrink-0" set:html={arrowSvg} />
       </a>
     </div>
 
     <!-- Cloud plans -->
-    <div class="reveal mt-8 flex flex-wrap items-center justify-between gap-4">
-      <div class="bill-toggle inline-flex gap-0.5 rounded-full bg-card p-1" role="tablist" aria-label="Billing period">
-        <button type="button" data-period="monthly" role="tab" aria-selected="false" class="billing-toggle-btn inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground active:scale-[.98] border-0 border-transparent outline-none focus:outline-none focus:ring-0 focus-visible:ring-0">Monthly</button>
-        <button type="button" data-period="yearly" role="tab" aria-selected="true" class="billing-toggle-btn active inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm font-medium transition-colors active:scale-[.98] border-0 border-transparent outline-none focus:outline-none focus:ring-0 focus-visible:ring-0">
+    <div class="reveal mt-6 sm:mt-8 flex flex-wrap items-center justify-between gap-3 sm:gap-4">
+      <div class="bill-toggle inline-flex w-full sm:w-auto gap-0.5 rounded-full bg-card p-1" role="tablist" aria-label="Billing period">
+        <button type="button" data-period="monthly" role="tab" aria-selected="false" class="billing-toggle-btn flex-1 sm:flex-none inline-flex items-center justify-center gap-2 rounded-full px-4 py-2 sm:py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground active:scale-[.98] border-0 border-transparent outline-none focus:outline-none focus:ring-0 focus-visible:ring-0">Monthly</button>
+        <button type="button" data-period="yearly" role="tab" aria-selected="true" class="billing-toggle-btn active flex-1 sm:flex-none inline-flex items-center justify-center gap-2 rounded-full px-4 py-2 sm:py-1.5 text-sm font-medium transition-colors active:scale-[.98] border-0 border-transparent outline-none focus:outline-none focus:ring-0 focus-visible:ring-0">
           Yearly <span class="save text-xs font-semibold">{monthsFreeText(yearlyMonthsFreeValue)} free</span>
         </button>
       </div>
     </div>
 
-    <div class="cloud-grid reveal mt-5 grid items-stretch gap-4 sm:grid-cols-2 lg:grid-cols-4" data-period="yearly">
+    <div class="cloud-grid reveal mt-5 grid items-stretch gap-3 sm:gap-4 sm:grid-cols-2 lg:grid-cols-4" data-period="yearly">
       {tiers.map((t, idx) => (
-        <div class={`flex flex-col rounded-xl border-0 p-6 shadow-xs transition-colors ${cardColors[idx]}`}>
+        <div class={`flex flex-col rounded-xl border-0 p-5 sm:p-6 shadow-xs transition-colors ${cardColors[idx]}`}>
           <div>
             <div class="flex flex-wrap items-center gap-2">
               <span class="font-bold text-lg tracking-tight">{t.name}</span>

--- a/apps/landing/src/components/UseCaseLinks.astro
+++ b/apps/landing/src/components/UseCaseLinks.astro
@@ -13,16 +13,16 @@ interface Props {
 
 const { items, eyebrow, heading, soft = false } = Astro.props
 ---
-<section class:list={['py-20 sm:py-24', soft && 'border-y border-border bg-muted/30']}>
-  <div class="mx-auto max-w-6xl px-6">
+<section class:list={['py-14 sm:py-20 md:py-24', soft && 'border-y border-border bg-muted/30']}>
+  <div class="mx-auto max-w-6xl px-4 sm:px-6">
     <div class="reveal mx-auto max-w-2xl text-center">
       <p class="text-sm font-medium text-primary">{eyebrow}</p>
-      <h2 class="mt-3 text-balance font-semibold text-3xl sm:text-4xl tracking-tight">{heading}</h2>
+      <h2 class="mt-3 text-balance font-semibold text-2xl sm:text-3xl md:text-4xl tracking-tight">{heading}</h2>
     </div>
-    <div class="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+    <div class="mt-8 sm:mt-12 grid grid-cols-1 gap-3 sm:gap-4 sm:grid-cols-2 lg:grid-cols-4">
       {items.map((item) => (
         <a
-          class="reveal group flex flex-col rounded-xl border border-border bg-card p-6 shadow-sm transition-colors hover:border-ring/40"
+          class="reveal group flex flex-col rounded-xl border border-border bg-card p-5 sm:p-6 shadow-sm transition-colors hover:border-ring/40"
           href={`/${item.slug}`}
           data-cta={`usecase-link-${item.slug}`}
         >

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -506,10 +506,16 @@ const ogImage = new URL(image, Astro.site).toString()
 
     /* ── responsive ── */
     @media (max-width:1024px){
-      /* swap the inline nav + CTA cluster for a single hamburger → drawer */
+      /* swap the inline nav + CTA cluster for a single hamburger → drawer.
+         Hide every desktop CTA in .nav-cta (anchors + legacy .btn), keep only
+         the hamburger. (CTAs moved off `.btn` onto shared Tailwind classes.) */
       .nav-links{display:none}
-      .nav-cta > .theme-toggle,.nav-cta > .btn{display:none}
+      .nav-cta > .theme-toggle,
+      .nav-cta > a,
+      .nav-cta > .btn{display:none}
       .nav-toggle{display:inline-flex}
+      .nav-row{gap:12px}
+      .wrap{padding:0 16px}
     }
     @media (max-width:880px){
       .feature,.os{grid-template-columns:1fr;gap:34px}
@@ -524,7 +530,9 @@ const ogImage = new URL(image, Astro.site).toString()
       .cap-grid{grid-template-columns:1fr}
       /* comfortable 44px tap targets on phones */
       .nav-toggle,.nav-drawer-close,.theme-toggle{width:44px;height:44px}
-      .foot-col a{padding:5px 0}
+      .foot-col a{padding:5px 0;min-height:44px;display:inline-flex;align-items:center}
+      .wrap{padding:0 16px}
+      .nav-row{height:52px}
     }
 
     /* ── social proof ── */


### PR DESCRIPTION
## Summary
- **Bugfix:** After shared button classes, nav CTAs no longer used \`.btn\`, so mobile CSS never hid them — Star + Dashboard crowded the hamburger row.
- **Hero / Final CTA:** full-width stacked buttons on small screens, fluid type, tighter padding.
- **Pricing / FAQ / Features / Footer / Comparison:** consistent \`px-4\` gutters, better tap targets, swipe hint on comparison table.

## Test plan
- [x] \`pnpm run build\` in apps/landing
- [ ] Phone width (~375px): only brand + hamburger in nav; drawer works
- [ ] Hero CTAs stack full-width; no horizontal scroll
- [ ] Comparison table shows swipe hint and scrolls