### PR TITLE
fix(prefetch): align hover-prefetch query keys with consumers

### DIFF
--- a/apps/dashboard/src/lib/query/query-keys.test.ts
+++ b/apps/dashboard/src/lib/query/query-keys.test.ts
@@ -1,0 +1,117 @@
+import { hostConnectionKey } from './host-query-key'
+import { chartQueryKey, tableQueryKey } from './query-keys'
+import { describe, expect, test } from 'bun:test'
+
+describe('chartQueryKey', () => {
+  test('prefetch and useChartData build identical keys for a default env-host route', () => {
+    const hostId = 0
+    // What `prefetch.ts` passes for a hover prefetch.
+    const prefetchKey = chartQueryKey({
+      chartName: 'overview-cpu',
+      hostId,
+      params: null,
+      connectionKey: hostConnectionKey(hostId, null),
+    })
+
+    // What `useChartData` passes for the same route with no explicit
+    // interval/lastHours/params/timezone (the overview default). For an env
+    // host (id >= 0) the hook's `browserConnection` is always `null` too, so
+    // this is the true parity comparison, not an approximation.
+    const hookKey = chartQueryKey({
+      chartName: 'overview-cpu',
+      hostId,
+      interval: undefined,
+      lastHours: undefined,
+      params: undefined,
+      timezone: undefined,
+      connectionKey: hostConnectionKey(hostId, null),
+    })
+
+    expect(prefetchKey).toEqual(hookKey)
+    expect(prefetchKey).toEqual([
+      '/api/v1/charts',
+      'overview-cpu',
+      0,
+      undefined,
+      undefined,
+      'null',
+      undefined,
+      undefined,
+    ])
+  })
+
+  test('pins field ordering with explicit interval/lastHours/params/timezone/connection', () => {
+    const key = chartQueryKey({
+      chartName: 'query-count',
+      hostId: 2,
+      interval: '1 HOUR',
+      lastHours: 24,
+      params: { database: 'default' },
+      timezone: 'UTC',
+      connectionKey: 'conn-a',
+    })
+
+    expect(key).toEqual([
+      '/api/v1/charts',
+      'query-count',
+      2,
+      '1 HOUR',
+      24,
+      JSON.stringify({ database: 'default' }),
+      'UTC',
+      'conn-a',
+    ])
+  })
+})
+
+describe('tableQueryKey', () => {
+  test('prefetch and useTableData build identical keys for a default env-host route', () => {
+    const hostId = 0
+    // What `prefetch.ts` passes for a hover prefetch.
+    const prefetchKey = tableQueryKey({
+      queryConfigName: 'tables',
+      hostId,
+      searchParams: {},
+      connectionKey: hostConnectionKey(hostId, null),
+    })
+
+    // What `useTableData` passes for the same route with no explicit
+    // searchParams/timezone.
+    const hookKey = tableQueryKey({
+      queryConfigName: 'tables',
+      hostId,
+      searchParams: undefined,
+      timezone: undefined,
+      connectionKey: hostConnectionKey(hostId, null),
+    })
+
+    expect(prefetchKey).toEqual(hookKey)
+    expect(prefetchKey).toEqual([
+      '/api/v1/tables',
+      'tables',
+      0,
+      '{}',
+      undefined,
+      undefined,
+    ])
+  })
+
+  test('pins field ordering with explicit searchParams/timezone/connection', () => {
+    const key = tableQueryKey({
+      queryConfigName: 'tables',
+      hostId: 3,
+      searchParams: { search: 'foo', page: 2 },
+      timezone: 'Asia/Ho_Chi_Minh',
+      connectionKey: 'conn-b',
+    })
+
+    expect(key).toEqual([
+      '/api/v1/tables',
+      'tables',
+      3,
+      JSON.stringify({ search: 'foo', page: 2 }),
+      'Asia/Ho_Chi_Minh',
+      'conn-b',
+    ])
+  })
+})

--- a/apps/dashboard/src/lib/query/query-keys.ts
+++ b/apps/dashboard/src/lib/query/query-keys.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared TanStack Query key factories for chart/table data.
+ *
+ * `useChartData` / `useTableData` (live reads) and `prefetchRoute` (hover
+ * prefetch — see `lib/swr/prefetch.ts`) must build byte-identical keys, or
+ * TanStack Query hashes them differently and the prefetched cache entry is
+ * never hit: the seeded data becomes dead weight and the live hook refetches
+ * anyway. Route BOTH key shapes through these factories — never inline a key
+ * array at a call site — so a future field addition can't silently break
+ * prefetch again.
+ */
+
+export interface ChartQueryKeyParams {
+  chartName: string
+  hostId?: number | string
+  interval?: string
+  lastHours?: number
+  params?: Record<string, unknown> | null
+  timezone?: string
+  /** Precompute via `hostConnectionKey(numericHostId, browserConnection)`. */
+  connectionKey: string | undefined
+}
+
+export function chartQueryKey({
+  chartName,
+  hostId,
+  interval,
+  lastHours,
+  params,
+  timezone,
+  connectionKey,
+}: ChartQueryKeyParams) {
+  return [
+    '/api/v1/charts',
+    chartName,
+    hostId,
+    interval,
+    lastHours,
+    JSON.stringify(params ?? null),
+    timezone,
+    connectionKey,
+  ] as const
+}
+
+export interface TableQueryKeyParams {
+  queryConfigName: string
+  hostId?: number
+  searchParams?: Record<string, unknown> | null
+  timezone?: string
+  /** Precompute via `hostConnectionKey(hostId, browserConnection)`. */
+  connectionKey: string | undefined
+}
+
+export function tableQueryKey({
+  queryConfigName,
+  hostId,
+  searchParams,
+  timezone,
+  connectionKey,
+}: TableQueryKeyParams) {
+  return [
+    '/api/v1/tables',
+    queryConfigName,
+    hostId,
+    JSON.stringify(searchParams ?? {}),
+    timezone,
+    connectionKey,
+  ] as const
+}

--- a/apps/dashboard/src/lib/query/use-chart-data.ts
+++ b/apps/dashboard/src/lib/query/use-chart-data.ts
@@ -8,6 +8,7 @@ import {
   isCustomHost,
 } from '@/lib/host-fetch/resolve-host-fetch'
 import { hostConnectionKey } from '@/lib/query/host-query-key'
+import { chartQueryKey } from '@/lib/query/query-keys'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { REFRESH_INTERVAL, type RefreshInterval } from '@/lib/swr/config'
 import { throwIfNotOk } from '@/lib/swr/fetch-error'
@@ -91,16 +92,15 @@ export function useChartData<T extends ChartDataPoint = ChartDataPoint>({
     return `/api/v1/charts/${chartName}${queryString ? `?${queryString}` : ''}`
   }, [chartName, hostId, interval, lastHours, paramsKey, timezone])
 
-  const queryKey = [
-    '/api/v1/charts',
+  const queryKey = chartQueryKey({
     chartName,
     hostId,
     interval,
     lastHours,
-    JSON.stringify(params ?? null),
+    params,
     timezone,
-    hostConnectionKey(numericHostId, browserConnection),
-  ] as const
+    connectionKey: hostConnectionKey(numericHostId, browserConnection),
+  })
 
   const resolvedRefetchInterval =
     refreshInterval > 0

--- a/apps/dashboard/src/lib/query/use-table-data.ts
+++ b/apps/dashboard/src/lib/query/use-table-data.ts
@@ -9,6 +9,7 @@ import {
   isCustomHost,
 } from '@/lib/host-fetch/resolve-host-fetch'
 import { hostConnectionKey } from '@/lib/query/host-query-key'
+import { tableQueryKey } from '@/lib/query/query-keys'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { throwIfNotOk } from '@/lib/swr/fetch-error'
 import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
@@ -62,14 +63,13 @@ export function useTableData<T = unknown>(
     // searchParams is read inside but keyed via the stable searchParamsKey.
   }, [queryConfigName, hostId, searchParamsKey, timezone])
 
-  const queryKey = [
-    '/api/v1/tables',
+  const queryKey = tableQueryKey({
     queryConfigName,
     hostId,
-    JSON.stringify(searchParams ?? {}),
+    searchParams,
     timezone,
-    hostConnectionKey(hostId, browserConnection),
-  ] as const
+    connectionKey: hostConnectionKey(hostId, browserConnection),
+  })
 
   const resolvedRefetchInterval =
     refreshInterval && refreshInterval > 0

--- a/apps/dashboard/src/lib/swr/prefetch.ts
+++ b/apps/dashboard/src/lib/swr/prefetch.ts
@@ -4,14 +4,20 @@ import type { PrefetchConfig } from './route-prefetch-map'
 
 import { apiFetch } from './api-fetch'
 import { routePrefetchMap } from './route-prefetch-map'
+import { hostConnectionKey } from '@/lib/query/host-query-key'
+import { chartQueryKey, tableQueryKey } from '@/lib/query/query-keys'
 
 /**
  * Prefetch chart data and seed the TanStack Query cache.
- * Uses the same cache key structure as useChartData:
- * ['/api/v1/charts', chartName, hostId, interval, lastHours, JSON.stringify(params || null), timezone]
+ * Builds the cache key via `chartQueryKey` — the same factory `useChartData`
+ * uses — so the seeded entry is actually read on navigation instead of
+ * silently orphaning under a different key (issue #2489).
  *
- * For prefetching we use undefined for optional params (interval, lastHours, params, timezone)
+ * For prefetching we pass no interval/lastHours/timezone and `params: null`
  * since the default overview charts are fetched without these params.
+ * `hostConnectionKey(hostId, null)` matches what the hook computes for an env
+ * host (id >= 0) with no browser connection — the only case hover-prefetch
+ * currently targets.
  */
 function prefetchChart(
   queryClient: QueryClient,
@@ -19,15 +25,12 @@ function prefetchChart(
   hostId: number
 ): void {
   const url = `/api/v1/charts/${chartName}?hostId=${hostId}`
-  const queryKey = [
-    '/api/v1/charts',
+  const queryKey = chartQueryKey({
     chartName,
     hostId,
-    undefined, // interval
-    undefined, // lastHours
-    JSON.stringify(null), // params
-    undefined, // timezone (undefined = no timezone preference)
-  ]
+    params: null,
+    connectionKey: hostConnectionKey(hostId, null),
+  })
 
   apiFetch(url)
     .then((res) => {
@@ -45,8 +48,9 @@ function prefetchChart(
 
 /**
  * Prefetch table data and seed the TanStack Query cache.
- * Uses the same cache key structure as useTableData:
- * ['/api/v1/tables', queryConfigName, hostId, JSON.stringify(searchParams || {}), timezone]
+ * Builds the cache key via `tableQueryKey` — the same factory `useTableData`
+ * uses — so the seeded entry is actually read on navigation instead of
+ * silently orphaning under a different key (issue #2489).
  */
 function prefetchTable(
   queryClient: QueryClient,
@@ -54,13 +58,12 @@ function prefetchTable(
   hostId: number
 ): void {
   const url = `/api/v1/tables/${tableName}?hostId=${hostId}`
-  const queryKey = [
-    '/api/v1/tables',
-    tableName,
+  const queryKey = tableQueryKey({
+    queryConfigName: tableName,
     hostId,
-    JSON.stringify({}), // searchParams
-    undefined, // timezone (undefined = no timezone preference)
-  ]
+    searchParams: {},
+    connectionKey: hostConnectionKey(hostId, null),
+  })
 
   apiFetch(url)
     .then((res) => {


### PR DESCRIPTION
## What

Nav-link hover prefetch (`prefetchRoute`) built its own inline TanStack Query
key arrays for charts (7 elements) and tables (5 elements) — both shorter
than the keys `useChartData` (8 elements) and `useTableData` (6 elements)
actually read, missing the trailing `hostConnectionKey(...)` element.

## Why

TanStack Query hashes the whole key array, so the seeded cache entries were
never hit on navigation. The feature was dead weight: every nav-link hover
fired real `/api/v1/charts` and `/api/v1/tables` requests (~28-30 for the
overview route, each a Worker→ClickHouse round-trip) purely to populate
cache entries the live hooks could never read, adding pure extra load on
the user's ClickHouse cluster with zero benefit.

## Fix

- New `apps/dashboard/src/lib/query/query-keys.ts`: `chartQueryKey(...)` and
  `tableQueryKey(...)` factories — the single source of truth for both key
  shapes.
- `use-chart-data.ts` / `use-table-data.ts` now build their keys through
  these factories instead of inline arrays (no behavior change — byte
  identical key output).
- `lib/swr/prefetch.ts` now builds its keys through the same factories,
  computing `hostConnectionKey(hostId, null)` — which is exactly what the
  hooks compute for an env host (`hostId >= 0`) with no browser connection,
  since in that branch the hook's own `browserConnection` is also always
  `null`. That's the case hover-prefetch currently targets (nav links read
  `hostId` from `useHostId()`/`?host=`).
- New `query-keys.test.ts`: parity tests asserting the prefetch-call-shape
  and hook-call-shape produce identical arrays for a default env-host route,
  plus tests pinning field ordering with explicit interval/params/searchParams/timezone/connection.

## Scope note (not a regression)

Per-user browser connections (`hostId < 0`, cloud per-user connections) are
out of scope: resolving the real `browserConnection` object requires
`useMergedHosts()` React state that isn't available in `prefetch.ts`'s plain
function context. `hostConnectionKey(hostId, null)` still returns `undefined`
for that case, same as before this fix, so prefetch remains a no-op cache hit
for browser connections — unchanged pre-existing behavior, not worsened.

## Verification

- `rg -n "queryKey = \[" apps/dashboard/src/lib/swr/prefetch.ts
  apps/dashboard/src/lib/query/use-chart-data.ts
  apps/dashboard/src/lib/query/use-table-data.ts` → no matches; all three
  call sites route through the shared factories.
- `apps/dashboard/node_modules` symlinked from the main checkout for a
  targeted run (worktree has no install):
  - `bun test src/lib/query/query-keys.test.ts src/lib/query/host-query-key.test.ts` → 8 pass, 0 fail.
  - `bun test src/lib/swr src/lib/query` (also picks up `src/lib/query-config/**`) → 1084 pass, 0 fail.
  - `biome check` on all touched files → clean (biome reordered imports in `prefetch.ts` once via `--write`).
- Did **not** run `pnpm run build` locally (worktree has no root `node_modules`
  install per this project's isolated-worktree rules) — CI's build/typecheck
  job covers this.

Closes #2489

https://claude.ai/code/session_018h2h5erikMP3aM7p8YdXfY