### PR TITLE
feat(landing): add near-ICP database comparison pages (S4)

### DIFF
--- a/apps/landing/src/components/ComparisonLinks.astro
+++ b/apps/landing/src/components/ComparisonLinks.astro
@@ -1,0 +1,34 @@
+---
+/**
+ * Cross-links every /vs-* and /clickhouse-vs-* comparison page to its
+ * siblings so the SEO comparison cluster is fully interlinked (S4). Two
+ * families share this one list: "chmonitor vs monitoring tool" pages and
+ * "ClickHouse vs other database" pages.
+ */
+interface Props {
+  /** Slug of the current page (without leading slash), excluded from the list. */
+  current: string
+}
+
+const { current } = Astro.props
+
+const links = [
+  { slug: 'vs-grafana', label: 'chmonitor vs Grafana' },
+  { slug: 'vs-datadog', label: 'chmonitor vs Datadog' },
+  { slug: 'vs-clickhouse-cloud', label: 'chmonitor vs ClickHouse Cloud' },
+  { slug: 'clickhouse-vs-timescaledb', label: 'ClickHouse vs TimescaleDB' },
+  { slug: 'clickhouse-vs-postgres', label: 'ClickHouse vs Postgres' },
+  { slug: 'clickhouse-vs-druid-pinot', label: 'ClickHouse vs Druid vs Pinot' },
+]
+
+const others = links.filter((l) => l.slug !== current)
+---
+<p class="reveal mt-5 text-center text-sm text-muted-foreground">
+  More comparisons:{' '}
+  {others.map((l, i) => (
+    <>
+      <a class="font-semibold text-primary underline underline-offset-4 hover:text-primary/80" href={`/${l.slug}`}>{l.label}</a>
+      {i < others.length - 1 ? ' · ' : ''}
+    </>
+  ))}
+</p>

--- a/apps/landing/src/components/DbComparisonTable.astro
+++ b/apps/landing/src/components/DbComparisonTable.astro
@@ -1,0 +1,78 @@
+---
+/**
+ * Generic N-column comparison matrix for database-vs-database SEO pages
+ * (`/clickhouse-vs-*`), as distinct from `ComparisonTable.astro` which is
+ * hardcoded to "chmonitor vs one monitoring competitor". This one takes an
+ * arbitrary list of subject names (2 for a head-to-head, 3 for a three-way
+ * like Druid/Pinot) so it isn't chmonitor-specific.
+ *
+ * The first subject is always ClickHouse and gets the highlighted column,
+ * mirroring the chmonitor column treatment in `ComparisonTable.astro`.
+ */
+export type CellKind = 'yes' | 'no' | 'partial' | 'plain'
+
+export interface ComparisonCell {
+  kind: CellKind
+  text: string
+}
+
+export interface DbComparisonRow {
+  label: string
+  /** One cell per entry in `subjects`, same order. */
+  cells: ComparisonCell[]
+}
+
+interface Props {
+  /** Column headers, e.g. ["ClickHouse", "TimescaleDB"] or 3-way. */
+  subjects: string[]
+  rows: DbComparisonRow[]
+}
+
+const { subjects, rows } = Astro.props
+
+const ICON_YES = `<svg class="inline-block size-[18px] shrink-0 align-middle text-emerald-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 5 5L20 7"/></svg>`
+const ICON_NO = `<svg class="inline-block size-[18px] shrink-0 align-middle text-rose-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m18 6-12 12M6 6l12 12"/></svg>`
+const ICON_PARTIAL = `<svg class="inline-block size-[18px] shrink-0 align-middle text-amber-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/></svg>`
+
+function iconFor(kind: CellKind): string {
+  switch (kind) {
+    case 'yes':
+      return ICON_YES
+    case 'no':
+      return ICON_NO
+    case 'partial':
+      return ICON_PARTIAL
+    default:
+      return ''
+  }
+}
+---
+<div class="reveal overflow-hidden rounded-xl border border-border shadow-sm">
+  <div class="overflow-x-auto">
+    <table class="w-full min-w-[640px] border-collapse text-sm">
+      <thead>
+        <tr class="bg-muted">
+          <th class="min-w-[160px] whitespace-nowrap px-5 py-3.5 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground"></th>
+          {subjects.map((subject, i) => (
+            <th class={`whitespace-nowrap px-5 py-3.5 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground ${i === 0 ? 'bg-primary/5' : ''}`}>{subject}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <tr class="border-t border-border">
+            <td class="whitespace-nowrap px-5 py-3.5 font-medium text-foreground">{row.label}</td>
+            {row.cells.map((cell, i) => (
+              <td class={`px-5 py-3.5 text-pretty text-muted-foreground ${i === 0 ? 'bg-primary/5' : ''}`}>
+                <span class="inline-flex items-start gap-2">
+                  {cell.kind !== 'plain' && <Fragment set:html={iconFor(cell.kind)} />} {cell.text}
+                </span>
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+  <div class="border-t border-border bg-muted px-5 py-3.5 text-xs text-muted-foreground"><slot name="note" /></div>
+</div>

--- a/apps/landing/src/data/db-comparisons.ts
+++ b/apps/landing/src/data/db-comparisons.ts
@@ -1,0 +1,368 @@
+/**
+ * Row data for the /clickhouse-vs-* near-ICP database comparison pages
+ * (`DbComparisonTable.astro`) — plans/05-implementation-tasks.md S4.
+ *
+ * Unlike `comparisons.ts` (chmonitor vs a monitoring tool), these compare the
+ * underlying databases themselves. Every row is sourced from each project's
+ * public docs as of July 2026 (see each page's `note` slot for links) and
+ * deliberately includes rows where the other database wins — no strawmen.
+ */
+import type { DbComparisonRow } from '../components/DbComparisonTable.astro'
+
+export const timescaledbRows: DbComparisonRow[] = [
+  {
+    label: 'Core storage model',
+    cells: [
+      {
+        kind: 'plain',
+        text: 'Purpose-built columnar (MergeTree): every column stored and compressed separately, built for scanning wide analytical queries',
+      },
+      {
+        kind: 'plain',
+        text: 'A PostgreSQL extension: hypertables auto-partition by time; Hypercore (2.18+) adds a columnar store for cold chunks on top of the Postgres row-store',
+      },
+    ],
+  },
+  {
+    label: 'SQL dialect & ecosystem',
+    cells: [
+      {
+        kind: 'plain',
+        text: 'ClickHouse SQL: broad standard SQL plus CH-specific functions and table engines; the driver/ORM ecosystem is younger',
+      },
+      {
+        kind: 'plain',
+        text: 'Full PostgreSQL SQL and ecosystem — any Postgres driver, ORM, or extension (PostGIS, pgvector) works unmodified',
+      },
+    ],
+  },
+  {
+    label: 'ACID transactions & joins',
+    cells: [
+      {
+        kind: 'partial',
+        text: 'No multi-statement transactions; join support has improved a lot but denormalizing wide tables is still the idiomatic pattern at scale',
+      },
+      {
+        kind: 'yes',
+        text: "Full Postgres ACID transactions and a mature relational join planner, inherited unchanged",
+      },
+    ],
+  },
+  {
+    label: 'High-cardinality aggregation at scale',
+    cells: [
+      {
+        kind: 'yes',
+        text: 'Vectorized columnar execution scans billions of rows per second on modest hardware — the core design goal',
+      },
+      {
+        kind: 'partial',
+        text: 'Hypercore compression narrows the gap on cold data, but row-store execution still trails on wide ad hoc GROUP BY scans over hot data',
+      },
+    ],
+  },
+  {
+    label: 'Write pattern',
+    cells: [
+      {
+        kind: 'partial',
+        text: 'Optimized for large batch inserts; frequent tiny inserts create excess parts that need background merging',
+      },
+      {
+        kind: 'yes',
+        text: "Handles continuous small writes gracefully via Postgres MVCC — the common time-series/IoT ingestion pattern",
+      },
+    ],
+  },
+  {
+    label: 'Continuous / materialized aggregation',
+    cells: [
+      {
+        kind: 'yes',
+        text: 'Materialized views and projections, insert-triggered, ship in every edition',
+      },
+      {
+        kind: 'partial',
+        text: 'Continuous aggregates (self-refreshing materialized views) are a first-class feature, but ship under the Timescale License, not the Apache 2.0 core',
+      },
+    ],
+  },
+  {
+    label: 'Horizontal / distributed scale',
+    cells: [
+      {
+        kind: 'yes',
+        text: 'Native sharding and replication across many nodes is a hallmark use case, from a single node to petabyte-scale clusters',
+      },
+      {
+        kind: 'no',
+        text: 'Multi-node distributed hypertables were sunset in v2.13; scaling is single-node (Hypercore) plus Timescale Cloud for managed scale-out',
+      },
+    ],
+  },
+  {
+    label: 'Operational surface',
+    cells: [
+      {
+        kind: 'partial',
+        text: 'One extra moving part: ClickHouse Keeper (or ZooKeeper) coordinates replication and merges',
+      },
+      {
+        kind: 'yes',
+        text: "It's Postgres — one familiar system, one set of ops runbooks, one skillset to hire for",
+      },
+    ],
+  },
+  {
+    label: 'Licensing',
+    cells: [
+      { kind: 'plain', text: 'Apache 2.0, fully open source' },
+      {
+        kind: 'plain',
+        text: 'Core is Apache 2.0; compression, continuous aggregates, retention policies and bloom indexes ship under the source-available Timescale License (free unless resold as a hosted DBaaS)',
+      },
+    ],
+  },
+  {
+    label: 'Best fit',
+    cells: [
+      {
+        kind: 'plain',
+        text: 'Ad hoc analytics over huge, high-cardinality datasets: event/log analytics, real-time dashboards, wide GROUP BY across billions of rows',
+      },
+      {
+        kind: 'plain',
+        text: 'Time-series metrics with standard relational needs: IoT/financial data, complex joins, ACID guarantees, one Postgres skillset for OLTP and time-series',
+      },
+    ],
+  },
+]
+
+export const postgresRows: DbComparisonRow[] = [
+  {
+    label: 'Storage model',
+    cells: [
+      { kind: 'plain', text: 'Column-oriented (MergeTree): each column stored and compressed contiguously' },
+      { kind: 'plain', text: 'Row-oriented (heap + MVCC): each row stored contiguously, tuned for point lookups and transactions' },
+    ],
+  },
+  {
+    label: 'OLTP: single-row reads/writes',
+    cells: [
+      {
+        kind: 'no',
+        text: 'No true row-level UPDATE/DELETE — an ALTER … DELETE rewrites entire affected parts and can visibly degrade the cluster',
+      },
+      {
+        kind: 'yes',
+        text: 'Purpose-built for this: MVCC, row locks and indexes make single-row transactions fast and safe',
+      },
+    ],
+  },
+  {
+    label: 'Aggregation over large tables',
+    cells: [
+      {
+        kind: 'yes',
+        text: 'Vectorized execution plus columnar compression aggregates billions of rows per second without hand-tuned indexes',
+      },
+      {
+        kind: 'partial',
+        text: 'Fast with the right B-tree/BRIN indexes and enough RAM, but full-table scans over huge fact tables are inherently slower on row storage; Citus/columnar extensions close some of the gap',
+      },
+    ],
+  },
+  {
+    label: 'Joins',
+    cells: [
+      {
+        kind: 'partial',
+        text: 'JOIN support and the query planner have improved a lot, but denormalizing wide tables is still the idiomatic ClickHouse pattern for best performance',
+      },
+      { kind: 'yes', text: 'A mature cost-based planner handles complex multi-table joins well out of the box' },
+    ],
+  },
+  {
+    label: 'Indexing',
+    cells: [
+      {
+        kind: 'partial',
+        text: 'Performance depends on the primary key sort order plus skip indices — no general-purpose secondary index',
+      },
+      { kind: 'yes', text: 'Rich secondary indexing: B-tree, GIN, GiST, BRIN, partial and expression indexes' },
+    ],
+  },
+  {
+    label: 'Concurrency model',
+    cells: [
+      {
+        kind: 'partial',
+        text: 'Tuned for fewer, heavier analytical queries rather than thousands of small concurrent transactions',
+      },
+      { kind: 'yes', text: 'MVCC handles many concurrent small transactions cleanly — the OLTP sweet spot' },
+    ],
+  },
+  {
+    label: 'Compression & storage cost at scale',
+    cells: [
+      {
+        kind: 'yes',
+        text: "Columnar compression routinely reaches 10x+ on typical analytical data, cutting both storage and I/O",
+      },
+      {
+        kind: 'partial',
+        text: "Standard TOAST/page compression is modest; matching ClickHouse's ratios needs a columnar extension (Citus columnar, TimescaleDB Hypercore)",
+      },
+    ],
+  },
+  {
+    label: 'Ecosystem & extensions',
+    cells: [
+      {
+        kind: 'partial',
+        text: 'A narrower, fast-growing catalog: Kafka/S3/MySQL/PostgreSQL table engines, dbt-clickhouse, Grafana/Superset support',
+      },
+      {
+        kind: 'yes',
+        text: 'The deepest extension ecosystem in open-source databases: PostGIS, pgvector, TimescaleDB, Citus, decades of drivers and ORMs',
+      },
+    ],
+  },
+  {
+    label: 'Licensing',
+    cells: [
+      { kind: 'plain', text: 'Apache 2.0' },
+      { kind: 'plain', text: 'The PostgreSQL License — a permissive, OSI-approved license with effectively no restrictions' },
+    ],
+  },
+  {
+    label: 'Best fit',
+    cells: [
+      {
+        kind: 'plain',
+        text: 'Analytics dashboards, event/log analytics, and ad hoc GROUP BY over historical data at a scale where indexes stop helping',
+      },
+      {
+        kind: 'plain',
+        text: 'Transactional application data, referential integrity, and analytics that fit comfortably within what indexes and RAM can cover',
+      },
+    ],
+  },
+]
+
+export const druidPinotRows: DbComparisonRow[] = [
+  {
+    label: 'Primary design goal',
+    cells: [
+      { kind: 'plain', text: 'General-purpose OLAP: one engine for ad hoc SQL analytics and dashboards' },
+      {
+        kind: 'plain',
+        text: 'Real-time OLAP for sub-second interactive dashboards over streaming plus historical data',
+      },
+      {
+        kind: 'plain',
+        text: 'Ultra-low-latency, high-QPS analytics embedded directly in user-facing products (built at LinkedIn)',
+      },
+    ],
+  },
+  {
+    label: 'Node architecture',
+    cells: [
+      {
+        kind: 'plain',
+        text: 'Comparatively simple: ClickHouse server nodes plus built-in Keeper for replication coordination',
+      },
+      {
+        kind: 'plain',
+        text: 'Multiple specialized services — Coordinator, Overlord, Broker, Historical, MiddleManager — plus ZooKeeper and deep storage (S3/HDFS)',
+      },
+      { kind: 'plain', text: 'Three-tier — Controller, Broker, Server — plus ZooKeeper and deep storage' },
+    ],
+  },
+  {
+    label: 'Real-time streaming ingestion',
+    cells: [
+      {
+        kind: 'partial',
+        text: 'The Kafka table engine and materialized views support streaming, but batch inserts are the idiomatic pattern — frequent tiny inserts create excess parts',
+      },
+      {
+        kind: 'yes',
+        text: 'Built natively for continuous Kafka/Kinesis ingestion with segment-based real-time-to-historical handoff',
+      },
+      { kind: 'yes', text: 'Same native streaming design — events are indexed as soon as they land, for immediate queryability' },
+    ],
+  },
+  {
+    label: 'Query latency at high concurrency',
+    cells: [
+      {
+        kind: 'partial',
+        text: 'Scales to high concurrency but is tuned more for large ad hoc scans than guaranteed sub-second SLAs at massive QPS',
+      },
+      { kind: 'yes', text: 'Optimized for sub-second interactive dashboard queries' },
+      { kind: 'yes', text: 'Explicitly built for very high QPS, single-digit-millisecond point and aggregation lookups' },
+    ],
+  },
+  {
+    label: 'SQL completeness & ad hoc flexibility',
+    cells: [
+      {
+        kind: 'yes',
+        text: 'The richest, most complete SQL dialect of the three — the strongest fit for exploratory, hand-written analytical SQL',
+      },
+      {
+        kind: 'partial',
+        text: 'Druid SQL covers most common queries but with more restrictions than a general-purpose SQL engine, particularly around joins',
+      },
+      {
+        kind: 'partial',
+        text: 'A Calcite-based SQL layer over the native query API; join support has historically been limited',
+      },
+    ],
+  },
+  {
+    label: 'Operational complexity',
+    cells: [
+      { kind: 'yes', text: 'Fewer moving parts: no mandatory ZooKeeper for a single-node or simple replicated setup' },
+      {
+        kind: 'no',
+        text: 'A heavier footprint: multiple specialized services, ZooKeeper and deep storage are required even for small deployments',
+      },
+      { kind: 'no', text: 'Same story: ZooKeeper, deep storage and multiple service tiers required from day one' },
+    ],
+  },
+  {
+    label: 'Deployment footprint (small workloads)',
+    cells: [
+      { kind: 'yes', text: 'Runs comfortably as a single node for small-to-medium workloads, then scales out' },
+      { kind: 'no', text: 'Architected for distributed operation from the start — comparatively heavy for a small deployment' },
+      { kind: 'no', text: 'Same — designed distributed-first' },
+    ],
+  },
+  {
+    label: 'Proven at scale',
+    cells: [
+      { kind: 'plain', text: 'General analytics and log/event data — including product-analytics backends like PostHog' },
+      { kind: 'plain', text: 'Real-time streaming dashboards at companies including Netflix and Confluent' },
+      { kind: 'plain', text: 'User-facing real-time features at LinkedIn (50+ products) and Uber, serving 100K+ QPS at millisecond latency' },
+    ],
+  },
+  {
+    label: 'Licensing',
+    cells: [
+      { kind: 'plain', text: 'Apache 2.0' },
+      { kind: 'plain', text: 'Apache 2.0 (Apache Software Foundation project)' },
+      { kind: 'plain', text: 'Apache 2.0 (Apache Software Foundation project)' },
+    ],
+  },
+  {
+    label: 'Best fit',
+    cells: [
+      { kind: 'plain', text: 'Pick this for general-purpose analytics, ad hoc SQL, and the simplest ops of the three' },
+      { kind: 'plain', text: 'Pick this for streaming-native, sub-second interactive dashboards over time-partitioned event data' },
+      { kind: 'plain', text: 'Pick this for extremely high-QPS, low-latency analytics features baked directly into a product' },
+    ],
+  },
+]

--- a/apps/landing/src/pages/clickhouse-vs-druid-pinot.astro
+++ b/apps/landing/src/pages/clickhouse-vs-druid-pinot.astro
@@ -1,0 +1,135 @@
+---
+// Database-vs-database SEO comparison page (near-ICP, plans/05-implementation-tasks.md S4).
+// Three-way: ClickHouse vs Apache Druid vs Apache Pinot.
+import Base from '../layouts/Base.astro'
+import Nav from '../components/Nav.astro'
+import DbComparisonTable from '../components/DbComparisonTable.astro'
+import ComparisonLinks from '../components/ComparisonLinks.astro'
+import FinalCta from '../components/FinalCta.astro'
+import Footer from '../components/Footer.astro'
+import { druidPinotRows } from '../data/db-comparisons'
+
+const canonical = new URL(Astro.url.pathname, Astro.site).toString()
+const breadcrumbJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: new URL('/', Astro.site).toString() },
+    { '@type': 'ListItem', position: 2, name: 'ClickHouse vs Druid vs Pinot', item: canonical },
+  ],
+}
+
+const faqs = [
+  {
+    q: 'Which is faster: ClickHouse, Druid, or Pinot?',
+    a: "It depends what you're measuring. Pinot is built for the lowest point-lookup latency at very high QPS (single-digit milliseconds), Druid for sub-second interactive dashboard queries over streaming data, and ClickHouse for the broadest ad hoc analytical SQL — including large scans Druid and Pinot aren't optimized for.",
+  },
+  {
+    q: 'Why do Druid and Pinot need ZooKeeper and ClickHouse mostly doesn\'t?',
+    a: "Druid and Pinot were architected from the start as distributed, multi-service systems (coordinator, broker, historical/server nodes) that need a coordination layer. ClickHouse can run as a single node and uses its own built-in Keeper only when you add replication — a smaller operational surface for small-to-medium deployments.",
+  },
+  {
+    q: 'Is ClickHouse a real-time OLAP database like Druid or Pinot?',
+    a: 'It can ingest from Kafka and query fresh data, but its idiomatic ingestion pattern is larger batch inserts — frequent tiny inserts create excess parts that need merging. Druid and Pinot are purpose-built for continuous streaming ingestion with immediate queryability, which is their core differentiator.',
+  },
+  {
+    q: 'Which one should I pick for a startup?',
+    a: "For most teams, ClickHouse: simplest to operate as a single node, the richest SQL for ad hoc exploration, and it scales out when you need it. Reach for Druid or Pinot specifically when you're building a user-facing product feature that needs guaranteed low-latency queries at very high concurrency.",
+  },
+]
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map(({ q, a }) => ({
+    '@type': 'Question',
+    name: q,
+    acceptedAnswer: { '@type': 'Answer', text: a },
+  })),
+}
+---
+<Base
+  title="ClickHouse vs Druid vs Pinot — Honest 2026 Comparison"
+  description="A 3-way comparison of ClickHouse, Apache Druid and Apache Pinot: architecture, real-time ingestion, query latency, operational complexity and when to pick each, with sources."
+>
+  <script type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd)} is:inline />
+  <script type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} is:inline />
+  <Nav />
+  <main id="top">
+    <section class="band" style="padding-bottom:0">
+      <div class="wrap">
+        <div class="sec-head price-head reveal">
+          <span class="eyebrow">ClickHouse vs Druid vs Pinot</span>
+          <h1>Three real-time OLAP engines, three different jobs</h1>
+          <p>ClickHouse, Apache Druid and Apache Pinot are often shortlisted together, but they were built for different problems: general-purpose SQL analytics, streaming-native interactive dashboards, and ultra-low-latency user-facing features, respectively. Here's the honest, row-by-row comparison — including where the other two win.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="matrix" class="band band-soft">
+      <div class="wrap">
+        <div class="sec-head reveal" style="text-align:center">
+          <span class="eyebrow">Comparison matrix</span>
+          <h2>ClickHouse vs Apache Druid vs Apache Pinot</h2>
+          <p>Where each engine actually wins.</p>
+        </div>
+        <DbComparisonTable subjects={['ClickHouse', 'Apache Druid', 'Apache Pinot']} rows={druidPinotRows}>
+          <Fragment slot="note">
+            Druid and Pinot details reflect public docs as of July 2026 and may change — verify at <a href="https://druid.apache.org/docs/latest/design/architecture/" target="_blank" rel="noopener">druid.apache.org</a> and <a href="https://docs.pinot.apache.org/architecture-and-concepts/concepts/architecture" target="_blank" rel="noopener">docs.pinot.apache.org</a>. ClickHouse rows reflect the open-source engine.
+          </Fragment>
+        </DbComparisonTable>
+      </div>
+    </section>
+
+    <section id="fit" class="band">
+      <div class="wrap">
+        <div class="sec-head reveal" style="text-align:center">
+          <span class="eyebrow">Decision guide</span>
+          <h2>Which one fits your workload</h2>
+          <p>All three are open-source, distributed, and OLAP-flavored — the split is in what they optimize for.</p>
+        </div>
+        <div class="cap-grid">
+          <div class="cap reveal">
+            <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="m19 9-5 5-4-4-3 3"/></svg></span>
+            <h4>Choose ClickHouse for general-purpose analytics</h4>
+            <p>The richest SQL dialect of the three, the simplest single-node-to-cluster operational path, and the best fit for ad hoc exploratory queries.</p>
+          </div>
+          <div class="cap reveal">
+            <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19V5M4 19h16M8 15l3-4 3 3 4-6"/></svg></span>
+            <h4>Choose Druid for streaming dashboards</h4>
+            <p>Native segment-based real-time-to-historical ingestion built for sub-second, always-fresh interactive dashboards over event data.</p>
+          </div>
+          <div class="cap reveal">
+            <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 3"/></svg></span>
+            <h4>Choose Pinot for user-facing latency SLAs</h4>
+            <p>Purpose-built for single-digit-millisecond queries at very high QPS — the right tool when the query result is rendered directly in your product.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="faq" class="band band-soft">
+      <div class="wrap">
+        <div class="sec-head reveal" style="text-align:center">
+          <span class="eyebrow">FAQ</span>
+          <h2>Questions &amp; answers</h2>
+        </div>
+        <div class="reveal mx-auto mt-8 sm:mt-10 max-w-3xl">
+          {faqs.map(({ q, a }) => (
+            <details class="changelog-faq group border-b border-border first:border-t">
+              <summary class="flex min-h-12 cursor-pointer list-none items-center justify-between gap-3 sm:gap-4 py-4 sm:py-5 text-left text-sm sm:text-base font-semibold text-foreground marker:content-none [&::-webkit-details-marker]:hidden">
+                <span class="min-w-0 flex-1 text-pretty">{q}</span>
+                <span class="shrink-0 text-xl font-normal text-muted-foreground group-open:hidden" aria-hidden="true">+</span>
+                <span class="shrink-0 text-xl font-normal text-muted-foreground hidden group-open:inline" aria-hidden="true">&minus;</span>
+              </summary>
+              <div class="faq-ans pb-5 text-muted-foreground">{a}</div>
+            </details>
+          ))}
+        </div>
+      </div>
+    </section>
+
+    <ComparisonLinks current="clickhouse-vs-druid-pinot" />
+    <FinalCta />
+  </main>
+  <Footer />
+</Base>

--- a/apps/landing/src/pages/clickhouse-vs-postgres.astro
+++ b/apps/landing/src/pages/clickhouse-vs-postgres.astro
@@ -1,0 +1,139 @@
+---
+// Database-vs-database SEO comparison page (near-ICP, plans/05-implementation-tasks.md S4).
+import Base from '../layouts/Base.astro'
+import Nav from '../components/Nav.astro'
+import DbComparisonTable from '../components/DbComparisonTable.astro'
+import ComparisonLinks from '../components/ComparisonLinks.astro'
+import FinalCta from '../components/FinalCta.astro'
+import Footer from '../components/Footer.astro'
+import { postgresRows } from '../data/db-comparisons'
+
+const canonical = new URL(Astro.url.pathname, Astro.site).toString()
+const breadcrumbJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: new URL('/', Astro.site).toString() },
+    { '@type': 'ListItem', position: 2, name: 'ClickHouse vs Postgres', item: canonical },
+  ],
+}
+
+const faqs = [
+  {
+    q: 'Is ClickHouse faster than PostgreSQL for analytics?',
+    a: 'For aggregations over large historical tables, generally yes — ClickHouse only reads the columns a query touches and executes in a vectorized, compressed form, so it scans and aggregates far more rows per second than a row-store. For single-row lookups and small, well-indexed queries, Postgres is at least as fast and often faster.',
+  },
+  {
+    q: 'Can I just add indexes to PostgreSQL instead of adopting ClickHouse?',
+    a: "For moderate data volumes, yes — the right B-tree/BRIN indexes and enough RAM take Postgres a long way. The point where that stops working is roughly when full-table scans over your largest fact tables become routine; that's the signal to consider a columnar engine.",
+  },
+  {
+    q: "Should I replace Postgres with ClickHouse, or run both?",
+    a: 'Most teams run both: PostgreSQL for transactional application data (orders, users, billing) and ClickHouse for analytics (events, logs, metrics), often replicating from Postgres into ClickHouse via CDC or the built-in PostgreSQL table engine.',
+  },
+  {
+    q: 'Does ClickHouse support JOINs like PostgreSQL?',
+    a: "Yes, but the two differ. ClickHouse's join support and query planner have improved substantially, but denormalizing wide tables is still the idiomatic pattern for best performance at scale — Postgres's cost-based planner handles complex multi-table joins more naturally out of the box.",
+  },
+]
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map(({ q, a }) => ({
+    '@type': 'Question',
+    name: q,
+    acceptedAnswer: { '@type': 'Answer', text: a },
+  })),
+}
+---
+<Base
+  title="ClickHouse vs Postgres for Analytics — Honest 2026 Comparison"
+  description="ClickHouse vs PostgreSQL for analytical workloads: columnar vs row storage, aggregation speed, joins, indexing and concurrency — the real trade-offs, with sources."
+>
+  <script type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd)} is:inline />
+  <script type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} is:inline />
+  <Nav />
+  <main id="top">
+    <section class="band" style="padding-bottom:0">
+      <div class="wrap">
+        <div class="sec-head price-head reveal">
+          <span class="eyebrow">ClickHouse vs Postgres</span>
+          <h1>Columnar analytics vs the world's most trusted relational database</h1>
+          <p>PostgreSQL is the safe, general-purpose default — transactions, joins, indexes, a mature ecosystem, and it handles a surprising amount of analytics with the right indexes. ClickHouse gives up some of that relational comfort for columnar scan speed at a scale Postgres wasn't built for. Here's where each one actually wins.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="matrix" class="band band-soft">
+      <div class="wrap">
+        <div class="sec-head reveal" style="text-align:center">
+          <span class="eyebrow">Comparison matrix</span>
+          <h2>ClickHouse vs PostgreSQL</h2>
+          <p>Where each database actually wins — Postgres included.</p>
+        </div>
+        <DbComparisonTable subjects={['ClickHouse', 'PostgreSQL']} rows={postgresRows}>
+          <Fragment slot="note">
+            PostgreSQL details reflect the mainline engine and its public documentation as of July 2026 — verify at <a href="https://www.postgresql.org/docs/" target="_blank" rel="noopener">postgresql.org/docs</a>. Columnar/analytics extensions (Citus, TimescaleDB) are noted separately where relevant since they aren't part of core Postgres. ClickHouse rows reflect the open-source engine.
+          </Fragment>
+        </DbComparisonTable>
+      </div>
+    </section>
+
+    <section id="fit" class="band">
+      <div class="wrap">
+        <div class="sec-head reveal" style="text-align:center">
+          <span class="eyebrow">Decision guide</span>
+          <h2>Which one fits your workload</h2>
+          <p>The honest split: transactional correctness and flexibility vs raw aggregation speed at scale.</p>
+        </div>
+        <div class="cap-grid">
+          <div class="cap reveal">
+            <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="m19 9-5 5-4-4-3 3"/></svg></span>
+            <h4>Choose ClickHouse for large-scale aggregation</h4>
+            <p>Event/log analytics, product analytics, or any dashboard doing GROUP BY across billions of historical rows where indexes stop helping.</p>
+          </div>
+          <div class="cap reveal">
+            <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 10h18"/></svg></span>
+            <h4>Choose ClickHouse for cheap, fast storage</h4>
+            <p>10x+ columnar compression on typical analytical data cuts both storage cost and the I/O each query has to do.</p>
+          </div>
+          <div class="cap reveal">
+            <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M9 12l2 2 4-4"/><circle cx="12" cy="12" r="9"/></svg></span>
+            <h4>Choose Postgres for transactional data</h4>
+            <p>Orders, users, billing — anywhere you need ACID transactions, row-level updates, and referential integrity as first-class guarantees.</p>
+          </div>
+          <div class="cap reveal">
+            <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 1v22M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg></span>
+            <h4>Choose Postgres for moderate-scale analytics</h4>
+            <p>If your reporting queries fit comfortably within what a well-indexed table and enough RAM can cover, you don't need a second database yet.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="faq" class="band band-soft">
+      <div class="wrap">
+        <div class="sec-head reveal" style="text-align:center">
+          <span class="eyebrow">FAQ</span>
+          <h2>Questions &amp; answers</h2>
+        </div>
+        <div class="reveal mx-auto mt-8 sm:mt-10 max-w-3xl">
+          {faqs.map(({ q, a }) => (
+            <details class="changelog-faq group border-b border-border first:border-t">
+              <summary class="flex min-h-12 cursor-pointer list-none items-center justify-between gap-3 sm:gap-4 py-4 sm:py-5 text-left text-sm sm:text-base font-semibold text-foreground marker:content-none [&::-webkit-details-marker]:hidden">
+                <span class="min-w-0 flex-1 text-pretty">{q}</span>
+                <span class="shrink-0 text-xl font-normal text-muted-foreground group-open:hidden" aria-hidden="true">+</span>
+                <span class="shrink-0 text-xl font-normal text-muted-foreground hidden group-open:inline" aria-hidden="true">&minus;</span>
+              </summary>
+              <div class="faq-ans pb-5 text-muted-foreground">{a}</div>
+            </details>
+          ))}
+        </div>
+      </div>
+    </section>
+
+    <ComparisonLinks current="clickhouse-vs-postgres" />
+    <FinalCta />
+  </main>
+  <Footer />
+</Base>

--- a/apps/landing/src/pages/clickhouse-vs-timescaledb.astro
+++ b/apps/landing/src/pages/clickhouse-vs-timescaledb.astro
@@ -1,0 +1,142 @@
+---
+// Database-vs-database SEO comparison page (near-ICP, plans/05-implementation-tasks.md S4).
+// Distinct from /vs-grafana etc, which compare chmonitor against a monitoring tool —
+// this compares the underlying databases and tells people who land here where
+// chmonitor fits once they've picked one.
+import Base from '../layouts/Base.astro'
+import Nav from '../components/Nav.astro'
+import DbComparisonTable from '../components/DbComparisonTable.astro'
+import ComparisonLinks from '../components/ComparisonLinks.astro'
+import FinalCta from '../components/FinalCta.astro'
+import Footer from '../components/Footer.astro'
+import { timescaledbRows } from '../data/db-comparisons'
+
+const canonical = new URL(Astro.url.pathname, Astro.site).toString()
+const breadcrumbJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: new URL('/', Astro.site).toString() },
+    { '@type': 'ListItem', position: 2, name: 'ClickHouse vs TimescaleDB', item: canonical },
+  ],
+}
+
+const faqs = [
+  {
+    q: 'Is TimescaleDB faster than ClickHouse?',
+    a: 'For single-row reads/writes and standard relational queries, yes — it inherits PostgreSQL\'s OLTP performance. For wide ad hoc aggregations across billions of rows, ClickHouse\'s columnar engine is generally faster because it only reads the columns a query touches and scans them in a vectorized, compressed form.',
+  },
+  {
+    q: 'Can TimescaleDB replace ClickHouse for analytics?',
+    a: 'For moderate-scale time-series analytics with relational needs (joins, ACID transactions), yes. For high-cardinality, exploratory analytics over huge historical datasets, or workloads that need to scale out across many nodes, ClickHouse is the better fit — TimescaleDB sunset multi-node distributed hypertables in v2.13.',
+  },
+  {
+    q: 'Do I need ClickHouse if I already use PostgreSQL?',
+    a: "Not necessarily. If your analytical queries run fast enough on Postgres (with or without TimescaleDB), keep one database. Reach for ClickHouse when GROUP BY/aggregation queries over your largest tables get too slow even with the right indexes — that's the point where columnar storage starts to matter.",
+  },
+  {
+    q: 'How do I monitor a ClickHouse cluster once I pick it?',
+    a: 'chmonitor reads ClickHouse system tables directly — no exporters or agents — and ships pre-built pages for queries, merges, parts and replication, plus a recommend-only advisor and an AI agent. It self-hosts for free or runs as a hosted cloud.',
+  },
+]
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map(({ q, a }) => ({
+    '@type': 'Question',
+    name: q,
+    acceptedAnswer: { '@type': 'Answer', text: a },
+  })),
+}
+---
+<Base
+  title="ClickHouse vs TimescaleDB — Honest 2026 Comparison"
+  description="ClickHouse vs TimescaleDB compared: columnar OLAP vs a Postgres time-series extension — storage, joins, compression, distributed scale, licensing and when to pick each, with sources."
+>
+  <script type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd)} is:inline />
+  <script type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} is:inline />
+  <Nav />
+  <main id="top">
+    <section class="band" style="padding-bottom:0">
+      <div class="wrap">
+        <div class="sec-head price-head reveal">
+          <span class="eyebrow">ClickHouse vs TimescaleDB</span>
+          <h1>A columnar OLAP engine vs a Postgres time-series extension</h1>
+          <p>TimescaleDB gives you time-series superpowers without leaving PostgreSQL — full SQL, joins, ACID transactions, one familiar operational surface. ClickHouse trades that relational comfort for raw columnar scan speed at a scale TimescaleDB isn't built to reach. Neither is "better" in the abstract — here's the honest, row-by-row comparison.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="matrix" class="band band-soft">
+      <div class="wrap">
+        <div class="sec-head reveal" style="text-align:center">
+          <span class="eyebrow">Comparison matrix</span>
+          <h2>ClickHouse vs TimescaleDB</h2>
+          <p>Where each database actually wins — TimescaleDB included.</p>
+        </div>
+        <DbComparisonTable subjects={['ClickHouse', 'TimescaleDB']} rows={timescaledbRows}>
+          <Fragment slot="note">
+            TimescaleDB details reflect public docs as of July 2026 and may change — verify at <a href="https://docs.timescale.com/about/latest/timescaledb-editions/" target="_blank" rel="noopener">Tiger Data's edition comparison</a>, the <a href="https://www.tigerdata.com/legal/licenses" target="_blank" rel="noopener">Timescale License page</a> and the <a href="https://github.com/timescale/timescaledb/blob/main/docs/MultiNodeDeprecation.md" target="_blank" rel="noopener">multi-node deprecation notice</a>. ClickHouse rows reflect the open-source engine, not any specific vendor's build.
+          </Fragment>
+        </DbComparisonTable>
+      </div>
+    </section>
+
+    <section id="fit" class="band">
+      <div class="wrap">
+        <div class="sec-head reveal" style="text-align:center">
+          <span class="eyebrow">Decision guide</span>
+          <h2>Which one fits your workload</h2>
+          <p>The honest split: relational comfort and moderate scale vs columnar speed at high cardinality and volume.</p>
+        </div>
+        <div class="cap-grid">
+          <div class="cap reveal">
+            <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="m19 9-5 5-4-4-3 3"/></svg></span>
+            <h4>Choose ClickHouse for high-cardinality analytics</h4>
+            <p>Event/log analytics, product analytics, or any workload doing wide ad hoc GROUP BY across billions of rows where indexes stop helping.</p>
+          </div>
+          <div class="cap reveal">
+            <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3a14 14 0 0 1 0 18M12 3a14 14 0 0 0 0 18"/></svg></span>
+            <h4>Choose ClickHouse to scale out across nodes</h4>
+            <p>Native sharding and replication handle petabyte-scale clusters — the model TimescaleDB moved away from when it sunset multi-node.</p>
+          </div>
+          <div class="cap reveal">
+            <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M9 12l2 2 4-4"/><circle cx="12" cy="12" r="9"/></svg></span>
+            <h4>Choose TimescaleDB for relational time-series</h4>
+            <p>IoT/financial metrics with real joins, ACID transactions, and referential integrity — standard Postgres semantics you don't want to give up.</p>
+          </div>
+          <div class="cap reveal">
+            <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 1v22M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg></span>
+            <h4>Choose TimescaleDB for one skillset, one system</h4>
+            <p>If your app data and your time-series data both live comfortably in Postgres, one operational surface beats running two databases.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="faq" class="band band-soft">
+      <div class="wrap">
+        <div class="sec-head reveal" style="text-align:center">
+          <span class="eyebrow">FAQ</span>
+          <h2>Questions &amp; answers</h2>
+        </div>
+        <div class="reveal mx-auto mt-8 sm:mt-10 max-w-3xl">
+          {faqs.map(({ q, a }) => (
+            <details class="changelog-faq group border-b border-border first:border-t">
+              <summary class="flex min-h-12 cursor-pointer list-none items-center justify-between gap-3 sm:gap-4 py-4 sm:py-5 text-left text-sm sm:text-base font-semibold text-foreground marker:content-none [&::-webkit-details-marker]:hidden">
+                <span class="min-w-0 flex-1 text-pretty">{q}</span>
+                <span class="shrink-0 text-xl font-normal text-muted-foreground group-open:hidden" aria-hidden="true">+</span>
+                <span class="shrink-0 text-xl font-normal text-muted-foreground hidden group-open:inline" aria-hidden="true">&minus;</span>
+              </summary>
+              <div class="faq-ans pb-5 text-muted-foreground">{a}</div>
+            </details>
+          ))}
+        </div>
+      </div>
+    </section>
+
+    <ComparisonLinks current="clickhouse-vs-timescaledb" />
+    <FinalCta />
+  </main>
+  <Footer />
+</Base>

--- a/apps/landing/src/pages/vs-clickhouse-cloud.astro
+++ b/apps/landing/src/pages/vs-clickhouse-cloud.astro
@@ -2,6 +2,7 @@
 import Base from '../layouts/Base.astro'
 import Nav from '../components/Nav.astro'
 import ComparisonTable from '../components/ComparisonTable.astro'
+import ComparisonLinks from '../components/ComparisonLinks.astro'
 import FinalCta from '../components/FinalCta.astro'
 import Footer from '../components/Footer.astro'
 import { clickhouseCloudRows } from '../data/comparisons'
@@ -80,6 +81,7 @@ const breadcrumbJsonLd = {
       </div>
     </section>
 
+    <ComparisonLinks current="vs-clickhouse-cloud" />
     <FinalCta />
   </main>
   <Footer />

--- a/apps/landing/src/pages/vs-datadog.astro
+++ b/apps/landing/src/pages/vs-datadog.astro
@@ -2,6 +2,7 @@
 import Base from '../layouts/Base.astro'
 import Nav from '../components/Nav.astro'
 import ComparisonTable from '../components/ComparisonTable.astro'
+import ComparisonLinks from '../components/ComparisonLinks.astro'
 import FinalCta from '../components/FinalCta.astro'
 import Footer from '../components/Footer.astro'
 import { datadogRows } from '../data/comparisons'
@@ -80,6 +81,7 @@ const breadcrumbJsonLd = {
       </div>
     </section>
 
+    <ComparisonLinks current="vs-datadog" />
     <FinalCta />
   </main>
   <Footer />

--- a/apps/landing/src/pages/vs-grafana.astro
+++ b/apps/landing/src/pages/vs-grafana.astro
@@ -2,6 +2,7 @@
 import Base from '../layouts/Base.astro'
 import Nav from '../components/Nav.astro'
 import ComparisonTable from '../components/ComparisonTable.astro'
+import ComparisonLinks from '../components/ComparisonLinks.astro'
 import FinalCta from '../components/FinalCta.astro'
 import Footer from '../components/Footer.astro'
 import { grafanaRows } from '../data/comparisons'
@@ -80,6 +81,7 @@ const breadcrumbJsonLd = {
       </div>
     </section>
 
+    <ComparisonLinks current="vs-grafana" />
     <FinalCta />
   </main>
   <Footer />


### PR DESCRIPTION
## Summary
- Adds three new SEO comparison pages per the 2026H2 market research plan (S4): `/clickhouse-vs-timescaledb`, `/clickhouse-vs-postgres`, `/clickhouse-vs-druid-pinot` — honest, sourced database-vs-database comparisons for near-ICP search traffic (people choosing an analytics database, not yet chmonitor users).
- New `DbComparisonTable.astro`: a generic N-column comparison matrix (2-way or 3-way), distinct from the existing chmonitor-specific `ComparisonTable.astro` used by `/vs-grafana`, `/vs-datadog`, `/vs-clickhouse-cloud`.
- New `ComparisonLinks.astro`: interlinks all six comparison pages (the three existing "chmonitor vs tool" pages plus the three new "ClickHouse vs database" pages), added to all six pages.
- Each page follows the existing `/vs-*` template (`Base`/`Nav`/`FinalCta`/`Footer`, `.band`/`.cap-grid` styling), plus a page-specific FAQ with `FAQPage` JSON-LD and a `BreadcrumbList` JSON-LD, matching house SEO conventions.
- Every comparison row is sourced from each project's public docs as of July 2026 (TimescaleDB licensing/multi-node deprecation, Druid/Pinot architecture) with a dated "verify at ..." disclaimer under each table, and deliberately includes rows where the other database wins — no strawmen.

## Test plan
- [x] `pnpm install` (apps/landing) resolves cleanly against the frozen lockfile.
- [x] `biome lint` on the new/changed TS data file passes (Biome doesn't process `.astro` in this repo; verified `.astro` structure manually — tag balance, `Fragment`/JSX patterns cross-checked against the existing shipped `/vs-*` pages).
- [ ] Full `pnpm run build` (skipped per task constraints — parallel builds OOM the dev machine; standard CI build will validate types/routes).

Closes #2386