### PR TITLE
fix(clickhouse-client): distinguish transient probe errors from missing tables

### DIFF
--- a/apps/dashboard/src/lib/ai/advisor/capacity-forecaster.ts
+++ b/apps/dashboard/src/lib/ai/advisor/capacity-forecaster.ts
@@ -280,7 +280,10 @@ export function computeTtlSuggestion(
 // ---------------------------------------------------------------------------
 
 async function isPartLogAvailable(hostId: number): Promise<boolean> {
-  return checkTableExists(hostId, 'system', 'part_log')
+  // 'unknown' means the probe itself failed (network/timeout/auth), not a
+  // confirmed answer — treat it as unavailable here, same as this function's
+  // prior fail-closed behavior (never fabricate a forecast, see file header).
+  return (await checkTableExists(hostId, 'system', 'part_log')) === true
 }
 
 async function queryDailyNewPartBytes(

--- a/apps/dashboard/src/lib/cache/index.test.ts
+++ b/apps/dashboard/src/lib/cache/index.test.ts
@@ -1,0 +1,48 @@
+import {
+  getMemoryCache,
+  getQueryCache,
+  resetMemoryCacheInstance,
+  resetQueryCacheInstance,
+} from './index'
+import { beforeEach, describe, expect, it, spyOn } from 'bun:test'
+
+// Regression coverage for issue #2505: resetting a cache singleton must
+// dispose the outgoing adapter (stopping its cleanup `setInterval`) instead
+// of just nulling the reference and orphaning the timer.
+describe('cache singleton reset — dispose on reset', () => {
+  beforeEach(() => {
+    resetQueryCacheInstance()
+    resetMemoryCacheInstance()
+  })
+
+  it('resetQueryCacheInstance disposes the outgoing adapter before nulling it', () => {
+    const instance = getQueryCache()
+    const disposeSpy = spyOn(instance, 'dispose')
+
+    resetQueryCacheInstance()
+
+    expect(disposeSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('resetMemoryCacheInstance disposes the outgoing adapter before nulling it', () => {
+    const instance = getMemoryCache()
+    const disposeSpy = spyOn(instance, 'dispose')
+
+    resetMemoryCacheInstance()
+
+    expect(disposeSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('getQueryCache constructs a fresh adapter after a reset', () => {
+    const first = getQueryCache()
+    resetQueryCacheInstance()
+    const second = getQueryCache()
+
+    expect(second).not.toBe(first)
+  })
+
+  it('is a no-op (does not throw) when no instance exists yet', () => {
+    expect(() => resetQueryCacheInstance()).not.toThrow()
+    expect(() => resetMemoryCacheInstance()).not.toThrow()
+  })
+})

--- a/apps/dashboard/src/lib/cache/index.ts
+++ b/apps/dashboard/src/lib/cache/index.ts
@@ -25,9 +25,11 @@ export function getMemoryCache(): QueryCacheAdapter {
 }
 
 export function resetQueryCacheInstance(): void {
+  cacheInstance?.dispose?.()
   cacheInstance = null
 }
 
 export function resetMemoryCacheInstance(): void {
+  memoryCacheInstance?.dispose?.()
   memoryCacheInstance = null
 }

--- a/apps/dashboard/src/lib/cache/types.ts
+++ b/apps/dashboard/src/lib/cache/types.ts
@@ -6,4 +6,6 @@ export interface CacheOptions {
 
 export interface QueryCacheAdapter {
   wrap<T>(fn: () => Promise<T>, options: CacheOptions): Promise<T>
+  /** Release any adapter-owned resources (e.g. a cleanup interval timer). */
+  dispose?(): void
 }

--- a/apps/dashboard/src/routes/api/v1/table-availability.ts
+++ b/apps/dashboard/src/routes/api/v1/table-availability.ts
@@ -70,7 +70,10 @@ async function resolveTableAvailability(
   const tbl = parts.length > 1 ? parts[1] : parts[0]
 
   try {
-    return await checkTableExists(hostId, db, tbl)
+    const result = await checkTableExists(hostId, db, tbl)
+    // 'unknown' = the probe itself failed (network/timeout/auth), not a
+    // confirmed answer — omit from the map, same as the catch below.
+    return result === 'unknown' ? undefined : result
   } catch (err) {
     error('[GET /api/v1/table-availability] Check table error:', err, {
       requestId,

--- a/packages/clickhouse-client/src/__tests__/clickhouse-version.test.ts
+++ b/packages/clickhouse-client/src/__tests__/clickhouse-version.test.ts
@@ -31,6 +31,8 @@ const {
   getTableInfoMessage,
   SYSTEM_TABLE_INFO,
   checkTableExists,
+  checkTableHasData,
+  checkTableAvailability,
   getClickHouseVersion,
   setVersionCacheL2Provider,
   clearVersionCache,
@@ -493,11 +495,115 @@ describe('checkTableExists', () => {
     expect(result).toBe(false)
   })
 
-  it('returns false when the underlying client query throws', async () => {
+  // Regression coverage for issue #2505: a transient probe failure
+  // (network/timeout/auth) must not be reported the same as a
+  // confirmed-missing table.
+  it('returns "unknown" (not false) when the underlying client query throws', async () => {
     mockClientQuery.mockRejectedValue(new Error('connection refused'))
 
     const result = await checkTableExists(0, 'system', 'query_log')
+    expect(result).toBe('unknown')
+  })
+})
+
+describe('checkTableHasData', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    process.env.CLICKHOUSE_HOST = 'http://localhost:8123'
+    process.env.CLICKHOUSE_USER = 'default'
+    process.env.CLICKHOUSE_PASSWORD = ''
+    resetEnvCache()
+    clientPool.clear()
+    mockCreateClient.mockReset()
+    mockClientQuery.mockReset()
+    mockCreateClient.mockReturnValue(mockClient)
+    mockClientQuery.mockResolvedValue({
+      json: () => Promise.resolve([{ has_data: 1 }]),
+    })
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  it('returns true when the query reports rows present', async () => {
+    const result = await checkTableHasData(0, 'system.query_log')
+    expect(result).toBe(true)
+  })
+
+  it('returns false when the query reports no rows', async () => {
+    mockClientQuery.mockResolvedValue({
+      json: () => Promise.resolve([{ has_data: 0 }]),
+    })
+
+    const result = await checkTableHasData(0, 'system.query_log')
     expect(result).toBe(false)
+  })
+
+  it('returns "unknown" (not false) when the underlying client query throws', async () => {
+    mockClientQuery.mockRejectedValue(new Error('timeout'))
+
+    const result = await checkTableHasData(0, 'system.query_log')
+    expect(result).toBe('unknown')
+  })
+})
+
+describe('checkTableAvailability', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    process.env.CLICKHOUSE_HOST = 'http://localhost:8123'
+    process.env.CLICKHOUSE_USER = 'default'
+    process.env.CLICKHOUSE_PASSWORD = ''
+    resetEnvCache()
+    clientPool.clear()
+    mockCreateClient.mockReset()
+    mockClientQuery.mockReset()
+    mockCreateClient.mockReturnValue(mockClient)
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  it('reports checkFailed (not a confirmed "does not exist") when the existence probe errors', async () => {
+    mockClientQuery.mockRejectedValue(new Error('connection refused'))
+
+    const result = await checkTableAvailability(0, 'system', 'backup_log')
+
+    expect(result.exists).toBe(false)
+    expect(result.checkFailed).toBe(true)
+    expect(result.message).not.toContain('does not exist')
+  })
+
+  it('reports a confirmed missing table without checkFailed when the probe succeeds', async () => {
+    mockClientQuery.mockResolvedValue({
+      json: () => Promise.resolve([{ exists: 0 }]),
+    })
+
+    const result = await checkTableAvailability(0, 'system', 'backup_log')
+
+    expect(result.exists).toBe(false)
+    expect(result.checkFailed).toBeUndefined()
+    expect(result.message).toContain('does not exist')
+  })
+
+  it('reports checkFailed when the table exists but the has-data probe errors', async () => {
+    // 1st call: checkTableExists (inside checkTableAvailability) — succeeds.
+    mockClientQuery.mockResolvedValueOnce({
+      json: () => Promise.resolve([{ exists: 1 }]),
+    })
+    // 2nd call: checkTableHasData — the probe itself fails.
+    mockClientQuery.mockRejectedValueOnce(new Error('timeout'))
+
+    const result = await checkTableAvailability(0, 'system', 'backup_log')
+
+    expect(result.exists).toBe(true)
+    expect(result.hasData).toBe(false)
+    expect(result.checkFailed).toBe(true)
   })
 })
 

--- a/packages/clickhouse-client/src/__tests__/table-existence-cache.test.ts
+++ b/packages/clickhouse-client/src/__tests__/table-existence-cache.test.ts
@@ -126,4 +126,45 @@ describe('checkTableExists — L2 (KV) cache wiring (issue #2183)', () => {
     expect(second).toBe(true)
     expect(mockClientQuery).toHaveBeenCalledTimes(1)
   })
+
+  // Regression coverage for issue #2505: a probe failure (network/timeout/
+  // auth) must be distinguishable from a confirmed-missing table.
+  describe('transient probe failures (issue #2505)', () => {
+    it('returns "unknown" (not false) when the probe query throws', async () => {
+      mockClientQuery.mockRejectedValue(new Error('connection refused'))
+
+      const result = await l2cache.checkTableExists(0, 'system', 'backup_log')
+
+      expect(result).toBe('unknown')
+    })
+
+    it('never caches an "unknown" result — the next probe retries ClickHouse', async () => {
+      mockClientQuery.mockRejectedValueOnce(new Error('timeout'))
+      mockClientQuery.mockResolvedValueOnce({
+        json: () => Promise.resolve([{ count: '1' }]),
+      })
+
+      const first = await l2cache.checkTableExists(0, 'system', 'backup_log')
+      expect(first).toBe('unknown')
+      expect(l2cache.tableCacheSize()).toBe(0)
+
+      const second = await l2cache.checkTableExists(0, 'system', 'backup_log')
+      expect(second).toBe(true)
+      expect(mockClientQuery).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not write an "unknown" result to the L2 (KV) cache', async () => {
+      const setSpy = mock(async () => {})
+      l2cache.setTableExistenceL2Provider(() => ({
+        get: async () => null,
+        set: setSpy,
+      }))
+      mockClientQuery.mockRejectedValue(new Error('connection refused'))
+
+      const result = await l2cache.checkTableExists(0, 'system', 'backup_log')
+
+      expect(result).toBe('unknown')
+      expect(setSpy).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/clickhouse-client/src/__tests__/table-validator.test.ts
+++ b/packages/clickhouse-client/src/__tests__/table-validator.test.ts
@@ -255,5 +255,78 @@ describe('Table Validator', () => {
         'backup_log'
       )
     })
+
+    it('should tag a confirmed-missing table with reason "table_missing"', async () => {
+      const { tableExistenceCache } = await import('../table-existence-cache')
+      const mockCheckTableExists =
+        tableExistenceCache.checkTableExists as jest.MockedFunction<
+          typeof tableExistenceCache.checkTableExists
+        >
+      mockCheckTableExists.mockResolvedValue(false)
+
+      const config: QueryConfigLike = {
+        name: 'test',
+        sql: 'SELECT * FROM system.backup_log',
+        columns: ['name'],
+        optional: true,
+        tableCheck: 'system.backup_log',
+      }
+
+      const result = await validateTableExistence(config, 0)
+      expect(result.reason).toBe('table_missing')
+    })
+
+    // Regression coverage for issue #2505: a transient probe failure
+    // (network/timeout/auth) must never be reported the same as a
+    // confirmed-missing table.
+    it('should return shouldProceed false with reason "probe_failed" when the probe errors, without listing the table as missing', async () => {
+      const { tableExistenceCache } = await import('../table-existence-cache')
+      const mockCheckTableExists =
+        tableExistenceCache.checkTableExists as jest.MockedFunction<
+          typeof tableExistenceCache.checkTableExists
+        >
+
+      // Simulate a transient probe failure (checkTableExists resolves
+      // 'unknown', not false, on a network/timeout/auth error).
+      mockCheckTableExists.mockResolvedValue('unknown')
+
+      const config: QueryConfigLike = {
+        name: 'test',
+        sql: 'SELECT * FROM system.backup_log',
+        columns: ['name'],
+        optional: true,
+        tableCheck: 'system.backup_log',
+      }
+
+      const result = await validateTableExistence(config, 0)
+      expect(result.shouldProceed).toBe(false)
+      expect(result.reason).toBe('probe_failed')
+      expect(result.missingTables).toEqual([])
+      expect(result.error).toContain('system.backup_log')
+    })
+
+    it('should prioritize "probe_failed" over "table_missing" when some tables error and others are confirmed missing', async () => {
+      const { tableExistenceCache } = await import('../table-existence-cache')
+      const mockCheckTableExists =
+        tableExistenceCache.checkTableExists as jest.MockedFunction<
+          typeof tableExistenceCache.checkTableExists
+        >
+
+      mockCheckTableExists.mockImplementation(async (_hostId, _db, tbl) =>
+        tbl === 'backup_log' ? 'unknown' : false
+      )
+
+      const config: QueryConfigLike = {
+        name: 'test',
+        sql: 'SELECT * FROM system.backup_log',
+        columns: ['name'],
+        optional: true,
+        tableCheck: ['system.backup_log', 'system.error_log'],
+      }
+
+      const result = await validateTableExistence(config, 0)
+      expect(result.shouldProceed).toBe(false)
+      expect(result.reason).toBe('probe_failed')
+    })
   })
 })

--- a/packages/clickhouse-client/src/clickhouse-version.ts
+++ b/packages/clickhouse-client/src/clickhouse-version.ts
@@ -205,12 +205,16 @@ export async function getClickHouseVersion(
 /**
  * Check if a specific table exists on the host
  * Uses raw client to avoid circular dependency with fetchData
+ *
+ * Returns `'unknown'` (not `false`) when the probe itself fails
+ * (network/timeout/auth) — the caller must not treat that the same as a
+ * confirmed-missing table. See issue #2505.
  */
 export async function checkTableExists(
   hostId: number,
   database: string,
   table: string
-): Promise<boolean> {
+): Promise<boolean | 'unknown'> {
   try {
     const configs = getClickHouseConfigs()
     const clientConfig = configs[hostId]
@@ -228,18 +232,21 @@ export async function checkTableExists(
     const data = (await resultSet.json()) as { exists: number }[]
     return data?.[0]?.exists === 1
   } catch {
-    return false
+    return 'unknown'
   }
 }
 
 /**
  * Check if a table has data (is not empty)
  * Uses raw client to avoid circular dependency with fetchData
+ *
+ * Returns `'unknown'` (not `false`) when the probe itself fails — see
+ * {@link checkTableExists}.
  */
 export async function checkTableHasData(
   hostId: number,
   fullTableName: string
-): Promise<boolean> {
+): Promise<boolean | 'unknown'> {
   try {
     const configs = getClickHouseConfigs()
     const clientConfig = configs[hostId]
@@ -256,7 +263,7 @@ export async function checkTableHasData(
     const data = (await resultSet.json()) as { has_data: number }[]
     return data?.[0]?.has_data === 1
   } catch {
-    return false
+    return 'unknown'
   }
 }
 
@@ -266,6 +273,13 @@ export async function checkTableHasData(
 export interface TableAvailability {
   exists: boolean
   hasData: boolean
+  /**
+   * True when existence/data could not be verified due to a probe failure
+   * (network/timeout/auth) — `exists`/`hasData` are a fail-closed `false` in
+   * this case, NOT a confirmed "missing table" / "empty table" result. See
+   * issue #2505.
+   */
+  checkFailed?: boolean
   message?: string
 }
 
@@ -278,6 +292,14 @@ export async function checkTableAvailability(
   table: string
 ): Promise<TableAvailability> {
   const exists = await checkTableExists(hostId, database, table)
+  if (exists === 'unknown') {
+    return {
+      exists: false,
+      hasData: false,
+      checkFailed: true,
+      message: `Could not verify table ${database}.${table} — connection issue while checking availability.`,
+    }
+  }
   if (!exists) {
     return {
       exists: false,
@@ -287,6 +309,14 @@ export async function checkTableAvailability(
   }
 
   const hasData = await checkTableHasData(hostId, `${database}.${table}`)
+  if (hasData === 'unknown') {
+    return {
+      exists: true,
+      hasData: false,
+      checkFailed: true,
+      message: `Table ${database}.${table} exists, but could not verify whether it has data — connection issue.`,
+    }
+  }
   if (!hasData) {
     return {
       exists: true,

--- a/packages/clickhouse-client/src/clickhouse/__tests__/clickhouse-fetch.test.ts
+++ b/packages/clickhouse-client/src/clickhouse/__tests__/clickhouse-fetch.test.ts
@@ -423,6 +423,34 @@ describe('clickhouse-fetch', () => {
         expect(mockClientQuery).not.toHaveBeenCalled()
       })
 
+      // Regression coverage for issue #2505: a transient probe failure
+      // (network/timeout/auth) must be classified as a network error, not
+      // "table not found" — the UI copy for the two must differ.
+      it('should classify a probe failure as a network error, not table_not_found', async () => {
+        const queryConfig: QueryConfigLike = {
+          name: 'test',
+          sql: 'SELECT * FROM system.backup_log',
+          optional: true,
+        } as QueryConfigLike
+
+        mockValidateTableExistence.mockResolvedValue({
+          shouldProceed: false,
+          missingTables: [],
+          reason: 'probe_failed',
+          error:
+            'Could not verify table availability (connection issue): system.backup_log',
+        })
+
+        const result = await fetchData({ ...defaultParams, queryConfig })
+
+        expect(result.data).toBeNull()
+        expect(result.error?.type).toBe('network_error')
+        expect(result.error?.message).toContain(
+          'Could not verify table availability'
+        )
+        expect(mockClientQuery).not.toHaveBeenCalled()
+      })
+
       it('should not validate when queryConfig.optional is false', async () => {
         const queryConfig: QueryConfigLike = {
           name: 'test',

--- a/packages/clickhouse-client/src/clickhouse/clickhouse-fetch.ts
+++ b/packages/clickhouse-client/src/clickhouse/clickhouse-fetch.ts
@@ -196,13 +196,20 @@ export const fetchData = async <
 
       if (!validation.shouldProceed) {
         const missingTables = validation.missingTables
+        // A probe failure (network/timeout/auth) means table existence is
+        // unknown, not confirmed missing — classify it as a network error so
+        // the UI shows a connectivity/retry message instead of "table does
+        // not exist" (issue #2505).
+        const isProbeFailure = validation.reason === 'probe_failed'
         const errorMessage =
           validation.error ||
           `Missing required tables: ${missingTables.join(', ')}`
 
         warn(
-          `Skipping query "${queryConfig.name}" due to missing tables:`,
-          missingTables
+          isProbeFailure
+            ? `Skipping query "${queryConfig.name}" — could not verify table availability:`
+            : `Skipping query "${queryConfig.name}" due to missing tables:`,
+          isProbeFailure ? errorMessage : missingTables
         )
 
         return {
@@ -214,7 +221,7 @@ export const fetchData = async <
             host: clientConfig.host,
           },
           error: {
-            type: 'table_not_found',
+            type: isProbeFailure ? 'network_error' : 'table_not_found',
             message: errorMessage,
             details: {
               missingTables,

--- a/packages/clickhouse-client/src/table-existence-cache.ts
+++ b/packages/clickhouse-client/src/table-existence-cache.ts
@@ -48,11 +48,21 @@ export function setTableExistenceL2Provider(
   l2CacheProvider = provider
 }
 
+/**
+ * Result of a table-existence probe.
+ * - `true` / `false`: the probe succeeded and definitively determined
+ *   existence.
+ * - `'unknown'`: the probe itself failed (network blip, timeout, auth, …) —
+ *   existence could not be determined. Callers must not treat this the same
+ *   as `false` ("table missing"); see issue #2505.
+ */
+export type TableExistsResult = boolean | 'unknown'
+
 export async function checkTableExists(
   hostId: number,
   database: string,
   table: string
-): Promise<boolean> {
+): Promise<TableExistsResult> {
   const key = `${hostId}:${database}.${table}`
   const cached = cache.get(key)
   if (cached !== undefined) {
@@ -103,7 +113,10 @@ export async function checkTableExists(
     return exists
   } catch (err) {
     error(`Error checking table ${database}.${table}:`, err)
-    return false
+    // Transient probe failure (network/timeout/auth) — NOT "table missing".
+    // Never cached (falls through without `cache.set`/L2 `set`), so the next
+    // probe retries naturally.
+    return 'unknown'
   }
 }
 

--- a/packages/clickhouse-client/src/table-validator.ts
+++ b/packages/clickhouse-client/src/table-validator.ts
@@ -25,9 +25,19 @@ import type { QueryConfigLike } from '@chm/sql-builder'
 import { tableExistenceCache } from './table-existence-cache'
 import { getAllSqlStrings } from '@chm/sql-builder'
 
+/**
+ * Why `shouldProceed` is false:
+ * - `table_missing`: the probe succeeded and the table definitively does not
+ *   exist (optional-table UX: "requires configuration").
+ * - `probe_failed`: the probe itself errored (network/timeout/auth) —
+ *   existence is unknown, NOT confirmed missing. See issue #2505.
+ */
+export type TableValidationReason = 'table_missing' | 'probe_failed'
+
 export type TableValidationResult = {
   shouldProceed: boolean
   missingTables: string[]
+  reason?: TableValidationReason
   error?: string
 }
 
@@ -113,23 +123,38 @@ export async function validateTableExistence(
   }
 
   // Check all tables in parallel
-  const missingTables = (
-    await Promise.all(
-      tablesToCheck.map(async (fullName) => {
-        const [db, tbl] = fullName.split('.')
-        if (!db || !tbl) return fullName // malformed name
-        const exists = await tableExistenceCache.checkTableExists(
-          hostId,
-          db,
-          tbl
-        )
-        return exists ? null : fullName
-      })
-    )
-  ).filter(Boolean) as string[]
+  const results = await Promise.all(
+    tablesToCheck.map(async (fullName) => {
+      const [db, tbl] = fullName.split('.')
+      if (!db || !tbl) return { fullName, exists: false as const } // malformed name — treat as missing
+      const exists = await tableExistenceCache.checkTableExists(hostId, db, tbl)
+      return { fullName, exists }
+    })
+  )
+
+  // A probe failure (network/timeout/auth) means existence is unknown, not
+  // confirmed missing — surface it distinctly so callers don't render
+  // "table does not exist" for what's actually a transient error.
+  const unknownTables = results
+    .filter((r) => r.exists === 'unknown')
+    .map((r) => r.fullName)
+
+  if (unknownTables.length > 0) {
+    return {
+      shouldProceed: false,
+      missingTables: [],
+      reason: 'probe_failed',
+      error: `Could not verify table availability (connection issue): ${unknownTables.join(', ')}`,
+    }
+  }
+
+  const missingTables = results
+    .filter((r) => r.exists === false)
+    .map((r) => r.fullName)
 
   return {
     shouldProceed: missingTables.length === 0,
     missingTables,
+    reason: missingTables.length > 0 ? 'table_missing' : undefined,
   }
 }


### PR DESCRIPTION
## What / why

Optional-table probes (`system.backup_log`, `system.error_log`,
`system.zookeeper`, ...) caught ANY failure — network blip, timeout, auth —
and reported it identically to a confirmed-missing table. The UI then showed
"table does not exist / requires configuration" for what was actually a
transient connectivity error. Bundled: the query-cache singleton reset
functions nulled the instance without calling `dispose()`, orphaning the
adapter's 60s cleanup `setInterval` (`dispose()` was dead code).

## Changes

- `packages/clickhouse-client/src/table-existence-cache.ts`:
  `checkTableExists` now returns a tri-state `TableExistsResult` (`true |
  false | 'unknown'`) instead of collapsing a caught probe error to `false`.
  An `'unknown'` result is never cached (L1 or L2), so the next probe retries
  naturally.
- `packages/clickhouse-client/src/clickhouse-version.ts`: same tri-state fix
  for `checkTableExists`/`checkTableHasData`; `checkTableAvailability` (its
  internal consumer) now reports a distinct `checkFailed: true` + message
  instead of conflating a probe failure with "does not exist".
- `packages/clickhouse-client/src/table-validator.ts`: `validateTableExistence`
  buckets probe results into confirmed-missing vs unresolvable. When any
  table's probe fails, it returns `shouldProceed: false` with `reason:
  'probe_failed'` (vs `'table_missing'`) and a connection-issue message,
  without listing the table as "missing".
- `packages/clickhouse-client/src/clickhouse/clickhouse-fetch.ts`: `fetchData`
  maps `reason: 'probe_failed'` to the existing `FetchDataErrorType`
  `'network_error'` instead of `'table_not_found'`. This reuses the
  already-wired UI copy/variant end to end (`card-error-utils.ts` →
  `'offline'` variant / "You're offline"; `lib/error-utils.ts` → "Connection
  Error" / "Network connection error...") — no new error taxonomy needed. It
  also automatically fixes a latent bug in `routes/api/v1/menu-counts/$key.ts`,
  whose comment already states the intent ("return null count only when the
  table genuinely does not exist... other failures must surface") but
  couldn't honor it while probe failures were misreported as
  `table_not_found`.
- `apps/dashboard/src/lib/cache/{types,index}.ts`: `QueryCacheAdapter` gained
  an optional `dispose?(): void`; `resetQueryCacheInstance` /
  `resetMemoryCacheInstance` now call `instance?.dispose?.()` before nulling.
- Boundary fixups for two out-of-scope callers of the now tri-state
  `checkTableExists` (type-correctness only, no behavior change — both
  already treated a caught error the same way `'unknown'` is now handled):
  `routes/api/v1/table-availability.ts` (`'unknown'` → omit from the
  availability map, same as its existing catch) and
  `lib/ai/advisor/capacity-forecaster.ts`'s `isPartLogAvailable` (`'unknown'`
  → `false`, same as its prior fail-closed behavior).

## Verification

- `bun test packages --isolate` (matches CI's `test:packages:ci` script
  exactly): **943 pass, 0 fail** across 40 files.
- `apps/dashboard`: targeted run `bun test src/lib/cache/index.test.ts
  src/lib/ch-cloud/billing-sync.test.ts
  src/lib/ai/advisor/__tests__/capacity-forecaster.test.ts --isolate`:
  **33 pass, 0 fail**.
- Did not run `pnpm run build` / `tsc` locally per this environment's
  build-avoidance policy for parallel worktrees — reasoned through the type
  changes manually (tri-state propagation, `Extract<>` behavior for
  `spyOn` on the new optional `dispose?` member, etc.). CI's `dashboard`
  compile-check will validate.

Note: an initial plain `bun test` (no `--isolate`) surfaced 2 failures that
turned out to be **pre-existing** cross-file `mock.module` leakage in
`table-existence-cache.test.ts`, reproducible identically on unmodified
`origin/main` — unrelated to this change and out of scope here. CI already
works around it via `bun test --isolate` (see `.github/workflows/test.yml`
comment), which is why the verification above uses that exact invocation.

Closes #2505

https://claude.ai/code/session_018h2h5erikMP3aM7p8YdXfY