### PR TITLE
test(deploy): pin deployment-mode defaults against the runtime resolver

### DIFF
--- a/apps/dashboard/scripts/deploy-defaults.test.ts
+++ b/apps/dashboard/scripts/deploy-defaults.test.ts
@@ -1,0 +1,46 @@
+// Pins the deploy-time env projection (modeDefaultVars) against the runtime
+// resolver (src/lib/config/deployment-mode.ts resolveConfig/modeDefaults) so
+// the two copies of "what a mode means" can never silently drift — see the
+// module comment in ./deploy-defaults.ts and #2067 / #2055.
+
+import { resolveConfig } from '../src/lib/config/deployment-mode'
+import {
+  DEPLOYMENT_MODES,
+  modeDefaults,
+  modeDefaultVars,
+} from './deploy-defaults'
+import { describe, expect, test } from 'bun:test'
+
+describe('modeDefaultVars — fail-closed to self-hosted', () => {
+  test('oss → no vars emitted', () => {
+    // A missing/junk CHM_DEPLOYMENT_MODE must never inject a cloud var into an
+    // oss deploy's worker [vars] — the fail-closed invariant this plan pins.
+    expect(modeDefaultVars('oss')).toEqual({})
+  })
+
+  test('cloud → exactly the five cloud vars', () => {
+    expect(modeDefaultVars('cloud')).toEqual({
+      CHM_CLOUD_MODE: 'true',
+      CHM_AUTH_PROVIDER: 'clerk',
+      CHM_CLERK_PUBLIC_READ: 'true',
+      CHM_FEATURE_USER_CONNECTIONS_DB: 'true',
+      CHM_FEATURE_CONVERSATION_DB: 'true',
+    })
+  })
+})
+
+describe('modeDefaultVars — anti-drift vs the runtime resolver', () => {
+  const mock = (vars: Record<string, string>) => (k: string) => vars[k]
+
+  test('projecting a mode to vars and resolving them back yields the same posture', () => {
+    // modeDefaultVars() intentionally never emits CHM_DEPLOYMENT_MODE itself
+    // (see its docstring), so resolveConfig() falls back to 'oss' for `mode`
+    // when fed only the projected vars — every OTHER field must still match
+    // modeDefaults(mode) exactly, since each concrete flag is set explicitly.
+    for (const mode of DEPLOYMENT_MODES) {
+      const vars = modeDefaultVars(mode)
+      const { mode: _resolvedMode, ...posture } = resolveConfig(mock(vars))
+      expect(posture).toEqual(modeDefaults(mode))
+    }
+  })
+})


### PR DESCRIPTION
## What

Adds `apps/dashboard/scripts/deploy-defaults.test.ts` covering
`modeDefaultVars()` — the function that projects `CHM_DEPLOYMENT_MODE`
into the concrete `[vars]` the deploy script (`patch-wrangler-env.ts`)
injects into the Cloudflare Worker config:

- `modeDefaultVars('oss')` → `{}` (fail-closed: no cloud vars leak into
  an OSS deploy)
- `modeDefaultVars('cloud')` → exactly the five expected cloud vars
- **Anti-drift check**: for each mode, feeding the projected vars back
  through `resolveConfig()`/`modeDefaults()` (the runtime resolver in
  `src/lib/config/deployment-mode.ts`) resolves to the same posture as
  `modeDefaults(mode)` — so the deploy-time projection and the
  runtime resolver can never silently diverge.

## Why

`modeDefaultVars()` decides, at deploy time, whether production runs
as public read-only Cloud or as OSS. Its own comment warns a mismatch
"would silently drop the cloud public-read posture → anon 401". It had
zero test coverage before this PR.

## Deviation from plan: `patch-wrangler-env.test.ts` not added

Plan 77 (Step 2) also asked for a `patch-wrangler-env.test.ts` covering
`parseDotenv()` and the vars/name/routes/D1 "patch step". This is
**not included** — the plan's own STOP conditions anticipate exactly
this situation and ask to report instead of refactoring source under a
test-only, LOW-risk plan.

**Root cause**: `patch-wrangler-env.ts` has no function boundary around
its side effects — the entire script (argv parsing, an `existsSync`
check that calls `process.exit(1)` when `dist/server/wrangler.json` is
missing, `parseDotenv` calls against the real committed
`.env.production`/`.env.preview`, and the final `writeFileSync`) runs
unconditionally at module-import time. Importing the module for
**any** export — even just `parseDotenv` — therefore executes all of
it. Verified directly in this environment (no `dist/` build output):

```
$ bun -e "import('./scripts/patch-wrangler-env.ts')"
❌ Generated config not found: .../apps/dashboard/dist/server/wrangler.json
   Run `pnpm run build` first.
exit code: 1
```

A `bun:test` file importing this module would crash the whole test
process (not just fail one test) whenever `dist/` isn't already built
— which is always true in a clean checkout/CI test step that runs
before the build step.

**Proposed minimal follow-up refactor** (not done here, out of this
plan's scope — "git diff shows only test files plus optional export
keywords"):
1. Wrap the side-effecting bottom section (argv parsing through the
   final `writeFileSync`/`console.log`) in `if (import.meta.main) { ... }`
   so importing the module for its exports no longer runs them.
2. Add `export` to `parseDotenv` (already a pure function, no behavior
   change).
3. Extract the "patch step" (vars merge with the `DEPLOY_OVERRIDE_KEYS`
   allowlist, D1 `database_id` injection, `assets.html_handling`,
   name/routes assignment) into a pure exported function taking
   `(generated, vars, config)` and returning the patched object, so it
   can be exercised with an in-memory fixture instead of real files.

One data point confirmed by reading (not executing, since it requires
the guard above): `parseDotenv` overlay order is `{ ...production,
...preview }`, i.e. **preview wins over production** — matches the plan's
expected direction.

## Tests run locally

Worktree has no `node_modules` (per swarm convention); symlinked
`node_modules` from the main checkout to run tests, then removed the
symlinks before committing (they never touched git status — properly
gitignored).

```
cd apps/dashboard && bun test scripts/deploy-defaults.test.ts
# 3 pass, 0 fail, 4 expect() calls
```

CI will also run this via its own install.

## Scope

- `git diff` = one new test file only. No source changes.
- `plans/README.md` intentionally not touched (updated centrally per
  swarm convention).

Closes #2494

https://claude.ai/code/session_018h2h5erikMP3aM7p8YdXfY