### PR TITLE
fix(menu): preserve href search params in HostPrefixedLink

### DIFF
--- a/apps/dashboard/src/components/menu/__tests__/link-with-context.test.ts
+++ b/apps/dashboard/src/components/menu/__tests__/link-with-context.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test'
+import { mergeHrefSearch } from '@/components/menu/link-with-context'
+
+// Regression coverage for https://github.com/chmonitor/chmonitor/issues/2496:
+// HostPrefixedLink used to drop a menu href's own query string entirely,
+// silently killing deep-link intent like `/keeper?path=/` and
+// `/charts?name=...`. mergeHrefSearch is the pure param-merging logic
+// extracted so it's testable without rendering the component.
+describe('mergeHrefSearch', () => {
+  test('merges query params from the href with the host param', () => {
+    expect(mergeHrefSearch('/charts?name=a,b', 2)).toEqual({
+      name: 'a,b',
+      host: 2,
+    })
+  })
+
+  test('href without a query string yields only host', () => {
+    expect(mergeHrefSearch('/merges', 0)).toEqual({ host: 0 })
+  })
+
+  test('host always wins over a colliding host param baked into the href', () => {
+    expect(mergeHrefSearch('/x?host=9', 1)).toEqual({ host: 1 })
+  })
+
+  // The two real menu.ts entries called out in the bug report.
+  test('keeper deep link preserves path=/', () => {
+    expect(mergeHrefSearch('/keeper?path=/', 0)).toEqual({
+      path: '/',
+      host: 0,
+    })
+  })
+
+  test('charts deep link preserves the comma-separated chart names', () => {
+    expect(
+      mergeHrefSearch(
+        '/charts?name=connections-http,connections-interserver',
+        0
+      )
+    ).toEqual({
+      name: 'connections-http,connections-interserver',
+      host: 0,
+    })
+  })
+})

--- a/apps/dashboard/src/components/menu/link-with-context.tsx
+++ b/apps/dashboard/src/components/menu/link-with-context.tsx
@@ -11,6 +11,28 @@ import { usePathname } from '@/lib/next-compat'
 import { useHostId } from '@/lib/swr'
 import { prefetchRoute } from '@/lib/swr/prefetch'
 
+/**
+ * Menu hrefs may carry their own query string (e.g. `/keeper?path=/`,
+ * `/charts?name=a,b`) that gets lost once split into TanStack Router's
+ * `to`/`search` pair. Merge those params into `search` so the deep-link
+ * intent survives, with `host` always set last so it wins over any
+ * colliding param baked into the href.
+ */
+export function mergeHrefSearch(
+  href: string,
+  hostId: number
+): Record<string, unknown> {
+  const queryString = href.split('?')[1]
+  const search: Record<string, unknown> = {}
+  if (queryString) {
+    for (const [key, value] of new URLSearchParams(queryString)) {
+      search[key] = value
+    }
+  }
+  search.host = hostId
+  return search
+}
+
 export const HostPrefixedLink = ({
   href,
   children,
@@ -61,7 +83,7 @@ export const HostPrefixedLink = ({
   // Pass `host` as a number to match the root route's validateSearch schema —
   // string values get JSON-encoded ("%220%22") which produces 404s during prerender.
   const toPath = href.split('?')[0]
-  const searchParams = { host: hostId }
+  const searchParams = mergeHrefSearch(href, hostId)
 
   // Check if this link is active
   const isActive = siblingHrefs

--- a/apps/dashboard/src/lib/menu/__tests__/menu-config-invariants.test.ts
+++ b/apps/dashboard/src/lib/menu/__tests__/menu-config-invariants.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Structural invariants for src/menu.ts — 1000+ lines of declarative config,
+ * the highest-churn file in the app, with no direct test before this one.
+ * `MenuItem` has no explicit id field, so "identity" here is: a leaf item's
+ * href (its actual navigational destination) and a sibling group's titles
+ * (what a user sees listed together in one dropdown).
+ *
+ * Known-legitimate exception, not a bug: a group parent may repeat its first
+ * child's href (e.g. "Merges" both links directly to /merges AND lists
+ * /merges again inside its own dropdown with a description) — that's a
+ * container mirroring its own landing page. Only *leaf* items (no nested
+ * `items`) are required to have a distinct href.
+ */
+
+import { menuItemsConfig } from '@/menu'
+
+import type { MenuItem } from '@/components/menu/types'
+
+import { describe, expect, test } from 'bun:test'
+import { readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+interface FlatItem {
+  item: MenuItem
+  isLeaf: boolean
+}
+
+function flatten(items: MenuItem[], out: FlatItem[] = []): FlatItem[] {
+  for (const item of items) {
+    out.push({ item, isLeaf: !item.items || item.items.length === 0 })
+    if (item.items) flatten(item.items, out)
+  }
+  return out
+}
+
+const leaves = flatten(menuItemsConfig)
+  .filter((f) => f.isLeaf)
+  .map((f) => f.item)
+
+describe('menu.ts structural invariants', () => {
+  test('every leaf item (no children) has a non-empty href', () => {
+    const offenders = leaves.filter((item) => !item.href).map((i) => i.title)
+    expect(offenders).toEqual([])
+  })
+
+  test('hrefs are unique among leaf items', () => {
+    const titlesByHref = new Map<string, string[]>()
+    for (const item of leaves) {
+      if (!item.href) continue
+      const titles = titlesByHref.get(item.href) ?? []
+      titles.push(item.title)
+      titlesByHref.set(item.href, titles)
+    }
+    const duplicates = [...titlesByHref.entries()].filter(
+      ([, titles]) => titles.length > 1
+    )
+    expect(duplicates).toEqual([])
+  })
+
+  test('sibling titles are unique within each dropdown / list', () => {
+    function checkSiblings(items: MenuItem[], path: string) {
+      const counts = new Map<string, number>()
+      for (const item of items) {
+        counts.set(item.title, (counts.get(item.title) ?? 0) + 1)
+      }
+      const duplicated = [...counts.entries()]
+        .filter(([, count]) => count > 1)
+        .map(([title]) => title)
+      expect(duplicated, `duplicate sibling titles under ${path}`).toEqual([])
+      for (const item of items) {
+        if (item.items) checkSiblings(item.items, `${path} > ${item.title}`)
+      }
+    }
+    checkSiblings(menuItemsConfig, 'root')
+  })
+})
+
+describe('menu.ts hrefs resolve to a real route file', () => {
+  // Pathless TanStack Router layout groups reachable from menu.ts. `api` is
+  // excluded — those are data endpoints, never menu hrefs.
+  const ROUTE_GROUPS = ['(dashboard)', '(peerdb)']
+  const ROUTES_ROOT = fileURLToPath(new URL('../../../routes', import.meta.url))
+
+  function walk(dir: string, out: string[] = []): string[] {
+    for (const entry of readdirSync(dir)) {
+      if (entry.startsWith('-')) continue // colocated non-route file/dir
+      const full = join(dir, entry)
+      if (statSync(full).isDirectory()) {
+        walk(full, out)
+      } else if (entry.endsWith('.ts') || entry.endsWith('.tsx')) {
+        out.push(full)
+      }
+    }
+    return out
+  }
+
+  // Mirrors TanStack Router's file-based conventions used under src/routes:
+  // pathless `(group)` segments don't appear in the URL, a folder's
+  // `index.tsx` maps to the folder's own path, and `route.tsx` is a layout
+  // file with no URL segment of its own.
+  function fileToRoutePath(file: string): string | null {
+    const rel = relative(ROUTES_ROOT, file).replace(/\.(tsx|ts)$/, '')
+    const segments = rel.split('/')
+    const basename = segments[segments.length - 1]
+    if (basename === 'route' || basename.endsWith('.test')) return null
+    const cleaned = segments
+      .filter((seg) => !/^\(.*\)$/.test(seg))
+      .filter((seg, i, arr) => !(seg === 'index' && i === arr.length - 1))
+    return `/${cleaned.join('/')}`
+  }
+
+  const knownRoutePaths = new Set(
+    ROUTE_GROUPS.flatMap((group) => walk(join(ROUTES_ROOT, group)))
+      .map(fileToRoutePath)
+      .filter((p): p is string => p !== null)
+  )
+
+  test('discovers a meaningful number of route files', () => {
+    expect(knownRoutePaths.size).toBeGreaterThan(50)
+  })
+
+  test('every leaf href path (before ?) matches an existing route file', () => {
+    const offenders = leaves
+      .filter((item) => item.href && !/^https?:\/\//.test(item.href))
+      .map((item) => ({ title: item.title, path: item.href.split('?')[0] }))
+      .filter(({ path }) => !knownRoutePaths.has(path))
+    expect(offenders).toEqual([])
+  })
+})


### PR DESCRIPTION
## What

`HostPrefixedLink` computed `search` as just `{ host: hostId }`, dropping
any query string baked into the menu `href` itself. Two `menu.ts` entries
carry meaningful params that were silently dead:

- `/keeper?path=/` (loses `path`)
- `/charts?name=connections-http,connections-interserver` (loses `name` —
  without it `routes/(dashboard)/charts.tsx` falls back to the generic
  quick-picks grid instead of the intended chart set)

## Why

Both links looked fine in `menu.ts` but silently lost their deep-link
intent once rendered, since `href.split('?')[1]` was parsed for `toPath`
but never merged into `search`.

## Changes

- Extract `mergeHrefSearch(href, hostId)` in `link-with-context.tsx`: parses
  `href`'s own query string via `URLSearchParams`, spreads those entries
  into `search`, then sets `host: hostId` last so it always wins on key
  collision (e.g. a stray `?host=9` in an href can never override the
  actual active host).
- Add `src/lib/menu/__tests__/menu-config-invariants.test.ts` — `menu.ts`
  is 1000+ lines of declarative config, the highest-churn file in the app,
  with no direct test before this. Guards:
  - every leaf item (no nested `items`) has a non-empty `href`
  - `href` is unique among leaf items (group parents that intentionally
    mirror their first child's href, e.g. "Merges" → `/merges`, are
    excluded — they're containers, not leaves)
  - sibling titles are unique within each dropdown/list
  - every leaf href's path (before `?`) resolves to a real route file
    under `src/routes/(dashboard)/` or `src/routes/(peerdb)/` (scanned
    from the filesystem directly, since the generated `routeTree.gen.ts`
    isn't present when `bun test` runs in CI)

## Verification

Ran locally (worktree had no `node_modules`; symlinked from the main
checkout to enable a targeted run — CI runs the full suite normally):

```
$ cd apps/dashboard && bun test src/components/menu src/lib/menu
 26 pass
 0 fail
```

Also manually verified the new invariant test actually catches
regressions (not vacuous): temporarily injected a dangling href and a
duplicate sibling title into `menu.ts` and confirmed each assertion
failed with a clear message, then reverted (`git diff` confirmed
`menu.ts` itself is untouched by this PR).

Closes #2496

https://claude.ai/code/session_018h2h5erikMP3aM7p8YdXfY