### PR TITLE
fix(landing): align FAQ/pricing/integration copy with shipped product

### DIFF
--- a/apps/landing/src/components/FAQ.astro
+++ b/apps/landing/src/components/FAQ.astro
@@ -22,7 +22,7 @@ const faqs = [
   },
   {
     q: 'What is the difference between self-host and cloud?',
-    a: 'Self-hosting gives you full control over deployment, data routing and configuration, and it is always free. The hosted cloud at <a href="https://dash.chmonitor.dev" target="_blank" rel="noopener">dash.chmonitor.dev</a> lets you connect a ClickHouse cluster without deploying anything. Cloud is currently in early access; pricing is not yet finalised.',
+    a: 'Self-hosting gives you full control over deployment, data routing and configuration, and it is always free. The hosted cloud at <a href="https://dash.chmonitor.dev" target="_blank" rel="noopener">dash.chmonitor.dev</a> lets you connect a ClickHouse cluster without deploying anything. Cloud is in early access — see <a href="/pricing">pricing</a> for the current Free, Pro ($29/mo) and Max ($99/mo) tiers. Prices may change before GA; early-access accounts will be grandfathered.',
   },
   {
     q: 'Which ClickHouse versions are supported?',

--- a/apps/landing/src/components/FinalCta.astro
+++ b/apps/landing/src/components/FinalCta.astro
@@ -37,7 +37,7 @@ import { btnOnDarkOutline, btnOnDarkPrimary } from '../lib/button-classes'
             target="_blank"
             rel="noopener"
           >
-            Read the Docs
+            Read the docs
           </a>
           <a
             class={`${btnOnDarkOutline} w-full sm:w-auto`}

--- a/apps/landing/src/components/Footer.astro
+++ b/apps/landing/src/components/Footer.astro
@@ -16,7 +16,7 @@ function fmtDate(iso: string) {
             </span>
             chmonitor
           </a>
-          <p class="mt-4 text-pretty text-sm text-muted-foreground">chmonitor reads your cluster's system tables and turns them into views your whole team can act on, no more memorising table names or hand-writing diagnostic SQL.</p>
+          <p class="mt-4 text-pretty text-sm text-muted-foreground">chmonitor reads your cluster's system tables and turns them into views your whole team can act on, no more memorizing table names or hand-writing diagnostic SQL.</p>
         </div>
         <div class="grid grid-cols-2 gap-x-8 gap-y-10 sm:flex sm:flex-wrap sm:gap-x-12">
           <div class="min-w-0 sm:min-w-36">

--- a/apps/landing/src/components/ProductHighlights.tsx
+++ b/apps/landing/src/components/ProductHighlights.tsx
@@ -17,7 +17,7 @@ const HIGHLIGHTS = [
   {
     icon: Bell,
     title: 'Alerting adapters',
-    body: 'Compound rules, maintenance windows, Opsgenie, PagerDuty, Slack and email — routed per host or rule.',
+    body: 'Compound rules, maintenance windows, Opsgenie, PagerDuty and Slack — routed per host or rule.',
   },
   {
     icon: Database,

--- a/apps/landing/src/data/use-cases.test.ts
+++ b/apps/landing/src/data/use-cases.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, test } from 'bun:test'
 
 // Roadmap/unwired channel and feature names that must never appear as a
 // shipped-feature claim on a use-case page. See use-cases.ts's top comment
-// for the audit trail (Telegram/PagerDuty adapters exist as pure formatters
-// but are not consumed by the health-sweep dispatch — genuinely unwired).
-const DENYLIST = ['telegram', 'pagerduty', 'pager duty', 'opsgenie', 'email']
+// for the audit trail. PagerDuty and Opsgenie were removed from this list
+// once their health-sweep dispatch + settings UI shipped on main (plan 93);
+// the Telegram adapter is still a pure formatter with no dispatch wired, and
+// email transport is held pending a fire-path decision (#2218).
+const DENYLIST = ['telegram', 'email']
 
 // Structured copy fields to scan — NOT the raw source file text, which
 // legitimately mentions denylisted names in comments/docs.

--- a/apps/landing/src/data/use-cases.ts
+++ b/apps/landing/src/data/use-cases.ts
@@ -5,9 +5,10 @@
  * Every claim here must map to a real, shipped chmonitor capability: this
  * file IS the honesty-audit surface for those pages. `use-cases.test.ts`
  * enforces the shape (unique slug/title/h1/description) and a denylist of
- * roadmap-only feature names (PagerDuty, Telegram, OpsGenie, email alerts,
- * DDL auto-apply) that are not wired to any UI today — see the alerting
- * adapters audit trail in that file's comments.
+ * roadmap-only feature names (Telegram, email alerts, DDL auto-apply) that
+ * are not wired to any UI today — see the alerting adapters audit trail in
+ * that file's comments. PagerDuty and Opsgenie dispatch from the health
+ * sweep and have settings UI, so they are not denylisted.
  */
 
 export interface UseCaseBenefit {


### PR DESCRIPTION
## What

Fixes four copy inconsistencies on the landing page's money-adjacent
marketing surface (plan 93, issue #2510):

1. **FAQ vs pricing page** — the FAQ said cloud "pricing is not yet
   finalised" while `/pricing` already renders concrete Free / Pro
   ($29) / Max ($99) tiers. Rewrote the answer to link `/pricing` and
   note early-access accounts are grandfathered.
2. **Stale honesty denylist** — `use-cases.ts`'s `use-cases.test.ts`
   denylist blocked PagerDuty/Opsgenie as "roadmap-only", but both are
   genuinely shipped on `main` (see verification below). Removed them
   from the denylist; also removed the now-false "email" claim from
   `ProductHighlights.tsx`, which the denylist's own reasoning (email
   fire-path held, #2218) says must not be claimed as shipped.
3. **British spellings** — "finalised" (`FAQ.astro`) → "finalized",
   "memorising" (`Footer.astro`) → "memorizing".
4. **CTA casing** — unified `FinalCta.astro`'s "Read the Docs" to
   sentence case "Read the docs", matching `OpenSource.astro` and
   `404.astro`.

## How each claim was verified

- **Pricing tiers**: read `packages/pricing/src/plans.ts` directly —
  Free $0, Pro $29/mo, Max $99/mo (`BILLING_PLANS`). The file's own
  strategy note says "grandfather early-access accounts" at GA, so the
  FAQ's grandfathering sentence is backed by that source of truth.
- **PagerDuty reachability**: `apps/dashboard/src/lib/health/server-sweep.ts`
  imports `buildPagerDutyBody`/`postPagerDutyEvent` and POSTs to the
  real PagerDuty Events API v2 on trigger/resolve. The UI is
  `alert-routing-dialog.tsx`, rendered from `health-settings-dialog.tsx`,
  rendered unconditionally from `routes/(dashboard)/health.tsx` — a
  plain dashboard route with no feature flag. There's also a dedicated
  `GET /api/v1/health/pagerduty-services` route to list services.
- **Opsgenie reachability**: same file dispatches via
  `dispatchOpsgenie` (`opsgenie-dispatch.ts`) to the real Opsgenie
  Alert API, and `health-settings-dialog.tsx` has an "Opsgenie alerts"
  status/test-button section wired to `/api/v1/health/opsgenie-test`.
  Also unconditional, no flag.
- **Telegram stays denylisted**: `adapters/telegram.ts` is a pure body
  formatter; `server-sweep.ts` has no Telegram dispatch call at all —
  confirmed genuinely unwired.
- **Email stays denylisted**: `plans/README.md` lists #2218 as HELD
  ("No-op transport... Owner chose to defer this decision"). Note the
  code itself (`email-transport.ts`) does implement real Mailgun/SendGrid
  HTTP dispatch (only the SMTP provider option is a stub) — but per
  plan 93's explicit instruction this must not be claimed shipped
  regardless, so email stays off the marketing copy and on the
  denylist pending that decision being revisited.

## Out of scope (per plan)

- Pricing numbers themselves (source of truth stays `@chm/pricing`).
- Image optimization (plan 90).
- Adding new PagerDuty/Opsgenie marketing copy to the use-case pages —
  the plan only requires the denylist to stop *blocking* such mentions,
  not that this PR add new claims. Left `use-cases.ts` page content
  otherwise untouched to keep the diff surgical.

## Test plan

- [x] `rg -n "finalised|memorising|Read the Docs" apps/landing/src` → no matches
- [x] Manually traced `use-cases.test.ts`'s denylist test against the
      unmodified `useCases` array content — PagerDuty/Opsgenie/Telegram/
      email never appeared in structured copy fields before or after,
      so the test remains green (this PR only loosens/documents the list).
- [x] `biome check --write` on the three touched `.ts`/`.tsx` files — no
      fixes needed.
- [ ] CI: landing `bun test` + build (worktree has no `node_modules`,
      could not run locally — watching CI).

Closes #2510

https://claude.ai/code/session_018h2h5erikMP3aM7p8YdXfY