### PR TITLE
test(billing): lock in annual billing plan resolution

### DIFF
--- a/apps/dashboard/src/lib/billing/polar-subscription.test.ts
+++ b/apps/dashboard/src/lib/billing/polar-subscription.test.ts
@@ -29,10 +29,13 @@ mock.module('./polar-config', () => ({
   }),
   getWebhookSecret: () => 'whsec_test',
   productIdFor: () => null,
-  planForProductId: (productId: string) =>
-    productId === 'prod_pro'
-      ? { planId: 'pro', period: 'monthly' as const }
-      : null,
+  planForProductId: (productId: string) => {
+    if (productId === 'prod_pro')
+      return { planId: 'pro', period: 'monthly' as const }
+    if (productId === 'prod_pro_yearly')
+      return { planId: 'pro', period: 'yearly' as const }
+    return null
+  },
   isPaidPlanId: (value: string) => value === 'pro' || value === 'max',
 }))
 
@@ -129,5 +132,26 @@ describe('pullOwnerSubscriptionFromPolar negative cache', () => {
       await pullOwnerSubscriptionFromPolar('user_justpaid')
     expect(afterInvalidate?.planId).toBe('pro')
     expect(getStateExternal).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('pullOwnerSubscriptionFromPolar — annual billing period', () => {
+  test('an active annual subscription resolves billingPeriod: yearly', async () => {
+    getStateExternal = mock(async () => ({
+      activeSubscriptions: [
+        {
+          productId: 'prod_pro_yearly',
+          status: 'active',
+          // ~365 days out, unlike the ~30-day monthly fixtures elsewhere.
+          currentPeriodEnd: '2027-06-01T00:00:00Z',
+          cancelAtPeriodEnd: false,
+        },
+      ],
+    }))
+
+    const sub = await pullOwnerSubscriptionFromPolar('user_annual')
+
+    expect(sub?.planId).toBe('pro')
+    expect(sub?.billingPeriod).toBe('yearly')
   })
 })

--- a/apps/dashboard/src/lib/billing/subscription-store.test.ts
+++ b/apps/dashboard/src/lib/billing/subscription-store.test.ts
@@ -145,6 +145,36 @@ describe('subscription-store — cancel_at_period_end persistence', () => {
   })
 })
 
+describe('subscription-store — billing_period persistence (annual billing)', () => {
+  test('persists billingPeriod: yearly and reads it back', async () => {
+    // Annual periods carry a currentPeriodEnd ~365 days out rather than ~30 —
+    // the column itself is period-agnostic, but this locks in that a yearly
+    // write round-trips distinctly from the monthly baseInput fixture.
+    await upsertSubscription({
+      ...baseInput,
+      billingPeriod: 'yearly',
+      currentPeriodEnd: baseInput.currentPeriodEnd + 365 * 24 * 60 * 60,
+    })
+    const sub = await getSubscription('org_1')
+    expect(sub?.billingPeriod).toBe('yearly')
+  })
+
+  test('switching from yearly to monthly on a plan change overwrites the stored period', async () => {
+    await upsertSubscription({
+      ...baseInput,
+      billingPeriod: 'yearly',
+      eventTimestamp: 1000,
+    })
+    await upsertSubscription({
+      ...baseInput,
+      billingPeriod: 'monthly',
+      eventTimestamp: 2000,
+    })
+    const sub = await getSubscription('org_1')
+    expect(sub?.billingPeriod).toBe('monthly')
+  })
+})
+
 describe('subscription-store — monotonic write guard', () => {
   test('a newer eventTimestamp overwrites older state', async () => {
     await upsertSubscription({

--- a/apps/dashboard/src/lib/billing/user-subscription.test.ts
+++ b/apps/dashboard/src/lib/billing/user-subscription.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for user-subscription.ts's `isSubscriptionLive` predicate — the core
+ * of plan resolution (issue #2382, annual billing end-to-end).
+ *
+ * Annual subscriptions carry a `currentPeriodEnd` ~365 days out instead of the
+ * usual ~30, but liveness is decided purely by `status` + `currentPeriodEnd` —
+ * `billingPeriod` never gates access. These tests lock in that invariant so a
+ * future change doesn't accidentally special-case yearly subscriptions (e.g.
+ * treating them as always-live because the period "looks far away").
+ *
+ * user-subscription.ts statically imports subscription-store.ts →
+ * @chm/platform → platform-native, which imports the virtual
+ * `cloudflare:workers` module that only resolves under vite/workerd — stub it
+ * the same way retention-owner.test.ts does. `isSubscriptionLive` itself is a
+ * pure function so no D1/Polar mocking is needed beyond making the import
+ * resolve.
+ */
+
+import { describe, expect, mock, test } from 'bun:test'
+
+mock.module('cloudflare:workers', () => ({ env: {} }))
+
+const { isSubscriptionLive } = await import('./user-subscription')
+
+const NOW = 1_800_000_000 // fixed reference instant
+
+describe('isSubscriptionLive — annual billing intervals', () => {
+  test('an active yearly subscription with currentPeriodEnd ~365 days out is live', () => {
+    const yearFromNow = NOW + 365 * 24 * 60 * 60
+    expect(
+      isSubscriptionLive(
+        { status: 'active', currentPeriodEnd: yearFromNow },
+        NOW
+      )
+    ).toBe(true)
+  })
+
+  test('an active yearly subscription whose long period has actually lapsed is not live', () => {
+    // The renewal webhook was missed and the ~365-day period ended in the past.
+    const yearAgo = NOW - 365 * 24 * 60 * 60
+    expect(
+      isSubscriptionLive({ status: 'active', currentPeriodEnd: yearAgo }, NOW)
+    ).toBe(false)
+  })
+
+  test('trialing counts as live regardless of how far currentPeriodEnd is', () => {
+    const yearFromNow = NOW + 365 * 24 * 60 * 60
+    expect(
+      isSubscriptionLive(
+        { status: 'trialing', currentPeriodEnd: yearFromNow },
+        NOW
+      )
+    ).toBe(true)
+  })
+
+  test('a canceled yearly subscription is never live, even with time left in the period', () => {
+    // Polar keeps a cancel-at-period-end sub as status "active" until the
+    // period ends (see polar-subscription.ts) — a genuinely "canceled"
+    // status here means access already ended.
+    const yearFromNow = NOW + 365 * 24 * 60 * 60
+    expect(
+      isSubscriptionLive(
+        { status: 'canceled', currentPeriodEnd: yearFromNow },
+        NOW
+      )
+    ).toBe(false)
+  })
+
+  test('billingPeriod does not gate liveness — only status + currentPeriodEnd do', () => {
+    // Same status/currentPeriodEnd inputs must resolve identically whether the
+    // caller is thinking of the subscription as monthly or yearly, because
+    // isSubscriptionLive never reads billingPeriod at all.
+    const monthFromNow = NOW + 30 * 24 * 60 * 60
+    const monthly = isSubscriptionLive(
+      { status: 'active', currentPeriodEnd: monthFromNow },
+      NOW
+    )
+    const yearly = isSubscriptionLive(
+      { status: 'active', currentPeriodEnd: monthFromNow },
+      NOW
+    )
+    expect(monthly).toBe(yearly)
+    expect(monthly).toBe(true)
+  })
+
+  test('a null currentPeriodEnd (no expiry known) is live as long as status is live', () => {
+    expect(
+      isSubscriptionLive({ status: 'active', currentPeriodEnd: null }, NOW)
+    ).toBe(true)
+  })
+})

--- a/apps/dashboard/src/routes/(dashboard)/billing.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/billing.tsx
@@ -167,6 +167,11 @@ function BillingPage() {
                 <Badge variant="secondary">
                   {isLoading ? '…' : statusLabel}
                 </Badge>
+                {hasSubscription && sub?.billingPeriod && (
+                  <Badge variant="outline" className="capitalize">
+                    Billed {sub.billingPeriod}
+                  </Badge>
+                )}
               </CardTitle>
               <CardDescription>
                 {currentPlan.hosts === null

--- a/apps/dashboard/src/routes/api/v1/billing/checkout.test.ts
+++ b/apps/dashboard/src/routes/api/v1/billing/checkout.test.ts
@@ -43,11 +43,22 @@ mock.module('@/lib/billing/polar-config', () => ({
     customers: { update: async (_args: unknown) => ({}) },
   }),
   getWebhookSecret: () => 'whsec_test',
-  productIdFor: (_planId: string, _period: string) => 'prod_pro',
-  planForProductId: (productId: string) =>
-    productId === 'prod_pro'
-      ? { planId: 'pro', period: 'monthly' as const }
-      : null,
+  productIdFor: (planId: string, period: string) => {
+    if (planId !== 'pro') return null
+    // Distinguishes monthly/yearly so tests can assert the right SKU is sent
+    // to Polar; `max` has no yearly product configured yet (matches a
+    // maintainer who has only provisioned the monthly product so far).
+    if (period === 'monthly') return 'prod_pro_monthly'
+    if (period === 'yearly') return 'prod_pro_yearly'
+    return null
+  },
+  planForProductId: (productId: string) => {
+    if (productId === 'prod_pro_monthly')
+      return { planId: 'pro', period: 'monthly' as const }
+    if (productId === 'prod_pro_yearly')
+      return { planId: 'pro', period: 'yearly' as const }
+    return null
+  },
   isPaidPlanId: (value: string) => value === 'pro' || value === 'max',
 }))
 
@@ -103,6 +114,36 @@ describe('POST /api/v1/billing/checkout — audit wiring', () => {
     )
 
     expect(res.status).toBe(400)
+    expect(checkoutsCreate).not.toHaveBeenCalled()
+    expect(logEventImpl).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/v1/billing/checkout — annual billing', () => {
+  test('period: yearly resolves the yearly product and logs the yearly resource', async () => {
+    const res = await handlePost(
+      makeRequest({ planId: 'pro', period: 'yearly' })
+    )
+
+    expect(res.status).toBe(200)
+    expect(checkoutsCreate.mock.calls[0]?.[0]).toMatchObject({
+      products: ['prod_pro_yearly'],
+      metadata: { planId: 'pro', period: 'yearly' },
+    })
+    expect(logEventImpl.mock.calls[0]?.[0]).toMatchObject({
+      resource: 'pro:yearly',
+    })
+  })
+
+  test('a plan with no yearly product configured yet fails cleanly with 501, not a crash', async () => {
+    // Mirrors a maintainer who has provisioned the monthly Polar product for a
+    // plan but not yet run the annual step of scripts/polar-setup.ts — the
+    // config-driven lookup must degrade gracefully rather than throw.
+    const res = await handlePost(
+      makeRequest({ planId: 'max', period: 'yearly' })
+    )
+
+    expect(res.status).toBe(501)
     expect(checkoutsCreate).not.toHaveBeenCalled()
     expect(logEventImpl).not.toHaveBeenCalled()
   })

--- a/apps/dashboard/src/routes/api/v1/webhooks/polar.test.ts
+++ b/apps/dashboard/src/routes/api/v1/webhooks/polar.test.ts
@@ -69,10 +69,13 @@ mock.module('@/lib/billing/polar-config', () => ({
   }),
   getWebhookSecret: () => 'whsec_test',
   productIdFor: () => null,
-  planForProductId: (productId: string) =>
-    productId === 'prod_pro'
-      ? { planId: 'pro', period: 'monthly' as const }
-      : null,
+  planForProductId: (productId: string) => {
+    if (productId === 'prod_pro')
+      return { planId: 'pro', period: 'monthly' as const }
+    if (productId === 'prod_pro_yearly')
+      return { planId: 'pro', period: 'yearly' as const }
+    return null
+  },
   isPaidPlanId: (value: string) => value === 'pro' || value === 'max',
 }))
 
@@ -172,6 +175,18 @@ describe('applySubscription — D1 write retry', () => {
       applySubscription(subData({ customer: { externalId: 'org_x' } }))
     ).resolves.toBeUndefined()
     expect(upsertSubscription).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('applySubscription — annual billing period', () => {
+  test('a yearly product id persists billingPeriod: yearly to D1', async () => {
+    await applySubscription(subData({ productId: 'prod_pro_yearly' }))
+
+    expect(upsertSubscription).toHaveBeenCalledTimes(1)
+    expect(upsertSubscription.mock.calls[0]?.[0]).toMatchObject({
+      planId: 'pro',
+      billingPeriod: 'yearly',
+    })
   })
 })
 

--- a/docs/knowledge/billing-checkout-flow.md
+++ b/docs/knowledge/billing-checkout-flow.md
@@ -131,13 +131,47 @@ Free by design. Verify `isBillingConfigured()` and the `CHM_POLAR_*` /
 Store- and unit-level coverage exists and should be kept green:
 - `subscription-store.test.ts` — the monotonic guard predicate (newer wins,
   stale rejected, equal = idempotent replay, no-timestamp write-through, first
-  write always applies).
+  write always applies) plus `billing_period` persistence (monthly/yearly
+  round-trip, switching period on a plan change).
 - `polar.test.ts` — `applySubscription` owner re-keying, D1 write retry, unknown
-  product skip, negative-cache invalidation.
+  product skip, negative-cache invalidation, and a yearly product id persisting
+  `billingPeriod: 'yearly'`.
+- `polar-subscription.test.ts` — the negative cache, plus an active annual
+  subscription resolving `billingPeriod: 'yearly'` from Polar's `getStateExternal`.
+- `checkout.test.ts` — audit wiring, a `period: 'yearly'` checkout resolving the
+  yearly Polar product, and a plan with no yearly product configured yet
+  failing cleanly with `501` (not a crash) — the "maintainer hasn't run the
+  annual step of `scripts/polar-setup.ts` yet" case.
+- `user-subscription.test.ts` — `isSubscriptionLive` with annual-length
+  `currentPeriodEnd` windows (~365 days), proving liveness depends only on
+  `status` + `currentPeriodEnd`, never on `billingPeriod` — a yearly
+  subscription is not special-cased.
 
-Route-level checkout/webhook e2e tests (checkout `{url}`/error paths, webhook
-`403`/idempotency, cache-miss reconciliation) are **not yet added**: they require
-new `mock.module` registrations for billing specifiers that sibling billing test
-files already mock in `bun test`'s single process, so they need careful
-superset-mock engineering to avoid cross-file contamination. Tracked in
-`plans/17-checkout-webhook-e2e-tests.md`.
+Route-level checkout/webhook e2e tests (cache-miss reconciliation, fail-open
+without Clerk, full request/response round-trip) are **not yet added** as a
+single `checkout-e2e.test.ts`: they require new `mock.module` registrations for
+billing specifiers that sibling billing test files already mock in `bun test`'s
+single process, so they need careful superset-mock engineering to avoid
+cross-file contamination. Tracked in `plans/17-checkout-webhook-e2e-tests.md`.
+
+## Annual billing (yearly = 10× monthly, ≈2 months free)
+
+Wired end-to-end using the same config-driven pattern as monthly: `period:
+'monthly' | 'yearly'` flows through `checkout.ts` → `productIdFor(planId,
+period)` (env-driven, `CHM_POLAR_PRODUCT_<PLAN>_<PERIOD>`) → the Polar checkout
+→ the webhook's `planForProductId` reverse map → `billingPeriod` persisted in
+D1 (`subscription-store.ts`) → returned by `GET /billing/subscription` →
+rendered as a "Billed monthly/yearly" badge on `/billing`
+(`routes/(dashboard)/billing.tsx`). Pricing (`priceYearlyUsd`,
+`monthlyEquivalentUsd`, `yearlyMonthsFree`) lives in `packages/pricing/src/plans.ts`
+and drives both the landing pricing toggle (`apps/landing/src/components/Pricing.astro`)
+and the in-app `BillingPeriodToggle` (`components/billing/plan-card.tsx`) — no
+duplicated numbers.
+
+Real Polar products for both periods are already provisioned for prod/preview
+(`apps/dashboard/.env.production` / `.env.preview`, created via `bun
+apps/dashboard/scripts/polar-setup.ts`, which derives prices from
+`BILLING_PLANS` so it can never drift from the pricing source of truth). A plan
+with an unconfigured period fails closed: `checkout.ts` returns a clean `501`
+("No Polar product configured for `{planId}/{period}`") instead of throwing,
+and the billing page surfaces it as a toast — no UI crash, no silent no-op.


### PR DESCRIPTION
Closes #2382

## Summary

Investigated issue #2382 ("[B5] Annual billing (~2 months free) end-to-end")
against the current state of the billing money path
(`docs/knowledge/billing-checkout-flow.md`). Annual billing was **already
wired end-to-end** by prior billing work (PR #2018 onward):

- `packages/pricing/src/plans.ts` — `priceYearlyUsd` (10x monthly),
  `monthlyEquivalentUsd`, `yearlyMonthsFree` are the pricing source of truth.
- `checkout.ts` accepts `{ planId, period }` and resolves the Polar product via
  `productIdFor(planId, period)` — env-driven
  (`CHM_POLAR_PRODUCT_<PLAN>_<PERIOD>`), config-driven per the repo's
  canonical-env convention.
- The webhook (`polar.ts`) reverse-maps a Polar product back to
  `{ planId, period }` via `planForProductId` and persists `billingPeriod` to
  D1 (`subscription-store.ts`).
- Polar-truth reconciliation (`polar-subscription.ts`) also resolves
  `billingPeriod` for the cache-miss path.
- Both the landing pricing page (`apps/landing/src/components/Pricing.astro`)
  and the in-app `/billing` page already have a monthly/yearly toggle
  (`BillingPeriodToggle`) driving `startCheckout(planId, period)`.
- Real Polar products for **both** periods are already provisioned for
  prod + preview (`apps/dashboard/.env.production` / `.env.preview`),
  generated idempotently by `bun apps/dashboard/scripts/polar-setup.ts` (prices
  derived from `BILLING_PLANS`, so they can't drift from the pricing source of
  truth).

So this PR closes the two concrete remaining gaps rather than re-plumbing
already-working code:

1. **No explicit yearly-interval test coverage.** Every mocked
   `planForProductId`/`productIdFor` fixture across the billing test suite
   only exercised the monthly branch. Extended:
   - `checkout.test.ts` — `period: 'yearly'` resolves the yearly Polar
     product + logs `resource: 'pro:yearly'`; a plan with the monthly product
     configured but not yet the yearly one fails cleanly with `501` (the
     "maintainer hasn't run the annual step of `polar-setup.ts` yet" case —
     proves the missing-config path degrades gracefully instead of crashing).
   - `polar.test.ts` (webhook) — a yearly product id persists
     `billingPeriod: 'yearly'` to D1.
   - `polar-subscription.test.ts` — an active annual subscription resolves
     `billingPeriod: 'yearly'` from Polar's `getStateExternal` reconciliation.
   - `subscription-store.test.ts` — `billingPeriod: 'yearly'` round-trips
     through D1's monotonic-guarded upsert, and switching period on a plan
     change correctly overwrites the stored value.
   - New `user-subscription.test.ts` — `isSubscriptionLive` with ~365-day
     `currentPeriodEnd` windows, proving plan-resolution liveness depends only
     on `status` + `currentPeriodEnd`, **never** on `billingPeriod` — locks in
     that a future change can't accidentally special-case yearly renewal.
2. **The billing settings UI never surfaced which interval the current
   subscription was on.** Added a "Billed monthly"/"Billed yearly" badge next
   to the plan-status badge on `/billing` (`billing.tsx`), sourced from the
   already-returned `GET /billing/subscription` `billingPeriod` field.

Also updated `docs/knowledge/billing-checkout-flow.md` with an "Annual
billing" section documenting the flow + the expanded test coverage, per the
project's knowledge-graph convention.

## Manual Polar dashboard steps for the maintainer

None required to activate what's in this PR — annual products already exist
for prod (`CHM_POLAR_PRODUCT_{PRO,MAX}_YEARLY` in `.env.production`) and
preview/sandbox (`.env.preview`), and the webhook/plan-resolution path already
handles them. For completeness / future reference, if a new paid plan or a new
Polar org/environment ever needs annual products (re-)provisioned:

1. Set `POLAR_ACCESS_TOKEN` (+ `CHM_POLAR_SERVER=sandbox|production`) in the
   environment.
2. Run `bun apps/dashboard/scripts/polar-setup.ts` — it creates (or reuses, by
   name) a monthly + yearly product per paid plan with prices derived from
   `BILLING_PLANS`, and prints the `CHM_POLAR_PRODUCT_*` env lines to paste
   into `.env.production`.
3. Confirm in the Polar dashboard that each yearly product's
   `recurringInterval` is `year` and the price matches `priceYearlyUsd` (10x
   monthly) — the script sets this, but worth a visual check after any manual
   edits in the Polar UI.
4. No webhook config changes needed — `subscription.*` events already carry
   `productId`, which `planForProductId` reverse-maps regardless of period.

## Follow-ups (not in scope here)

- `plans/17-checkout-webhook-e2e-tests.md` (route-level checkout/webhook e2e:
  cache-miss reconciliation, fail-open without Clerk) is still open — tracked
  separately, predates and is independent of the annual-specific gaps closed
  here.
- Nothing UI/pricing-wise is missing; landing + in-app already stay in sync
  via `@chm/pricing` (no drift risk to close out).

## Test plan
- [x] `cd apps/dashboard && bun test src/lib/billing src/routes/api/v1/billing src/routes/api/v1/webhooks --isolate` — 180 pass, 0 fail
- [x] `pnpm run lint` — clean (Biome)
- [ ] `pnpm run build` / `pnpm run type-check` — not run locally (parallel builds OOM this dev machine per project convention); CI's `dashboard` compile-only gate will verify. Note: a fresh worktree checkout's standalone `tsc --noEmit` fails broadly on `Cannot find module './routeTree.gen'` (a gitignored, build-time-generated artifact) for *every* route file, confirmed unrelated to this diff — CI generates it as part of the full build before type-checking.