### PR TITLE
feat(mcp): add registry manifest + one-command install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,30 @@ plus a short list of what you changed:
 
 **llms.txt** — standardized file that helps AI coding agents discover and understand the codebase structure. Access at `https://your-domain.com/llms.txt` or `/llms.txt` in local development.
 
-**MCP Server** — exposes a Model Context Protocol endpoint at `/api/mcp` for AI tools to query your ClickHouse cluster directly. See [docs/knowledge/mcp-server.md](docs/knowledge/mcp-server.md) for setup.
+**MCP Server** — exposes a Model Context Protocol endpoint at `/api/mcp` for AI tools to query your ClickHouse cluster directly (read-only). One-command install:
+
+```bash
+# Claude Code
+claude mcp add --transport http clickhouse-monitor https://your-chmonitor.example.com/api/mcp \
+  --header "Authorization: Bearer chm_your_api_key"
+```
+
+```json
+// Claude Desktop (claude_desktop_config.json) or Cursor (.cursor/mcp.json)
+{
+  "mcpServers": {
+    "clickhouse-monitor": {
+      "url": "https://your-chmonitor.example.com/api/mcp",
+      "headers": { "Authorization": "Bearer chm_your_api_key" }
+    }
+  }
+}
+```
+
+Omit the `Authorization` header/flag for an unauthenticated local instance. Full client
+walkthroughs (Claude Desktop, Claude Code, Cursor, any MCP client) and auth setup:
+[docs/content/reference/mcp-clients.mdx](docs/content/reference/mcp-clients.mdx) ·
+[docs/knowledge/mcp-server.md](docs/knowledge/mcp-server.md).
 
 **Knowledge Graph** — developer-facing notes in `docs/knowledge/` with decisions, conventions, and architecture docs. See [docs/knowledge/README.md](docs/knowledge/README.md) for the index.
 

--- a/docs/content/guide/features/mcp.mdx
+++ b/docs/content/guide/features/mcp.mdx
@@ -16,6 +16,18 @@ Turn your chmonitor instance into a remote Model Context Protocol server so AI a
   }}
 />
 
+## Quickstart
+
+One-command install for Claude Code:
+
+```bash
+claude mcp add --transport http clickhouse-monitor https://your-chmonitor.example.com/api/mcp \
+  --header "Authorization: Bearer chm_your_api_key"
+```
+
+Omit `--header` for an unauthenticated local instance. For Claude Desktop, Cursor, and
+any other MCP client, see [MCP Client Setup](/reference/mcp-clients).
+
 ## What it does
 
 chmonitor exposes a remote MCP (Model Context Protocol) endpoint at `/api/mcp`. External AI tools — Claude Desktop, Cursor, or any MCP-compatible client — can connect and run tools against your ClickHouse cluster without direct database access.

--- a/docs/content/reference/mcp-server.mdx
+++ b/docs/content/reference/mcp-server.mdx
@@ -32,7 +32,19 @@ Connect a client, then verify the connection.
 <Step>
 ### Add the server to your client
 
-<Tabs items={['Claude Desktop', 'Cursor']}>
+<Tabs items={['Claude Code', 'Claude Desktop', 'Cursor']}>
+<Tab value="Claude Code">
+
+One command:
+
+```bash
+claude mcp add --transport http clickhouse-monitor https://your-deployment.example.com/api/mcp \
+  --header "Authorization: Bearer chm_your_api_key"
+```
+
+Omit `--header` for a local unauthenticated instance.
+
+</Tab>
 <Tab value="Claude Desktop">
 
 Add to your MCP client config file:

--- a/docs/internal/2026h2-market/mcp-registry-submissions.md
+++ b/docs/internal/2026h2-market/mcp-registry-submissions.md
@@ -1,0 +1,215 @@
+# MCP registry submissions (M3)
+
+> Source: 2026-H2 market research, task **M3** in
+> [`05-implementation-tasks.md`](./05-implementation-tasks.md) /
+> [issue #2390](https://github.com/chmonitor/chmonitor/issues/2390). This doc holds the
+> exact payload/text for each external registry — the agent that prepared this does not
+> submit to external services, so a maintainer sends these by hand. See
+> [`docs/knowledge/mcp-server.md`](../../knowledge/mcp-server.md) for the in-repo half
+> (`server.json`, one-command install docs).
+
+**Server identity used everywhere below:**
+
+| Field | Value |
+|---|---|
+| Name | chmonitor |
+| Endpoint | `https://dash.chmonitor.dev/api/mcp` (streamable-http, stateless) |
+| Repo | <https://github.com/chmonitor/chmonitor> (source: `apps/mcp` + `packages/mcp-server`) |
+| Homepage | <https://chmonitor.dev> |
+| Auth | `Authorization: Bearer chm_...` (API key, see [`/operate/authentication/api-keys`](https://docs.chmonitor.dev/operate/authentication/api-keys)) or Clerk OAuth on the hosted instance; self-hosted instances may run open on a trusted network |
+| Category | Database / observability / DevOps |
+| Tools | `query`, `list_databases`, `list_tables`, `get_table_schema`, `get_metrics`, `get_running_queries`, `get_slow_queries`, `get_merge_status`, `explore_table_schema`, `analyze_performance` (read-only) |
+
+One-line pitch: **"Give your AI agent safe, read-only access to ClickHouse system tables — ask Claude why your query is slow, why parts are piling up, or why replication is lagging."**
+
+---
+
+## 1. Official MCP Registry (registry.modelcontextprotocol.io)
+
+**What's already in-repo:** `server.json` at the repo root, validated against
+`https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`
+(`name: io.github.chmonitor/chmonitor`, `remotes[0]` = the streamable-http endpoint
+above). Nothing to hand-copy — the maintainer publishes that file as-is.
+
+**Publish steps** (from repo root, needs a GitHub account with write access to the
+`chmonitor` org — that's what proves the `io.github.chmonitor/*` namespace):
+
+```bash
+# 1. Install the CLI
+curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+  | tar xz mcp-publisher && sudo mv mcp-publisher /usr/local/bin/
+
+# 2. Authenticate (device flow — opens github.com/login/device)
+mcp-publisher login github
+
+# 3. Publish server.json from the repo root
+mcp-publisher publish
+
+# 4. Verify
+curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.chmonitor/chmonitor"
+```
+
+**Upkeep:** bump the `version` field in `server.json` and re-run `mcp-publisher publish`
+whenever the MCP tool list, auth model, or endpoint URL changes — the registry does not
+auto-sync from the repo.
+
+**Optional upgrade:** chmonitor owns `chmonitor.dev`, so the namespace could later move
+from `io.github.chmonitor/chmonitor` to a DNS-verified `dev.chmonitor/chmonitor` (add a
+`_mcp-registry.chmonitor.dev` TXT record with a challenge token from
+`mcp-publisher login dns`). Not required — GitHub auth is sufficient — but a cleaner
+long-term name if the maintainer wants it.
+
+**Optional follow-up (not implemented here):** a GitHub Actions job that runs
+`mcp-publisher publish` on release, using a registry token stored as a repo secret. See
+<https://github.com/modelcontextprotocol/registry> docs ("Publish with GitHub Actions")
+if this is worth automating later — skipped in this change since it needs the
+maintainer to mint and store that credential first.
+
+---
+
+## 2. PulseMCP (pulsemcp.com)
+
+**Submit at:** <https://www.pulsemcp.com/submit>
+
+The form's only required field is a **URL** ("Can be a GitHub repository, a subfolder of
+a repository, or a standalone website"). Submit type: **MCP Server** (there's a toggle
+for Server vs. Client).
+
+**URL to submit:** `https://github.com/chmonitor/chmonitor/tree/main/apps/mcp`
+
+If the form expands to ask for more (PulseMCP has iterated on this form; re-check before
+submitting), use:
+
+- **Name:** chmonitor
+- **Description:** Read-only MCP server for ClickHouse monitoring — query schema, slow
+  queries, merges, replication, and cluster health. Part of chmonitor, an open-source
+  operational advisor for ClickHouse (recommends projections, skip indexes, partition
+  keys, and materialized views from `system.*`, never auto-applies DDL).
+- **Repo:** <https://github.com/chmonitor/chmonitor>
+- **Website:** <https://chmonitor.dev>
+- **Category:** Databases / DevOps / Observability
+
+PulseMCP's homepage also states they now work directly with partners for curated,
+quality-controlled listings (contact `hello@pulsemcp.com`) — worth a follow-up email if
+the self-serve form is slow to process.
+
+---
+
+## 3. cursor.directory
+
+**Submit at:** <https://cursor.directory/mcp> (look for the "Submit" affordance on the
+MCP section; cursor.directory is community-run and has changed its submission UI more
+than once, so verify the current flow before sending — no stable public API or GitHub PR
+process was found as of this writing).
+
+**Payload to paste into whatever form is live:**
+
+- **Name:** chmonitor
+- **Tagline:** ClickHouse monitoring and query diagnostics for your AI agent
+- **Description:** Connects Cursor to a ClickHouse cluster through chmonitor's MCP
+  server. Query schema, inspect running/slow queries, check merge and replication
+  health, and get read-only answers about why a query is slow or why parts are piling
+  up — without giving the agent direct database credentials.
+- **Config snippet** (what cursor.directory typically shows users to add to
+  `.cursor/mcp.json`):
+
+  ```json
+  {
+    "mcpServers": {
+      "clickhouse-monitor": {
+        "url": "https://dash.chmonitor.dev/api/mcp",
+        "headers": { "Authorization": "Bearer chm_your_api_key" }
+      }
+    }
+  }
+  ```
+
+- **Repo:** <https://github.com/chmonitor/chmonitor>
+- **Category:** Database / DevOps
+
+---
+
+## 4. Smithery (smithery.ai)
+
+Smithery's primary flow is "connect a GitHub repo, Smithery builds/hosts it" (via a
+`smithery.yaml` describing a `build` + `startCommand`) — that model doesn't fit
+chmonitor, which already runs as a long-lived remote HTTP server operators self-host or
+use at `dash.chmonitor.dev`. **Do not add a `smithery.yaml`** that tells Smithery to
+build/run the server; that would be misleading (Smithery would try to containerize and
+host a copy instead of pointing at the real, already-running endpoint).
+
+**Submit instead as an externally-hosted remote server:**
+
+1. Go to <https://smithery.ai> → sign in → "Add Server" / "New" (their new-server
+   flow currently starts from a GitHub repo URL; if it insists on a build config,
+   choose the "remote / already deployed" option rather than "build from source" — this
+   has moved around Smithery's UI, re-check at submission time).
+2. Point it at: <https://github.com/chmonitor/chmonitor> (repo), remote endpoint
+   `https://dash.chmonitor.dev/api/mcp`.
+3. Fields to fill:
+   - **Name:** chmonitor
+   - **Description:** (same as PulseMCP above)
+   - **Transport:** Streamable HTTP
+   - **Auth:** Bearer token (API key) — mark as required; mention Clerk OAuth is also
+     accepted on the hosted instance
+   - **Tools:** the 10-tool list in the table above (`query`, `list_databases`, …)
+
+If Smithery's flow strictly requires a `smithery.yaml` even for remote servers, a
+minimal one (not added to the repo by this change — add only if Smithery's own docs
+confirm this shape at submission time) would look like:
+
+```yaml
+# smithery.yaml — NOT committed; reference only, verify against
+# https://smithery.ai/docs/build before adding to the repo.
+runtime: "remote"
+remote:
+  url: "https://dash.chmonitor.dev/api/mcp"
+  transport: "streamable-http"
+  headers:
+    Authorization:
+      description: "Bearer chm_ API key or Clerk OAuth token"
+      required: true
+```
+
+---
+
+## 5. Glama (glama.ai)
+
+Glama indexes servers directly from a GitHub repo — no form fields beyond the repo URL
+are documented; it crawls the README, tool schemas, and annotations.
+
+**Submit at:** <https://glama.ai/mcp/servers> (look for "Add server" / "Submit"; as with
+the others, verify the current entry point before sending).
+
+**URL to submit:** `https://github.com/chmonitor/chmonitor`
+
+Glama's quality bar favors "a real README with an install guide" over a bare git URL —
+the repo README's MCP Server section (one-command `claude mcp add` + Cursor JSON
+snippet, added in this change) and
+[`docs/content/reference/mcp-server.mdx`](../../content/reference/mcp-server.mdx) /
+[`mcp-clients.mdx`](../../content/reference/mcp-clients.mdx) should satisfy that. If
+Glama's submission form asks for fields explicitly:
+
+- **Name:** chmonitor
+- **Repository:** <https://github.com/chmonitor/chmonitor>
+- **Installation snippet:** the `claude mcp add --transport http clickhouse-monitor
+  https://dash.chmonitor.dev/api/mcp --header "Authorization: Bearer chm_..."`
+  one-liner from the README
+- **Transport:** Streamable HTTP
+- **Tool count:** 10
+- **One-line capability summary:** (same one-line pitch as the top of this doc)
+
+Glama also supports multiple listed servers per domain if a repo exposes more than one —
+not applicable here since `apps/mcp` is the single MCP endpoint for the whole product.
+
+---
+
+## Not in scope for this task
+
+- **awesome-clickhouse PR** and **README-as-landing-page** polish are task **M4**
+  ([`05-implementation-tasks.md`](./05-implementation-tasks.md)), already prepared
+  separately in
+  [`awesome-clickhouse-submission.md`](./awesome-clickhouse-submission.md).
+- **GitHub Actions auto-publish** to the official registry on release — flagged as a
+  follow-up above, not implemented (needs a registry token secret the maintainer must
+  mint first).

--- a/docs/knowledge/mcp-server.md
+++ b/docs/knowledge/mcp-server.md
@@ -3,7 +3,7 @@ id: mcp-server
 title: MCP Server
 type: reference
 status: active
-updated: 2026-05-13
+updated: 2026-07-10
 tags:
   - mcp
   - api
@@ -85,6 +85,24 @@ exposure is visible in logs and cannot be silently forgotten.
 - `packages/mcp-server/src/http.ts` — auth gate (`defaultAuthenticator`)
 - `packages/mcp-server/src/auth/` — api-key + Clerk OAuth verifiers
 - Tests: `packages/mcp-server/src/__tests__/http.test.ts`
+
+## Distribution: registry listing + one-command install
+
+- **`server.json`** (repo root) — the [official MCP Registry](https://github.com/modelcontextprotocol/registry)
+  manifest (`io.github.chmonitor/chmonitor`), pointing at the hosted remote endpoint
+  (`https://dash.chmonitor.dev/api/mcp`, streamable-http). Validate against
+  `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`
+  before editing (bump `version` whenever the listing changes; publish with
+  `mcp-publisher publish` after `mcp-publisher login github`).
+- **One-command install** — `claude mcp add --transport http ...` snippets live in
+  README.md, `docs/content/guide/features/mcp.mdx` (Quickstart), and
+  `docs/content/reference/mcp-server.mdx` / `mcp-clients.mdx` (full per-client
+  walkthroughs: Claude Code, Claude Desktop, Cursor, generic client). Keep all four in
+  sync when the endpoint path, tool list, or auth header shape changes.
+- **External registry submissions** (official registry, PulseMCP, cursor.directory,
+  Smithery, Glama) are prepared but NOT auto-submitted — exact payload/text for each is
+  in `docs/internal/2026h2-market/mcp-registry-submissions.md` for a maintainer to send
+  manually.
 
 ## Consuming external MCP servers (per-user registry)
 

--- a/server.json
+++ b/server.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.chmonitor/chmonitor",
+  "title": "chmonitor",
+  "description": "Read-only MCP server for ClickHouse: schema, queries, merges, replication, and cluster health.",
+  "websiteUrl": "https://chmonitor.dev",
+  "repository": {
+    "url": "https://github.com/chmonitor/chmonitor",
+    "source": "github",
+    "subfolder": "apps/mcp"
+  },
+  "version": "0.2.9",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://dash.chmonitor.dev/api/mcp",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "Bearer token: a chm_ API key (see /operate/authentication/api-keys) or a Clerk OAuth access token. Required on the hosted dash.chmonitor.dev instance; self-hosted instances may run without it.",
+          "isRequired": true,
+          "isSecret": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add a schema-validated `server.json` at the repo root so `apps/mcp` (the remote streamable-http MCP server at `https://dash.chmonitor.dev/api/mcp`) can be published to the official MCP Registry (`io.github.chmonitor/chmonitor`).
- Add a one-command `claude mcp add` install + Cursor JSON snippet to `README.md`'s MCP Server section.
- Add a Quickstart section (CLI one-liner) to `docs/content/guide/features/mcp.mdx`, and a "Claude Code" tab to `docs/content/reference/mcp-server.mdx` (mirroring the existing tab in `mcp-clients.mdx`).
- Update `docs/knowledge/mcp-server.md` with a "Distribution" section documenting `server.json`, the doc/README sync points, and where the external submission payloads live.
- Prepare exact submission payloads for PulseMCP, cursor.directory, Smithery, and Glama in `docs/internal/2026h2-market/mcp-registry-submissions.md` — **not submitted**, since an agent shouldn't create accounts/submit to third-party services. A maintainer sends these by hand; the doc also has the `mcp-publisher` CLI commands to publish `server.json` to the official registry.

## Verification
- `server.json` validated against `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json` with `jsonschema` (passes).
- `pnpm exec biome check server.json` — clean.
- Manually balance-checked the new `<Tabs>`/`<Tab>`/`<Step>` MDX blocks (open/close counts match) in both edited `.mdx` files.
- No app code changed — targeted checks only, per house convention (full `pnpm run build` skipped intentionally to avoid the parallel-build OOM risk called out in the task).

## Test plan
- [ ] Skim rendered `docs.chmonitor.dev` MCP pages after merge (Quickstart section + Claude Code tab) once the docs site rebuilds.
- [ ] Maintainer runs `mcp-publisher login github` + `mcp-publisher publish` from repo root to publish `server.json` to the official MCP Registry.
- [ ] Maintainer works through `docs/internal/2026h2-market/mcp-registry-submissions.md` for PulseMCP / cursor.directory / Smithery / Glama.

## Follow-ups (noted in the submissions doc, not implemented here)
- Optional: move the registry namespace from `io.github.chmonitor/chmonitor` to a DNS-verified `dev.chmonitor/chmonitor` (chmonitor owns `chmonitor.dev`).
- Optional: a GitHub Actions job to auto-publish `server.json` on release (needs a registry token secret to be minted first).
- M4 (awesome-clickhouse PR + README-as-landing-page) is a separate task, already prepared in `docs/internal/2026h2-market/awesome-clickhouse-submission.md`.

Closes #2390