### PR TITLE
chore(ci): make unit-tests a required merge check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,8 @@ Use semantic commit format with consistent scope for commit messages and PR titl
 auto-merge (`gh pr merge --auto --squash`) and babysit it (`/github:babysit-pr`):
 watch CI, fix failures, confirm the merge and production deploy. Do NOT ask the
 user whether to babysit — just do it. Known non-required checks (`e2e-test`,
-`e2e-test-tsr`, `component-test`, `unit-tests`) do not block auto-merge.
+`e2e-test-tsr`, `component-test`) do not block auto-merge. `unit-tests` IS a
+required check (required alongside `dashboard` since 2026-07-10, plan 75).
 
 **Stale bot-review gate (authorized override).** When a bot reviewer
 (CodeRabbit / `coderabbitai[bot]`, Sourcery, Gemini) leaves a


### PR DESCRIPTION
Makes the ~300-file bun suite an actual merge gate.

- Branch protection on `main` now requires `unit-tests` alongside `dashboard` (applied via `gh api`, verified: `["dashboard","unit-tests"]`).
- Flake sweep per plan 75: last 30 `test.yml` runs on main → 11 success, 0 failures, 18 cancelled (concurrency-group cancellations from rapid main pushes, not flakes), 1 in-progress. No quarantines needed.
- Full local suite: exit 0. Context name verified against PR #2521 checks (`unit-tests`).
- Updates the CLAUDE.md PR-workflow wording that listed `unit-tests` as non-required.

Out of scope per plan: e2e-test / e2e-test-tsr / component-test stay non-required.

Closes #2492

https://claude.ai/code/session_018h2h5erikMP3aM7p8YdXfY