### PR TITLE
fix(security): dedupe constantTimeEqual into one tested implementation

### DIFF
--- a/apps/dashboard/src/lib/auth/agent-api-token.test.ts
+++ b/apps/dashboard/src/lib/auth/agent-api-token.test.ts
@@ -1,0 +1,45 @@
+import { isValidAgentApiBearerToken } from './agent-api-token'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+function makeRequest(headers: Record<string, string> = {}): Request {
+  return new Request('https://example.com/api/v1/test', { headers })
+}
+
+const originalAgentApiToken = process.env.AGENT_API_TOKEN
+
+beforeEach(() => {
+  delete process.env.AGENT_API_TOKEN
+})
+
+afterEach(() => {
+  if (originalAgentApiToken === undefined) {
+    delete process.env.AGENT_API_TOKEN
+  } else {
+    process.env.AGENT_API_TOKEN = originalAgentApiToken
+  }
+})
+
+describe('isValidAgentApiBearerToken', () => {
+  test('rejects when AGENT_API_TOKEN is unset', async () => {
+    const request = makeRequest({ authorization: 'Bearer anything' })
+    expect(await isValidAgentApiBearerToken(request)).toBe(false)
+  })
+
+  test('rejects when no Authorization header is provided', async () => {
+    process.env.AGENT_API_TOKEN = 'correct-token'
+    const request = makeRequest()
+    expect(await isValidAgentApiBearerToken(request)).toBe(false)
+  })
+
+  test('rejects a wrong bearer token', async () => {
+    process.env.AGENT_API_TOKEN = 'correct-token'
+    const request = makeRequest({ authorization: 'Bearer wrong-token' })
+    expect(await isValidAgentApiBearerToken(request)).toBe(false)
+  })
+
+  test('accepts the correct bearer token', async () => {
+    process.env.AGENT_API_TOKEN = 'correct-token'
+    const request = makeRequest({ authorization: 'Bearer correct-token' })
+    expect(await isValidAgentApiBearerToken(request)).toBe(true)
+  })
+})

--- a/apps/dashboard/src/lib/auth/agent-api-token.ts
+++ b/apps/dashboard/src/lib/auth/agent-api-token.ts
@@ -1,15 +1,5 @@
 import { getBearerToken } from '@chm/mcp-server/auth'
-
-function constantTimeEqual(a: Uint8Array, b: Uint8Array): boolean {
-  if (a.length !== b.length) return false
-
-  let diff = 0
-  for (let index = 0; index < a.length; index += 1) {
-    diff |= a[index] ^ b[index]
-  }
-
-  return diff === 0
-}
+import { constantTimeEqual } from '@/lib/auth/providers/constant-time'
 
 async function sha256(input: string): Promise<Uint8Array> {
   const digest = await crypto.subtle.digest(

--- a/apps/dashboard/src/lib/auth/providers/constant-time.test.ts
+++ b/apps/dashboard/src/lib/auth/providers/constant-time.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Truth-table tests for the shared timing-safe comparators (constant-time.ts).
+ *
+ * `constantTimeEqual` / `secretsMatch` back every shared-secret check in the
+ * app (proxy/trusted auth providers, cron routes, Slack + deployment webhook
+ * signatures, the agent API bearer token). A silent regression here — e.g.
+ * back to a length-leaking `===` — would be invisible without a test.
+ */
+
+import { constantTimeEqual, secretsMatch } from './constant-time'
+import { describe, expect, test } from 'bun:test'
+
+describe('constantTimeEqual', () => {
+  test('returns true for equal buffers', () => {
+    expect(
+      constantTimeEqual(
+        new Uint8Array([1, 2, 3, 4]),
+        new Uint8Array([1, 2, 3, 4])
+      )
+    ).toBe(true)
+  })
+
+  test('returns false when one byte differs', () => {
+    expect(
+      constantTimeEqual(
+        new Uint8Array([1, 2, 3, 4]),
+        new Uint8Array([1, 2, 3, 5])
+      )
+    ).toBe(false)
+  })
+
+  test('returns false on length mismatch', () => {
+    expect(
+      constantTimeEqual(new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 3, 4]))
+    ).toBe(false)
+  })
+
+  test('returns true for two empty buffers', () => {
+    expect(constantTimeEqual(new Uint8Array(), new Uint8Array())).toBe(true)
+  })
+
+  test('returns false for empty vs non-empty', () => {
+    expect(constantTimeEqual(new Uint8Array(), new Uint8Array([1]))).toBe(false)
+  })
+})
+
+describe('secretsMatch', () => {
+  test('returns true for equal strings', () => {
+    expect(secretsMatch('hunter2', 'hunter2')).toBe(true)
+  })
+
+  test('returns false when one character differs', () => {
+    expect(secretsMatch('hunter2', 'hunter3')).toBe(false)
+  })
+
+  test('returns false on length mismatch', () => {
+    expect(secretsMatch('short', 'longer-secret')).toBe(false)
+  })
+
+  test('returns true for two empty strings', () => {
+    expect(secretsMatch('', '')).toBe(true)
+  })
+
+  test('returns false for empty vs non-empty', () => {
+    expect(secretsMatch('', 'nonempty')).toBe(false)
+  })
+
+  test('encodes as UTF-8 before comparing (multi-byte characters)', () => {
+    const secret = '密码🔒test'
+    expect(secretsMatch(secret, secret)).toBe(true)
+    expect(secretsMatch(secret, '密码🔒tesT')).toBe(false)
+  })
+})


### PR DESCRIPTION
## What

`lib/auth/agent-api-token.ts` carried a verbatim inline copy of the
timing-safe `constantTimeEqual` comparator that already lives in
`lib/auth/providers/constant-time.ts` (shared by the `proxy` and
`trusted` auth providers). Neither had a test.

- Replace the inline copy in `agent-api-token.ts` with the shared
  import (`@/lib/auth/providers/constant-time`) — no behavior change.
- Add `providers/constant-time.test.ts`: truth-table tests for
  `constantTimeEqual` (equal/one-byte-diff/length-mismatch/empty vs
  empty/empty vs non-empty) and the same table for `secretsMatch`,
  plus a multi-byte UTF-8 case to exercise its `TextEncoder` path.
- Add `agent-api-token.test.ts`: `isValidAgentApiBearerToken` —
  `AGENT_API_TOKEN` unset → reject, no Authorization header → reject,
  wrong token → reject, correct token → accept.

## Why

The comparator is security-critical (constant-time secret comparison
that avoids leaking length/prefix via timing). A silent regression to
a non-constant-time or length-leaking form in either copy would have
been invisible without a test, and the duplication let the two copies
drift apart.

## Scope

Out of scope (per plan): the comparator algorithm itself, provider
auth flows, and `packages/mcp-server`'s own `getBearerToken` (unrelated
import, untouched).

## Verification

- `rg -n "constantTimeEqual" apps/dashboard/src/lib/auth` → exactly
  one `export function constantTimeEqual` definition
  (`providers/constant-time.ts`); all other hits are imports/usages.
- `cd apps/dashboard && bun test src/lib/auth` → 96 pass, 0 fail
  (10 files, up from 8 — the two new test files).
- `cd apps/dashboard && bun test src/lib/feature-permissions` → 53
  pass, 0 fail (sanity check on `agent-api-token.ts`'s consumer,
  `feature-permissions/server.ts`).
- Ran locally via symlinked `node_modules` from the main checkout
  (worktree has none installed); not run via `pnpm run build` per the
  no-build rule for this worktree — CI's `dashboard` compile-only
  check covers that.

Closes #2495

https://claude.ai/code/session_018h2h5erikMP3aM7p8YdXfY