### PR TITLE
fix(routing): unify hostId validation across routes

### DIFF
--- a/apps/dashboard/src/lib/api/shared/validators/__tests__/host-id.test.ts
+++ b/apps/dashboard/src/lib/api/shared/validators/__tests__/host-id.test.ts
@@ -30,9 +30,16 @@ describe('validateHostId', () => {
     expect(validateHostId('0')).toBe(0)
   })
 
-  test('parses leading-numeric strings the way parseInt does', () => {
-    // parseInt('1abc', 10) === 1; the function does not reject trailing junk.
-    expect(validateHostId('1abc')).toBe(1)
+  test('rejects trailing non-digit characters (unlike parseInt)', () => {
+    // parseInt('1abc', 10) === 1; the strict parser must not silently
+    // truncate at the first non-digit — that risks routing a mistyped/junk
+    // hostId to a real, but wrong, host.
+    expect(() => validateHostId('1abc')).toThrow(
+      'Invalid hostId: must be a non-negative number'
+    )
+    expect(() => validateHostId('2abc')).toThrow(
+      'Invalid hostId: must be a non-negative number'
+    )
   })
 
   test('throws when hostId is null', () => {

--- a/apps/dashboard/src/lib/api/shared/validators/host-id.ts
+++ b/apps/dashboard/src/lib/api/shared/validators/host-id.ts
@@ -11,6 +11,19 @@ import type { ApiError } from '@/lib/api/types'
 import { ApiErrorType } from '@/lib/api/types'
 
 /**
+ * Strictly parse a hostId string as a non-negative integer.
+ *
+ * Unlike `parseInt`, this rejects strings with trailing non-digit characters
+ * (e.g. `"2abc"` would otherwise parse as `2`) by requiring the entire string
+ * to be digits before converting.
+ *
+ * @returns The parsed integer, or `NaN` if `raw` is not a valid integer string.
+ */
+function parseStrictHostId(raw: string): number {
+  return /^\d+$/.test(raw) ? Number(raw) : NaN
+}
+
+/**
  * Validate and extract hostId from URL search params
  *
  * @param hostId - The hostId value from URLSearchParams (can be null)
@@ -31,7 +44,7 @@ export function validateHostId(hostId: string | null): number {
     throw new Error('Missing required parameter: hostId')
   }
 
-  const parsed = parseInt(hostId, 10)
+  const parsed = parseStrictHostId(hostId)
 
   if (Number.isNaN(parsed) || parsed < 0) {
     throw new Error('Invalid hostId: must be a non-negative number')
@@ -64,7 +77,7 @@ export function validateHostIdWithError(hostId: unknown): ApiError | undefined {
     typeof hostId === 'number'
       ? hostId
       : typeof hostId === 'string'
-        ? parseInt(hostId, 10)
+        ? parseStrictHostId(hostId)
         : NaN
 
   if (Number.isNaN(parsed) || parsed < 0) {
@@ -105,7 +118,7 @@ export function getAndValidateHostId(
     }
   }
 
-  const parsed = parseInt(hostId, 10)
+  const parsed = parseStrictHostId(hostId)
 
   if (Number.isNaN(parsed) || parsed < 0) {
     return {

--- a/apps/dashboard/src/lib/clickhouse-helpers.test.ts
+++ b/apps/dashboard/src/lib/clickhouse-helpers.test.ts
@@ -65,23 +65,25 @@ describe('validateHostId', () => {
       expect(validateHostId(42)).toBe(42)
     })
 
-    test('negative number returns 0', () => {
-      expect(validateHostId(-1)).toBe(0)
-      expect(validateHostId(-100)).toBe(0)
+    test('negative number throws', () => {
+      expect(() => validateHostId(-1)).toThrow('Invalid hostId: -1')
+      expect(() => validateHostId(-100)).toThrow('Invalid hostId: -100')
     })
 
-    test('non-integer (float) returns 0', () => {
-      expect(validateHostId(1.5)).toBe(0)
-      expect(validateHostId(0.1)).toBe(0)
+    test('non-integer (float) throws', () => {
+      expect(() => validateHostId(1.5)).toThrow('Invalid hostId: 1.5')
+      expect(() => validateHostId(0.1)).toThrow('Invalid hostId: 0.1')
     })
 
-    test('NaN returns 0', () => {
-      expect(validateHostId(Number.NaN)).toBe(0)
+    test('NaN throws', () => {
+      expect(() => validateHostId(Number.NaN)).toThrow('Invalid hostId: NaN')
     })
 
-    test('Infinity returns 0 (not an integer)', () => {
+    test('Infinity throws (not an integer)', () => {
       // Number.isInteger(Infinity) === false → falls into the guard
-      expect(validateHostId(Number.POSITIVE_INFINITY)).toBe(0)
+      expect(() => validateHostId(Number.POSITIVE_INFINITY)).toThrow(
+        'Invalid hostId: Infinity'
+      )
     })
   })
 
@@ -99,46 +101,50 @@ describe('validateHostId', () => {
       expect(validateHostId(' 3 ')).toBe(3)
     })
 
-    test('non-numeric string returns 0', () => {
-      expect(validateHostId('abc')).toBe(0)
-      expect(validateHostId('1a')).toBe(0)
-      expect(validateHostId('a1')).toBe(0)
+    test('non-numeric string throws (no more silent coercion)', () => {
+      expect(() => validateHostId('abc')).toThrow('Invalid hostId: abc')
+      expect(() => validateHostId('1a')).toThrow('Invalid hostId: 1a')
+      expect(() => validateHostId('a1')).toThrow('Invalid hostId: a1')
     })
 
-    test('empty string returns 0', () => {
+    test('trailing garbage after digits throws (unlike parseInt)', () => {
+      expect(() => validateHostId('2abc')).toThrow('Invalid hostId: 2abc')
+    })
+
+    test('empty string returns 0 (treated as missing, like undefined)', () => {
       expect(validateHostId('')).toBe(0)
     })
 
-    test('whitespace-only string returns 0', () => {
+    test('whitespace-only string returns 0 (treated as missing)', () => {
       expect(validateHostId('   ')).toBe(0)
     })
 
-    test('float string returns 0 (contains dot, fails /^\\d+$/ test)', () => {
-      expect(validateHostId('1.5')).toBe(0)
+    test('float string throws (contains dot, fails /^\\d+$/ test)', () => {
+      expect(() => validateHostId('1.5')).toThrow('Invalid hostId: 1.5')
     })
 
-    test('negative numeric string returns 0 (contains minus, fails /^\\d+$/ test)', () => {
-      expect(validateHostId('-1')).toBe(0)
+    test('negative numeric string throws (contains minus, fails /^\\d+$/ test)', () => {
+      expect(() => validateHostId('-1')).toThrow('Invalid hostId: -1')
     })
   })
 
-  describe('other types → 0', () => {
-    test('boolean returns 0', () => {
-      expect(validateHostId(true)).toBe(0)
-      expect(validateHostId(false)).toBe(0)
+  describe('other types → throw', () => {
+    test('boolean throws', () => {
+      expect(() => validateHostId(true)).toThrow('Invalid hostId: true')
+      expect(() => validateHostId(false)).toThrow('Invalid hostId: false')
     })
 
-    test('object returns 0', () => {
-      expect(validateHostId({})).toBe(0)
-      expect(validateHostId({ id: 1 })).toBe(0)
+    test('object throws', () => {
+      expect(() => validateHostId({})).toThrow()
+      expect(() => validateHostId({ id: 1 })).toThrow()
     })
 
-    test('array returns 0', () => {
-      expect(validateHostId([1])).toBe(0)
+    test('array throws', () => {
+      expect(() => validateHostId([1])).toThrow()
     })
 
-    test('symbol returns 0', () => {
-      expect(validateHostId(Symbol('x'))).toBe(0)
+    test('symbol throws', () => {
+      expect(() => validateHostId(Symbol('x'))).toThrow()
     })
   })
 })
@@ -208,11 +214,11 @@ describe('fetchDataWithHost', () => {
     expect((capturedArgs as Record<string, unknown>).hostId).toBe(5)
   })
 
-  test('invalid string hostId falls back to 0', async () => {
-    let capturedHostId: unknown
+  test('invalid string hostId returns a query_error result (no silent fallback)', async () => {
+    let fetchDataCalled = false
 
-    fetchDataImpl = async (args) => {
-      capturedHostId = (args as unknown as Record<string, unknown>).hostId
+    fetchDataImpl = async () => {
+      fetchDataCalled = true
       return {
         data: [],
         metadata: { queryId: '', duration: 0, rows: 0, host: '' },
@@ -220,9 +226,19 @@ describe('fetchDataWithHost', () => {
       }
     }
 
-    await fetchDataWithHost({ query: 'SELECT 1', hostId: 'bad' })
+    const result = await fetchDataWithHost({
+      query: 'SELECT 1',
+      hostId: 'bad',
+    })
 
-    expect(capturedHostId).toBe(0)
+    // fetchData must never be reached with an unvalidated hostId.
+    expect(fetchDataCalled).toBe(false)
+
+    const err = (result as unknown as Record<string, unknown>)
+      .error as unknown as Record<string, unknown>
+    expect(err.type).toBe('query_error')
+    expect(err.message).toBe('Invalid hostId: bad')
+    expect(logErrorCalls).toHaveLength(1)
   })
 
   test('default hostId is 0 when omitted', async () => {

--- a/apps/dashboard/src/lib/clickhouse-helpers.ts
+++ b/apps/dashboard/src/lib/clickhouse-helpers.ts
@@ -72,31 +72,24 @@ export function validateHostId(hostId: unknown): number {
   }
 
   if (typeof hostId === 'string') {
-    if (!/^\d+$/.test(hostId.trim())) {
-      ErrorLogger.logWarning(`Invalid hostId: ${hostId}`, {
-        component: 'validateHostId',
-      })
+    const trimmed = hostId.trim()
+    // Empty/whitespace-only is treated as "missing" (like undefined/null),
+    // not malformed — callers may pass through an unset form field this way.
+    if (trimmed === '') {
       return 0
     }
-    const parsed = parseInt(hostId, 10)
-    if (Number.isNaN(parsed) || parsed < 0) {
-      ErrorLogger.logWarning(`Invalid hostId: ${hostId}`, {
-        component: 'validateHostId',
-      })
-      return 0
+    if (/^\d+$/.test(trimmed)) {
+      return parseInt(trimmed, 10)
     }
-    return parsed
+    throw new Error(`Invalid hostId: ${hostId}`)
   }
 
   if (typeof hostId === 'number') {
-    if (hostId < 0 || !Number.isInteger(hostId)) {
-      ErrorLogger.logWarning(`Invalid hostId: ${hostId}`, {
-        component: 'validateHostId',
-      })
-      return 0
+    if (Number.isInteger(hostId) && hostId >= 0) {
+      return hostId
     }
-    return hostId
+    throw new Error(`Invalid hostId: ${hostId}`)
   }
 
-  return 0
+  throw new Error(`Invalid hostId: ${String(hostId)}`)
 }

--- a/apps/dashboard/src/routes/-root-search.test.ts
+++ b/apps/dashboard/src/routes/-root-search.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Tests for the root route's `?host=` search-param validator.
+ *
+ * `validateSearch` feeds `useHostId()` (via `useSearch({ strict: false })`),
+ * which every query/chart hook trusts to be a plain number. Junk input must
+ * resolve to host 0 instead of flowing downstream as NaN/Infinity/a float,
+ * which previously produced error states instead of a graceful default.
+ */
+
+import { validateSearch } from './-root-search'
+import { describe, expect, test } from 'bun:test'
+
+describe('validateSearch', () => {
+  test('valid integer strings parse to the matching number', () => {
+    expect(validateSearch({ host: '0' })).toEqual({ host: 0 })
+    expect(validateSearch({ host: '3' })).toEqual({ host: 3 })
+    expect(validateSearch({ host: '42' })).toEqual({ host: 42 })
+  })
+
+  test('negative integers are kept (client-side connection ids)', () => {
+    expect(validateSearch({ host: '-5' })).toEqual({ host: -5 })
+    expect(validateSearch({ host: -1 })).toEqual({ host: -1 })
+  })
+
+  test('fractional values default to 0', () => {
+    expect(validateSearch({ host: '1.5' })).toEqual({ host: 0 })
+    expect(validateSearch({ host: 0.1 })).toEqual({ host: 0 })
+  })
+
+  test('non-numeric junk defaults to 0', () => {
+    expect(validateSearch({ host: 'abc' })).toEqual({ host: 0 })
+    expect(validateSearch({ host: '2abc' })).toEqual({ host: 0 })
+  })
+
+  test('missing host param defaults to 0', () => {
+    expect(validateSearch({})).toEqual({ host: 0 })
+  })
+
+  test('null and undefined host default to 0', () => {
+    expect(validateSearch({ host: null })).toEqual({ host: 0 })
+    expect(validateSearch({ host: undefined })).toEqual({ host: 0 })
+  })
+
+  test('non-finite values default to 0', () => {
+    expect(validateSearch({ host: 'Infinity' })).toEqual({ host: 0 })
+    expect(validateSearch({ host: 'NaN' })).toEqual({ host: 0 })
+  })
+
+  test('host 0 is preserved, not treated as falsy/missing', () => {
+    expect(validateSearch({ host: 0 })).toEqual({ host: 0 })
+    expect(validateSearch({ host: '0' })).toEqual({ host: 0 })
+  })
+})

--- a/apps/dashboard/src/routes/-root-search.ts
+++ b/apps/dashboard/src/routes/-root-search.ts
@@ -1,0 +1,29 @@
+/**
+ * Root route `?host=` search-param validation.
+ *
+ * Extracted from `__root.tsx` into its own module (the `-` prefix keeps
+ * TanStack Router from treating it as a route file) so it can be unit tested
+ * without pulling in `__root.tsx`'s CSS/provider imports, which don't resolve
+ * under `bun test`.
+ */
+
+// Typed global `?host=` search param, declared on the ROOT so every route
+// inherits it and useHostId can read it via useSearch({ strict: false }).
+// Mirrors the Next app's host parsing (Number() coerce, fall back to 0).
+export interface RootSearch {
+  host: number
+}
+
+/**
+ * `?host` must be a finite integer; anything else (missing, `NaN`,
+ * fractional, `Infinity`) defaults to host `0`. Negative integers are kept —
+ * they identify client-side browser/database connections (see
+ * `isCustomHost` in `lib/host-fetch/resolve-host-fetch.ts`), not server-side
+ * env hosts, so this validator must not reject them.
+ */
+export function validateSearch(search: Record<string, unknown>): RootSearch {
+  const parsed = Number(search.host)
+  return {
+    host: Number.isInteger(parsed) ? parsed : 0,
+  }
+}

--- a/apps/dashboard/src/routes/__root.tsx
+++ b/apps/dashboard/src/routes/__root.tsx
@@ -6,6 +6,7 @@ import {
 } from '@tanstack/react-router'
 
 import appCss from '../styles.css?url'
+import { validateSearch } from './-root-search'
 import { type ReactNode, useEffect } from 'react'
 import { ClerkAuthProvider } from '@/components/clerk/clerk-auth-provider'
 import { WebMcpRegistration } from '@/components/webmcp'
@@ -20,13 +21,6 @@ import { UserConnectionsCacheGuard } from '@/lib/hooks/user-connections-cache-gu
 import { QueryProvider } from '@/lib/query/provider'
 import { getDeployTarget } from '@/lib/telemetry/environment'
 import { ThemeProvider } from '@/lib/theme/theme-provider'
-
-// Typed global `?host=` search param, declared on the ROOT so every route
-// inherits it and useHostId can read it via useSearch({ strict: false }).
-// Mirrors the Next app's host parsing (Number() coerce, fall back to 0).
-interface RootSearch {
-  host: number
-}
 
 // schema.org JSON-LD. `alternateName` lists the brand's keyword variations so
 // search engines map "ch monitor" / "ch monitoring" / "ClickHouse monitoring
@@ -51,15 +45,6 @@ const STRUCTURED_DATA = {
   offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
   sameAs: ['https://github.com/chmonitor/chmonitor'],
 } as const
-
-function validateSearch(search: Record<string, unknown>): RootSearch {
-  const raw = search.host
-  const parsed = Number(raw)
-  return {
-    host:
-      raw === undefined || raw === null || Number.isNaN(parsed) ? 0 : parsed,
-  }
-}
 
 export const Route = createRootRoute({
   validateSearch,


### PR DESCRIPTION
## What

Unifies three inconsistent hostId validators (plan 74, issue #2491):

1. **`routes/__root.tsx`** — the root `?host=` search validator accepted
   junk (`?host=-5`, `?host=1.5`) and passed it through unchanged, producing
   error states downstream instead of defaulting to host 0. Now only a
   finite integer is accepted; anything else defaults to `0`. Negative
   integers are still kept — they identify client-side browser/database
   connections (`lib/host-fetch/resolve-host-fetch.ts`), not env hosts.
   Extracted into `routes/-root-search.ts` (the `-` prefix keeps TanStack
   Router from treating it as a route) so it's unit-testable without
   pulling in `__root.tsx`'s CSS/provider imports.

2. **`lib/api/shared/validators/host-id.ts`** — `parseInt` silently
   truncated malformed strings (`"2abc"` parsed as `2`). Replaced with a
   strict `/^\d+$/` + `Number` parse shared across `validateHostId`,
   `validateHostIdWithError`, and `getAndValidateHostId`, so trailing
   garbage is now rejected everywhere in this file.

3. **`lib/clickhouse-helpers.ts`** — `validateHostId` silently coerced any
   malformed value (bad strings, negatives, floats, wrong types) to host
   `0`, which could silently serve the wrong host's data for a request
   that meant a different host. It now throws on malformed input;
   `fetchDataWithHost`'s existing `try`/`catch` already converts that into
   a structured `query_error` result, so no new error-handling path was
   needed. `undefined`/`null`/empty string still default to host `0`.

## Why

Reported in plan 74: three call sites disagreed on what counts as a valid
hostId, and two of them silently produced host `0` for malformed input
instead of surfacing an error — risking a request being served by the
wrong host's data.

## Verification

- Enumerated all callers of `fetchDataWithHost` (`rg -n
  "fetchDataWithHost|validateHostId" apps/dashboard/src`): the only real
  external caller is `routes/api/v1/health/custom-rules/test.ts`, which
  already pre-validates hostId (`!Number.isInteger(hostId) || hostId < 0`)
  before calling `fetchDataWithHost` — so it never depended on the silent
  coercion for malformed values, and is unaffected.
- Checked callers of `host-id.ts`'s exports (`data.ts` via
  `getAndValidateHostId` and `validateDataRequest`) — both already branch
  on the returned `ApiError`, so stricter rejection surfaces as a proper
  400 instead of crashing.
- Checked Cypress e2e specs for `?host=` usage — all use `host=0` or
  `host=999` (valid integers), none depend on junk passthrough.
- Ran targeted tests locally via symlinked `node_modules` (bun test
  runner): `src/routes/-root-search.test.ts` (8 pass), `src/lib/
  clickhouse-helpers.test.ts` + `src/lib/api/shared/validators/__tests__/
  host-id.test.ts` (54 pass), and `src/lib/api/shared/validators/
  __tests__/request.test.ts` (51 pass, unaffected — no regressions).
- Did not run the full build (`pnpm run build`) or full test suite
  locally per worktree constraints (no `node_modules` installed) — CI
  runs both.

## Test plan

- [x] `?host=1.5` and `?host=abc` resolve to 0; `?host=-2` preserved
- [x] `"2abc"` rejected by the API validator (`host-id.ts`)
- [x] No silent malformed→0 coercion remains in `clickhouse-helpers.ts`
      (only the `undefined`/`null`/empty-string branch returns 0)
- [x] New/updated unit tests pass locally (see Verification)
- [ ] CI build + full test suite (pending)

Closes #2491

https://claude.ai/code/session_018h2h5erikMP3aM7p8YdXfY