### PR TITLE
fix(bug-handler): fail closed when BUG_ALLOWED_SENDERS is unset

### DIFF
--- a/apps/bug-handler/src/config.test.ts
+++ b/apps/bug-handler/src/config.test.ts
@@ -60,6 +60,31 @@ describe('parseConfig — comma-list parsing', () => {
   })
 })
 
+describe('parseConfig — BUG_ALLOWED_SENDERS fail-closed semantics', () => {
+  it('unset -> built-in Sentry-only default', () => {
+    const cfg = parseConfig({})
+    expect(cfg.allowedSenders).toEqual([
+      '@sentry.io',
+      '@notifications.sentry.io',
+    ])
+  })
+
+  it('explicitly empty string -> rejects every sender', () => {
+    const cfg = parseConfig({ BUG_ALLOWED_SENDERS: '' })
+    expect(cfg.allowedSenders).toEqual([])
+  })
+
+  it('"*" -> allows every sender', () => {
+    const cfg = parseConfig({ BUG_ALLOWED_SENDERS: '*' })
+    expect(cfg.allowedSenders).toEqual(['*'])
+  })
+
+  it('explicit list is unchanged by the fail-closed default', () => {
+    const cfg = parseConfig({ BUG_ALLOWED_SENDERS: '@sentry.io' })
+    expect(cfg.allowedSenders).toEqual(['@sentry.io'])
+  })
+})
+
 describe('parseConfig — GITHUB_REPOSITORY parsing', () => {
   it('parses a valid owner/repo', () => {
     const cfg = parseConfig({ GITHUB_REPOSITORY: 'chmonitor/chmonitor' })
@@ -121,8 +146,12 @@ describe('parseConfig — trimming', () => {
 })
 
 describe('isSenderAllowed', () => {
-  it('allows any sender when the list is empty', () => {
-    expect(isSenderAllowed('anyone@anywhere.com', [])).toBe(true)
+  it('rejects any sender when the list is empty (fail closed)', () => {
+    expect(isSenderAllowed('anyone@anywhere.com', [])).toBe(false)
+  })
+
+  it('allows any sender when the list contains the "*" wildcard', () => {
+    expect(isSenderAllowed('anyone@anywhere.com', ['*'])).toBe(true)
   })
 
   it('matches exact address (case-insensitive)', () => {

--- a/apps/bug-handler/src/config.ts
+++ b/apps/bug-handler/src/config.ts
@@ -30,8 +30,9 @@ export interface BugHandlerConfig {
   // Optional prefix prepended to the issue title (e.g. "[Sentry] ").
   titlePrefix: string
 
-  // When non-empty, only these senders (exact address or @domain suffix) may
-  // create issues.  Empty list = allow all.
+  // Senders (exact address or @domain suffix) allowed to create issues.
+  // See `parseConfig` for how BUG_ALLOWED_SENDERS maps to this list:
+  // unset -> built-in Sentry default, "" -> reject all, "*" -> allow all.
   allowedSenders: string[]
 
   // Base URL for the GitHub REST API.  Overridable for tests / GHES.
@@ -40,6 +41,14 @@ export interface BugHandlerConfig {
 
 const DEFAULT_LABELS = ['bug', 'sentry', 'automated']
 const DEFAULT_API_BASE = 'https://api.github.com'
+
+// This worker exists to turn Sentry alert mail into GitHub issues — when the
+// operator hasn't set BUG_ALLOWED_SENDERS at all, fail closed to Sentry's
+// known sending domains instead of accepting mail from anyone.
+const DEFAULT_ALLOWED_SENDERS = ['@sentry.io', '@notifications.sentry.io']
+
+// Explicit opt-out: BUG_ALLOWED_SENDERS=* accepts mail from any sender.
+const ALLOW_ALL_SENDERS = '*'
 
 /** Split a comma-separated env value into a trimmed, non-empty string array. */
 function splitList(raw: string | undefined): string[] {
@@ -82,10 +91,17 @@ export function parseConfig(
 
   const assignees = splitList(env.BUG_ISSUE_ASSIGNEES)
 
-  // allowedSenders: lower-case for case-insensitive matching
-  const allowedSenders = splitList(env.BUG_ALLOWED_SENDERS).map((s) =>
-    s.toLowerCase()
-  )
+  // allowedSenders: lower-case for case-insensitive matching.
+  //   - unset (BUG_ALLOWED_SENDERS not set at all) -> built-in Sentry-only
+  //     default, so the worker fails closed instead of accepting any sender.
+  //   - "" (explicitly set to empty)               -> reject every sender.
+  //   - "*"                                        -> explicit opt-out,
+  //     allow every sender.
+  //   - comma list                                 -> parsed allowlist.
+  const allowedSenders =
+    env.BUG_ALLOWED_SENDERS === undefined
+      ? DEFAULT_ALLOWED_SENDERS
+      : splitList(env.BUG_ALLOWED_SENDERS).map((s) => s.toLowerCase())
 
   return {
     targetAddress: rawTarget || undefined,
@@ -102,7 +118,12 @@ export function parseConfig(
 /**
  * Return true when `address` is permitted according to the allowedSenders list.
  *
+ * `allowedSenders` is fail-closed: an empty list rejects every sender (see
+ * `parseConfig` for how BUG_ALLOWED_SENDERS maps to this list). To allow
+ * every sender, include the "*" sentinel.
+ *
  * Matching rules (case-insensitive):
+ *   - Wildcard:     "*"                 matches every address
  *   - Exact match:  "alerts@sentry.io"  matches  "alerts@sentry.io"
  *   - Domain match: "@sentry.io"        matches any address ending in @sentry.io
  *   - Plain domain: "sentry.io"         matches any address ending in @sentry.io
@@ -112,7 +133,7 @@ export function isSenderAllowed(
   address: string,
   allowedSenders: string[]
 ): boolean {
-  if (allowedSenders.length === 0) return true
+  if (allowedSenders.includes(ALLOW_ALL_SENDERS)) return true
   const lower = address.toLowerCase()
   return allowedSenders.some((rule) => {
     if (rule.startsWith('@')) {

--- a/apps/bug-handler/src/index.test.ts
+++ b/apps/bug-handler/src/index.test.ts
@@ -4,7 +4,13 @@ import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-/** Minimal env that satisfies all required config fields */
+/**
+ * Minimal env that satisfies all required config fields.
+ * BUG_ALLOWED_SENDERS is the explicit "*" opt-out so tests unrelated to the
+ * allowlist itself (happy path, recipient guard, misconfiguration) aren't
+ * affected by the fail-closed default — see the dedicated "sender allowlist"
+ * describe block below for allowlist-specific behavior.
+ */
 const FULL_ENV = {
   BUG_HANDLER_TARGET_ADDRESS: 'bug@chmonitor.dev',
   GITHUB_REPOSITORY: 'chmonitor/chmonitor',
@@ -12,7 +18,7 @@ const FULL_ENV = {
   BUG_ISSUE_LABELS: 'bug,sentry,automated',
   BUG_ISSUE_ASSIGNEES: 'duyetbot',
   BUG_ISSUE_TITLE_PREFIX: '[Sentry] ',
-  BUG_ALLOWED_SENDERS: '',
+  BUG_ALLOWED_SENDERS: '*',
   GITHUB_API_BASE: 'https://api.github.com',
 }
 
@@ -288,20 +294,90 @@ describe('worker.email — recipient guard', () => {
 describe('worker.email — sender allowlist', () => {
   let originalFetch: typeof globalThis.fetch
   let calls: FetchCall[]
+  let consoleWarnSpy: ReturnType<typeof spyOn>
 
   beforeEach(() => {
     originalFetch = globalThis.fetch
     const mock = makeMockFetch()
     calls = mock.calls
     globalThis.fetch = mock.mockFetch as typeof fetch
+    consoleWarnSpy = spyOn(console, 'warn').mockImplementation(() => {})
   })
 
   afterEach(() => {
     globalThis.fetch = originalFetch
+    consoleWarnSpy.mockRestore()
   })
 
-  it('blocks a sender not in the allowlist', async () => {
+  it('blocks a sender not in the allowlist and logs sender + subject', async () => {
     const env = { ...FULL_ENV, BUG_ALLOWED_SENDERS: '@sentry.io' }
+    const message = makeMessage(
+      'bug@chmonitor.dev',
+      'spam@evil.com',
+      SENTRY_ALERT_MIME
+    )
+    const pending: Promise<unknown>[] = []
+    const ctx = {
+      ...makeCtx(),
+      waitUntil: (p: Promise<unknown>) => {
+        pending.push(p)
+      },
+    } as unknown as ExecutionContext
+
+    await worker.email(message, env, ctx)
+    await Promise.all(pending)
+
+    expect(calls).toHaveLength(0)
+    expect(consoleWarnSpy).toHaveBeenCalled()
+    const msg = (consoleWarnSpy.mock.calls[0] as string[])[0] as string
+    expect(msg).toContain('spam@evil.com')
+    expect(msg).toContain('TypeError')
+  })
+
+  it('allows a sender that matches the allowlist domain', async () => {
+    const env = { ...FULL_ENV, BUG_ALLOWED_SENDERS: '@sentry.io' }
+    const message = makeMessage(
+      'bug@chmonitor.dev',
+      'alerts@sentry.io',
+      SENTRY_ALERT_MIME
+    )
+    const pending: Promise<unknown>[] = []
+    const ctx = {
+      ...makeCtx(),
+      waitUntil: (p: Promise<unknown>) => {
+        pending.push(p)
+      },
+    } as unknown as ExecutionContext
+
+    await worker.email(message, env, ctx)
+    await Promise.all(pending)
+
+    expect(calls).toHaveLength(1)
+  })
+
+  it('falls back to the built-in Sentry default when BUG_ALLOWED_SENDERS is unset, allowing a Sentry sender', async () => {
+    const env = { ...FULL_ENV, BUG_ALLOWED_SENDERS: undefined }
+    const message = makeMessage(
+      'bug@chmonitor.dev',
+      'alerts@sentry.io',
+      SENTRY_ALERT_MIME
+    )
+    const pending: Promise<unknown>[] = []
+    const ctx = {
+      ...makeCtx(),
+      waitUntil: (p: Promise<unknown>) => {
+        pending.push(p)
+      },
+    } as unknown as ExecutionContext
+
+    await worker.email(message, env, ctx)
+    await Promise.all(pending)
+
+    expect(calls).toHaveLength(1)
+  })
+
+  it('falls back to the built-in Sentry default when BUG_ALLOWED_SENDERS is unset, rejecting a non-Sentry sender', async () => {
+    const env = { ...FULL_ENV, BUG_ALLOWED_SENDERS: undefined }
     const message = makeMessage(
       'bug@chmonitor.dev',
       'spam@evil.com',
@@ -321,11 +397,32 @@ describe('worker.email — sender allowlist', () => {
     expect(calls).toHaveLength(0)
   })
 
-  it('allows a sender that matches the allowlist domain', async () => {
-    const env = { ...FULL_ENV, BUG_ALLOWED_SENDERS: '@sentry.io' }
+  it('rejects every sender when BUG_ALLOWED_SENDERS is explicitly empty', async () => {
+    const env = { ...FULL_ENV, BUG_ALLOWED_SENDERS: '' }
     const message = makeMessage(
       'bug@chmonitor.dev',
       'alerts@sentry.io',
+      SENTRY_ALERT_MIME
+    )
+    const pending: Promise<unknown>[] = []
+    const ctx = {
+      ...makeCtx(),
+      waitUntil: (p: Promise<unknown>) => {
+        pending.push(p)
+      },
+    } as unknown as ExecutionContext
+
+    await worker.email(message, env, ctx)
+    await Promise.all(pending)
+
+    expect(calls).toHaveLength(0)
+  })
+
+  it('allows any sender when BUG_ALLOWED_SENDERS is "*"', async () => {
+    const env = { ...FULL_ENV, BUG_ALLOWED_SENDERS: '*' }
+    const message = makeMessage(
+      'bug@chmonitor.dev',
+      'anyone@example.com',
       SENTRY_ALERT_MIME
     )
     const pending: Promise<unknown>[] = []

--- a/apps/bug-handler/src/index.ts
+++ b/apps/bug-handler/src/index.ts
@@ -44,7 +44,9 @@ export interface Env {
   // Optional prefix prepended to the issue title (default: '').
   BUG_ISSUE_TITLE_PREFIX?: string
 
-  // Comma-separated allowed sender addresses / domains (default: allow all).
+  // Comma-separated allowed sender addresses / domains. Unset defaults to
+  // Sentry's known sending domains (fail closed); "" rejects every sender;
+  // "*" explicitly allows every sender.
   BUG_ALLOWED_SENDERS?: string
 
   // GitHub API base URL — override for GitHub Enterprise or tests.
@@ -77,10 +79,12 @@ export default {
 
       // 4. Sender allowlist check — use the SMTP envelope sender (message.from)
       //    which is what Cloudflare Email Routing validated at the protocol level,
-      //    not the MIME From header which can be spoofed.
+      //    not the MIME From header which can be spoofed. Log sender + subject
+      //    so operators notice when legitimate mail is being dropped (e.g.
+      //    BUG_ALLOWED_SENDERS misconfigured, or Sentry changed its sending domain).
       if (!isSenderAllowed(message.from, config.allowedSenders)) {
         console.warn(
-          `[bug-handler] rejected envelope sender ${message.from} — not in allowedSenders list`
+          `[bug-handler] rejected envelope sender ${message.from} (subject: "${parsed.subject}") — not in allowedSenders list`
         )
         return
       }

--- a/docs/knowledge/bug-handler-email-worker.md
+++ b/docs/knowledge/bug-handler-email-worker.md
@@ -3,7 +3,7 @@ id: bug-handler-email-worker
 type: spec
 related: [observability-sentry, deployment, cluster-topology]
 tags: [bug-handler, email, cloudflare, github-issues, sentry, automation]
-updated: 2026-06-30
+updated: 2026-07-10
 ---
 
 # Bug-handler email worker (email → GitHub issue)
@@ -31,7 +31,27 @@ Built like `apps/telemetry`: own `pnpm-lock.yaml` (not in the root workspace), o
 | `BUG_ISSUE_LABELS` | `wrangler.toml` `[vars]` default | e.g. `bug,sentry,automated`. |
 | `BUG_ISSUE_ASSIGNEES` | CI `--var` from repo **variable** | Auto-assign a bot/user, e.g. `duyetbot`. |
 | `BUG_ISSUE_TITLE_PREFIX` | `wrangler.toml` `[vars]` default | e.g. `[Sentry] `. |
-| `BUG_ALLOWED_SENDERS` | optional | Allowlist of senders/domains; default allow-all. Matched against the **SMTP envelope sender** (`message.from`), not the spoofable MIME `From:`. |
+| `BUG_ALLOWED_SENDERS` | optional | Allowlist of senders/domains; **fails closed**. Matched against the **SMTP envelope sender** (`message.from`), not the spoofable MIME `From:`. |
+
+### `BUG_ALLOWED_SENDERS` semantics (fail closed)
+
+The worker exists to turn Sentry alert mail into GitHub issues, so an unset
+allowlist must NOT mean "accept anyone" — that would let any sender open
+issues in the configured repo. `parseConfig` resolves `BUG_ALLOWED_SENDERS` to
+one of:
+
+| Value | Resolves to | Effect |
+|-------|-------------|--------|
+| unset (not in env at all) | built-in default `['@sentry.io', '@notifications.sentry.io']` | Sentry-only, fail closed |
+| `""` (explicitly set to empty) | `[]` | rejects every sender |
+| `"*"` | `['*']` | explicit opt-out — allows every sender |
+| `"a@b.com,@c.com"` | parsed comma list | unchanged allowlist behavior |
+
+Rejected senders are logged at `console.warn` with the sender address and
+subject before the message is dropped (no issue created, no GitHub API call).
+If Sentry ever changes its alert-sending domain, mail from it starts being
+silently rejected — that warn log is the operator's only signal, so alert on
+it (or watch Worker logs) rather than assuming silence means no bug reports.
 
 ## Pipeline (`src/`)
 
@@ -54,6 +74,6 @@ Email Routing on the zone → custom address (e.g. `bug@chmonitor.dev`) →
 
 ## Tests
 
-`bun test src/` — 82 tests across config / parse-email / github-issue / index
+`bun test src/` — 91 tests across config / parse-email / github-issue / index
 (the last is an integration test that drives the real `email()` handler with a
 fake `ForwardableEmailMessage` and a stubbed `fetch`).


### PR DESCRIPTION
## What

`isSenderAllowed` in `apps/bug-handler/src/config.ts` failed open: an unset
`BUG_ALLOWED_SENDERS` (the default, and current production state — it's not
set anywhere in `wrangler.toml` or CI) let **any** sender emailing
`bug@chmonitor.dev` create GitHub issues in the configured repo. SPF only
authenticates the sending *domain*, not authorization, and the worker's
intended source is Sentry alert mail only.

`parseConfig` now resolves `BUG_ALLOWED_SENDERS` to:

| Value | Resolves to | Effect |
|---|---|---|
| unset | `['@sentry.io', '@notifications.sentry.io']` | Sentry-only, fail closed (new default) |
| `""` (explicit empty) | `[]` | rejects every sender |
| `"*"` | `['*']` | explicit opt-out — allows every sender |
| comma list | parsed list | unchanged |

`isSenderAllowed([])` now rejects (previously allowed) — the `"*"` sentinel
is the new explicit "allow all" signal. Rejected senders are logged with
sender + subject at `warn` level before the message is dropped, so operators
notice misconfiguration or a Sentry sending-domain change.

## Why

Issue spam / content injection into the tracker (which coding agents read)
via any sender who discovers the address — see #2502.

## Files changed

- `apps/bug-handler/src/config.ts` — new default/sentinel constants, updated
  `parseConfig` and `isSenderAllowed` semantics
- `apps/bug-handler/src/index.ts` — warn-log now includes the subject; `Env`
  doc comment updated
- `apps/bug-handler/src/config.test.ts`, `apps/bug-handler/src/index.test.ts`
  — extended for the unset/""/"*"/explicit-list cases + the warn-log
  assertion; `FULL_ENV`'s `BUG_ALLOWED_SENDERS` moved from `''` (previously
  "allow all") to the explicit `'*'` opt-out so unrelated tests keep their
  original "no sender restriction" intent
- `docs/knowledge/bug-handler-email-worker.md` — documents the three cases
  and the warn-log signal; bumped `updated:` date

## Verification

- Ran locally by symlinking the repo-root `node_modules` (this worktree has
  none) plus a direct link to bun's own `postal-mime` cache entry
  (`~/.bun/install/cache`, no install command run) so `bun test` could
  resolve the worker's one runtime dependency:
  - `bun test src/` — **91 pass, 0 fail** (up from 82 baseline + 9 new)
  - `tsc --noEmit` — clean
- Checked the STOP condition in the plan (production relying on non-Sentry
  senders): `BUG_ALLOWED_SENDERS` is not set in `wrangler.toml` or any CI
  workflow, and the repo has **zero** issues carrying the bot's
  `bug`+`sentry`+`automated` labels — the worker has not created any issue
  in production yet, Sentry or otherwise, so the default change drops no
  real mail.
- CI (bug-handler's own job) will re-run the full suite.

Closes #2502

https://claude.ai/code/session_018h2h5erikMP3aM7p8YdXfY