### PR TITLE
fix(agent): cap unbounded results from freeform SQL tools

### DIFF
--- a/apps/dashboard/src/lib/ai/agent/prompts/clickhouse-instructions.ts
+++ b/apps/dashboard/src/lib/ai/agent/prompts/clickhouse-instructions.ts
@@ -209,7 +209,7 @@ const SEC_PERFORMANCE_CONSTRAINTS = `
 ## Performance Constraints
 
 - **Query timeout**: Queries timeout after 60 seconds
-- **Row limits**: Default to 1000 rows for display; use LIMIT explicitly for larger result sets
+- **Row limits**: \`query\` and \`query_and_visualize\` automatically cap results to 1000 rows (with \`truncated: true\` and a note when hit) — use LIMIT explicitly or aggregate the query instead of relying on the cap for larger result sets
 - **Large table handling**: For tables >100M rows, use SAMPLE clause or aggregate first
 - **Memory awareness**: Be cautious with JOINs on large tables - consider sample sizes
 `

--- a/apps/dashboard/src/lib/ai/agent/tools/__tests__/helpers.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/__tests__/helpers.test.ts
@@ -7,6 +7,9 @@ const {
   isValidTableIdentifier,
   hostIdSchema,
   requiredHostIdSchema,
+  capResultRows,
+  truncationNote,
+  MAX_QUERY_RESULT_ROWS,
 } = await import('../helpers')
 
 describe('resolveHostId', () => {
@@ -82,6 +85,46 @@ describe('hostIdSchema', () => {
     expect(hostIdSchema.safeParse('-2').success).toBe(false)
     expect(hostIdSchema.safeParse(1.5).success).toBe(false)
     expect(hostIdSchema.safeParse('abc').success).toBe(false)
+  })
+})
+
+describe('capResultRows', () => {
+  test('returns data unchanged and truncated: false when under the cap', () => {
+    const data = Array.from({ length: 10 }, (_, i) => i)
+    const result = capResultRows(data, 1000)
+    expect(result.data).toEqual(data)
+    expect(result.truncated).toBe(false)
+  })
+
+  test('returns data unchanged and truncated: false when exactly at the cap', () => {
+    const data = Array.from({ length: 1000 }, (_, i) => i)
+    const result = capResultRows(data, 1000)
+    expect(result.data).toHaveLength(1000)
+    expect(result.truncated).toBe(false)
+  })
+
+  test('truncates to maxRows and flags truncated: true when over the cap', () => {
+    const data = Array.from({ length: 1500 }, (_, i) => i)
+    const result = capResultRows(data, 1000)
+    expect(result.data).toHaveLength(1000)
+    expect(result.data[999]).toBe(999)
+    expect(result.truncated).toBe(true)
+  })
+
+  test('defaults maxRows to MAX_QUERY_RESULT_ROWS (1000)', () => {
+    expect(MAX_QUERY_RESULT_ROWS).toBe(1000)
+    const data = Array.from({ length: 1200 }, (_, i) => i)
+    const result = capResultRows(data)
+    expect(result.data).toHaveLength(1000)
+    expect(result.truncated).toBe(true)
+  })
+})
+
+describe('truncationNote', () => {
+  test('mentions the row cap and how to see the full result set', () => {
+    const note = truncationNote(1000)
+    expect(note).toContain('1000 rows')
+    expect(note).toContain('LIMIT')
   })
 })
 

--- a/apps/dashboard/src/lib/ai/agent/tools/__tests__/schema-tools.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/__tests__/schema-tools.test.ts
@@ -145,8 +145,10 @@ describe('createSchemaTools', () => {
         sql: 'SELECT * FROM system.tables LIMIT 10',
       })
 
-      expect(Array.isArray(result)).toBe(true)
-      expect(result[0].result).toBe('query data')
+      expect(Array.isArray(result.data)).toBe(true)
+      expect(result.data[0].result).toBe('query data')
+      expect(result.truncated).toBe(false)
+      expect(result.note).toBeUndefined()
     })
 
     test('uses provided hostId', async () => {
@@ -159,7 +161,41 @@ describe('createSchemaTools', () => {
         hostId: 2,
       })
 
-      expect(Array.isArray(result)).toBe(true)
+      expect(Array.isArray(result.data)).toBe(true)
+    })
+
+    test('caps results at 1000 rows and flags truncation', async () => {
+      mockFetchData.mockImplementation(async () => ({
+        data: Array.from({ length: 1500 }, (_, i) => ({ id: i })),
+        error: null,
+      }))
+
+      const tools = createSchemaTools(0) as any
+
+      const result = await tools.query.execute({
+        sql: 'SELECT id FROM big_table',
+      })
+
+      expect(result.data).toHaveLength(1000)
+      expect(result.truncated).toBe(true)
+      expect(result.note).toContain('truncated to 1000 rows')
+    })
+
+    test('does not truncate results at or under 1000 rows', async () => {
+      mockFetchData.mockImplementation(async () => ({
+        data: Array.from({ length: 1000 }, (_, i) => ({ id: i })),
+        error: null,
+      }))
+
+      const tools = createSchemaTools(0) as any
+
+      const result = await tools.query.execute({
+        sql: 'SELECT id FROM medium_table',
+      })
+
+      expect(result.data).toHaveLength(1000)
+      expect(result.truncated).toBe(false)
+      expect(result.note).toBeUndefined()
     })
   })
 

--- a/apps/dashboard/src/lib/ai/agent/tools/__tests__/visualization-tools.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/__tests__/visualization-tools.test.ts
@@ -190,5 +190,39 @@ describe('createVisualizationTools', () => {
       expect(result.viz.sortOrder).toBeUndefined()
       expect(result.viz.readable).toBeUndefined()
     })
+
+    test('caps rows at 1000 and flags truncation, building the chart from capped data', async () => {
+      mockFetchData.mockImplementation(async () => ({
+        data: Array.from({ length: 1500 }, (_, i) => ({
+          label: `row_${i}`,
+          value: i,
+        })),
+        error: null,
+      }))
+
+      const tools = createVisualizationTools(0) as any as any
+
+      const result = await tools.query_and_visualize.execute({
+        sql: 'SELECT label, value FROM big_table',
+      })
+
+      expect(result.rows).toHaveLength(1000)
+      expect(result.rowCount).toBe(1000)
+      expect(result.truncated).toBe(true)
+      expect(result.note).toContain('truncated to 1000 rows')
+    })
+
+    test('does not flag truncation for results at or under 1000 rows', async () => {
+      setupVisualizationMocks()
+
+      const tools = createVisualizationTools(0) as any as any
+
+      const result = await tools.query_and_visualize.execute({
+        sql: 'SELECT event_date, tenant_id, event_name, value FROM analytics.events LIMIT 10',
+      })
+
+      expect(result.truncated).toBe(false)
+      expect(result.note).toBeUndefined()
+    })
   })
 })

--- a/apps/dashboard/src/lib/ai/agent/tools/helpers.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/helpers.ts
@@ -146,6 +146,41 @@ export async function validatedReadOnlyQuery(options: {
 }
 
 /**
+ * Max rows returned to the model by the freeform-SQL tools (`query`,
+ * `query_and_visualize`). Dedicated tools cap independently (e.g. list_tables
+ * at 500 rows); this bounds agent-authored SQL that has no LIMIT, matching
+ * the "default to 1000 rows" guidance in SEC_PERFORMANCE_CONSTRAINTS.
+ * Mirrored in packages/mcp-server/src/tools/helpers.ts for the standalone
+ * MCP server's own `query` tool (separate implementation, no shared code).
+ */
+export const MAX_QUERY_RESULT_ROWS = 1000
+
+/**
+ * Cap an array of query result rows to `maxRows`, flagging truncation so the
+ * caller can surface a visible note to the model instead of silently
+ * dropping rows.
+ */
+export function capResultRows<T>(
+  data: T[],
+  maxRows: number = MAX_QUERY_RESULT_ROWS
+): { data: T[]; truncated: boolean } {
+  if (!Array.isArray(data) || data.length <= maxRows) {
+    return { data, truncated: false }
+  }
+  return { data: data.slice(0, maxRows), truncated: true }
+}
+
+/**
+ * Human-readable note explaining a truncated result set, matching the
+ * `list_tables` truncation-note shape/wording.
+ */
+export function truncationNote(
+  maxRows: number = MAX_QUERY_RESULT_ROWS
+): string {
+  return `Results truncated to ${maxRows} rows. Add a LIMIT clause or aggregate the query to see the full result set.`
+}
+
+/**
  * Execute a write query (KILL, OPTIMIZE, etc.) against ClickHouse.
  * No readonly setting. Use only for control actions.
  */

--- a/apps/dashboard/src/lib/ai/agent/tools/schema-tools.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/schema-tools.ts
@@ -1,9 +1,11 @@
 import { z } from 'zod'
 
 import {
+  capResultRows,
   hostIdSchema,
   readOnlyQuery,
   resolveHostId,
+  truncationNote,
   validatedReadOnlyQuery,
 } from './helpers'
 import { dynamicTool } from 'ai'
@@ -22,11 +24,16 @@ export function createSchemaTools(hostId: number) {
           sql: string
           hostId?: number
         }
-        const result = await validatedReadOnlyQuery({
+        const result = (await validatedReadOnlyQuery({
           sql,
           hostId: paramHostId ?? hostId,
-        })
-        return result
+        })) as unknown[]
+        const { data, truncated } = capResultRows(result)
+        return {
+          data,
+          truncated,
+          ...(truncated && { note: truncationNote() }),
+        }
       },
     }),
 

--- a/apps/dashboard/src/lib/ai/agent/tools/visualization-tools.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/visualization-tools.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod'
 
-import { hostIdSchema, resolveHostId, validatedReadOnlyQuery } from './helpers'
+import {
+  capResultRows,
+  hostIdSchema,
+  resolveHostId,
+  truncationNote,
+  validatedReadOnlyQuery,
+} from './helpers'
 import { dynamicTool } from 'ai'
 
 export function createVisualizationTools(hostId: number) {
@@ -78,10 +84,11 @@ export function createVisualizationTools(hostId: number) {
         }
 
         const effectiveHostId = resolveHostId(paramHostId, hostId)
-        const rows = (await validatedReadOnlyQuery({
+        const rawRows = (await validatedReadOnlyQuery({
           sql,
           hostId: effectiveHostId,
         })) as Record<string, unknown>[]
+        const { data: rows, truncated } = capResultRows(rawRows)
 
         const columns = rows.length > 0 ? Object.keys(rows[0]) : []
         const firstRow = rows[0] ?? {}
@@ -135,6 +142,8 @@ export function createVisualizationTools(hostId: number) {
           rows,
           rowCount: rows.length,
           columns,
+          truncated,
+          ...(truncated && { note: truncationNote() }),
           viz: {
             chartType: resolvedChartType,
             xKey: resolvedXKey,

--- a/docs/content/guide/ai-agent.mdx
+++ b/docs/content/guide/ai-agent.mdx
@@ -275,7 +275,7 @@ env-gated control tools), see [Capabilities](/guide/ai-agent/capabilities).
 
 | Tool | Purpose |
 |---|---|
-| `query` | Execute a read-only SQL query (SELECT / WITH / DESCRIBE / EXPLAIN only) |
+| `query` | Execute a read-only SQL query (SELECT / WITH / DESCRIBE / EXPLAIN only). Results are capped at 1000 rows (`truncated: true` + a note when hit). |
 | `list_databases` | List all databases with their engines and comments |
 | `list_tables` | List tables in a database with row counts and sizes |
 | `get_table_schema` | Get column definitions for a table including types, defaults, and comments |
@@ -292,6 +292,10 @@ env-gated control tools), see [Capabilities](/guide/ai-agent/capabilities).
 The `query` tool — the only tool that accepts arbitrary SQL — validates every statement before execution via `validateSqlQuery` (`@chm/sql-builder`). It **throws** on any write or DDL statement and on dangerous ClickHouse commands. Allowed prefixes: `SELECT`, `WITH` (CTE), `DESCRIBE`, `EXPLAIN`. Rejected: `INSERT`, `ALTER`, `DROP`, `CREATE`, `TRUNCATE`, `RENAME`, `DELETE`, `UPDATE`, `SYSTEM RELOAD/FLUSH/KILL/SHUTDOWN`, `GRANT`, `REVOKE`, `ATTACH`, `DETACH`, `KILL`, `SET`, multi-statement payloads (`;` chaining), and dangerous table functions (`remote()`, `url()`, `s3()`, etc.).
 
 All other MCP tools run fixed SELECT queries and pass `readonly: '1'` to the ClickHouse connection — they cannot issue writes regardless of the validator.
+
+### Result size caps
+
+The freeform-SQL tools (`query` in both the in-app agent and the MCP server, plus the agent's `query_and_visualize`) cap results to 1000 rows before serializing them back to the model — dedicated tools cap independently (e.g. `list_tables` at 500 rows). The SQL itself is never rewritten (no `LIMIT` injection); a query that returns more than the cap comes back with only the first 1000 rows, `truncated: true`, and a `note` telling the model to add its own `LIMIT` or aggregation to see the full result set. Queries at or under the cap are unaffected (`truncated: false`, no `note`).
 
 
 ## Agent Discovery & RFC Compliance

--- a/docs/content/guide/ai-agent/capabilities.mdx
+++ b/docs/content/guide/ai-agent/capabilities.mdx
@@ -33,7 +33,7 @@ Control tools (`kill_query`, `kill_mutation`, `optimize_table`) are disabled unl
 
 | Tool | Description | Notes |
 |---|---|---|
-| `query` | Execute a read-only SQL query on ClickHouse. | SELECT / WITH / DESCRIBE / EXPLAIN only. Write statements are rejected. |
+| `query` | Execute a read-only SQL query on ClickHouse. | SELECT / WITH / DESCRIBE / EXPLAIN only. Write statements are rejected. Results are capped at 1000 rows (`truncated: true` + a note when hit) — add your own `LIMIT` or aggregation for larger result sets. |
 | `list_databases` | List all databases with engine and comment metadata. | |
 | `list_tables` | List tables in a database with row counts and size. | |
 | `get_table_schema` | Get column definitions for a specific table. | |
@@ -56,7 +56,7 @@ Control tools (`kill_query`, `kill_mutation`, `optimize_table`) are disabled unl
 | `load_skill` | Load an expert guide (skill) with SQL recipes for a specific domain. | |
 | `find_reference_query` | Search the dashboard's built-in library of 100+ vetted, version-aware monitoring queries and return the closest matches (name, description, SQL). | Read-only, deterministic keyword-overlap lookup over the built-in `QueryConfig` catalog — executes nothing. Meant to be used before hand-writing `system.*` SQL. |
 | `ask_user` | Ask the user a question to gather information before proceeding. | |
-| `query_and_visualize` | Run a SQL query and return an interactive chart config. | Chart type is auto-detected from result columns. |
+| `query_and_visualize` | Run a SQL query and return an interactive chart config. | Chart type is auto-detected from result columns. Rows are capped at 1000 (`truncated: true` + a note when hit) before the chart is built. |
 | `explain_anomaly_score` | Explain a per-host/per-metric statistical anomaly baseline (mean, stddev, median, MAD, sample count) and, given a value, its z-score and anomaly verdict. | Read-only. Reports "no baseline yet" during cold start (falls back to a static threshold). |
 | `get_optimization_recommendations` | Analyze a slow query (by `queryId` from system.query_log, or raw `sql`) and return ranked skip-index, projection, partition-key, and PREWHERE recommendations with DDL/rewrite text, rationale, risk, effort, and an estimated granules/bytes saved. | Read-only and recommend-only — reads EXPLAIN + `system.tables`/`system.columns`/`system.data_skipping_indexes`/`system.parts`; never executes or applies any DDL or rewrite. Every impact figure is explicitly labeled an estimate. |
 | `suggest_dashboard` | Map a natural-language request to a dashboard layout built only from charts in the chart registry, auto-placed on the plan-57 12-column grid. | Recommend-only — never persists anything. The chat UI shows an "Apply to dashboard" action that loads the layout into the dashboard builder's unsaved working grid; saving still requires the existing save action. Rejects any chart name not present in both the client and API chart registries. |

--- a/packages/mcp-server/src/__tests__/query.test.ts
+++ b/packages/mcp-server/src/__tests__/query.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, mock, test } from 'bun:test'
+
+// Mock fetchData before importing the tool
+const mockFetchData = mock(() => Promise.resolve({ data: [], error: null }))
+
+mock.module('@chm/clickhouse-client', () => ({
+  fetchData: mockFetchData,
+}))
+
+import { registerQueryTool } from '../tools/query'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+/** Helper to get the registered tool handler */
+function getToolHandler(server: McpServer, name: string) {
+  const tools = (server as any)._registeredTools
+  const tool = tools?.[name]
+  if (!tool?.handler) throw new Error(`Tool "${name}" not found`)
+  return (args: Record<string, unknown>) => tool.handler(args, {})
+}
+
+describe('registerQueryTool', () => {
+  test('registers without errors', () => {
+    const server = new McpServer({ name: 'test', version: '0.0.1' })
+    expect(() => registerQueryTool(server)).not.toThrow()
+  })
+
+  test('returns rows unchanged and truncated: false when at or under the cap', async () => {
+    mockFetchData.mockResolvedValue({
+      data: Array.from({ length: 10 }, (_, i) => ({ id: i })),
+      error: null,
+    })
+
+    const server = new McpServer({ name: 'test', version: '0.0.1' })
+    registerQueryTool(server)
+    const call = getToolHandler(server, 'query')
+
+    const result = await call({ sql: 'SELECT id FROM small_table' })
+    const payload = JSON.parse(result.content[0].text)
+
+    expect(payload.data).toHaveLength(10)
+    expect(payload.truncated).toBe(false)
+    expect(payload.note).toBeUndefined()
+  })
+
+  test('caps results at 1000 rows and includes a truncation note', async () => {
+    mockFetchData.mockResolvedValue({
+      data: Array.from({ length: 1500 }, (_, i) => ({ id: i })),
+      error: null,
+    })
+
+    const server = new McpServer({ name: 'test', version: '0.0.1' })
+    registerQueryTool(server)
+    const call = getToolHandler(server, 'query')
+
+    const result = await call({ sql: 'SELECT id FROM big_table' })
+    const payload = JSON.parse(result.content[0].text)
+
+    expect(payload.data).toHaveLength(1000)
+    expect(payload.truncated).toBe(true)
+    expect(payload.note).toContain('truncated to 1000 rows')
+  })
+
+  test('rejects non-SELECT SQL before running the query', async () => {
+    const server = new McpServer({ name: 'test', version: '0.0.1' })
+    registerQueryTool(server)
+    const call = getToolHandler(server, 'query')
+
+    const result = await call({ sql: 'DROP TABLE big_table' })
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain('Validation error')
+  })
+
+  test('surfaces ClickHouse errors without touching the cap logic', async () => {
+    mockFetchData.mockResolvedValue({
+      data: null,
+      error: new Error('Connection refused'),
+    })
+
+    const server = new McpServer({ name: 'test', version: '0.0.1' })
+    registerQueryTool(server)
+    const call = getToolHandler(server, 'query')
+
+    const result = await call({ sql: 'SELECT 1' })
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain('Connection refused')
+  })
+})

--- a/packages/mcp-server/src/tools/helpers.ts
+++ b/packages/mcp-server/src/tools/helpers.ts
@@ -90,3 +90,36 @@ export async function runReadonlyQuery(
 
   return toJsonResult(result.data)
 }
+
+/**
+ * Max rows returned to the model by the standalone MCP server's freeform
+ * `query` tool. Mirrors
+ * `apps/dashboard/src/lib/ai/agent/tools/helpers.ts` (`MAX_QUERY_RESULT_ROWS`)
+ * — kept in sync manually since this package cannot import from `apps/*`.
+ */
+export const MAX_QUERY_RESULT_ROWS = 1000
+
+/**
+ * Cap an array of query result rows to `maxRows`, flagging truncation so the
+ * caller can surface a visible note to the model instead of silently
+ * dropping rows. Mirrors `capResultRows` in the dashboard agent's tool
+ * helpers.
+ */
+export function capResultRows<T>(
+  data: T[],
+  maxRows: number = MAX_QUERY_RESULT_ROWS
+): { data: T[]; truncated: boolean } {
+  if (!Array.isArray(data) || data.length <= maxRows) {
+    return { data, truncated: false }
+  }
+  return { data: data.slice(0, maxRows), truncated: true }
+}
+
+/**
+ * Human-readable note explaining a truncated result set.
+ */
+export function truncationNote(
+  maxRows: number = MAX_QUERY_RESULT_ROWS
+): string {
+  return `Results truncated to ${maxRows} rows. Add a LIMIT clause or aggregate the query to see the full result set.`
+}

--- a/packages/mcp-server/src/tools/query.ts
+++ b/packages/mcp-server/src/tools/query.ts
@@ -2,7 +2,14 @@ import type { DataFormat } from '@clickhouse/client'
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
-import { hostIdSchema, runReadonlyQuery, toErrorResult } from './helpers'
+import {
+  capResultRows,
+  hostIdSchema,
+  runReadonlyFetch,
+  toErrorResult,
+  toJsonResult,
+  truncationNote,
+} from './helpers'
 import { validateSqlQuery } from '@chm/sql-builder'
 import { z } from 'zod/v3'
 
@@ -27,8 +34,25 @@ export function registerQueryTool(server: McpServer) {
         )
       }
 
-      return runReadonlyQuery(sql, hostId, {
+      const result = await runReadonlyFetch({
+        query: sql,
+        hostId,
         format: (format ?? 'JSONEachRow') as DataFormat,
+      })
+
+      if (result.error) {
+        return toErrorResult(`Error: ${result.error.message}`)
+      }
+
+      if (!Array.isArray(result.data)) {
+        return toJsonResult(result.data)
+      }
+
+      const { data, truncated } = capResultRows(result.data)
+      return toJsonResult({
+        data,
+        truncated,
+        ...(truncated && { note: truncationNote() }),
       })
     }
   )


### PR DESCRIPTION
## Summary

- `query` and `query_and_visualize` (dashboard agent tools) and the standalone MCP server's `query` tool now cap results to 1000 rows before serializing them back to the model — dedicated tools like `list_tables` already did this, but the freeform-SQL tools had no cap.
- Truncation is visible to the model: a `truncated: true` flag plus a `note` telling it to add its own `LIMIT` or aggregation. Results at or under the cap are unaffected (`truncated: false`, no `note`).
- Added `capResultRows` / `truncationNote` / `MAX_QUERY_RESULT_ROWS` in `apps/dashboard/src/lib/ai/agent/tools/helpers.ts`; mirrored (small, package can't cross-import) in `packages/mcp-server/src/tools/helpers.ts`, which covers both `apps/mcp` and the in-process `/api/mcp` route (both go through `@chm/mcp-server/http` → `registerAllTools`).
- Updated `docs/content/guide/ai-agent.mdx` + `docs/content/guide/ai-agent/capabilities.mdx` and the agent's system prompt (`SEC_PERFORMANCE_CONSTRAINTS`) to describe the enforced cap.

Closes #2454
Part of #2322

## Test plan
- [x] `bun test src/lib/ai/agent/tools --isolate` (dashboard) — 136 pass, including new truncation tests in `helpers.test.ts`, `schema-tools.test.ts`, `visualization-tools.test.ts`
- [x] `bun test packages/mcp-server --isolate` — 119 pass, including new `packages/mcp-server/src/__tests__/query.test.ts`
- [x] `bun test src/lib/ai/agent/tools/tool-docs-sync.test.ts --isolate` — anti-drift docs test passes
- [x] `biome check` on all changed files — clean
- [x] Confirmed 2 pre-existing failures in `src/lib/ai/agent` (unrelated `@ai-sdk/provider-utils` export + D1-binding test) exist identically on `main`, not introduced by this change