### PR TITLE
fix(billing): count pending invitations in org seat pre-check

### DIFF
--- a/apps/dashboard/src/routes/api/v1/org/invite.test.ts
+++ b/apps/dashboard/src/routes/api/v1/org/invite.test.ts
@@ -1,16 +1,17 @@
 /**
- * Tests for POST /api/v1/org/invite (plan 20) — the pre-emptive seat-cap gate
- * that rejects an over-cap invite with a 402 BEFORE any Clerk invitation is
- * created, plus the auth/role gates and the fail-open path (plan/member-count
- * resolution throws → invite proceeds ungated, matching self-hosted/OSS
- * "stays whole").
+ * Tests for POST /api/v1/org/invite (plans 20 and 99) — the pre-emptive
+ * seat-cap gate that rejects an over-cap invite with a 402 BEFORE any Clerk
+ * invitation is created (counting both current members AND pending
+ * invitations — plan 99), plus the auth/role gates and the fail-open path
+ * (plan/member/invite resolution throws → invite proceeds ungated, matching
+ * self-hosted/OSS "stays whole").
  *
  * mock.module style mirrors routes/api/v1/webhooks/clerk.test.ts: each mocked
  * export is a stable wrapper delegating to a per-test `let` binding, and
  * `@clerk/tanstack-react-start/server` is mocked with the full superset of
  * methods used across the suite (this file adds
- * `createOrganizationInvitation`) so registration stays order-independent when
- * CI runs `bun test src/ --isolate`.
+ * `createOrganizationInvitation` and `getOrganizationInvitationList`) so
+ * registration stays order-independent when CI runs `bun test src/ --isolate`.
  */
 
 import { beforeEach, describe, expect, mock, test } from 'bun:test'
@@ -55,6 +56,13 @@ let getOrganizationMembershipList = mock(
     data: [] as unknown[],
   })
 )
+let getOrganizationInvitationList = mock(
+  async (_args: {
+    organizationId: string
+    status?: string[]
+    limit: number
+  }) => ({ data: [] as unknown[] })
+)
 let deleteOrganizationMembership = mock(
   async (_args: { organizationId: string; userId: string }) => ({})
 )
@@ -84,6 +92,11 @@ mock.module('@clerk/tanstack-react-start/server', () => ({
         organizationId: string
         limit: number
       }) => getOrganizationMembershipList(args),
+      getOrganizationInvitationList: (args: {
+        organizationId: string
+        status?: string[]
+        limit: number
+      }) => getOrganizationInvitationList(args),
       createOrganization: (args: { name: string; createdBy: string }) =>
         createOrganization(args),
       deleteOrganizationMembership: (args: {
@@ -106,6 +119,10 @@ function membershipsOfSize(count: number) {
   return { data: Array.from({ length: count }) }
 }
 
+function invitationsOfSize(count: number) {
+  return { data: Array.from({ length: count }) }
+}
+
 function makeRequest(body: unknown = { emailAddress: 'new@example.com' }) {
   return new Request('https://dash.example.com/api/v1/org/invite', {
     method: 'POST',
@@ -124,6 +141,7 @@ beforeEach(() => {
     orgRole: 'org:admin',
   }))
   getOrganizationMembershipList = mock(async () => ({ data: [] }))
+  getOrganizationInvitationList = mock(async () => ({ data: [] }))
   deleteOrganizationMembership = mock(async () => ({}))
   usersGetOrganizationMembershipList = mock(async () => ({ data: [] }))
   createOrganization = mock(async () => ({ id: 'org_new' }))
@@ -220,12 +238,56 @@ describe('POST /api/v1/org/invite — pre-emptive seat gate', () => {
 
     expect(res.status).toBe(200)
     expect(getOrganizationMembershipList).not.toHaveBeenCalled()
+    expect(getOrganizationInvitationList).not.toHaveBeenCalled()
     expect(createOrganizationInvitation).toHaveBeenCalledTimes(1)
   })
 
   test('fail-open: plan/member resolution throws (no Clerk) → invite proceeds, no 402', async () => {
     getPlanForOwner = mock(async () => {
       throw new Error('Clerk not configured')
+    })
+
+    const res = await handlePost(makeRequest())
+
+    expect(res.status).toBe(200)
+    expect(createOrganizationInvitation).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('POST /api/v1/org/invite — pending invitations count toward the seat cap', () => {
+  test('members=2, pending=0 (cap=3): allowed — the Clerk invitation is created', async () => {
+    getOrganizationMembershipList = mock(async () => membershipsOfSize(2))
+    getOrganizationInvitationList = mock(async () => invitationsOfSize(0))
+
+    const res = await handlePost(makeRequest())
+
+    expect(res.status).toBe(200)
+    expect(getOrganizationInvitationList).toHaveBeenCalledWith({
+      organizationId: 'org_1',
+      status: ['pending'],
+      limit: 100,
+    })
+    expect(createOrganizationInvitation).toHaveBeenCalledTimes(1)
+  })
+
+  test('members=2, pending=1 (cap=3): blocked — 402 reason seat_limit BEFORE the invite is created', async () => {
+    getOrganizationMembershipList = mock(async () => membershipsOfSize(2))
+    getOrganizationInvitationList = mock(async () => invitationsOfSize(1))
+
+    const res = await handlePost(makeRequest())
+    const body = (await res.json()) as {
+      error: { details?: { reason?: string } }
+    }
+
+    expect(res.status).toBe(402)
+    expect(body.error.details?.reason).toBe('seat_limit')
+    expect(createOrganizationInvitation).not.toHaveBeenCalled()
+  })
+
+  test('fail-open: pending-invitation list call throws → check is skipped, invite proceeds', async () => {
+    getOrganizationMembershipList = mock(async () => membershipsOfSize(2))
+    getOrganizationInvitationList = mock(async () => {
+      throw new Error('Clerk API hiccup')
     })
 
     const res = await handlePost(makeRequest())

--- a/apps/dashboard/src/routes/api/v1/org/invite.ts
+++ b/apps/dashboard/src/routes/api/v1/org/invite.ts
@@ -28,11 +28,11 @@
  * The org id is always session-derived via `resolveBillingOwner()`, never a
  * request param, so a caller can only ever invite into their own org.
  *
- * Fail-open (self-hosted/OSS stays whole): plan resolution + member-count
- * enumeration is wrapped in `preCheckSeatLimit`, which returns `null` — "skip
- * the check" — on ANY failure there (Clerk not configured, Clerk API hiccup).
- * A seat-check failure can never block an invite; it can only under-enforce,
- * matching the fail-safe convention used by `countOwnerHosts`
+ * Fail-open (self-hosted/OSS stays whole): plan resolution + member/pending
+ * invite enumeration is wrapped in `preCheckSeatLimit`, which returns `null`
+ * — "skip the check" — on ANY failure there (Clerk not configured, Clerk API
+ * hiccup). A seat-check failure can never block an invite; it can only
+ * under-enforce, matching the fail-safe convention used by `countOwnerHosts`
  * (lib/billing/org-host-count.ts).
  */
 import { createFileRoute } from '@tanstack/react-router'
@@ -98,7 +98,7 @@ function seatLimitResponse(check: LimitCheck): Response {
 
 /**
  * Pre-check the org's seat cap for one more invite. Returns `null` when the
- * check should be SKIPPED — the plan is unlimited, or plan/member-count
+ * check should be SKIPPED — the plan is unlimited, or plan/member/invite
  * resolution threw (most commonly: Clerk isn't configured). Never throws.
  *
  * At invite time the new member has NOT been added yet, so this passes the
@@ -106,6 +106,11 @@ function seatLimitResponse(check: LimitCheck): Response {
  * webhook rollback in webhooks/clerk.ts, which fires after Clerk has already
  * added the member and so subtracts one to ask the same "room for one more?"
  * question against the pre-addition roster.
+ *
+ * Counts pending invitations too, not just current members: without this, an
+ * org already at its seat cap could dispatch unlimited invites (each one only
+ * bounced post-hoc, after accept, by the webhook rollback — a worse UX and a
+ * correctness gap).
  */
 async function preCheckSeatLimit(orgId: string): Promise<LimitCheck | null> {
   try {
@@ -113,13 +118,22 @@ async function preCheckSeatLimit(orgId: string): Promise<LimitCheck | null> {
     if (plan.seats == null) return null // unlimited — nothing to check
 
     const { clerkClient } = await import('@clerk/tanstack-react-start/server')
+    const client = clerkClient()
+    // Both list calls cap at 100 with no pagination — fine while seat caps
+    // top out at 10, but an org with >100 members/pending-invites would
+    // undercount here.
     const memberships =
-      await clerkClient().organizations.getOrganizationMembershipList({
+      await client.organizations.getOrganizationMembershipList({
         organizationId: orgId,
         limit: 100,
       })
+    const pending = await client.organizations.getOrganizationInvitationList({
+      organizationId: orgId,
+      status: ['pending'],
+      limit: 100,
+    })
 
-    return checkSeatLimit(plan, memberships.data.length)
+    return checkSeatLimit(plan, memberships.data.length + pending.data.length)
   } catch {
     return null
   }


### PR DESCRIPTION
## What

`preCheckSeatLimit` (in `POST /api/v1/org/invite`) counted only current
org members when deciding whether one more invite fits the plan's seat
cap. Pending invitations were invisible to it.

## Why

An org already at its seat cap (e.g. 3/3 members on Pro) could dispatch
unlimited invites past the cap — each over-cap invite was only bounced
post-hoc by the `organizationMembership.created` webhook rollback
*after* the invitee accepted. That's a worse UX (accept, then get
kicked) and a correctness gap independent of when the UI wires this
route up (it isn't yet — see the route's KNOWN GAP doc comment).

## Change

`preCheckSeatLimit` now also fetches pending invitations via Clerk's
`getOrganizationInvitationList({ organizationId, status: ['pending'] })`
and adds that count to the membership count before calling
`checkSeatLimit`. Error posture is unchanged — any failure resolving
plan/members/invites (e.g. Clerk not configured) still returns `null`
("skip the check"), never throws, matching the fail-open/self-hosted-
stays-whole convention used elsewhere in this file.

Both the membership and invitation list calls stay capped at
`limit: 100` with no pagination (documented inline) — fine while seat
caps top out at 10, addressed if that ever changes.

Out of scope (per plan 99): the webhook rollback itself, the seat-cap
UI (plan 20), and pagination beyond the clarifying comment.

## Verification

- `cd apps/dashboard && bun test src/routes/api/v1/org/invite.test.ts --isolate` — 11 pass
- `cd apps/dashboard && bun test src/routes/api/v1/org src/lib/billing --isolate` — 151 pass, 0 fail (148 pass on base before this change — exactly the 3 new tests added, no regressions)
- `biome check --write` on both touched files — clean
- This worktree has no `node_modules`; tests were run via a temporary symlink to the main checkout's `node_modules` (removed before commit). `pnpm run build` was not run per this environment's rules — CI will run it.

New tests added (in the existing `invite.test.ts`, new `describe` block):
- members=2, pending=0 (cap=3) → allowed, invitation created
- members=2, pending=1 (cap=3) → blocked, 402 `reason: seat_limit`
- pending-invitation list call throws → check is skipped (fail open), invite proceeds
- plus one added assertion on the pre-existing enterprise-bypass test (`getOrganizationInvitationList` not called when plan is unlimited)

Closes #2516

https://claude.ai/code/session_018h2h5erikMP3aM7p8YdXfY