### PR TITLE
fix(landing): update homepage structure verify for current hero

### DIFF
--- a/apps/landing/scripts/verify-landing-structure.ts
+++ b/apps/landing/scripts/verify-landing-structure.ts
@@ -11,8 +11,11 @@ const html = readFileSync(distIndex, 'utf8')
 const required = [
   'data-hero',
   'data-hero-features',
-  'The ops dashboard for ClickHouse',
-  'data-hero-slogan',
+  // Headline may include a <br> between "dashboard" and "for" — match pieces.
+  'The ops dashboard',
+  'for ClickHouse',
+  'data-cta="hero-primary"',
+  'data-cta="hero-self-host"',
 ] as const
 
 const forbidden = [
@@ -28,6 +31,9 @@ const forbidden = [
   'Tabbed product preview',
   'UI monitoring for ClickHouse',
   '/#feature-index',
+  // Removed rotating slogan surface — do not reintroduce a false match via JS.
+  'data-hero-slogan',
+  'data-slogans',
 ] as const
 
 let failed = false

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -743,25 +743,6 @@ const ogImage = new URL(image, Astro.site).toString()
         start();
       });
     })();
-    // hero rotating slogans (static first line in HTML; JS only cycles)
-    (function(){
-      var el = document.querySelector('[data-hero-slogan]');
-      if(!el) return;
-      var raw = el.getAttribute('data-slogans') || '[]';
-      var slogans = [];
-      try { slogans = JSON.parse(raw); } catch (_) {}
-      if(!Array.isArray(slogans) || slogans.length < 2) return;
-      if(window.matchMedia && matchMedia('(prefers-reduced-motion:reduce)').matches) return;
-      var i = 0;
-      setInterval(function(){
-        el.style.opacity = '0';
-        setTimeout(function(){
-          i = (i + 1) % slogans.length;
-          el.textContent = slogans[i];
-          el.style.opacity = '1';
-        }, 280);
-      }, 4500);
-    })();
     // screenshot zoom (native <dialog>, no React)
     (function(){
       var dlg = document.getElementById('screenshot-zoom-dialog');


### PR DESCRIPTION
## Summary
- Structure verify matched the old rotating slogan via a **false positive** (JS `querySelector('[data-hero-slogan]')` still in the bundle).
- Require current hero headline + CTAs; forbid slogan markers.
- Remove dead slogan-rotator script from Base.

## Test plan
- [x] \`cd apps/landing && pnpm run build && bun scripts/verify-landing-structure.ts\`