### PR TITLE
chore(blog): sync latest-posts snapshot, calendar; fix biome format on main

### DIFF
--- a/apps/blog/CONTENT-CALENDAR.md
+++ b/apps/blog/CONTENT-CALENDAR.md
@@ -39,7 +39,7 @@ published (`draft: false`, merged to main)
 | 3 | how-to | Ask your cluster anything: the AI agent over MCP | clickhouse ai agent mcp | `/guide/ai-agent` | planned |
 | 4 | troubleshooting | Why is my ClickHouse replication lagging? | clickhouse replication lag | `/guide/features` (replication section) | planned |
 | 5 | how-to | The query advisor: DDL recommendations you review, not that run themselves | clickhouse query optimization advisor | `/guide/ai-agent` (advisor tools) | planned |
-| 6 | case-study | Diagnosing a slow-query regression start to finish | clickhouse slow query diagnosis | `/guide/features` | planned |
+| 6 | case-study | Diagnosing a slow-query regression start to finish | clickhouse slow query diagnosis | `/guide/features` | done (`find-slow-clickhouse-queries.md`, published 2026-07-10, covers this slot as a how-to) |
 | 7 | troubleshooting | Reading `system.merges` when merges pile up | clickhouse merges stuck | `/guide/features` | planned |
 | 8 | how-to | Self-hosting chmonitor on Docker in five minutes | self-host clickhouse dashboard docker | `/operate/deploy/docker` | planned |
 | 9 | how-to | Self-hosting chmonitor on Kubernetes | clickhouse monitoring kubernetes | `/operate/deploy/k8s` | planned |

--- a/apps/landing/src/data/db-comparisons.ts
+++ b/apps/landing/src/data/db-comparisons.ts
@@ -45,7 +45,7 @@ export const timescaledbRows: DbComparisonRow[] = [
       },
       {
         kind: 'yes',
-        text: "Full Postgres ACID transactions and a mature relational join planner, inherited unchanged",
+        text: 'Full Postgres ACID transactions and a mature relational join planner, inherited unchanged',
       },
     ],
   },
@@ -71,7 +71,7 @@ export const timescaledbRows: DbComparisonRow[] = [
       },
       {
         kind: 'yes',
-        text: "Handles continuous small writes gracefully via Postgres MVCC — the common time-series/IoT ingestion pattern",
+        text: 'Handles continuous small writes gracefully via Postgres MVCC — the common time-series/IoT ingestion pattern',
       },
     ],
   },
@@ -143,8 +143,14 @@ export const postgresRows: DbComparisonRow[] = [
   {
     label: 'Storage model',
     cells: [
-      { kind: 'plain', text: 'Column-oriented (MergeTree): each column stored and compressed contiguously' },
-      { kind: 'plain', text: 'Row-oriented (heap + MVCC): each row stored contiguously, tuned for point lookups and transactions' },
+      {
+        kind: 'plain',
+        text: 'Column-oriented (MergeTree): each column stored and compressed contiguously',
+      },
+      {
+        kind: 'plain',
+        text: 'Row-oriented (heap + MVCC): each row stored contiguously, tuned for point lookups and transactions',
+      },
     ],
   },
   {
@@ -180,7 +186,10 @@ export const postgresRows: DbComparisonRow[] = [
         kind: 'partial',
         text: 'JOIN support and the query planner have improved a lot, but denormalizing wide tables is still the idiomatic ClickHouse pattern for best performance',
       },
-      { kind: 'yes', text: 'A mature cost-based planner handles complex multi-table joins well out of the box' },
+      {
+        kind: 'yes',
+        text: 'A mature cost-based planner handles complex multi-table joins well out of the box',
+      },
     ],
   },
   {
@@ -190,7 +199,10 @@ export const postgresRows: DbComparisonRow[] = [
         kind: 'partial',
         text: 'Performance depends on the primary key sort order plus skip indices — no general-purpose secondary index',
       },
-      { kind: 'yes', text: 'Rich secondary indexing: B-tree, GIN, GiST, BRIN, partial and expression indexes' },
+      {
+        kind: 'yes',
+        text: 'Rich secondary indexing: B-tree, GIN, GiST, BRIN, partial and expression indexes',
+      },
     ],
   },
   {
@@ -200,7 +212,10 @@ export const postgresRows: DbComparisonRow[] = [
         kind: 'partial',
         text: 'Tuned for fewer, heavier analytical queries rather than thousands of small concurrent transactions',
       },
-      { kind: 'yes', text: 'MVCC handles many concurrent small transactions cleanly — the OLTP sweet spot' },
+      {
+        kind: 'yes',
+        text: 'MVCC handles many concurrent small transactions cleanly — the OLTP sweet spot',
+      },
     ],
   },
   {
@@ -208,7 +223,7 @@ export const postgresRows: DbComparisonRow[] = [
     cells: [
       {
         kind: 'yes',
-        text: "Columnar compression routinely reaches 10x+ on typical analytical data, cutting both storage and I/O",
+        text: 'Columnar compression routinely reaches 10x+ on typical analytical data, cutting both storage and I/O',
       },
       {
         kind: 'partial',
@@ -233,7 +248,10 @@ export const postgresRows: DbComparisonRow[] = [
     label: 'Licensing',
     cells: [
       { kind: 'plain', text: 'Apache 2.0' },
-      { kind: 'plain', text: 'The PostgreSQL License — a permissive, OSI-approved license with effectively no restrictions' },
+      {
+        kind: 'plain',
+        text: 'The PostgreSQL License — a permissive, OSI-approved license with effectively no restrictions',
+      },
     ],
   },
   {
@@ -255,7 +273,10 @@ export const druidPinotRows: DbComparisonRow[] = [
   {
     label: 'Primary design goal',
     cells: [
-      { kind: 'plain', text: 'General-purpose OLAP: one engine for ad hoc SQL analytics and dashboards' },
+      {
+        kind: 'plain',
+        text: 'General-purpose OLAP: one engine for ad hoc SQL analytics and dashboards',
+      },
       {
         kind: 'plain',
         text: 'Real-time OLAP for sub-second interactive dashboards over streaming plus historical data',
@@ -277,7 +298,10 @@ export const druidPinotRows: DbComparisonRow[] = [
         kind: 'plain',
         text: 'Multiple specialized services — Coordinator, Overlord, Broker, Historical, MiddleManager — plus ZooKeeper and deep storage (S3/HDFS)',
       },
-      { kind: 'plain', text: 'Three-tier — Controller, Broker, Server — plus ZooKeeper and deep storage' },
+      {
+        kind: 'plain',
+        text: 'Three-tier — Controller, Broker, Server — plus ZooKeeper and deep storage',
+      },
     ],
   },
   {
@@ -291,7 +315,10 @@ export const druidPinotRows: DbComparisonRow[] = [
         kind: 'yes',
         text: 'Built natively for continuous Kafka/Kinesis ingestion with segment-based real-time-to-historical handoff',
       },
-      { kind: 'yes', text: 'Same native streaming design — events are indexed as soon as they land, for immediate queryability' },
+      {
+        kind: 'yes',
+        text: 'Same native streaming design — events are indexed as soon as they land, for immediate queryability',
+      },
     ],
   },
   {
@@ -301,8 +328,14 @@ export const druidPinotRows: DbComparisonRow[] = [
         kind: 'partial',
         text: 'Scales to high concurrency but is tuned more for large ad hoc scans than guaranteed sub-second SLAs at massive QPS',
       },
-      { kind: 'yes', text: 'Optimized for sub-second interactive dashboard queries' },
-      { kind: 'yes', text: 'Explicitly built for very high QPS, single-digit-millisecond point and aggregation lookups' },
+      {
+        kind: 'yes',
+        text: 'Optimized for sub-second interactive dashboard queries',
+      },
+      {
+        kind: 'yes',
+        text: 'Explicitly built for very high QPS, single-digit-millisecond point and aggregation lookups',
+      },
     ],
   },
   {
@@ -325,44 +358,80 @@ export const druidPinotRows: DbComparisonRow[] = [
   {
     label: 'Operational complexity',
     cells: [
-      { kind: 'yes', text: 'Fewer moving parts: no mandatory ZooKeeper for a single-node or simple replicated setup' },
+      {
+        kind: 'yes',
+        text: 'Fewer moving parts: no mandatory ZooKeeper for a single-node or simple replicated setup',
+      },
       {
         kind: 'no',
         text: 'A heavier footprint: multiple specialized services, ZooKeeper and deep storage are required even for small deployments',
       },
-      { kind: 'no', text: 'Same story: ZooKeeper, deep storage and multiple service tiers required from day one' },
+      {
+        kind: 'no',
+        text: 'Same story: ZooKeeper, deep storage and multiple service tiers required from day one',
+      },
     ],
   },
   {
     label: 'Deployment footprint (small workloads)',
     cells: [
-      { kind: 'yes', text: 'Runs comfortably as a single node for small-to-medium workloads, then scales out' },
-      { kind: 'no', text: 'Architected for distributed operation from the start — comparatively heavy for a small deployment' },
+      {
+        kind: 'yes',
+        text: 'Runs comfortably as a single node for small-to-medium workloads, then scales out',
+      },
+      {
+        kind: 'no',
+        text: 'Architected for distributed operation from the start — comparatively heavy for a small deployment',
+      },
       { kind: 'no', text: 'Same — designed distributed-first' },
     ],
   },
   {
     label: 'Proven at scale',
     cells: [
-      { kind: 'plain', text: 'General analytics and log/event data — including product-analytics backends like PostHog' },
-      { kind: 'plain', text: 'Real-time streaming dashboards at companies including Netflix and Confluent' },
-      { kind: 'plain', text: 'User-facing real-time features at LinkedIn (50+ products) and Uber, serving 100K+ QPS at millisecond latency' },
+      {
+        kind: 'plain',
+        text: 'General analytics and log/event data — including product-analytics backends like PostHog',
+      },
+      {
+        kind: 'plain',
+        text: 'Real-time streaming dashboards at companies including Netflix and Confluent',
+      },
+      {
+        kind: 'plain',
+        text: 'User-facing real-time features at LinkedIn (50+ products) and Uber, serving 100K+ QPS at millisecond latency',
+      },
     ],
   },
   {
     label: 'Licensing',
     cells: [
       { kind: 'plain', text: 'Apache 2.0' },
-      { kind: 'plain', text: 'Apache 2.0 (Apache Software Foundation project)' },
-      { kind: 'plain', text: 'Apache 2.0 (Apache Software Foundation project)' },
+      {
+        kind: 'plain',
+        text: 'Apache 2.0 (Apache Software Foundation project)',
+      },
+      {
+        kind: 'plain',
+        text: 'Apache 2.0 (Apache Software Foundation project)',
+      },
     ],
   },
   {
     label: 'Best fit',
     cells: [
-      { kind: 'plain', text: 'Pick this for general-purpose analytics, ad hoc SQL, and the simplest ops of the three' },
-      { kind: 'plain', text: 'Pick this for streaming-native, sub-second interactive dashboards over time-partitioned event data' },
-      { kind: 'plain', text: 'Pick this for extremely high-QPS, low-latency analytics features baked directly into a product' },
+      {
+        kind: 'plain',
+        text: 'Pick this for general-purpose analytics, ad hoc SQL, and the simplest ops of the three',
+      },
+      {
+        kind: 'plain',
+        text: 'Pick this for streaming-native, sub-second interactive dashboards over time-partitioned event data',
+      },
+      {
+        kind: 'plain',
+        text: 'Pick this for extremely high-QPS, low-latency analytics features baked directly into a product',
+      },
     ],
   },
 ]

--- a/apps/landing/src/data/latest-posts.json
+++ b/apps/landing/src/data/latest-posts.json
@@ -1,14 +1,32 @@
 [
   {
-    "title": "Alerting to Slack and Discord",
-    "date": "2026-07-03",
+    "title": "Finding your slowest ClickHouse queries with system.query_log",
+    "date": "2026-07-10",
     "tag": "How-to",
-    "url": "https://docs.chmonitor.dev/guide/guides/alerting-slack-discord"
+    "url": "https://blog.chmonitor.dev/find-slow-clickhouse-queries/"
   },
   {
-    "title": "chmonitor v0.3 — a full rebuild",
-    "date": "2026-06-29",
-    "tag": "Release",
-    "url": "https://blog.chmonitor.dev/v0.3/"
+    "title": "5 min of ClickHouse: Escaping MEMORY_LIMIT_EXCEEDED Without Buying a Bigger Box",
+    "date": "2026-07-10",
+    "tag": "5 min of ClickHouse",
+    "url": "https://blog.chmonitor.dev/clickhouse-memory-limit-exceeded/"
+  },
+  {
+    "title": "5 min of ClickHouse: Partition Key Mistakes That Quietly Kill Performance",
+    "date": "2026-07-09",
+    "tag": "5 min of ClickHouse",
+    "url": "https://blog.chmonitor.dev/clickhouse-partition-key-mistakes/"
+  },
+  {
+    "title": "5 min of ClickHouse: Projections vs Materialized Views — A Decision Tree",
+    "date": "2026-07-07",
+    "tag": "5 min of ClickHouse",
+    "url": "https://blog.chmonitor.dev/clickhouse-projections-vs-materialized-views/"
+  },
+  {
+    "title": "5 min of ClickHouse: PREWHERE vs WHERE — How Granule Skipping Actually Works",
+    "date": "2026-07-06",
+    "tag": "5 min of ClickHouse",
+    "url": "https://blog.chmonitor.dev/clickhouse-prewhere-vs-where/"
   }
 ]


### PR DESCRIPTION
Follow-ups from the merged blog PRs #2458 and #2461, plus a main-branch hygiene fix:

- Regenerated `apps/landing/src/data/latest-posts.json` via `pnpm run sync-latest-posts` so the landing footer shows the new posts.
- Marked the week-6 slow-query slot in `apps/blog/CONTENT-CALENDAR.md` as done (`find-slow-clickhouse-queries.md`).
- Formatted `apps/landing/src/data/db-comparisons.ts` (landed unformatted in #2460); `biome check .` on main was failing, which broke the repo-wide pre-push hook for every contributor.

Note: pre-push suite ran 6022 tests with a single flaky timeout in `control-tools.test.ts` (`optimize_table`) unrelated to this JSON/markdown/format-only diff; CI is the gate.