### PR TITLE
fix(insights): add NaN guards to FastestScanStat and AvgDurationStat

### DIFF
--- a/apps/dashboard/src/routes/(dashboard)/-insights/record-stats.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/-insights/record-stats.tsx
@@ -70,9 +70,10 @@ export function FastestScanStat({
   if (
     d.bytes_per_second === null ||
     d.bytes_per_second === undefined ||
+    Number.isNaN(Number(d.bytes_per_second)) ||
     d.readable_speed === null ||
     d.readable_speed === undefined ||
-    d.readable_speed === 'NaN'
+    String(d.readable_speed).toLowerCase() === 'nan'
   ) {
     return statEmpty(label, sql, data, metadata)
   }

--- a/apps/dashboard/src/routes/(dashboard)/-insights/traffic-stats.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/-insights/traffic-stats.tsx
@@ -153,6 +153,9 @@ export function AvgDurationStat({
   if (isLoading) return statLoading(label)
   if (error || !data?.length) return statEmpty(label, sql, data, metadata)
   const d = data[0] as { avg_duration_ms: number; query_count: number }
+  if (Number.isNaN(Number(d.avg_duration_ms))) {
+    return statEmpty(label, sql, data, metadata)
+  }
   return (
     <StatCard
       title={label}


### PR DESCRIPTION
## Summary
- `FastestScanStat`: replace exact-case `'NaN'` string match with `Number.isNaN(Number(bytes_per_second))` + lowercase-normalized `readable_speed` check, matching the pattern already used by `LargestScanStat`/`LongestQueryStat`.
- `AvgDurationStat`: add a `Number.isNaN(Number(avg_duration_ms))` guard, since the aggregate subquery always returns one row (so `!data?.length` never trips on zero-query windows).

## Test plan
- Manual reasoning: ClickHouse's `formatReadableSize` renders NaN as lowercase `"nan"`, which the old exact match on `'NaN'` never caught; now guarded.
- No existing test file colocated with these components.

Fixes #2469