### PR TITLE
fix(docs): stop remote image fetch from failing docs build

### DIFF
--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -19,6 +19,15 @@ export const docs = defineDocs({
 export default defineConfig({
   mdxOptions: {
     remarkPlugins: [remarkMdxMermaid],
+    // Third-party deploy badges (e.g. vercel.com/button,
+    // deploy.workers.cloudflare.com/button) are remote images referenced from
+    // MDX. remark-image fetches every remote image at build time to compute
+    // its dimensions by default — a single timeout on the badge host fails
+    // the whole docs build. Disable that external size lookup so the build
+    // never depends on third-party image host availability (#2462).
+    remarkImageOptions: {
+      external: false,
+    },
     rehypeCodeOptions: {
       // Spread the defaults first so required options (e.g. `themes`) are kept.
       ...rehypeCodeDefaultOptions,


### PR DESCRIPTION
## Summary
- remark-image (fumadocs) fetches every remote image referenced in MDX at build time to compute its size. Third-party deploy badges (`vercel.com/button`, `deploy.workers.cloudflare.com/button`) are remote images, so a single network timeout on those hosts failed the whole `apps/docs` build (observed on main, #2462).
- Set `mdxOptions.remarkImageOptions.external = false` in `apps/docs/source.config.ts` so remark-image never attempts to fetch external image sizes — the docs build no longer depends on third-party image host availability. Display is unaffected: the `<img>` `src` still points at the original remote URL, browsers fetch it at page-view time as before.
- Audited `docs/content/**` for build-time-fetched remote images (`rg -n 'https?://[^) "]+\.(png|svg|jpg|jpeg|gif|webp)|vercel.com/button' docs/content/`): only the two deploy badges above; no other MDX page references a remote image.

Closes #2462

## Test plan
- [x] `cd apps/docs && pnpm run build` succeeds normally.
- [x] Reproduced the original failure: with a preload script forcing `fetch()` to `vercel.com` / `deploy.workers.cloudflare.com` to throw (simulating unreachable hosts), the build fails on `main` with the exact `[Remark Image] Failed obtain image size for https://vercel.com/button ...` error from the issue.
- [x] Same simulated-blocked-host build with this fix applied: succeeds (`✓ built in 1m 28s`, prerender OK), and the verification script confirms zero fetch attempts to the blocked hosts.
- [x] Confirmed the built output still references the original remote badge URLs as `<img src>`, so runtime rendering is unchanged.