### PR TITLE
fix(security): block comment bypass of SQL dangerous-function guard

### DIFF
--- a/docs/knowledge/sql-validator-threat-model.md
+++ b/docs/knowledge/sql-validator-threat-model.md
@@ -3,7 +3,7 @@ id: sql-validator-threat-model
 title: SQL Validator Threat Model & False-Positive Class
 type: decision
 status: active
-updated: 2026-06-20
+updated: 2026-07-10
 tags:
   - security
   - sql
@@ -57,6 +57,26 @@ slow-queries, error-rate-baseline). Root causes + fixes:
 
 The tightened OR-patterns are also **ReDoS-safe** (the old nested `.*` runs risked
 catastrophic backtracking).
+
+## Comment-bypass hardening (2026-07-10, issue #2465)
+
+The keyword/function blocklists are raw-text regexes, and `DANGEROUS_FUNCTIONS`
+matched `<name>\s*(`. `\s*` matches whitespace but **not** a comment, so
+`remote/*x*/('h','d','t')` and `url/**/('http://169.254.169.254/…')` parsed
+identically for ClickHouse (a comment is insignificant whitespace between tokens)
+yet slipped past the guard — an unauthenticated SSRF/exfiltration vector on the
+default `auth: none` self-hosted install.
+
+Fix: `validateSqlQuery` now runs **all** injection/function patterns (and the
+statement-type prefix check) against a comment-normalized copy produced by
+`stripSqlComments`. That helper walks the string and replaces every `/* */`
+block, `--` line, and `#` line comment with a single space — matching
+ClickHouse's own tokenization (`remote/**/(` → `remote (` → blocked; a comment
+*inside* an identifier stays split, as ClickHouse reads it). Crucially it leaves
+string literals (`'…'`), double-quoted and backtick identifiers untouched
+(honoring `\` escapes and doubled quotes), so a benign literal like
+`'-- text'` or `'/* text */'` is never mistaken for a comment. Regression cases
+live in `sql-validator.test.ts` ("dangerous functions via comment bypass").
 
 ## Rule: keep shipped SQL and the validator in sync
 

--- a/packages/sql-builder/src/__tests__/sql-validator.test.ts
+++ b/packages/sql-builder/src/__tests__/sql-validator.test.ts
@@ -762,6 +762,92 @@ describe.skipIf(actuallyMocked)('validateSqlQuery', () => {
     })
   })
 
+  // Regression for issue #2465: the DANGEROUS_FUNCTIONS blocklist used `\s*(`
+  // between the function name and its `(`, which does not match a comment. A
+  // block/line comment placed there (`remote/*x*/(...)`) parses identically for
+  // ClickHouse but slipped past the guard, enabling SSRF/exfiltration via
+  // remote/url/s3/mysql/postgresql/etc. Comments are now normalized to
+  // whitespace before detection, so no comment/whitespace trick reassembles a
+  // blocked call.
+  describe('dangerous functions via comment bypass (issue #2465)', () => {
+    test('rejects the exact issue payloads', () => {
+      expect(() =>
+        validateSqlQuery("SELECT * FROM remote/*x*/('host','db','t')")
+      ).toThrow('Potentially dangerous SQL detected')
+      expect(() =>
+        validateSqlQuery(
+          "SELECT * FROM url/**/('http://169.254.169.254/','CSV','x String')"
+        )
+      ).toThrow('Potentially dangerous SQL detected')
+    })
+
+    test('rejects each dangerous function obfuscated with a block comment', () => {
+      const cases = [
+        "SELECT * FROM remote/*x*/('h','d','t')",
+        "SELECT * FROM remoteSecure/**/('h','d','t')",
+        "SELECT * FROM url/**/('http://x','CSV','a String')",
+        "SELECT * FROM s3/*a*/('bucket/key')",
+        "SELECT * FROM mysql/*a*/('h','d','t','u','p')",
+        "SELECT * FROM postgresql/*a*/('h','d','t','u','p')",
+        "SELECT * FROM jdbc/*a*/('ds','t')",
+        "SELECT * FROM odbc/*a*/('dsn','t')",
+        "SELECT * FROM hdfs/*a*/('hdfs://x','CSV')",
+        "SELECT * FROM file/*a*/('x.csv','CSV')",
+      ]
+      for (const sql of cases) {
+        expect(() => validateSqlQuery(sql)).toThrow(
+          'Potentially dangerous SQL detected'
+        )
+      }
+    })
+
+    test('rejects line-comment (--) obfuscation between name and paren', () => {
+      expect(() =>
+        validateSqlQuery("SELECT * FROM remote --c\n('h','d','t')")
+      ).toThrow('Potentially dangerous SQL detected')
+    })
+
+    test('rejects hash-comment (#) obfuscation between name and paren', () => {
+      expect(() =>
+        validateSqlQuery("SELECT * FROM url #c\n('http://x','CSV','a String')")
+      ).toThrow('Potentially dangerous SQL detected')
+    })
+
+    test('rejects multiple / nested-style and multi-line comment obfuscation', () => {
+      expect(() =>
+        validateSqlQuery("SELECT * FROM remote/*a*//*b*/('h','d','t')")
+      ).toThrow('Potentially dangerous SQL detected')
+      expect(() =>
+        validateSqlQuery("SELECT * FROM s3/* multi\n line\n comment */('b/k')")
+      ).toThrow('Potentially dangerous SQL detected')
+    })
+
+    // A comment-like sequence INSIDE a string literal must NOT be treated as a
+    // comment: stripping it would corrupt the literal and could hide/expose
+    // tokens. These are legitimate read-only queries and must pass unchanged.
+    test('does not false-positive on comment-like text inside string literals', () => {
+      // Block-comment markers inside a literal are data, not a comment. (Note
+      // the literal deliberately contains the exact `remote/*x*/(` bypass string
+      // to prove it is treated as data — `\s*(` never matched it here anyway.)
+      expect(() =>
+        validateSqlQuery("SELECT 'remote/*x*/(1)' AS s FROM system.one")
+      ).not.toThrow()
+      // Line-comment markers (-- and #) inside a literal are data.
+      expect(() =>
+        validateSqlQuery("SELECT '-- not a comment' AS s")
+      ).not.toThrow()
+      expect(() =>
+        validateSqlQuery("SELECT '# not a comment' AS s")
+      ).not.toThrow()
+      // Doubled single-quote escaping keeps the stripper inside the literal.
+      expect(() =>
+        validateSqlQuery("SELECT 'it''s /*fine*/ text' AS s")
+      ).not.toThrow()
+      // A stray */ inside a literal must not desync comment tracking.
+      expect(() => validateSqlQuery("SELECT 'x */ y' AS s")).not.toThrow()
+    })
+  })
+
   describe('non-SELECT queries', () => {
     test('should reject INSERT at start', () => {
       expect(() => validateSqlQuery('INSERT INTO users VALUES (1)')).toThrow()

--- a/packages/sql-builder/src/sql-validator.ts
+++ b/packages/sql-builder/src/sql-validator.ts
@@ -124,6 +124,87 @@ const SQL_INJECTION_PATTERNS = [
 ]
 
 /**
+ * Strip SQL comments to their whitespace equivalent, leaving string literals and
+ * quoted identifiers untouched.
+ *
+ * ClickHouse treats a comment as insignificant whitespace between tokens, so a
+ * `/* ... *\/` block or `--` / `#` line comment placed between a function name and
+ * its `(` (e.g. `remote/*x*\/(...)`) parses identically to `remote(...)`. The
+ * keyword/function blocklists below only see raw text, so without normalization a
+ * comment can be used to break up an otherwise-blocked token. Replacing each
+ * comment with a single space mirrors ClickHouse's own tokenization: it re-joins
+ * `remote/**\/(` into a matchable `remote (`, while a comment placed *inside* an
+ * identifier (`remo/**\/te`) stays split — exactly as ClickHouse would read it.
+ *
+ * Comment markers are only honored outside string literals (`'...'`), quoted
+ * identifiers (`"..."`), and backtick identifiers (`` `...` ``), so a benign
+ * literal like `'a -- b'` or `'/* not a comment *\/'` is preserved verbatim and
+ * never produces a false positive.
+ *
+ * @param sql - The raw SQL string
+ * @returns The SQL with all comments replaced by single spaces
+ * @internal
+ */
+export function stripSqlComments(sql: string): string {
+  let out = ''
+  let i = 0
+  const n = sql.length
+  // Active string/identifier quote char, or null when in normal SQL context.
+  let quote: "'" | '"' | '`' | null = null
+
+  while (i < n) {
+    const ch = sql[i]
+
+    if (quote !== null) {
+      // Inside a string literal or quoted identifier: copy verbatim, honoring
+      // both backslash escapes (\' \" \`) and SQL-standard doubled quotes ('').
+      if (ch === '\\' && i + 1 < n) {
+        out += ch + sql[i + 1]
+        i += 2
+        continue
+      }
+      if (ch === quote) {
+        if (sql[i + 1] === quote) {
+          // Doubled quote is an escaped quote, still inside the literal.
+          out += ch + sql[i + 1]
+          i += 2
+          continue
+        }
+        quote = null
+      }
+      out += ch
+      i += 1
+      continue
+    }
+
+    // Normal SQL context: detect comment openers before anything else.
+    if (ch === '/' && sql[i + 1] === '*') {
+      // Block comment: skip until the matching */ (or end of input).
+      i += 2
+      while (i < n && !(sql[i] === '*' && sql[i + 1] === '/')) i += 1
+      i += 2 // consume the closing */ (harmless if we hit EOF first)
+      out += ' '
+      continue
+    }
+    if ((ch === '-' && sql[i + 1] === '-') || ch === '#') {
+      // Line comment (`--` or `#`): skip until newline, which is preserved.
+      i += ch === '#' ? 1 : 2
+      while (i < n && sql[i] !== '\n') i += 1
+      out += ' '
+      continue
+    }
+
+    if (ch === "'" || ch === '"' || ch === '`') {
+      quote = ch
+    }
+    out += ch
+    i += 1
+  }
+
+  return out
+}
+
+/**
  * Validate SQL query for basic safety and correctness
  *
  * Detects common SQL injection patterns and ensures the query is non-empty.
@@ -155,21 +236,25 @@ export function validateSqlQuery(sql: string): void {
     throw new Error('SQL query cannot be empty')
   }
 
+  // Normalize comments away BEFORE running keyword/function detection. A block or
+  // line comment placed between a blocked token and its `(` (e.g. `remote/*x*/(`)
+  // otherwise slips past `\s*\(` while parsing identically for ClickHouse. String
+  // literals are left intact so benign `'-- text'` / `'/* text */'` don't trip the
+  // patterns. See {@link stripSqlComments}.
+  const normalized = stripSqlComments(sql)
+
   // Check for SQL injection patterns
   for (const pattern of SQL_INJECTION_PATTERNS) {
-    if (pattern.test(sql)) {
+    if (pattern.test(normalized)) {
       throw new Error(
         'Potentially dangerous SQL detected. Only SELECT, WITH, DESCRIBE, and EXPLAIN queries are allowed.'
       )
     }
   }
 
-  // Strip leading comments before checking the statement type
-  const trimmed = sql
-    .trim()
-    .replace(/^(\/\*[\s\S]*?\*\/\s*|--[^\n]*\n\s*)*/g, '')
-    .trimStart()
-    .toUpperCase()
+  // Check the statement type on the comment-stripped query so a leading comment
+  // (in any position/quantity) cannot disguise the real first keyword.
+  const trimmed = normalized.trim().toUpperCase()
   if (
     !trimmed.startsWith('SELECT') &&
     !trimmed.startsWith('WITH') &&


### PR DESCRIPTION
## Vulnerability (#2465)

`validateSqlQuery`'s `DANGEROUS_FUNCTIONS` blocklist — the primary guard against SSRF/exfiltration table functions (`remote`, `remoteSecure`, `url`, `s3`, `mysql`, `postgresql`, `jdbc`, `odbc`, `hdfs`, `file`, `executable`, …) across nearly every SQL-accepting surface (MCP `query` tool, agent `query` tool, SQL explorer, `/api/v1/data` + `/explain`, browser-connections proxy, Slack commands) — matched `<name>\s*(`. `\s*` matches whitespace but **not** a SQL comment.

A block/line comment placed between the function name and its `(` bypassed the guard while parsing identically for ClickHouse (a comment is insignificant whitespace between tokens):

```sql
SELECT * FROM remote/*x*/('host','db','t')                                   -- passed
SELECT * FROM url/**/('http://169.254.169.254/...', 'CSV', 'x String')       -- passed
```

Comments are otherwise deliberately permitted by this validator, so there was no secondary catch. On the default `auth: none` self-hosted install this is an unauthenticated SSRF / cross-database exfiltration vector (readonly does not block read-context table functions).

## Fix

Normalize comments to whitespace **before** running every injection/function pattern and the statement-type prefix check. New `stripSqlComments` walks the query and replaces each `/* */` block, `--` line, and `#` line comment with a single space — mirroring ClickHouse tokenization (`remote/**/(` → `remote (` → blocked; a comment *inside* an identifier stays split, exactly as ClickHouse reads it).

Crucially, comment markers are only honored **outside** string literals (`'…'`), double-quoted identifiers, and backtick identifiers (honoring `\` escapes and doubled quotes), so a benign literal like `'-- text'` or `'/* text */'` is preserved verbatim and never produces a false positive.

## Test evidence

Added a `dangerous functions via comment bypass (issue #2465)` suite covering the exact issue payloads plus variants: every dangerous function with block comments, `--` and `#` line comments, multiple/multi-line comments, and a false-positive guard for comment-like text inside string literals (incl. doubled-quote escaping and stray `*/`).

- `packages/sql-builder`: 529 pass / 0 fail
- MCP `query-validation`: 17 pass
- Dashboard consumers (`data` sql-validation, `browser-connections/proxy`, shipped-SQL corpus, mcp-readonly-enforcement): 45 pass — no false positives on shipped queries
- `pnpm run lint`: clean

Closes #2465

https://claude.ai/code/session_01XbHNd3i7mySyqgs32PPXf3