### PR TITLE
test(billing): cover plan resolution and subscription-live boundary

### DIFF
--- a/apps/dashboard/src/lib/billing/polar-config.test.ts
+++ b/apps/dashboard/src/lib/billing/polar-config.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for polar-config.ts's product↔plan mapping — the bridge between a
+ * Polar checkout (productId) and our internal plan/period. A stale or
+ * misconfigured CHM_POLAR_PRODUCT_<PLAN>_<PERIOD> env var here grants the
+ * wrong plan after checkout, silently — no error, just wrong entitlements
+ * (issue #2493).
+ *
+ * `productIdFor` / `planForProductId` read directly from `process.env` via
+ * the module's private `readEnv()`, so tests just set/restore the relevant
+ * env vars around each test — same convention as lib/auth/provider.test.ts.
+ * No module mocking needed: polar-config.ts's only runtime import is
+ * `@polar-sh/sdk`, used lazily by `getPolarClient()`, which these tests never
+ * call.
+ */
+
+import type { BillingPeriod, PaidPlanId } from './polar-config'
+
+import { PAID_PLAN_IDS, planForProductId, productIdFor } from './polar-config'
+import { afterEach, describe, expect, test } from 'bun:test'
+
+const PERIODS: readonly BillingPeriod[] = ['monthly', 'yearly']
+
+function envKey(planId: PaidPlanId, period: BillingPeriod): string {
+  return `CHM_POLAR_PRODUCT_${planId.toUpperCase()}_${period.toUpperCase()}`
+}
+
+const ALL_ENV_KEYS = PAID_PLAN_IDS.flatMap((planId) =>
+  PERIODS.map((period) => envKey(planId, period))
+)
+const originalEnv = new Map(ALL_ENV_KEYS.map((key) => [key, process.env[key]]))
+
+afterEach(() => {
+  for (const key of ALL_ENV_KEYS) {
+    const original = originalEnv.get(key)
+    if (original === undefined) delete process.env[key]
+    else process.env[key] = original
+  }
+})
+
+describe('productIdFor / planForProductId — round trip', () => {
+  const cases = PAID_PLAN_IDS.flatMap((planId) =>
+    PERIODS.map((period) => [planId, period] as const)
+  )
+
+  test.each(
+    cases
+  )('%s/%s: planForProductId(productIdFor(plan, period)) round-trips to {plan, period}', (planId, period) => {
+    process.env[envKey(planId, period)] = `prod_${planId}_${period}_test`
+
+    const productId = productIdFor(planId, period)
+    expect(productId).toBe(`prod_${planId}_${period}_test`)
+    // The reverse map must recover exactly the plan/period that produced
+    // the id — this is the checkout→entitlement bridge; if it silently
+    // drifted, checkout would grant the wrong plan.
+    expect(planForProductId(productId as string)).toEqual({
+      planId,
+      period,
+    })
+  })
+})
+
+describe('productIdFor — unconfigured env', () => {
+  test('an unset CHM_POLAR_PRODUCT_* var resolves to null', () => {
+    delete process.env[envKey('pro', 'monthly')]
+    expect(productIdFor('pro', 'monthly')).toBeNull()
+  })
+
+  test('an empty-string env var resolves to null (readEnv treats "" as unset)', () => {
+    process.env[envKey('pro', 'monthly')] = ''
+    expect(productIdFor('pro', 'monthly')).toBeNull()
+  })
+})
+
+describe('planForProductId — unmapped product id', () => {
+  test('a product id that matches no configured plan/period returns null', () => {
+    for (const planId of PAID_PLAN_IDS) {
+      for (const period of PERIODS) {
+        process.env[envKey(planId, period)] = `prod_${planId}_${period}`
+      }
+    }
+
+    expect(planForProductId('prod_totally_unrelated')).toBeNull()
+  })
+
+  test('with every product id unset, an empty product id still never matches', () => {
+    // Guards against a naive implementation where every unconfigured slot
+    // resolving to the same "empty" sentinel could false-positive-match an
+    // equally empty productId argument.
+    for (const key of ALL_ENV_KEYS) delete process.env[key]
+
+    expect(planForProductId('')).toBeNull()
+  })
+})

--- a/apps/dashboard/src/lib/billing/user-subscription.test.ts
+++ b/apps/dashboard/src/lib/billing/user-subscription.test.ts
@@ -1,6 +1,9 @@
 /**
- * Tests for user-subscription.ts's `isSubscriptionLive` predicate — the core
- * of plan resolution (issue #2382, annual billing end-to-end).
+ * Tests for user-subscription.ts's plan-resolution contract:
+ * `isSubscriptionLive` (status allowlist + expiry boundary) and
+ * `getPlanIdForOwner` (issue #2382 annual billing end-to-end; issue #2493
+ * closes the coverage gap on the boundary + owner-resolution layer — the
+ * paid-vs-free decision itself had zero coverage before this).
  *
  * Annual subscriptions carry a `currentPeriodEnd` ~365 days out instead of the
  * usual ~30, but liveness is decided purely by `status` + `currentPeriodEnd` —
@@ -8,21 +11,87 @@
  * future change doesn't accidentally special-case yearly subscriptions (e.g.
  * treating them as always-live because the period "looks far away").
  *
+ * The expiry boundary is a strict `<`: a subscription whose `currentPeriodEnd`
+ * equals `nowSeconds` is still live for that instant. If that comparison ever
+ * flips to `<=`, a paying customer loses access one second early — the
+ * "expiry boundary" describe block below exists to catch exactly that
+ * regression.
+ *
  * user-subscription.ts statically imports subscription-store.ts →
  * @chm/platform → platform-native, which imports the virtual
  * `cloudflare:workers` module that only resolves under vite/workerd — stub it
  * the same way retention-owner.test.ts does. `isSubscriptionLive` itself is a
- * pure function so no D1/Polar mocking is needed beyond making the import
- * resolve.
+ * pure function so no D1/Polar mocking is needed for it beyond making the
+ * import resolve. `getPlanIdForOwner` DOES call through to the store/Polar
+ * reconciliation, so it additionally mocks `./subscription-store` and
+ * `./polar-subscription` with their FULL real export surface (not just what
+ * this file needs): bun's mock.module() registers per resolved specifier, and
+ * routes/api/v1/webhooks/polar.test.ts also mocks these same two modules (via
+ * the `@/` alias, which resolves to the same files) with a different, smaller
+ * export subset. Both files can run in one `bun test` process, so an
+ * incomplete mock here risks "export not found" if the OTHER file's factory
+ * wins the registration race — mirrors the documented pattern in
+ * polar-subscription.test.ts for polar-config.ts.
  */
 
-import { describe, expect, mock, test } from 'bun:test'
+import type { PlanId } from './plans'
+import type { OwnerSubscription } from './polar-subscription'
+import type {
+  UpsertSubscriptionInput,
+  UserSubscription,
+} from './subscription-store'
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
 
 mock.module('cloudflare:workers', () => ({ env: {} }))
 
-const { isSubscriptionLive } = await import('./user-subscription')
+let getSubscriptionImpl = mock(
+  async (_ownerId: string): Promise<UserSubscription | null> => null
+)
+let upsertSubscriptionImpl = mock(
+  async (_input: UpsertSubscriptionInput): Promise<void> => {}
+)
+mock.module('./subscription-store', () => ({
+  getSubscription: (ownerId: string) => getSubscriptionImpl(ownerId),
+  upsertSubscription: (input: UpsertSubscriptionInput) =>
+    upsertSubscriptionImpl(input),
+}))
+
+let pullOwnerSubscriptionFromPolarImpl = mock(
+  async (_externalId: string): Promise<OwnerSubscription | null> => null
+)
+mock.module('./polar-subscription', () => ({
+  pullOwnerSubscriptionFromPolar: (externalId: string) =>
+    pullOwnerSubscriptionFromPolarImpl(externalId),
+  invalidateNegativeCache: (_externalId: string) => {},
+  __resetPolarSubscriptionCacheForTests: () => {},
+}))
+
+const { isSubscriptionLive, getPlanIdForOwner } = await import(
+  './user-subscription'
+)
 
 const NOW = 1_800_000_000 // fixed reference instant
+
+/** A realistic D1-cached row; override only the fields a test cares about. */
+function fakeCachedSubscription(
+  overrides: Partial<UserSubscription> = {}
+): UserSubscription {
+  return {
+    userId: 'user_fixture',
+    ownerType: 'user',
+    planId: 'pro',
+    billingPeriod: 'monthly',
+    status: 'active',
+    polarSubscriptionId: 'sub_fixture',
+    polarCustomerId: 'cus_fixture',
+    currentPeriodEnd: null,
+    cancelAtPeriodEnd: false,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  }
+}
 
 describe('isSubscriptionLive — annual billing intervals', () => {
   test('an active yearly subscription with currentPeriodEnd ~365 days out is live', () => {
@@ -87,5 +156,88 @@ describe('isSubscriptionLive — annual billing intervals', () => {
     expect(
       isSubscriptionLive({ status: 'active', currentPeriodEnd: null }, NOW)
     ).toBe(true)
+  })
+})
+
+describe('isSubscriptionLive — status allowlist (LIVE vs DEAD statuses)', () => {
+  // Same unexpired currentPeriodEnd for every case so only `status` varies —
+  // isolates the allowlist check from the expiry boundary (covered below).
+  const unexpired = NOW + 30 * 24 * 60 * 60
+
+  test.each([
+    ['active', true],
+    ['trialing', true],
+    ['canceled', false],
+    ['past_due', false],
+    ['revoked', false],
+    // An unrecognized status must fail closed (not live), not fail open.
+    ['some_unrecognized_polar_status', false],
+  ] as const)('status "%s" with an unexpired period → live=%s', (status, expected) => {
+    expect(
+      isSubscriptionLive({ status, currentPeriodEnd: unexpired }, NOW)
+    ).toBe(expected)
+  })
+})
+
+describe('isSubscriptionLive — expiry boundary (strict less-than contract)', () => {
+  // The contract is `currentPeriodEnd < nowSeconds` ⇒ expired — strict, not
+  // `<=`. If someone "simplifies" that to `<=`, a subscription expiring at
+  // exactly `now` loses access one instant early; this table exists to fail
+  // loudly the moment that happens.
+  test.each([
+    [
+      'currentPeriodEnd === nowSeconds (the boundary instant itself)',
+      NOW,
+      true,
+    ],
+    ['currentPeriodEnd one second before nowSeconds', NOW - 1, false],
+    ['currentPeriodEnd is null (no expiry tracked)', null, true],
+  ] as const)('%s → live=%s', (_label, currentPeriodEnd, expected) => {
+    expect(
+      isSubscriptionLive({ status: 'active', currentPeriodEnd }, NOW)
+    ).toBe(expected)
+  })
+})
+
+describe('getPlanIdForOwner', () => {
+  beforeEach(() => {
+    // Default: no D1 row, no Polar customer — the common free-user case.
+    // Individual tests override one or both to exercise the other paths.
+    getSubscriptionImpl = mock(async () => null)
+    upsertSubscriptionImpl = mock(async () => {})
+    pullOwnerSubscriptionFromPolarImpl = mock(async () => null)
+  })
+
+  test('no subscription anywhere (D1 empty, Polar has no customer) resolves to free', async () => {
+    expect(await getPlanIdForOwner('user_none')).toBe('free')
+  })
+
+  test('a live cached subscription resolves to its own plan, not free', async () => {
+    getSubscriptionImpl = mock(async () =>
+      fakeCachedSubscription({ planId: 'max' })
+    )
+
+    expect(await getPlanIdForOwner('user_max')).toBe('max')
+  })
+
+  test('a dead cached subscription — and Polar confirms nothing live — resolves to free', async () => {
+    getSubscriptionImpl = mock(async () =>
+      fakeCachedSubscription({ status: 'canceled', planId: 'pro' })
+    )
+    pullOwnerSubscriptionFromPolarImpl = mock(async () => null)
+
+    expect(await getPlanIdForOwner('user_lapsed')).toBe('free')
+  })
+
+  test('an unknown/retired planId on an otherwise-live row falls back to free via validPlanId', async () => {
+    // Simulates a D1 row written before a plan was renamed or retired — D1
+    // data isn't compile-time checked, so validPlanId() is the runtime guard
+    // against exactly this. The cast is deliberate: PlanId's real union can't
+    // express an invalid id, which is the scenario under test.
+    getSubscriptionImpl = mock(async () =>
+      fakeCachedSubscription({ planId: 'legacy_tier_x' as PlanId })
+    )
+
+    expect(await getPlanIdForOwner('user_legacy')).toBe('free')
   })
 })


### PR DESCRIPTION
## What

Characterization tests for the paid-vs-free decision layer, which had zero
coverage: `isSubscriptionLive` (status allowlist + expiry boundary),
`getPlanIdForOwner`, and the Polar product<->plan mapping
(`productIdFor`/`planForProductId`).

## Why

An off-by-one at the expiry boundary silently downgrades a paying customer
(or extends a lapsed one); a stale product mapping grants the wrong plan
after checkout. Adjacent billing modules are already tested (entitlements,
plan-enforcement, seat-enforcement, subscription-store, polar-subscription)
— this closes the gap tying them together.

New coverage:
- **Expiry boundary (the core contract)**: `currentPeriodEnd === nowSeconds`
  is still live (strict `<`, not `<=`); `nowSeconds - 1` is not; `null` is
  always live. If the comparison operator ever flips, this fails loudly.
- **Status allowlist**: `active`/`trialing` are live; `canceled`/`past_due`/
  `revoked`/an unrecognized status all fail closed.
- **`getPlanIdForOwner`**: no subscription -> free; live subscription -> its
  plan; dead subscription (D1 dead + Polar confirms nothing) -> free; an
  unknown/retired planId on an otherwise-live row -> free via `validPlanId`.
- **`polar-config.ts` round trip**: `planForProductId(productIdFor(plan,
  period))` recovers `{plan, period}` for every paid plan x
  {monthly, yearly}; unset/empty env -> null; unmapped product id -> null.

## Scope note (drift from the plan)

`user-subscription.test.ts` already existed (issue #2382, annual billing,
landed after the plan was authored) but only covered `isSubscriptionLive`
for yearly-billing scenarios — missing the exact boundary case, non-canceled
dead statuses, and `getPlanIdForOwner` entirely. Extended it in place rather
than duplicating/overwriting.

**Deferred** (plan's stretch step 3): `resolveBillingOwner` /
`resolveOwnerUsage`. These need meaningfully more mocking surface (Clerk
`auth()` + 5 dependent stores) for a usage-aggregation concern that's
tangential to this plan's paid-vs-free focus — noting as deferred per the
plan's own escape hatch rather than gold-plating.

## Testing

Verified locally (bun 1.3.14, node_modules symlinked from the main
checkout since this worktree has none):
- `bun test src/lib/billing` -> 161 pass, 0 fail (14 files, includes the two
  changed/added files plus all pre-existing billing tests unaffected)
- `bun test src/ --isolate` (matches `pnpm run test` exactly) -> 6317 pass,
  0 fail, 389 files — full-suite run specifically to rule out the
  cross-file `mock.module` registration-race risk documented in
  `polar-subscription.test.ts`'s comments, since `getPlanIdForOwner`'s mocks
  of `./subscription-store` / `./polar-subscription` share a specifier with
  `routes/api/v1/webhooks/polar.test.ts`'s (smaller) mocks of the same two
  modules. Confirmed safe in both orderings and with/without `--isolate`.
- Did not run `pnpm run build` (no network/install in this worktree per
  environment constraints) — CI's `dashboard` check covers `tsc --noEmit`.

Closes #2493

https://claude.ai/code/session_018h2h5erikMP3aM7p8YdXfY