### PR TITLE
style(landing): round screenshots, focus ring, viewport-fit

### DIFF
--- a/apps/landing/src/components/FeatureShowcase.astro
+++ b/apps/landing/src/components/FeatureShowcase.astro
@@ -72,12 +72,14 @@ const icons: Record<string, string> = {
                   : 'min-[881px]:order-2'
               }
             >
-              <ScreenshotShot
-                id={section.id}
-                src={section.screenshot.src}
-                srcDark={section.screenshot.srcDark}
-                alt={section.screenshot.alt}
-              />
+              <div class="overflow-hidden rounded-xl shadow-[0_20px_60px_-18px_rgba(0,0,0,0.28)] dark:shadow-[0_20px_60px_-18px_rgba(0,0,0,0.65)]">
+                <ScreenshotShot
+                  id={section.id}
+                  src={section.screenshot.src}
+                  srcDark={section.screenshot.srcDark}
+                  alt={section.screenshot.alt}
+                />
+              </div>
             </div>
           </article>
         ))

--- a/apps/landing/src/components/ScreenshotShot.astro
+++ b/apps/landing/src/components/ScreenshotShot.astro
@@ -16,8 +16,7 @@ const paired = Boolean(srcDark)
   data-zoom-src={src}
   data-zoom-src-dark={srcDark}
   data-zoom-alt={alt}
-  class="relative block w-full overflow-hidden leading-none border-0 border-transparent outline-none focus:outline-none focus:ring-0 focus-visible:ring-0 focus-visible:outline-none"
-  style="border: 0; outline: none; background: none; padding: 0;"
+  class="group relative block w-full cursor-zoom-in overflow-hidden rounded-xl bg-transparent p-0 leading-none outline-none transition-shadow duration-200 hover:shadow-[0_24px_64px_-16px_rgba(0,0,0,0.35)] dark:hover:shadow-[0_24px_64px_-16px_rgba(0,0,0,0.7)] focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
   aria-label={`View full size: ${alt}`}
 >
   <img

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -12,7 +12,7 @@ const ogImage = new URL(image, Astro.site).toString()
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>{title}</title>
   <meta name="description" content={description} />
   <link rel="canonical" href={canonical} />
@@ -33,7 +33,8 @@ const ogImage = new URL(image, Astro.site).toString()
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
   <link rel="manifest" href="/site.webmanifest" />
-  <meta name="theme-color" content="#000000" />
+  <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+  <meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)" />
   <meta name="twitter:site" content="@chmonitor" />
   <script type="application/ld+json" set:html={JSON.stringify({
     "@context": "https://schema.org",


### PR DESCRIPTION
## Summary
- Feature screenshots: rounded clip + soft elevation shadow
- Zoom control: focus-visible ring, zoom cursor (no hard border — keeps structure verify green)
- \`viewport-fit=cover\` + light/dark \`theme-color\` for mobile browser chrome

## Test plan
- [x] Landing build
- [ ] Tab to a screenshot — focus ring visible
- [ ] Mobile Safari status bar matches theme