### PR TITLE
fix(connections): correct addConnection hostId return and single-flight device key

### DIFF
--- a/apps/dashboard/src/lib/connection-crypto/browser-crypto.test.ts
+++ b/apps/dashboard/src/lib/connection-crypto/browser-crypto.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import {
+  __resetDeviceKeyPromiseForTest,
+  decryptJson,
+  encryptJson,
+  getOrCreateDeviceKey,
+} from './browser-crypto'
+
+// Minimal in-memory IndexedDB stub — just enough for the device-key store
+// (single object store, get/put by key). Requests resolve on a microtask, which
+// is what opens the check-then-act race the single-flight guard must close.
+function installFakeIndexedDB() {
+  const data = new Map<string, unknown>()
+  let generateCount = 0
+
+  const fire = <T>(req: { onsuccess?: () => void; result: T }) => {
+    queueMicrotask(() => req.onsuccess?.())
+  }
+
+  const store = {
+    get(key: string) {
+      const req: { onsuccess?: () => void; onerror?: () => void; result: unknown } = {
+        result: data.has(key) ? data.get(key) : undefined,
+      }
+      fire(req)
+      return req
+    },
+    put(value: unknown, key: string) {
+      generateCount++
+      const req: { onsuccess?: () => void; onerror?: () => void } = {}
+      data.set(key, value)
+      queueMicrotask(() => req.onsuccess?.())
+      return req
+    },
+  }
+
+  const fakeIndexedDB = {
+    open() {
+      const req: {
+        onupgradeneeded?: () => void
+        onsuccess?: () => void
+        onerror?: () => void
+        result: unknown
+      } = {
+        result: {
+          objectStoreNames: { contains: () => true },
+          createObjectStore: () => store,
+          transaction: () => ({ objectStore: () => store }),
+        },
+      }
+      queueMicrotask(() => {
+        req.onupgradeneeded?.()
+        req.onsuccess?.()
+      })
+      return req
+    },
+  }
+
+  ;(globalThis as { indexedDB?: unknown }).indexedDB = fakeIndexedDB
+  return {
+    putCount: () => generateCount,
+  }
+}
+
+describe('browser-crypto device key', () => {
+  let harness: ReturnType<typeof installFakeIndexedDB>
+
+  beforeEach(() => {
+    __resetDeviceKeyPromiseForTest()
+    harness = installFakeIndexedDB()
+  })
+
+  afterEach(() => {
+    __resetDeviceKeyPromiseForTest()
+  })
+
+  it('single-flights concurrent creation onto one key (no first-run race)', async () => {
+    const [a, b, c] = await Promise.all([
+      getOrCreateDeviceKey(),
+      getOrCreateDeviceKey(),
+      getOrCreateDeviceKey(),
+    ])
+
+    // Same CryptoKey instance for every concurrent caller...
+    expect(a).toBe(b)
+    expect(b).toBe(c)
+    // ...and the key was persisted exactly once (no discarded key whose
+    // ciphertext would become undecryptable).
+    expect(harness.putCount()).toBe(1)
+  })
+
+  it('round-trips encrypt/decrypt with the shared key', async () => {
+    const value = { host: 'https://ch.example:8443', user: 'default' }
+    const encrypted = await encryptJson(value)
+    expect(await decryptJson(encrypted)).toEqual(value)
+  })
+})

--- a/apps/dashboard/src/lib/connection-crypto/browser-crypto.test.ts
+++ b/apps/dashboard/src/lib/connection-crypto/browser-crypto.test.ts
@@ -92,6 +92,6 @@ describe('browser-crypto device key', () => {
   it('round-trips encrypt/decrypt with the shared key', async () => {
     const value = { host: 'https://ch.example:8443', user: 'default' }
     const encrypted = await encryptJson(value)
-    expect(await decryptJson(encrypted)).toEqual(value)
+    expect(await decryptJson<typeof value>(encrypted)).toEqual(value)
   })
 })

--- a/apps/dashboard/src/lib/connection-crypto/browser-crypto.ts
+++ b/apps/dashboard/src/lib/connection-crypto/browser-crypto.ts
@@ -23,16 +23,29 @@ async function openKeyDb(): Promise<IDBDatabase> {
   })
 }
 
-async function getOrCreateDeviceKey(): Promise<CryptoKey> {
+// Single-flight guard: without it, `getOrCreateDeviceKey` is check-then-act
+// (read in a readonly tx, then generate + put in a separate readwrite tx). Two
+// concurrent first calls could both miss the key and each generate a distinct
+// one — last write wins, and ciphertext under the discarded key becomes
+// permanently undecryptable. Memoizing the in-flight promise collapses
+// concurrent callers onto one key. Reset to null on failure so a later call can
+// retry.
+let keyPromise: Promise<CryptoKey> | null = null
+
+async function createDeviceKey(): Promise<CryptoKey> {
   const db = await openKeyDb()
-  const stored = await new Promise<CryptoKey | null>((resolve, reject) => {
-    const tx = db.transaction(KEY_STORE_NAME, 'readonly')
-    const req = tx.objectStore(KEY_STORE_NAME).get(KEY_ID)
+
+  // Re-read inside the readwrite tx before generating, so a key persisted by a
+  // concurrent tab (or an earlier session) wins over a fresh generate.
+  const existing = await new Promise<CryptoKey | null>((resolve, reject) => {
+    const tx = db.transaction(KEY_STORE_NAME, 'readwrite')
+    const store = tx.objectStore(KEY_STORE_NAME)
+    const req = store.get(KEY_ID)
     req.onsuccess = () => resolve((req.result as CryptoKey) ?? null)
     req.onerror = () => reject(req.error)
   })
 
-  if (stored) return stored
+  if (existing) return existing
 
   const key = await crypto.subtle.generateKey(
     { name: ALGORITHM, length: 256 },
@@ -48,6 +61,22 @@ async function getOrCreateDeviceKey(): Promise<CryptoKey> {
   })
 
   return key
+}
+
+export function getOrCreateDeviceKey(): Promise<CryptoKey> {
+  if (keyPromise) return keyPromise
+
+  keyPromise = createDeviceKey().catch((error) => {
+    keyPromise = null
+    throw error
+  })
+
+  return keyPromise
+}
+
+/** Test-only: clear the memoized device-key promise between cases. */
+export function __resetDeviceKeyPromiseForTest(): void {
+  keyPromise = null
 }
 
 export async function encryptJson<T>(value: T): Promise<string> {

--- a/apps/dashboard/src/lib/hooks/use-browser-connections.ts
+++ b/apps/dashboard/src/lib/hooks/use-browser-connections.ts
@@ -8,6 +8,7 @@ import {
   BROWSER_CONNECTIONS_STORAGE_KEY,
   type BrowserConnection,
   type EncryptedBrowserConnectionsStore,
+  nextBrowserConnectionHostId,
 } from '@/lib/types/browser-connection'
 
 async function loadConnections(): Promise<BrowserConnection[]> {
@@ -30,7 +31,13 @@ async function loadConnections(): Promise<BrowserConnection[]> {
       return decryptJson<BrowserConnection[]>(parsed.encrypted)
     }
   } catch (error) {
-    console.error('Failed to load browser connections:', error)
+    // A decrypt failure here means stored connections are unrecoverable (e.g. a
+    // device key was regenerated). Log a distinct, diagnosable warning rather
+    // than silently dropping them into the empty-list fallback below.
+    console.error(
+      'Failed to load browser connections (stored connections could not be decrypted):',
+      error
+    )
   }
 
   return []
@@ -79,11 +86,15 @@ export function useBrowserConnections() {
       updatedAt: now,
     }
 
-    let result = newConnection
+    // Derive the (negative) hostId deterministically from the current state
+    // BEFORE dispatching, so the returned object is stable and correct. The
+    // React state updater does not run synchronously with this call, so we must
+    // not read the computed hostId back out of it (that returned hostId: 0, the
+    // placeholder, and navigated callers to ?host=0 — the first env host).
+    const hostId = nextBrowserConnectionHostId(connections)
+    const result: BrowserConnection = { ...newConnection, hostId }
+
     setConnections((prev) => {
-      const existingHostIds = prev.map((c) => c.hostId)
-      const hostId = Math.min(...existingHostIds, 0) - 1
-      result = { ...newConnection, hostId }
       const updated = [...prev, result]
       void saveConnections(updated)
       return updated

--- a/apps/dashboard/src/lib/types/browser-connection.test.ts
+++ b/apps/dashboard/src/lib/types/browser-connection.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  type BrowserConnection,
+  nextBrowserConnectionHostId,
+} from './browser-connection'
+
+const conn = (hostId: number): Pick<BrowserConnection, 'hostId'> => ({ hostId })
+
+describe('nextBrowserConnectionHostId', () => {
+  it('returns -1 for an empty list (never collides with env host 0)', () => {
+    expect(nextBrowserConnectionHostId([])).toBe(-1)
+  })
+
+  it('returns one below the smallest existing negative hostId', () => {
+    expect(nextBrowserConnectionHostId([conn(-1), conn(-2)])).toBe(-3)
+  })
+
+  it('ignores gaps and always goes below the minimum', () => {
+    expect(nextBrowserConnectionHostId([conn(-1), conn(-5)])).toBe(-6)
+  })
+
+  it('never returns 0 (the placeholder that routed callers to the first env host)', () => {
+    expect(nextBrowserConnectionHostId([conn(-1)])).not.toBe(0)
+    expect(nextBrowserConnectionHostId([])).not.toBe(0)
+  })
+})

--- a/apps/dashboard/src/lib/types/browser-connection.ts
+++ b/apps/dashboard/src/lib/types/browser-connection.ts
@@ -12,6 +12,18 @@ export interface BrowserConnection {
 export const BROWSER_CONNECTIONS_STORAGE_KEY =
   'clickhouse-monitor-browser-connections'
 
+/**
+ * Next hostId for a new browser connection: one below the smallest existing
+ * (negative) hostId, so browser connections never collide with env hosts
+ * (indexed 0, 1, 2, …). Pure and deterministic — callers derive the id from the
+ * current connection list rather than reading it back out of a React updater.
+ */
+export function nextBrowserConnectionHostId(
+  connections: readonly Pick<BrowserConnection, 'hostId'>[]
+): number {
+  return Math.min(...connections.map((c) => c.hostId), 0) - 1
+}
+
 /** Encrypted storage envelope (version 2). */
 export interface EncryptedBrowserConnectionsStore {
   version: 2


### PR DESCRIPTION
## Problem

Two defects in browser-stored connections (issue #2504):

1. **Wrong-host navigation.** `addConnection` computed the new negative `hostId` *inside* the `setConnections` updater and returned a variable reassigned there. React does not run the updater synchronously with the call, so callers received the placeholder `hostId: 0` and `add-host-dialog` navigated to `?host=0` (the first env host).
2. **First-run data loss.** `getOrCreateDeviceKey` was check-then-act with unawaited saves; two concurrent first saves could each generate a device key, last write wins, and ciphertext under the discarded key became permanently undecryptable — `loadConnections` swallowed the failure so connections silently vanished.

## Fix

- New pure `nextBrowserConnectionHostId(connections)` helper; `addConnection` derives the id deterministically from current state **before** dispatch and returns a stable object.
- Memoized single-flight device-key promise (reset to `null` on failure so retries work); re-reads the key inside the `readwrite` tx before generating for cross-tab safety.
- `loadConnections` now logs a distinct "could not be decrypted" warning instead of silently returning `[]`.

## Tests

- `nextBrowserConnectionHostId`: empty → -1, below-minimum, never 0.
- `getOrCreateDeviceKey`: concurrent calls resolve to one CryptoKey instance and persist exactly once; encrypt/decrypt round-trip.

All 6 targeted tests pass (`bun test`).

Fixes #2504