### PR TITLE
fix(charts): match tooltip breakdown dot colors to series; guard toLocaleString

### DIFF
--- a/apps/dashboard/src/components/charts/primitives/tooltip-breakdown-section.test.tsx
+++ b/apps/dashboard/src/components/charts/primitives/tooltip-breakdown-section.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * Tests for the tooltip breakdown section (plan 81, issue #2498).
+ *
+ * The legend dots previously used `var(--chart-${10 - index})` — descending,
+ * never matching the ascending series colors, and undefined past index 9
+ * (`--chart-0`, `--chart--1` → invisible dots). Dots must follow the exact
+ * series color arithmetic from `primitives/area.tsx` (`--chart-${index + 1}`,
+ * ascending, no modulo). The value cell previously called
+ * `value.toLocaleString()` unguarded, throwing on null/undefined.
+ *
+ * Rendering uses the repo's one-off happy-dom harness (same as
+ * `recent-query-expanded-details.test.tsx`), since components are otherwise
+ * covered by Cypress.
+ */
+
+import {
+  BreakdownSection,
+  type BreakdownValue,
+  breakdownColorVar,
+  formatBreakdownValue,
+} from './tooltip-breakdown-section'
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+beforeAll(() => {
+  GlobalRegistrator.register()
+  ;(
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+afterAll(async () => {
+  await GlobalRegistrator.unregister()
+})
+
+describe('breakdownColorVar', () => {
+  test('matches the series color arithmetic in area.tsx for every index', () => {
+    // area.tsx assigns series colors as `var(--chart-${index + 1})` (ascending,
+    // no modulo). The dot for breakdown row N must resolve the same token.
+    for (let index = 0; index < 20; index++) {
+      expect(breakdownColorVar(index)).toBe(`var(--chart-${index + 1})`)
+    }
+  })
+
+  test('index 12 still resolves a defined theme token (--chart-1..13)', () => {
+    // The theme defines --chart-1 through --chart-13; the old descending
+    // arithmetic went undefined from index 10 (`--chart-0`).
+    expect(breakdownColorVar(12)).toBe('var(--chart-13)')
+  })
+})
+
+describe('formatBreakdownValue', () => {
+  test('localizes numbers like the original rendering', () => {
+    expect(formatBreakdownValue(1234567)).toBe((1234567).toLocaleString())
+    expect(formatBreakdownValue(0)).toBe('0')
+  })
+
+  test('does not throw on non-numeric values', () => {
+    expect(formatBreakdownValue(undefined)).toBe('')
+    expect(formatBreakdownValue(null)).toBe('')
+    expect(formatBreakdownValue('n/a')).toBe('n/a')
+  })
+})
+
+describe('BreakdownSection', () => {
+  async function renderSection(
+    breakdownData: Array<[string, BreakdownValue]>,
+    item: unknown = {},
+    breakdownLabel?: string
+  ): Promise<{ text: string; html: string; cleanup: () => void }> {
+    const { act } = await import('react')
+    const { createRoot } = await import('react-dom/client')
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    act(() => {
+      root.render(
+        <BreakdownSection
+          breakdownData={breakdownData}
+          heading="Breakdown"
+          item={item}
+          breakdownLabel={breakdownLabel}
+        />
+      )
+    })
+
+    return {
+      text: container.textContent ?? '',
+      html: container.innerHTML,
+      cleanup: () => {
+        act(() => {
+          root.unmount()
+        })
+        container.remove()
+      },
+    }
+  }
+
+  test('renders non-numeric values without throwing and colors dots ascending', async () => {
+    const { text, html, cleanup } = await renderSection([
+      ['Select', 1234],
+      ['Insert', undefined],
+      ['Alter', 'n/a'],
+    ])
+
+    try {
+      expect(text).toContain('Select')
+      expect(text).toContain((1234).toLocaleString())
+      expect(text).toContain('n/a')
+      // Dots follow the series convention: row 0 → --chart-1, row 2 → --chart-3.
+      expect(html).toContain('var(--chart-1)')
+      expect(html).toContain('var(--chart-3)')
+      // The old descending arithmetic (--chart-10 for row 0) must be gone.
+      expect(html).not.toContain('var(--chart-10)')
+    } finally {
+      cleanup()
+    }
+  })
+
+  test('row index 10 gets a defined token instead of --chart-0', async () => {
+    const rows: Array<[string, BreakdownValue]> = Array.from(
+      { length: 11 },
+      (_, i) => [`kind-${i}`, i]
+    )
+    const { html, cleanup } = await renderSection(rows)
+
+    try {
+      expect(html).toContain('var(--chart-11)')
+      expect(html).not.toContain('var(--chart-0)')
+      expect(html).not.toContain('var(--chart--1)')
+    } finally {
+      cleanup()
+    }
+  })
+
+  test('non-object item falls back to the row name safely', async () => {
+    const { text, cleanup } = await renderSection(
+      [['Select', 1]],
+      undefined,
+      'query_kind'
+    )
+
+    try {
+      expect(text).toContain('Select')
+    } finally {
+      cleanup()
+    }
+  })
+})

--- a/apps/dashboard/src/components/charts/primitives/tooltip-breakdown-section.tsx
+++ b/apps/dashboard/src/components/charts/primitives/tooltip-breakdown-section.tsx
@@ -4,11 +4,37 @@
 
 import { TooltipColorIndicator } from './tooltip-color-indicator'
 
+/** Value of a breakdown entry as produced by `parseBreakdownData`. */
+export type BreakdownValue = number | string | null | undefined
+
 export interface BreakdownSectionProps {
-  breakdownData: Array<[string, any]>
+  breakdownData: Array<[string, BreakdownValue]>
   heading: string
-  item: any
+  /** Recharts tooltip item; only the optional `breakdownLabel` field is read from it. */
+  item: unknown
   breakdownLabel?: string
+}
+
+/**
+ * Color token for the breakdown dot at `index`.
+ *
+ * Mirrors the series color fallback in `primitives/area.tsx`
+ * (`--chart-${index + 1}`, ascending) so each dot follows the same convention
+ * as the series colors. Intentionally has no modulo: it stays identical to the
+ * series arithmetic, which is unbounded past the defined `--chart-1..13`
+ * tokens (pre-existing series behavior, tracked separately).
+ */
+export function breakdownColorVar(index: number): string {
+  return `var(--chart-${index + 1})`
+}
+
+/**
+ * Format a breakdown value for display without throwing on non-numbers.
+ */
+export function formatBreakdownValue(value: BreakdownValue): string {
+  return typeof value === 'number'
+    ? value.toLocaleString()
+    : String(value ?? '')
 }
 
 /**
@@ -46,9 +72,9 @@ export function BreakdownSection({
 
 interface BreakdownRowProps {
   name: string
-  value: any
+  value: BreakdownValue
   index: number
-  item: any
+  item: unknown
   breakdownLabel?: string
 }
 
@@ -62,21 +88,27 @@ function BreakdownRow({
   item,
   breakdownLabel,
 }: BreakdownRowProps) {
+  const rawLabel =
+    breakdownLabel && item && typeof item === 'object'
+      ? (item as Record<string, unknown>)[breakdownLabel]
+      : undefined
+  const label =
+    (typeof rawLabel === 'string' || typeof rawLabel === 'number') && rawLabel
+      ? String(rawLabel)
+      : name
+
   return (
     <div className="flex items-center justify-between gap-2" role="row">
       <div className="flex items-center gap-1.5 min-w-0">
         <TooltipColorIndicator
-          colorVar={`var(--chart-${10 - index})`}
+          colorVar={breakdownColorVar(index)}
           size="small"
         />
-        <span className="truncate">
-          {item[breakdownLabel as keyof typeof item] || name}
-        </span>
+        <span className="truncate">{label}</span>
       </div>
 
       <div className="text-foreground shrink-0 flex items-baseline gap-0.5 font-mono font-medium tabular-nums">
-        {value.toLocaleString()}
-        <span className="text-muted-foreground font-normal"></span>
+        {formatBreakdownValue(value)}
       </div>
     </div>
   )


### PR DESCRIPTION
## What

Fixes the chart tooltip breakdown section (`primitives/tooltip-breakdown-section.tsx`, plan 81):

- **Dot colors**: legend dots used `var(--chart-${10 - index})` — descending, never matching the ascending series colors, and undefined past index 9 (`--chart-0`, `--chart--1` → invisible dots). Dots now use `breakdownColorVar(index)` = `var(--chart-${index + 1})`, an exact mirror of the series arithmetic in `primitives/area.tsx` (the only series renderer that reaches this component — breakdown tooltips are area-chart-only, single category). No modulo, matching area.tsx exactly so dot and series can never disagree.
- **Value guard**: `value.toLocaleString()` was called on an `any`-typed value and threw on `null`/`undefined`; now `formatBreakdownValue` renders numbers localized and coerces everything else safely.
- **Cleanup**: removed the dead empty `<span>`; replaced the module's `any` props with minimal typed shapes (`BreakdownValue`, `item: unknown` narrowed internally — callers pass `unknown`, so signatures stay compatible with `area-chart-tooltip.tsx` untouched).

## Not changed (deliberate)

The >13-series token overflow (`var(--chart-14)`+ being undefined) is **pre-existing `area.tsx` behavior, intentionally not changed here** — the tooltip now inherits it by design so it stays identical to the series. Tracked in follow-up #2536 (unify series color arithmetic across area/bar/donut). Broad palette hygiene is separately scoped in #2518 (plan 101).

## Verification

- New `tooltip-breakdown-section.test.tsx` (bun + repo's happy-dom harness): color parity with area.tsx arithmetic for indexes 0–19, index 12 → defined `--chart-13`, row index 10 regression (was `--chart-0`), non-numeric values render without throwing, non-object `item` falls back safely — **7 pass locally**.
- `bun test src/components/charts --isolate`: 98 pass, 0 fail locally.
- `rg "10 - index"` in charts source → no matches (only the test's doc comment).
- Biome check clean on touched files. Full typecheck deferred to CI (`dashboard` job) per worktree constraints.

Closes #2498

https://claude.ai/code/session_018h2h5erikMP3aM7p8YdXfY