### PR TITLE
fix(data-table): centralize utility column ids; null-aware numeric sort

### DIFF
--- a/apps/dashboard/src/components/data-table/column-defs/column-defs.test.ts
+++ b/apps/dashboard/src/components/data-table/column-defs/column-defs.test.ts
@@ -1,6 +1,10 @@
 import type { QueryConfig } from '@/types/query-config'
 
-import { estimateColumnSizes } from './column-defs'
+import {
+  EXPAND_COLUMN_ID,
+  estimateColumnSizes,
+  UTILITY_COLUMN_IDS,
+} from './column-defs'
 import { describe, expect, test } from 'bun:test'
 
 /**
@@ -100,5 +104,28 @@ describe('estimateColumnSizes', () => {
       data
     )
     expect(sizes.v).toBe(size(40))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// UTILITY_COLUMN_IDS
+//
+// WHY: this is the single source of truth for synthetic (non-data) column
+// ids, previously re-listed inline in several places (one of which omitted
+// 'action', letting the row-action column participate in drag-to-reorder).
+// Pinning the exact membership here prevents that drift from recurring.
+// ---------------------------------------------------------------------------
+
+describe('UTILITY_COLUMN_IDS', () => {
+  test('contains exactly the three synthetic column ids', () => {
+    expect(UTILITY_COLUMN_IDS.size).toBe(3)
+    expect(UTILITY_COLUMN_IDS.has(EXPAND_COLUMN_ID)).toBe(true)
+    expect(UTILITY_COLUMN_IDS.has('select')).toBe(true)
+    expect(UTILITY_COLUMN_IDS.has('action')).toBe(true)
+  })
+
+  test('does not treat arbitrary data columns as utility columns', () => {
+    expect(UTILITY_COLUMN_IDS.has('query')).toBe(false)
+    expect(UTILITY_COLUMN_IDS.has('bytes')).toBe(false)
   })
 })

--- a/apps/dashboard/src/components/data-table/column-defs/column-defs.tsx
+++ b/apps/dashboard/src/components/data-table/column-defs/column-defs.tsx
@@ -34,6 +34,19 @@ import {
 
 export const EXPAND_COLUMN_ID = '__expand'
 
+/**
+ * Synthetic (non-data) column ids injected by the table system itself:
+ * `EXPAND_COLUMN_ID` (expand/collapse chevron), `select` (row-selection
+ * checkbox), and `action` (row action menu). Client-side filter, search,
+ * sort, card, and drag-reorder logic must exclude these — they carry no
+ * query-config data. Single source of truth; do not re-list these ids inline.
+ */
+export const UTILITY_COLUMN_IDS: ReadonlySet<string> = new Set([
+  EXPAND_COLUMN_ID,
+  'select',
+  'action',
+])
+
 /** Build the synthetic leftmost column that renders an expand/collapse chevron. */
 export function buildExpandColumnDef<
   TData extends RowData,

--- a/apps/dashboard/src/components/data-table/column-defs/index.ts
+++ b/apps/dashboard/src/components/data-table/column-defs/index.ts
@@ -16,5 +16,6 @@ export {
   estimateColumnSizes,
   getColumnDefs,
   normalizeColumnName,
+  UTILITY_COLUMN_IDS,
 } from './column-defs'
 export { isColumnFilterable, parseColumnFormat } from './utils'

--- a/apps/dashboard/src/components/data-table/components/data-table-content.tsx
+++ b/apps/dashboard/src/components/data-table/components/data-table-content.tsx
@@ -17,7 +17,7 @@ import {
   SortableContext,
 } from '@dnd-kit/sortable'
 import { memo, useCallback } from 'react'
-import { EXPAND_COLUMN_ID } from '@/components/data-table/column-defs'
+import { UTILITY_COLUMN_IDS } from '@/components/data-table/column-defs'
 import {
   TableBody as TableBodyRenderer,
   TableHeader as TableHeaderRenderer,
@@ -174,12 +174,12 @@ export const DataTableContent = memo(function DataTableContent<
   )
 
   // Extract column IDs for SortableContext.
-  // Exclude utility columns (__expand chevron, selection checkbox) — they are
-  // pinned to the left and must not be drag-reordered.
+  // Exclude utility columns (__expand chevron, selection checkbox, row action
+  // menu) — they are pinned/fixed and must not be drag-reordered.
   const columnIds = table
     .getAllLeafColumns()
     .map((col) => col.id)
-    .filter((id) => id !== EXPAND_COLUMN_ID && id !== 'select')
+    .filter((id) => !UTILITY_COLUMN_IDS.has(id))
 
   // The memoized body reads row output from the stable `table` instance, so it
   // needs an explicit signal to re-render when that output changes. The parent

--- a/apps/dashboard/src/components/data-table/components/data-table-header.tsx
+++ b/apps/dashboard/src/components/data-table/components/data-table-header.tsx
@@ -17,6 +17,7 @@ import { memo, useMemo, useState } from 'react'
 import { CardToolbar } from '@/components/cards/card-toolbar'
 import { CsvExportButton } from '@/components/data-table/buttons/csv-export-button'
 import { ResetColumnOrderButton } from '@/components/data-table/buttons/reset-column-order'
+import { UTILITY_COLUMN_IDS } from '@/components/data-table/column-defs'
 import { BulkActions } from '@/components/data-table/components/bulk-actions'
 import {
   DisplayOptionsDropdown,
@@ -145,7 +146,7 @@ export const DataTableHeader = memo(function DataTableHeader<
   const filterableColumns = useMemo(() => {
     const cols = table
       .getAllLeafColumns()
-      .filter((col) => !['__expand', 'select', 'action'].includes(col.id))
+      .filter((col) => !UTILITY_COLUMN_IDS.has(col.id))
     // Pre-compute labels once
     return cols.map((col) => {
       const header = col.columnDef.header

--- a/apps/dashboard/src/components/data-table/components/mobile-table-cards.tsx
+++ b/apps/dashboard/src/components/data-table/components/mobile-table-cards.tsx
@@ -30,8 +30,8 @@ import type {
 
 import { Fragment } from 'react'
 import {
-  EXPAND_COLUMN_ID,
   normalizeColumnName,
+  UTILITY_COLUMN_IDS,
 } from '@/components/data-table/column-defs'
 import { useTableDensityContext } from '@/components/data-table/context/table-density-context'
 import { DefaultExpandedRow } from '@/components/data-table/row-expand/default-renderer'
@@ -54,7 +54,6 @@ import {
 } from '@/components/ui/empty'
 import { cn } from '@/lib/utils'
 
-const UTILITY_COLUMNS = new Set(['select', 'action', EXPAND_COLUMN_ID])
 const PRIMARY_COLUMN_PRIORITY = [
   'query',
   'query_detail',
@@ -106,7 +105,7 @@ function pickPrimaryCell<TData extends RowData>(cells: Cell<TData, unknown>[]) {
     PRIMARY_COLUMN_PRIORITY.map((columnId) =>
       cells.find((cell) => cell.column.id === columnId)
     ).find(Boolean) ??
-    cells.find((cell) => !UTILITY_COLUMNS.has(cell.column.id)) ??
+    cells.find((cell) => !UTILITY_COLUMN_IDS.has(cell.column.id)) ??
     cells[0]
   )
 }
@@ -118,7 +117,9 @@ export function MobileSortMenu<TData extends RowData>({
 }) {
   const sortableColumns = table
     .getVisibleLeafColumns()
-    .filter((column) => column.getCanSort() && !UTILITY_COLUMNS.has(column.id))
+    .filter(
+      (column) => column.getCanSort() && !UTILITY_COLUMN_IDS.has(column.id)
+    )
 
   if (!sortableColumns.length) {
     return null
@@ -266,7 +267,7 @@ const MobileTableCard = function MobileTableCard<TData extends RowData>({
     (cell) =>
       !usedIds.has(cell.id) &&
       !hiddenIds.has(cell.id) &&
-      !UTILITY_COLUMNS.has(cell.column.id)
+      !UTILITY_COLUMN_IDS.has(cell.column.id)
   )
 
   const isSqlPrimary =

--- a/apps/dashboard/src/components/data-table/sorting-fns.test.ts
+++ b/apps/dashboard/src/components/data-table/sorting-fns.test.ts
@@ -1,0 +1,69 @@
+import { getCustomSortingFns } from './sorting-fns'
+import { describe, expect, test } from 'bun:test'
+
+/**
+ * WHY these tests exist:
+ *  - sort_column_using_actual_value used to return 0 for any pair it couldn't
+ *    parse as `typeof === 'number'`, which made null/undefined/numeric-string
+ *    values compare as equal to everything — nullable ClickHouse columns
+ *    (common with optional metrics) would then sort unpredictably instead of
+ *    deterministically. These tests pin the null-aware, coercing replacement.
+ */
+
+const sortFns = getCustomSortingFns()
+const sort = sortFns.sort_column_using_actual_value
+
+function makeRow(data: Record<string, unknown>) {
+  return { original: data } as { original: typeof data }
+}
+
+describe('sort_column_using_actual_value — null-aware numeric sort', () => {
+  test('sorts plain numbers ascending', () => {
+    const a = makeRow({ bytes: 100 })
+    const b = makeRow({ bytes: 50 })
+    expect(sort(a as never, b as never, 'bytes')).toBeGreaterThan(0)
+    expect(sort(b as never, a as never, 'bytes')).toBeLessThan(0)
+  })
+
+  test('null sorts after a valid number, regardless of argument order', () => {
+    const withValue = makeRow({ bytes: 50 })
+    const withNull = makeRow({ bytes: null })
+    // null (A) vs number (B) → A sorts after B → positive
+    expect(
+      sort(withNull as never, withValue as never, 'bytes')
+    ).toBeGreaterThan(0)
+    // number (A) vs null (B) → A sorts before B → negative
+    expect(sort(withValue as never, withNull as never, 'bytes')).toBeLessThan(0)
+  })
+
+  test('numeric strings are coerced for comparison', () => {
+    const stringValue = makeRow({ bytes: '5' })
+    const numberValue = makeRow({ bytes: 3 })
+    expect(
+      sort(stringValue as never, numberValue as never, 'bytes')
+    ).toBeGreaterThan(0)
+    expect(
+      sort(numberValue as never, stringValue as never, 'bytes')
+    ).toBeLessThan(0)
+  })
+
+  test('two nulls compare equal', () => {
+    const a = makeRow({ bytes: null })
+    const b = makeRow({ bytes: null })
+    expect(sort(a as never, b as never, 'bytes')).toBe(0)
+  })
+
+  test('undefined behaves the same as null (also sorts last)', () => {
+    const withValue = makeRow({ bytes: 10 })
+    const withUndefined = makeRow({})
+    expect(
+      sort(withUndefined as never, withValue as never, 'bytes')
+    ).toBeGreaterThan(0)
+  })
+
+  test('non-numeric strings on both sides compare equal (graceful fallthrough)', () => {
+    const a = makeRow({ query: 'SELECT 1' })
+    const b = makeRow({ query: 'SELECT 2' })
+    expect(sort(a as never, b as never, 'query')).toBe(0)
+  })
+})

--- a/apps/dashboard/src/components/data-table/sorting-fns.ts
+++ b/apps/dashboard/src/components/data-table/sorting-fns.ts
@@ -3,6 +3,17 @@ import type { Row, RowData, SortingFn } from '@tanstack/react-table'
 import type { ValueOf } from '@chm/types/generic'
 
 /**
+ * Coerces a cell value to a numeric sort key. Nullish or non-numeric values
+ * map to +Infinity so they consistently sort after valid numbers, instead of
+ * silently comparing equal to everything (the bug this replaces).
+ */
+function toSortValue(value: unknown): number {
+  if (value === null || value === undefined) return Number.POSITIVE_INFINITY
+  const num = Number(value)
+  return Number.isNaN(num) ? Number.POSITIVE_INFINITY : num
+}
+
+/**
  * Get sorting functions for the table.
  * Reference: https://tanstack.com/table/v8/docs/guide/sorting#custom-sorting-functions
  *
@@ -20,11 +31,14 @@ export const getCustomSortingFns = <TData extends RowData>() => {
       const valueA = rowA.original[colName as keyof TData]
       const valueB = rowB.original[colName as keyof TData]
 
-      if (typeof valueA === 'number' && typeof valueB === 'number') {
-        return valueA - valueB
-      }
+      const numA = toSortValue(valueA)
+      const numB = toSortValue(valueB)
 
-      return 0
+      // Both nullish/non-numeric — equal rather than an arbitrary order
+      // (also avoids Infinity - Infinity === NaN below).
+      if (!Number.isFinite(numA) && !Number.isFinite(numB)) return 0
+
+      return numA - numB
     },
   } as Record<string, SortingFn<TData>>
 }


### PR DESCRIPTION
## What

Centralizes the three synthetic data-table column ids (`__expand`, `select`,
`action`) behind a single exported `UTILITY_COLUMN_IDS` set, and fixes a
null-blind numeric sort.

- `column-defs/column-defs.tsx`: new `UTILITY_COLUMN_IDS: ReadonlySet<string>`
  next to `EXPAND_COLUMN_ID`, re-exported from `column-defs/index.ts`.
- Replaced the three inline enumerations with it:
  - `components/mobile-table-cards.tsx` (`UTILITY_COLUMNS` local Set removed)
  - `components/data-table-header.tsx` (filterable-columns list)
  - `components/data-table-content.tsx` — this one **omitted `'action'`**, so
    the row-action column was included in the `SortableContext` `items` used
    for drag-to-reorder, unlike its pinned `__expand`/`select` siblings. Fixed.
- `sorting-fns.ts`: `sort_column_using_actual_value` returned `0` (equal) for
  any pair that wasn't `typeof === 'number'`, so nullable ClickHouse columns
  (common for optional metrics) sorted unpredictably. Now coerces both sides
  with `Number()`; nullish/non-numeric values consistently sort after valid
  numbers (both nullish/non-numeric → equal, not an arbitrary order).

## Why

Per the plan: one copy of the utility-id list was missing `'action'`, and the
numeric sort silently treated all non-numbers (including `null`) as equal to
everything else.

## Tests

- New `sorting-fns.test.ts`: plain numbers, null-vs-number (both arg orders),
  numeric-string coercion, two-nulls-equal, undefined-same-as-null,
  both-non-numeric-equal (matches the pre-existing fallthrough test).
- New `UTILITY_COLUMN_IDS` describe block in `column-defs.test.ts`: exact
  3-id membership + rejects arbitrary data columns.
- Ran locally via a temporary `node_modules` symlink to the main checkout
  (this worktree has no install): `bun test src/components/data-table` →
  **73 pass, 0 fail** across all 5 test files in the directory (no existing
  test needed to change — the pre-existing
  `getCustomSortingFns → sort_column_using_actual_value` suite in
  `data-table-behaviors.test.ts` still passes unmodified).
- Did not run `pnpm run build` locally (no local install, per worktree
  constraints) — CI will cover the typecheck.

## Verification notes / deviation from plan

Investigated a second location that also duplicates this id check:
`renderers/table-header.tsx`'s `isUtilityColumn = isSelectColumn ||
isExpandColumn` (missing `'action'`) is what actually decides whether a
header renders through `DraggableTableHeader` (with a drag handle and
`useSortable` listeners) — independent of the `SortableContext` `items` list
fixed here. This looks like the more direct cause of the visible symptom
("action column shows a drag handle / is draggable"), since dnd-kit's
`useSortable` doesn't gate rendering on membership in a `SortableContext`'s
`items` array. The plan explicitly scopes this change to the three named
files + `column-defs` + `sorting-fns.ts`, and separately lists "renderer
components" as out of scope, so `renderers/table-header.tsx` was **not**
touched here. Flagging for a fast follow-up plan/issue — worth confirming
with a quick manual repro (enable column reordering on a table with an
action column, hover the action header) whether the drag handle still
appears after this PR.

Closes #2499

https://claude.ai/code/session_018h2h5erikMP3aM7p8YdXfY
