### PR TITLE
docs(readme): fix broken docs.chmonitor.dev links and stale badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![Build and Test](https://github.com/chmonitor/chmonitor/actions/workflows/ci.yml/badge.svg)](https://github.com/chmonitor/chmonitor/actions/workflows/ci.yml)
 [![GitHub stars](https://img.shields.io/github/stars/chmonitor/chmonitor?style=flat&logo=github&label=stars)](https://github.com/chmonitor/chmonitor/stargazers)
-<!-- NOTE: this uptime badge still uses the pre-rebrand `clickhouse-monitoring-vercel-app` slug and may be stale; verify against the live uptime source before relying on it. -->
-[![All-time uptime](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fduyet%2Fuptime%2FHEAD%2Fapi%2Fclickhouse-monitoring-vercel-app%2Fuptime.json)](https://duyet.github.io/uptime/history/clickhouse-monitoring-vercel-app)
 [![Latest release](https://img.shields.io/github/v/release/chmonitor/chmonitor?sort=semver&label=release)](https://github.com/chmonitor/chmonitor/releases)
 [![Docker image](https://img.shields.io/badge/ghcr.io-chmonitor%2Fchmonitor-2496ED?logo=docker&logoColor=white)](https://github.com/chmonitor/chmonitor/pkgs/container/chmonitor)
 [![License](https://img.shields.io/github/license/chmonitor/chmonitor)](LICENSE)
@@ -27,7 +25,7 @@
 > connection vars are unchanged; browser vars move from `NEXT_PUBLIC_*` to
 > `VITE_*` (old names still work as a fallback). See
 > **[Upgrading to v0.3](#upgrading-to-v03)** below or the full
-> [Migrate to v0.3](https://docs.chmonitor.dev/migrating/v0-3) guide.
+> [Migrate to v0.3](https://docs.chmonitor.dev/reference/migrating/v0-3) guide.
 
 ## Features
 
@@ -80,7 +78,7 @@ connection vars on any of these targets:
 - **[Cloudflare Workers](#cloudflare-workers)** — global edge deploy (how the
   demo at [dash.chmonitor.dev](https://dash.chmonitor.dev/?ref=github) runs).
 - **[One-click templates](docs/content/operate/deploy/one-click.mdx)** — Railway, Render, Fly.io.
-- **[Kubernetes (Helm)](https://docs.chmonitor.dev/deploy/k8s)** — for clusters.
+- **[Kubernetes (Helm)](https://docs.chmonitor.dev/operate/deploy/k8s)** — for clusters.
 
 Prefer to look before you install? Try the live demo above — no setup required.
 
@@ -213,7 +211,7 @@ variable prefix, and the old names keep working:
 
 `VITE_*` vars are **build-time inlined** — set them when building the image/Worker,
 not only at runtime. Full per-platform steps:
-[Migrate to v0.3](https://docs.chmonitor.dev/migrating/v0-3).
+[Migrate to v0.3](https://docs.chmonitor.dev/reference/migrating/v0-3).
 
 ### Migrate your config with an AI assistant
 
@@ -251,20 +249,20 @@ plus a short list of what you changed:
 
 ## Documentation
 
-- **[/docs](/docs)** - Full documentation site (local/docs)
+- **[docs/](/docs)** - Documentation source in this repository (see below for the live site)
 - **llms.txt** - AI agent discovery file for automated code understanding
 - https://zread.ai/chmonitor/chmonitor _(AI Generated)_
 - https://docs.chmonitor.dev
-  - [Getting Started](https://docs.chmonitor.dev/getting-started)
-    - [Local Development](https://docs.chmonitor.dev/getting-started/local)
-    - [User Role and Profile](https://docs.chmonitor.dev/getting-started/clickhouse-requirements)
-    - [Enable System Tables](https://docs.chmonitor.dev/getting-started/clickhouse-enable-system-tables)
-  - [Deployments](https://docs.chmonitor.dev/deploy)
-    - [Vercel](https://docs.chmonitor.dev/deploy/vercel)
-    - [Docker](https://docs.chmonitor.dev/deploy/docker)
-    - [Kubernetes Helm Chart](https://docs.chmonitor.dev/deploy/k8s)
+  - [Getting Started](https://docs.chmonitor.dev/guide/getting-started)
+    - [Local Development](https://docs.chmonitor.dev/guide/getting-started/local)
+    - [User Role and Profile](https://docs.chmonitor.dev/guide/getting-started/clickhouse-requirements)
+    - [Enable System Tables](https://docs.chmonitor.dev/guide/getting-started/clickhouse-enable-system-tables)
+  - [Deployments](https://docs.chmonitor.dev/operate/deploy)
+    - [Vercel](https://docs.chmonitor.dev/operate/deploy/vercel) _(legacy v0.2)_
+    - [Docker](https://docs.chmonitor.dev/operate/deploy/docker)
+    - [Kubernetes Helm Chart](https://docs.chmonitor.dev/operate/deploy/k8s)
     - [One-Click Deploy](docs/content/operate/deploy/one-click.mdx) — Railway / Render / Fly.io community templates
-  - [Advanced](https://docs.chmonitor.dev/advanced)
+  - Advanced
     - [Telemetry](docs/content/operate/advanced/telemetry.mdx) — opt-in, privacy-first usage metrics (off by default)
     - [Editions](docs/content/operate/advanced/editions.mdx) — open-core model: GPL-3.0 community is free forever; enterprise features gated by `CHM_EDITION`
   - [Reference](https://docs.chmonitor.dev/reference)

--- a/docs/content/guide/guides/connection-errors.mdx
+++ b/docs/content/guide/guides/connection-errors.mdx
@@ -1,6 +1,6 @@
 ---
 title: Connection errors
-description: Fix "Test connection" failures in ClickHouse Monitor — host not allowed, invalid URL, authentication failed, missing permissions, DNS, refused, TLS, and timeout errors.
+description: Fix "Test connection" failures in chmonitor — host not allowed, invalid URL, authentication failed, missing permissions, DNS, refused, TLS, and timeout errors.
 icon: PlugZap
 ---
 
@@ -20,7 +20,7 @@ The hosted service at **dash.chmonitor.dev** blocks connections to private, inte
 **Fix**
 
 - Use a public HTTPS endpoint — for example ClickHouse Cloud, or your own server exposed on a public host and port.
-- To monitor a **private** cluster (VPC, homelab, `localhost`, `10.x`, `192.168.x`), **self-host** ClickHouse Monitor inside your network instead. The self-hosted build has no address restriction. See [Deploy](/operate/deploy/self-host).
+- To monitor a **private** cluster (VPC, homelab, `localhost`, `10.x`, `192.168.x`), **self-host** chmonitor inside your network instead. The self-hosted build has no address restriction. See [Deploy](/operate/deploy/self-host).
 
 </Accordion>
 <Accordion title="Invalid host URL">
@@ -117,7 +117,7 @@ echo 'SELECT version()' | curl "https://host:8443/?user=monitoring&password=…"
 ```
 </Callout>
 
-For **private** clusters, [self-host ClickHouse Monitor](/operate/deploy/self-host) — the same dashboard, with no public-network requirement.
+For **private** clusters, [self-host chmonitor](/operate/deploy/self-host) — the same dashboard, with no public-network requirement.
 
 ## Related
 
@@ -125,5 +125,5 @@ For **private** clusters, [self-host ClickHouse Monitor](/operate/deploy/self-ho
 <Card title="Troubleshooting" href="/guide/guides/troubleshooting" description="Diagnose connection, auth, performance, and Kubernetes probe failures." />
 <Card title="ClickHouse requirements" href="/guide/getting-started/clickhouse-requirements" description="The least-privilege monitoring user and grants the dashboard needs." />
 <Card title="Connect a firewalled ClickHouse" href="/guide/guides/connect-firewalled-clickhouse" description="Reach a firewalled cluster from Cloud with a tunnel or dedicated egress IPs." />
-<Card title="Self-host" href="/operate/deploy/self-host" description="Run ClickHouse Monitor inside your network with no public-address restriction." />
+<Card title="Self-host" href="/operate/deploy/self-host" description="Run chmonitor inside your network with no public-address restriction." />
 </Cards>


### PR DESCRIPTION
## What

README.md's docs.chmonitor.dev links were missing the top-level route segment
(`/guide`, `/operate`, `/reference`) the live Fumadocs site uses, plus a
stale uptime badge and one docs page with the pre-rebrand product name.

- Rewrote every `docs.chmonitor.dev` link in `README.md` to its canonical
  path (both "Migrate to v0.3" callouts, the Kubernetes deploy link, and the
  full Getting Started / Deployments / Advanced doc list).
- Marked the Vercel deploy guide `_(legacy v0.2)_` — its docs page now
  explicitly targets the retired Next.js build only.
- Relabeled the local `/docs` repo-folder link so it isn't confused with the
  hosted docs site linked immediately above it.
- Dropped the "Advanced" hyperlink: `docs.chmonitor.dev/operate/advanced`
  404s (no index page for that directory) and no equivalent page exists;
  its two children (Telemetry, Editions) keep linking to their real files
  in-repo.
- Removed the "All-time uptime" badge and its staleness comment — the
  backing `duyet/uptime` GitHub repo and Pages site are both gone (confirmed
  404 / no-such-repo via the GitHub API), so there's no working slug to fix.
- Renamed "ClickHouse Monitor" → "chmonitor" in
  `docs/content/guide/guides/connection-errors.mdx`, the one docs page still
  carrying the pre-rebrand name.

## Why

Every "Getting Started"/"Deployments" link and both "Migrate to v0.3"
callouts pointed at stale paths from before the docs reorg into
`/guide`, `/operate`, `/reference` prefixes — the repo's front door sending
new users to unlabeled/incorrect URLs.

## Verified link targets (curl → 200)

- `https://docs.chmonitor.dev`
- `https://docs.chmonitor.dev/guide/getting-started`
- `https://docs.chmonitor.dev/guide/getting-started/local`
- `https://docs.chmonitor.dev/guide/getting-started/clickhouse-requirements`
- `https://docs.chmonitor.dev/guide/getting-started/clickhouse-enable-system-tables`
- `https://docs.chmonitor.dev/operate/deploy`
- `https://docs.chmonitor.dev/operate/deploy/vercel`
- `https://docs.chmonitor.dev/operate/deploy/docker`
- `https://docs.chmonitor.dev/operate/deploy/k8s`
- `https://docs.chmonitor.dev/reference`
- `https://docs.chmonitor.dev/reference/migrating/v0-3`
- `https://docs.chmonitor.dev/guide/guides/diagnostics-cli` (already correct, unchanged)

## Test plan

- [x] `rg -n "docs.chmonitor.dev" README.md` — every URL uses the corrected prefix
- [x] Curl sweep of all unique `docs.chmonitor.dev` links in README.md → all 200
- [x] `rg -n "ClickHouse Monitor" docs/content/guide/guides/connection-errors.mdx` → no matches
- [x] Confirmed `duyet/uptime` repo/Pages site no longer exists (404 via GitHub API and Pages URL) before removing the badge

Closes #2508

https://claude.ai/code/session_018h2h5erikMP3aM7p8YdXfY