### PR TITLE
fix(security): allowlist percentile chart param to block SQL injection (#2464)

### DIFF
--- a/apps/dashboard/src/lib/api/__tests__/charts/insight-charts.test.ts
+++ b/apps/dashboard/src/lib/api/__tests__/charts/insight-charts.test.ts
@@ -128,48 +128,51 @@ describe('insightCharts', () => {
       '99 ',
     ]
 
-    describe.each(percentileCharts)('chart "%s"', (chartName) => {
-      test.each(
-        maliciousValues
-      )('rejects malicious percentile %p (no injected fragment, safe fallback)', (percentile) => {
-        const result = insightCharts[chartName]({
-          lastHours: 24,
-          params: { percentile },
-        })
-        if (!('query' in result)) throw new Error('expected query')
-        const sql = result.query
-        // No hostile fragment survives into the SQL.
-        expect(sql).not.toContain('system.users')
-        expect(sql).not.toContain('UNION')
-        expect(sql).not.toContain('DROP')
-        expect(sql).not.toContain('--')
-        // The quantile level, when present, is always a bare `0.<int>`.
-        const levels = sql.match(/quantileTDigest\(([^)]*)\)/g) ?? []
-        for (const level of levels) {
-          expect(level).toMatch(/^quantileTDigest\(0\.\d{1,3}\)$/)
-        }
-        // Injection payloads fall back to the default p99.
-        if (sql.includes('quantileTDigest')) {
-          expect(sql).toContain('quantileTDigest(0.99)')
-        }
-      })
-
-      test('accepts the legitimate UI values 95/99/100', () => {
-        for (const percentile of ['95', '99', '100']) {
+    describe.each(percentileCharts.map((c) => [c] as const))(
+      'chart "%s"',
+      ([chartName]) => {
+        test.each(
+          maliciousValues
+        )('rejects malicious percentile %p (no injected fragment, safe fallback)', (percentile) => {
           const result = insightCharts[chartName]({
             lastHours: 24,
             params: { percentile },
           })
           if (!('query' in result)) throw new Error('expected query')
           const sql = result.query
-          if (percentile === '100') {
-            // p100 uses max() / drops the duration filter — no quantile level.
-            expect(sql).not.toContain('quantileTDigest(0.100)')
-          } else {
-            expect(sql).toContain(`quantileTDigest(0.${percentile})`)
+          // No hostile fragment survives into the SQL.
+          expect(sql).not.toContain('system.users')
+          expect(sql).not.toContain('UNION')
+          expect(sql).not.toContain('DROP')
+          expect(sql).not.toContain('--')
+          // The quantile level, when present, is always a bare `0.<int>`.
+          const levels = sql.match(/quantileTDigest\(([^)]*)\)/g) ?? []
+          for (const level of levels) {
+            expect(level).toMatch(/^quantileTDigest\(0\.\d{1,3}\)$/)
           }
-        }
-      })
-    })
+          // Injection payloads fall back to the default p99.
+          if (sql.includes('quantileTDigest')) {
+            expect(sql).toContain('quantileTDigest(0.99)')
+          }
+        })
+
+        test('accepts the legitimate UI values 95/99/100', () => {
+          for (const percentile of ['95', '99', '100']) {
+            const result = insightCharts[chartName]({
+              lastHours: 24,
+              params: { percentile },
+            })
+            if (!('query' in result)) throw new Error('expected query')
+            const sql = result.query
+            if (percentile === '100') {
+              // p100 uses max() / drops the duration filter — no quantile level.
+              expect(sql).not.toContain('quantileTDigest(0.100)')
+            } else {
+              expect(sql).toContain(`quantileTDigest(0.${percentile})`)
+            }
+          }
+        })
+      }
+    )
   })
 })

--- a/apps/dashboard/src/lib/api/__tests__/charts/insight-charts.test.ts
+++ b/apps/dashboard/src/lib/api/__tests__/charts/insight-charts.test.ts
@@ -128,9 +128,13 @@ describe('insightCharts', () => {
       '99 ',
     ]
 
+    // bun's `.each` spreads each tuple row into the callback args, so the
+    // callback receives the chart name directly (not a tuple to destructure).
+    // The 1-tuple mapping is only there to satisfy tsc's `.each` overloads,
+    // which reject a readonly array of bare strings.
     describe.each(percentileCharts.map((c) => [c] as const))(
       'chart "%s"',
-      ([chartName]) => {
+      (chartName) => {
         test.each(
           maliciousValues
         )('rejects malicious percentile %p (no injected fragment, safe fallback)', (percentile) => {

--- a/apps/dashboard/src/lib/api/__tests__/charts/insight-charts.test.ts
+++ b/apps/dashboard/src/lib/api/__tests__/charts/insight-charts.test.ts
@@ -90,4 +90,86 @@ describe('insightCharts', () => {
     expect(result.query).toMatch(/is_initial_query = 1\s+AND\s+event_time/)
     expect(result.query).not.toMatch(/is_initial_query = 1\s+event_time/)
   })
+
+  // ---------------------------------------------------------------------------
+  // SECURITY: percentile SQL-injection guard (issue #2464)
+  //
+  // `percentile` is spliced into raw SQL as the quantile level (`0.${p}`) rather
+  // than bound, and the endpoint is unauthenticated on the default self-hosted
+  // posture. Every chart that reads `percentile` must funnel it through the
+  // numeric allowlist so a hostile value can never reach ClickHouse.
+  // ---------------------------------------------------------------------------
+  describe('percentile injection guard', () => {
+    // The 8 call sites that read `params.percentile`.
+    const percentileCharts = [
+      'insight-largest-scan',
+      'insight-fastest-scan',
+      'insight-longest-query',
+      'insight-avg-duration',
+      'insight-total-queries',
+      'insight-total-scanned',
+      'insight-total-rows-read',
+      'insight-peak-memory',
+    ] as const
+
+    const maliciousValues = [
+      '99) FROM system.users--',
+      '50)),arbitrary--',
+      '1)) UNION SELECT * FROM system.users--',
+      '99; DROP TABLE t',
+      '0.99',
+      'abc',
+      '',
+      '-1',
+      '101',
+      '999',
+      '1e2',
+      ' 99',
+      '99 ',
+    ]
+
+    describe.each(percentileCharts)('chart "%s"', (chartName) => {
+      test.each(
+        maliciousValues
+      )('rejects malicious percentile %p (no injected fragment, safe fallback)', (percentile) => {
+        const result = insightCharts[chartName]({
+          lastHours: 24,
+          params: { percentile },
+        })
+        if (!('query' in result)) throw new Error('expected query')
+        const sql = result.query
+        // No hostile fragment survives into the SQL.
+        expect(sql).not.toContain('system.users')
+        expect(sql).not.toContain('UNION')
+        expect(sql).not.toContain('DROP')
+        expect(sql).not.toContain('--')
+        // The quantile level, when present, is always a bare `0.<int>`.
+        const levels = sql.match(/quantileTDigest\(([^)]*)\)/g) ?? []
+        for (const level of levels) {
+          expect(level).toMatch(/^quantileTDigest\(0\.\d{1,3}\)$/)
+        }
+        // Injection payloads fall back to the default p99.
+        if (sql.includes('quantileTDigest')) {
+          expect(sql).toContain('quantileTDigest(0.99)')
+        }
+      })
+
+      test('accepts the legitimate UI values 95/99/100', () => {
+        for (const percentile of ['95', '99', '100']) {
+          const result = insightCharts[chartName]({
+            lastHours: 24,
+            params: { percentile },
+          })
+          if (!('query' in result)) throw new Error('expected query')
+          const sql = result.query
+          if (percentile === '100') {
+            // p100 uses max() / drops the duration filter — no quantile level.
+            expect(sql).not.toContain('quantileTDigest(0.100)')
+          } else {
+            expect(sql).toContain(`quantileTDigest(0.${percentile})`)
+          }
+        }
+      })
+    })
+  })
 })

--- a/apps/dashboard/src/lib/api/charts/insight-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/insight-charts.ts
@@ -8,13 +8,38 @@ import type { ChartQueryBuilder } from './types'
 import { buildTimeFilter } from '@/lib/clickhouse-query'
 
 /**
+ * Default percentile when the request omits or supplies an invalid value.
+ */
+const DEFAULT_PERCENTILE = '99'
+
+/**
+ * Coerce a request-supplied `percentile` param to a safe numeric string before
+ * it is spliced into raw SQL as the quantile level (`0.${p}`).
+ *
+ * SECURITY (issue #2464): `percentile` reaches ClickHouse via string
+ * interpolation, not a bind parameter, so an unvalidated value is direct SQL
+ * injection (e.g. `50)),arbitrary--`). This endpoint is unauthenticated on the
+ * default self-hosted posture and public-read for cloud anonymous visitors, so
+ * the value MUST be constrained here. Accept only an integer 1–100 (the UI
+ * offers p95 / p99 / p100); anything else — non-numeric, out of range, or an
+ * injection payload — falls back to the default p99. The returned value is
+ * re-derived from the parsed integer, so the string that ever reaches SQL can
+ * only be digits.
+ */
+function sanitizePercentile(percentile: string): string {
+  if (!/^\d{1,3}$/.test(percentile)) return DEFAULT_PERCENTILE
+  const n = Number.parseInt(percentile, 10)
+  if (!Number.isInteger(n) || n < 1 || n > 100) return DEFAULT_PERCENTILE
+  return String(n)
+}
+
+/**
  * Aggregate expression for a percentile (or max for p100).
  * Uses quantileTDigest — lower memory than exact quantile on large query_log.
  */
 function percentileThreshold(percentile: string, column: string): string {
-  return percentile === '100'
-    ? `max(${column})`
-    : `quantileTDigest(0.${percentile})(${column})`
+  const p = sanitizePercentile(percentile)
+  return p === '100' ? `max(${column})` : `quantileTDigest(0.${p})(${column})`
 }
 
 /**
@@ -27,10 +52,11 @@ function percentileDurationFilter(
   percentile: string,
   timeFilter: string
 ): string {
-  if (percentile === '100') return ''
+  const p = sanitizePercentile(percentile)
+  if (p === '100') return ''
   const timeClause = timeFilter ? `AND ${timeFilter}` : ''
   return `AND query_duration_ms <= (
-    SELECT ${percentileThreshold(percentile, 'query_duration_ms')}
+    SELECT ${percentileThreshold(p, 'query_duration_ms')}
     FROM system.query_log
     WHERE type = 'QueryFinish' AND is_initial_query = 1 ${timeClause}
   )`


### PR DESCRIPTION
## Vulnerability

The `percentile` chart param on the Insights charts was spliced directly into
ClickHouse SQL as the quantile level with no validation:

```ts
`quantileTDigest(0.${percentile})(${column})`
```

`percentile` is read straight from the request (`params.params?.percentile`)
with only a default fallback and no shape check, and `validateChartParams` is
called without an allowlist. This gave any caller of
`GET /api/v1/charts/<name>?params={"percentile":"<injected>"}` arbitrary SQL
injection into the operator's connected ClickHouse host — e.g. breaking out of
the numeric literal to append subqueries/UNIONs, or chaining a `url()`/`remote()`
table function for SSRF/exfiltration. It bypasses `packages/sql-builder`'s
`validateSqlQuery` entirely (never invoked on chart-builder SQL). The endpoint is
**unauthenticated on the default self-hosted posture** (`auth: none`) and
**public-read for cloud anonymous visitors**, so it was remotely reachable.

Affected: all 8 insight-chart call sites reading `percentile`
(`insight-largest-scan`, `insight-fastest-scan`, `insight-longest-query`,
`insight-avg-duration`, `insight-total-queries`, `insight-total-scanned`,
`insight-total-rows-read`, `insight-peak-memory`).

## Fix

Constrain `percentile` at the root, in the two shared helpers
(`percentileThreshold` + `percentileDurationFilter`) that **all 8 call sites
funnel through**, via a new `sanitizePercentile`:

- Accept only an integer 1–100 (the UI offers p95/p99/p100).
- Non-numeric, out-of-range, or injection payloads fall back to the default p99
  (no 500, chart still renders).
- The level that reaches SQL is **re-derived from the parsed integer**, so it can
  only ever be digits — string interpolation is now safe by construction.

Audited every other chart param while here: `disk-size` (`name`, regex
`/^[\w-]+$/`) and `top-table-size` (`limit`, numeric coercion + range) are
already safe. `percentile` was the only injectable chart param.

## Test evidence

Added a `percentile injection guard` suite hitting **each** of the 8 charts with
injection payloads (`50)),arbitrary--`, `99) FROM system.users--`, UNION/DROP,
`0.99`, non-numeric, empty, `-1`, `101`, `999`, `1e2`, whitespace) — asserts no
hostile fragment (`system.users`/`UNION`/`DROP`/`--`) survives, every quantile
level matches `^quantileTDigest\(0\.\d{1,3}\)$`, and payloads fall back to p99.
Plus a positive test that legitimate 95/99/100 still work.

```
bun test src/lib/api/__tests__/charts/insight-charts.test.ts
164 pass, 0 fail, 779 expect() calls
```

`pnpm run lint` clean (only the pre-existing biome schema-version info, unrelated).

Closes #2464