### PR TITLE
fix(telemetry): bound and dedupe /v1/event inserts

### DIFF
--- a/apps/telemetry/README.md
+++ b/apps/telemetry/README.md
@@ -64,6 +64,12 @@ Primary key: `(day, instance_hash)` — one row per install per day.
 | `ch_flavor`   | TEXT    | oss/altinity/cloud/unknown |
 | `created_at`  | TEXT    | datetime('now') |
 
+Unique index: `(day, event, deploy_target, ch_version, ch_flavor)` (`INSERT OR
+IGNORE`) — `/v1/event` carries no `instance_hash`, so repeated identical
+events within the same UTC day collapse to one row instead of growing
+unbounded. Counts stay directionally correct for the analytics-only
+`events` table; this is not exact per-occurrence counting.
+
 ## Deploy
 
 ```bash

--- a/apps/telemetry/migrations/0004_dedupe_events.sql
+++ b/apps/telemetry/migrations/0004_dedupe_events.sql
@@ -1,0 +1,20 @@
+-- Bound the unauthenticated POST /v1/event insert (#2503): dedupe repeated
+-- identical events within the same UTC day instead of appending unbounded
+-- rows, mirroring how ping_daily dedupes on (day, instance_hash).
+--
+-- /v1/event carries no instance_hash (see
+-- apps/dashboard/src/lib/telemetry/event-sink.ts — only `event` + a flat,
+-- non-identifying props bag), so the dedup key is the coarser tuple the
+-- handler already extracts: (day, event, deploy_target, ch_version,
+-- ch_flavor). ch_version is NULL when absent/invalid; SQLite/D1 treat NULL as
+-- distinct from NULL in a plain UNIQUE index, so COALESCE it to '' here or
+-- two rows that both lack a ch_version would never dedupe against each other.
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_events_dedupe
+  ON events (
+    day,
+    event,
+    deploy_target,
+    COALESCE(ch_version, ''),
+    COALESCE(ch_flavor, '')
+  );

--- a/apps/telemetry/src/index.test.ts
+++ b/apps/telemetry/src/index.test.ts
@@ -185,3 +185,110 @@ describe('GET /v1/summary — double WHERE regression (#2466)', () => {
     expect(body.total_places).toBe(1)
   })
 })
+
+describe('POST /v1/event — bounded, deduped insert (#2503)', () => {
+  let db: Database
+
+  afterEach(() => {
+    db?.close()
+  })
+
+  // Mirrors migrations/0003_create_views.sql (events table) +
+  // migrations/0004_dedupe_events.sql (dedup unique index).
+  function seed() {
+    db = new Database(':memory:')
+    db.run(`
+      CREATE TABLE events (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        day           TEXT NOT NULL,
+        event         TEXT NOT NULL,
+        deploy_target TEXT,
+        ch_version    TEXT,
+        ch_flavor     TEXT,
+        created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `)
+    db.run(`
+      CREATE UNIQUE INDEX idx_events_dedupe
+        ON events (
+          day, event, deploy_target, COALESCE(ch_version, ''), COALESCE(ch_flavor, '')
+        )
+    `)
+  }
+
+  function post(body: unknown) {
+    const env: Env = { CHM_TELEMETRY_DB: makeMockD1(db) }
+    return worker.fetch(
+      new Request('https://telemetry.chmonitor.dev/v1/event', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      }),
+      env,
+      makeCtx()
+    )
+  }
+
+  function countEvents(): number {
+    return (db.query('SELECT COUNT(*) AS n FROM events').get() as { n: number })
+      .n
+  }
+
+  it('dedupes an identical event posted twice on the same day', async () => {
+    seed()
+    // No ch_version -> stored as NULL. Regression check for the COALESCE fix:
+    // a plain UNIQUE index would never dedupe two NULLs against each other.
+    const payload = { event: 'app_loaded', props: { deploy_target: 'docker' } }
+
+    const first = await post(payload)
+    const second = await post(payload)
+
+    expect(first.status).toBe(204)
+    expect(second.status).toBe(204)
+    expect(countEvents()).toBe(1)
+  })
+
+  it('stores separate rows for two different event names', async () => {
+    seed()
+    await post({ event: 'app_loaded', props: { deploy_target: 'docker' } })
+    await post({ event: 'health_viewed', props: { deploy_target: 'docker' } })
+
+    expect(countEvents()).toBe(2)
+  })
+
+  it('stores separate rows when ch_version differs (incl. set vs. absent)', async () => {
+    seed()
+    await post({
+      event: 'cluster_connected',
+      props: { deploy_target: 'docker', ch_version: '24.8' },
+    })
+    await post({
+      event: 'cluster_connected',
+      props: { deploy_target: 'docker' }, // no ch_version -> NULL
+    })
+
+    expect(countEvents()).toBe(2)
+  })
+
+  it('rejects an unknown event name and inserts nothing', async () => {
+    seed()
+    const res = await post({ event: 'not_a_real_event', props: {} })
+
+    expect(res.status).toBe(400)
+    expect(countEvents()).toBe(0)
+  })
+
+  it('does not dedupe the same event across different days', () => {
+    // /v1/event derives `day` from wall-clock time, not a request field, so
+    // the day dimension of the key is exercised directly at the storage
+    // layer with the same INSERT OR IGNORE statement the handler issues.
+    seed()
+    const insert = db.query(
+      'INSERT OR IGNORE INTO events (day, event, deploy_target, ch_version, ch_flavor) VALUES (?, ?, ?, ?, ?)'
+    )
+    insert.run('2026-07-01', 'app_loaded', 'docker', null, 'oss')
+    insert.run('2026-07-02', 'app_loaded', 'docker', null, 'oss')
+
+    expect(countEvents()).toBe(2)
+  })
+})

--- a/apps/telemetry/src/index.ts
+++ b/apps/telemetry/src/index.ts
@@ -789,10 +789,13 @@ export default {
       const chVersion = asVersion(props.ch_version)
       const chFlavor = asEnum(props.ch_flavor, CH_FLAVORS, 'unknown')
 
+      // Dedupe per (day, event, deploy_target, ch_version, ch_flavor): no
+      // instance_hash is sent here (unlike /v1/ping), so this coarser tuple
+      // is the bound — see migrations/0004_dedupe_events.sql.
       const day = new Date().toISOString().slice(0, 10)
       ctx.waitUntil(
         env.CHM_TELEMETRY_DB.prepare(
-          'INSERT INTO events (day, event, deploy_target, ch_version, ch_flavor) VALUES (?, ?, ?, ?, ?)'
+          'INSERT OR IGNORE INTO events (day, event, deploy_target, ch_version, ch_flavor) VALUES (?, ?, ?, ?, ?)'
         )
           .bind(day, event, deployTarget, chVersion || null, chFlavor || null)
           .run()


### PR DESCRIPTION
## What

The unauthenticated `POST /v1/event` handler did a plain `INSERT` per request
with no dedup and no rate limit, letting an anonymous client append unbounded
rows to the `events` D1 table. `/v1/ping` already self-bounds with
`INSERT OR IGNORE` keyed on `(day, instance_hash)` — this gives `events` the
same shape.

## Why

- `/v1/event` carries **no `instance_hash`** (confirmed by reading the client
  emitter, `apps/dashboard/src/lib/telemetry/event-sink.ts` — it only sends
  `event` + a flat, non-identifying `props` bag). So per the plan's fallback,
  the dedup key is the coarser tuple the handler already extracts: `(day,
  event, deploy_target, ch_version, ch_flavor)`.
- `ch_version` can be `NULL` (dropped when absent/invalid). SQLite/D1 treat
  `NULL` as distinct from `NULL` in a plain `UNIQUE` index, so two rows that
  both lack a `ch_version` would never dedupe against each other — the new
  index `COALESCE`s it (and `ch_flavor`, for symmetry/future-proofing since
  it's currently always non-null) to `''` to close that gap. Verified this
  experimentally against a real SQLite engine before writing it into the
  migration.

## STOP-condition check (did NOT trigger)

The plan's STOP condition is "the `events` table is consumed by a funnel that
needs true per-occurrence counts." Checked: `handleSummary` (`/v1/summary`)
only ever queries `ping_daily`, never `events`. The only reader of `events` is
the unused view `v_events_by_name` (not exposed over HTTP, not queried
anywhere else in the repo). No PostHog cross-wiring found. Dedup is safe.

## Changes

- `apps/telemetry/migrations/0004_dedupe_events.sql` — new unique index
  `idx_events_dedupe` on `(day, event, deploy_target, COALESCE(ch_version,
  ''), COALESCE(ch_flavor, ''))`.
- `apps/telemetry/src/index.ts` — `/v1/event` handler switches `INSERT` →
  `INSERT OR IGNORE`, plus a short comment pointing at the migration.
- `apps/telemetry/README.md` — documents the new unique index next to the
  existing `events` table schema doc.
- `apps/telemetry/src/index.test.ts` — 5 new tests (all against a real
  in-memory SQLite engine via `bun:sqlite`, matching this file's existing
  pattern): identical payload twice → 1 row; two different event names → 2
  rows; differing `ch_version` (set vs. absent/NULL) → 2 rows; invalid event
  → 400 with no insert; different `day` → 2 rows (driven directly at the
  storage layer since `day` is derived from wall-clock time, not a request
  field, so it isn't reachable through the HTTP handler in a test).

## Verification

- `bun test src/index.test.ts` (targeted run, node_modules symlinked in from
  the main checkout per the worktree's environment rules): **8 pass, 0 fail**
  (3 pre-existing + 5 new).
- `biome check` clean on all touched files.
- CI will run the full suite; this worktree has no installed dependencies for
  a full `pnpm run build`/`pnpm run test` pass, so that's left to CI.

## Deploy note for the babysitter

Telemetry's CI deploy step (`.github/workflows/cloudflare.yml`) runs
`wrangler deploy` for `apps/telemetry` but does **not** run
`wrangler d1 migrations apply` (unlike the `chm-cloud` D1 database, which CI
does migrate). This new migration likely needs a manual
`cd apps/telemetry && pnpm exec wrangler d1 migrations apply chm_telemetry --remote`
after merge for the dedup to take effect in production. This gap predates this
PR (migrations 0001-0003 have the same characteristic) and is out of scope for
plan 86 to fix.

## Deviation from plan

Plan 86 suggested preferring `(day, event, instance_hash, deploy_target)` if
the client sends an instance hash. It doesn't, so this implements the
documented fallback: `(day, event, deploy_target, ch_version, ch_flavor)`.

Closes #2503

https://claude.ai/code/session_018h2h5erikMP3aM7p8YdXfY