### PR TITLE
test(platform): pin binding-resolution contract

### DIFF
--- a/packages/platform/src/adapters/cloudflare.test.ts
+++ b/packages/platform/src/adapters/cloudflare.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Pins CloudflarePlatformBindings' binding-resolution contract:
+ * - env has the binding -> returned as-is (reference equality)
+ * - env lacks the binding, or the context has no env at all -> null
+ * - getCloudflareContext() throws -> null, the error never escapes
+ *
+ * `@opennextjs/cloudflare` is mocked out (this is the ONLY file that should
+ * import it, per cloudflare.ts's header comment) so these tests exercise the
+ * adapter's own null-swallowing logic in isolation. Plan 96 replaces
+ * getCloudflareContext with a different context source; these tests define
+ * the public contract that replacement must preserve.
+ */
+
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+const mockGetCloudflareContext = mock((): unknown => undefined)
+
+mock.module('@opennextjs/cloudflare', () => ({
+  getCloudflareContext: mockGetCloudflareContext,
+}))
+
+// Cache-busting query string gives this describe block its own module
+// instance, matching the convention in connection-pool.test.ts /
+// table-existence-cache.test.ts to avoid cross-file mock.module pollution
+// when the whole package runs as one Bun process (no --isolate).
+const { CloudflarePlatformBindings } = await import(
+  new URL('./cloudflare.ts?test=cloudflare-adapter', import.meta.url).href
+)
+
+describe('CloudflarePlatformBindings', () => {
+  let bindings: InstanceType<typeof CloudflarePlatformBindings>
+
+  beforeEach(() => {
+    mockGetCloudflareContext.mockReset()
+    mockGetCloudflareContext.mockReturnValue(undefined)
+    bindings = new CloudflarePlatformBindings()
+  })
+
+  describe('getD1Database', () => {
+    it('returns the binding as-is when present in env', () => {
+      const fakeDb = { __marker: 'd1' } as unknown as D1Database
+      mockGetCloudflareContext.mockReturnValue({ env: { MY_DB: fakeDb } })
+
+      expect(bindings.getD1Database('MY_DB')).toBe(fakeDb)
+    })
+
+    it('returns null when the binding name is absent from env', () => {
+      mockGetCloudflareContext.mockReturnValue({ env: { OTHER_DB: {} } })
+
+      expect(bindings.getD1Database('MY_DB')).toBeNull()
+    })
+
+    it('returns null when the context has no env', () => {
+      mockGetCloudflareContext.mockReturnValue({})
+
+      expect(bindings.getD1Database('MY_DB')).toBeNull()
+    })
+
+    it('returns null when getCloudflareContext() itself returns undefined', () => {
+      mockGetCloudflareContext.mockReturnValue(undefined)
+
+      expect(bindings.getD1Database('MY_DB')).toBeNull()
+    })
+
+    it('returns null, and does not throw, when getCloudflareContext() throws', () => {
+      mockGetCloudflareContext.mockImplementation(() => {
+        throw new Error('called outside a request context')
+      })
+
+      expect(() => bindings.getD1Database('MY_DB')).not.toThrow()
+      expect(bindings.getD1Database('MY_DB')).toBeNull()
+    })
+  })
+
+  describe('getDurableObjectNamespace', () => {
+    it('returns the binding as-is when present in env', () => {
+      const fakeNamespace = {
+        __marker: 'do',
+      } as unknown as DurableObjectNamespace
+      mockGetCloudflareContext.mockReturnValue({
+        env: { MY_DO: fakeNamespace },
+      })
+
+      expect(bindings.getDurableObjectNamespace('MY_DO')).toBe(fakeNamespace)
+    })
+
+    it('returns null when the binding name is absent from env', () => {
+      mockGetCloudflareContext.mockReturnValue({ env: { OTHER_DO: {} } })
+
+      expect(bindings.getDurableObjectNamespace('MY_DO')).toBeNull()
+    })
+
+    it('returns null when the context has no env', () => {
+      mockGetCloudflareContext.mockReturnValue({})
+
+      expect(bindings.getDurableObjectNamespace('MY_DO')).toBeNull()
+    })
+
+    it('returns null when getCloudflareContext() itself returns undefined', () => {
+      mockGetCloudflareContext.mockReturnValue(undefined)
+
+      expect(bindings.getDurableObjectNamespace('MY_DO')).toBeNull()
+    })
+
+    it('returns null, and does not throw, when getCloudflareContext() throws', () => {
+      mockGetCloudflareContext.mockImplementation(() => {
+        throw new Error('called outside a request context')
+      })
+
+      expect(() => bindings.getDurableObjectNamespace('MY_DO')).not.toThrow()
+      expect(bindings.getDurableObjectNamespace('MY_DO')).toBeNull()
+    })
+  })
+})

--- a/packages/platform/src/adapters/memory.test.ts
+++ b/packages/platform/src/adapters/memory.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Pins MemoryPlatformBindings' contract: every binding lookup returns null,
+ * unconditionally, for both methods. This is the non-Cloudflare fallback
+ * (dev/tests/self-hosted without D1) that every D1-backed store degrades to
+ * "not configured" against.
+ *
+ * Deviation from the plan: the plan's step 2 asked to test a "seeding
+ * interface" (get-after-set) on this adapter. There isn't one -- the current
+ * memory.ts carries no state at all and always returns null (see the file's
+ * own header comment). Per the plan's own scope ("no production changes" /
+ * "out of scope: production adapter code") and STOP condition ("do not
+ * refactor production code for testability here"), this suite tests the
+ * actual always-null contract instead of adding an unrequested seeding API.
+ */
+
+import type { PlatformBindings } from '../types'
+
+import { MemoryPlatformBindings } from './memory'
+import { describe, expect, it } from 'bun:test'
+
+describe('MemoryPlatformBindings', () => {
+  it('implements the PlatformBindings contract', () => {
+    const bindings: PlatformBindings = new MemoryPlatformBindings()
+
+    expect(typeof bindings.getD1Database).toBe('function')
+    expect(typeof bindings.getDurableObjectNamespace).toBe('function')
+  })
+
+  describe('getD1Database', () => {
+    it('returns null for a realistic binding name', () => {
+      const bindings = new MemoryPlatformBindings()
+
+      expect(bindings.getD1Database('CHM_CLOUD_D1')).toBeNull()
+    })
+
+    it('returns null for an empty binding name', () => {
+      const bindings = new MemoryPlatformBindings()
+
+      expect(bindings.getD1Database('')).toBeNull()
+    })
+
+    it('returns null consistently across repeated and differing calls', () => {
+      const bindings = new MemoryPlatformBindings()
+
+      expect(bindings.getD1Database('CHM_CLOUD_D1')).toBeNull()
+      expect(bindings.getD1Database('CHM_CLOUD_D1')).toBeNull()
+      expect(bindings.getD1Database('SOME_OTHER_DB')).toBeNull()
+    })
+  })
+
+  describe('getDurableObjectNamespace', () => {
+    it('returns null for a realistic binding name', () => {
+      const bindings = new MemoryPlatformBindings()
+
+      expect(
+        bindings.getDurableObjectNamespace('AGENT_CONVERSATIONS_DO')
+      ).toBeNull()
+    })
+
+    it('returns null for an empty binding name', () => {
+      const bindings = new MemoryPlatformBindings()
+
+      expect(bindings.getDurableObjectNamespace('')).toBeNull()
+    })
+
+    it('returns null consistently across repeated and differing calls', () => {
+      const bindings = new MemoryPlatformBindings()
+
+      expect(
+        bindings.getDurableObjectNamespace('AGENT_CONVERSATIONS_DO')
+      ).toBeNull()
+      expect(
+        bindings.getDurableObjectNamespace('AGENT_CONVERSATIONS_DO')
+      ).toBeNull()
+      expect(bindings.getDurableObjectNamespace('SOME_OTHER_DO')).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## What

Adds tests for `packages/platform`'s two `PlatformBindings` adapters, which
had zero tests despite being the single resolution choke point every
D1-backed store (connections, conversations, insights, billing subscription,
health) depends on:

- `packages/platform/src/adapters/cloudflare.test.ts` — mocks
  `@opennextjs/cloudflare`'s `getCloudflareContext` (this is the only
  production file that imports it) and covers both `getD1Database` and
  `getDurableObjectNamespace`: binding present in env -> returned as-is
  (reference equality), binding absent / context has no env -> `null`,
  `getCloudflareContext()` throws -> `null`, error never escapes.
- `packages/platform/src/adapters/memory.test.ts` — pins
  `MemoryPlatformBindings`' always-`null` contract for both methods.

No production code changed.

## Why

Plan 96 will replace `@opennextjs/cloudflare`'s `getCloudflareContext` with a
different context source. These tests pin the adapter's public
null-swallow-on-missing / null-swallow-on-throw contract so that spike has a
safety net to keep green while swapping the underlying context source.

## Deviation from the plan

The plan's step 2 asked to test the memory adapter's "seeding interface"
(get-after-set + missing-name -> null). Reading `memory.ts`, there isn't one
— it carries no internal state and unconditionally returns `null` from both
methods (see its own header comment: "Returns null for all bindings since no
platform services are available outside of Cloudflare Workers"). Per the
plan's own scope ("Test-only plan — no production changes" / "Out of scope:
production adapter code") and STOP condition ("do not refactor production
code for testability here — that seam is plan 96's business"), I tested the
actual always-null contract instead of adding an unrequested seeding API to
production code.

Also skipped adding a `test` script to `packages/platform/package.json`.
Verified empirically that **no** package under `packages/*`
(clickhouse-client, logger, mcp-server, pricing, sql-builder, types) has a
`test` script — there was no sibling to copy. `bun test` runs directly
without one, and the root `test:packages` / `test:packages:ci` scripts
(`bun test packages --isolate ...`, which is what the required `unit-tests`
CI job actually runs) already glob `packages/**/*.test.ts` regardless of
per-package scripts. Adding one here would diverge from every sibling
package's convention for no functional benefit.

## Tests

- `cd packages/platform && bun test` → **17 pass, 0 fail** (24 `expect()`
  calls, 2 files)
- Also ran `bun test packages/platform --isolate` from the repo root to
  match exactly how the required `unit-tests` CI job invokes
  `test:packages:ci` → same result, 17 pass.
- Ran locally via a temporary `node_modules` symlink into the main
  checkout (this worktree has no installed dependencies); symlink removed
  before committing.
- `biome check --write` run on both new files (one import-order fix
  applied).

Closes #2512

https://claude.ai/code/session_018h2h5erikMP3aM7p8YdXfY