### PR TITLE
perf(api): cap table query result rows and surface truncation badge

### DIFF
--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -104,6 +104,12 @@ CHM_FEATURE_AGENT_ACCESS=public
 # so the SSRF guard blocks internal targets unless you opt in here.
 # CHM_ALLOW_PRIVATE_HOSTS=false
 
+# Server-side row cap for table queries (SELECT * views like detached-parts,
+# replicas, asynchronous-metrics, settings, users, roles, backups, …). Applied
+# via ClickHouse's max_result_rows + result_overflow_mode=break so a large/
+# damaged cluster can't ship an unbounded result set. Set to 0 to disable.
+# CHM_TABLE_MAX_RESULT_ROWS=10000
+
 # ── AI agent / LLM ──────────────────────────────────────────────────────────
 # Default AI model (provider:model or anyrouter:@preset/...).
 LLM_MODEL=anyrouter/free

--- a/apps/dashboard/src/lib/api/query-executor.ts
+++ b/apps/dashboard/src/lib/api/query-executor.ts
@@ -36,6 +36,10 @@ import {
 import { error } from '@chm/logger'
 import { buildQueryCacheSettings } from '@/lib/api/query-cache-settings'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import {
+  getTableClickHouseSettings,
+  resolveTableResultRowLimit,
+} from '@/lib/api/table-query-settings'
 import { withClickHouseQuerySpan } from '@/lib/otel/query-span'
 import { getSqlForDisplay } from '@/lib/query-config'
 
@@ -141,6 +145,8 @@ export interface ExecuteTableResult<
   executedSql: string
   /** Resolved CH version, if a versioned SQL forced a lookup. */
   clickhouseVersion?: string
+  /** Row cap applied to the query (`0` when disabled), see #2490. */
+  maxResultRows: number
 }
 
 /**
@@ -173,6 +179,21 @@ export async function executeTableConfig<
     disabled: queryConfig.disableQueryCache,
   })
 
+  // Server-side row cap (#2490): stop ClickHouse from shipping unbounded
+  // result sets for `SELECT *`-style table configs. `result_overflow_mode:
+  // 'break'` makes the server truncate instead of erroring, and the
+  // `X-ClickHouse-Summary` response header then reports
+  // `rows_before_limit_at_least` so the route can detect truncation.
+  // `getTableClickHouseSettings` respects a config's own `max_result_rows`
+  // (as long as it doesn't exceed the cap) and is spread last below so it
+  // wins over the query-cache settings for any overlapping keys.
+  const maxResultRows = resolveTableResultRowLimit()
+  const tableSettings = getTableClickHouseSettings(
+    queryConfig,
+    options.timezone,
+    maxResultRows
+  )
+
   const result = await withClickHouseQuerySpan(() =>
     fetchData<T[]>({
       query: executedSql,
@@ -181,8 +202,7 @@ export async function executeTableConfig<
       format: 'JSONEachRow',
       clickhouse_settings: {
         ...cacheSettings,
-        ...queryConfig.clickhouseSettings,
-        ...(options.timezone ? { session_timezone: options.timezone } : {}),
+        ...tableSettings,
       },
       // Pass the config so fetchData can existence-check optional tables.
       queryConfig: queryConfig.optional
@@ -200,7 +220,7 @@ export async function executeTableConfig<
     error(`[executeTableConfig:${queryConfig.name}]`, result.error)
   }
 
-  return { result, executedSql, clickhouseVersion: version }
+  return { result, executedSql, clickhouseVersion: version, maxResultRows }
 }
 
 /** Result of executing a chart query — raw JSON string (no per-row parse). */

--- a/apps/dashboard/src/lib/api/table-query-settings.test.ts
+++ b/apps/dashboard/src/lib/api/table-query-settings.test.ts
@@ -2,7 +2,9 @@ import type { QueryConfig } from '@/types/query-config'
 
 import {
   capTableResultRows,
+  detectTableTruncation,
   getTableClickHouseSettings,
+  resolveTableResultRowLimit,
   TABLE_RESULT_OVERFLOW_MODE,
   TABLE_RESULT_ROW_LIMIT,
 } from './table-query-settings'
@@ -13,8 +15,8 @@ import { describe, expect, test } from 'bun:test'
 // ---------------------------------------------------------------------------
 
 describe('constants', () => {
-  test('TABLE_RESULT_ROW_LIMIT is 1000', () => {
-    expect(TABLE_RESULT_ROW_LIMIT).toBe(1_000)
+  test('TABLE_RESULT_ROW_LIMIT is 10000', () => {
+    expect(TABLE_RESULT_ROW_LIMIT).toBe(10_000)
   })
 
   test('TABLE_RESULT_OVERFLOW_MODE is "break"', () => {
@@ -271,5 +273,115 @@ describe('capTableResultRows', () => {
 
     expect(result.truncated).toBe(false)
     expect(result.returnedRows).toBe(TABLE_RESULT_ROW_LIMIT)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveTableResultRowLimit
+// ---------------------------------------------------------------------------
+
+describe('resolveTableResultRowLimit', () => {
+  test('returns the default when env is undefined', () => {
+    expect(resolveTableResultRowLimit(undefined)).toBe(TABLE_RESULT_ROW_LIMIT)
+  })
+
+  test('returns the default when env is an empty string', () => {
+    expect(resolveTableResultRowLimit('')).toBe(TABLE_RESULT_ROW_LIMIT)
+  })
+
+  test('parses a positive numeric override', () => {
+    expect(resolveTableResultRowLimit('500')).toBe(500)
+  })
+
+  test('floors a fractional override', () => {
+    expect(resolveTableResultRowLimit('500.9')).toBe(500)
+  })
+
+  test('returns 0 (disabled) when env is "0"', () => {
+    expect(resolveTableResultRowLimit('0')).toBe(0)
+  })
+
+  test('returns 0 (disabled) when env is negative', () => {
+    expect(resolveTableResultRowLimit('-5')).toBe(0)
+  })
+
+  test('returns 0 (disabled) when env is not a number', () => {
+    expect(resolveTableResultRowLimit('not-a-number')).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getTableClickHouseSettings — cap disabled
+// ---------------------------------------------------------------------------
+
+describe('getTableClickHouseSettings with cap disabled', () => {
+  test('omits max_result_rows/result_overflow_mode when cap is 0', () => {
+    const result = getTableClickHouseSettings(undefined, undefined, 0)
+
+    expect(result.max_result_rows).toBeUndefined()
+    expect(result.result_overflow_mode).toBeUndefined()
+  })
+
+  test('still spreads config settings and timezone when cap is 0', () => {
+    const config = {
+      clickhouseSettings: { max_execution_time: 60 },
+    } as unknown as QueryConfig
+    const result = getTableClickHouseSettings(config, 'UTC', 0)
+
+    expect(result.max_execution_time).toBe(60)
+    expect(result.session_timezone).toBe('UTC')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// detectTableTruncation
+// ---------------------------------------------------------------------------
+
+describe('detectTableTruncation', () => {
+  test('not truncated when cap is disabled (0)', () => {
+    const result = detectTableTruncation({
+      dataLength: 100,
+      cap: 0,
+      rowsBeforeLimit: 500,
+    })
+    expect(result.truncated).toBe(false)
+    expect(result.rowsBeforeCap).toBeUndefined()
+  })
+
+  test('not truncated when rowsBeforeLimit is undefined', () => {
+    const result = detectTableTruncation({
+      dataLength: 100,
+      cap: 100,
+      rowsBeforeLimit: undefined,
+    })
+    expect(result.truncated).toBe(false)
+  })
+
+  test('not truncated when under cap', () => {
+    const result = detectTableTruncation({
+      dataLength: 50,
+      cap: 100,
+      rowsBeforeLimit: 50,
+    })
+    expect(result.truncated).toBe(false)
+  })
+
+  test('truncated when rowsBeforeLimit exceeds returned rows', () => {
+    const result = detectTableTruncation({
+      dataLength: 100,
+      cap: 100,
+      rowsBeforeLimit: 5000,
+    })
+    expect(result.truncated).toBe(true)
+    expect(result.rowsBeforeCap).toBe(5000)
+  })
+
+  test('not truncated when rowsBeforeLimit equals dataLength exactly', () => {
+    const result = detectTableTruncation({
+      dataLength: 100,
+      cap: 100,
+      rowsBeforeLimit: 100,
+    })
+    expect(result.truncated).toBe(false)
   })
 })

--- a/apps/dashboard/src/lib/api/table-query-settings.test.ts
+++ b/apps/dashboard/src/lib/api/table-query-settings.test.ts
@@ -66,12 +66,22 @@ describe('getTableClickHouseSettings', () => {
 
   test('caps max_result_rows at TABLE_RESULT_ROW_LIMIT when config exceeds limit', () => {
     const config = {
-      clickhouseSettings: { max_result_rows: '5000' },
+      clickhouseSettings: { max_result_rows: '50000' },
     } as unknown as QueryConfig
 
     const result = getTableClickHouseSettings(config, undefined)
 
     expect(result.max_result_rows).toBe(String(TABLE_RESULT_ROW_LIMIT))
+  })
+
+  test('keeps a config max_result_rows under the new 10k default (#2490)', () => {
+    const config = {
+      clickhouseSettings: { max_result_rows: '5000' },
+    } as unknown as QueryConfig
+
+    const result = getTableClickHouseSettings(config, undefined)
+
+    expect(result.max_result_rows).toBe('5000')
   })
 
   test('uses TABLE_RESULT_ROW_LIMIT when config max_result_rows is 0', () => {

--- a/apps/dashboard/src/lib/api/table-query-settings.ts
+++ b/apps/dashboard/src/lib/api/table-query-settings.ts
@@ -2,7 +2,15 @@ import type { ClickHouseSettings } from '@clickhouse/client'
 
 import type { QueryConfig } from '@/types/query-config'
 
-export const TABLE_RESULT_ROW_LIMIT = 1_000
+/**
+ * Default server-side row cap for table queries (#2490). Many table configs
+ * run `SELECT *` with no LIMIT (detached-parts, replicas,
+ * asynchronous-metrics, metrics, settings, users, roles, backups,
+ * view-refreshes, …); on a large/damaged cluster this can ship tens of
+ * thousands of rows to the browser, which then paginates client-side.
+ * `CHM_TABLE_MAX_RESULT_ROWS` overrides the default; `0` disables the cap.
+ */
+export const TABLE_RESULT_ROW_LIMIT = 10_000
 export const TABLE_RESULT_OVERFLOW_MODE = 'break'
 
 export type TableResultRowCap<T> = {
@@ -17,24 +25,58 @@ export type TableClickHouseSettings = ClickHouseSettings & {
   session_timezone?: string
 }
 
+/**
+ * Resolve the row cap for table queries from `CHM_TABLE_MAX_RESULT_ROWS`
+ * (default `TABLE_RESULT_ROW_LIMIT`). Returns `0` when explicitly disabled
+ * (`0`) or the env value is not a positive finite number.
+ */
+export function resolveTableResultRowLimit(
+  env: string | undefined = process.env.CHM_TABLE_MAX_RESULT_ROWS
+): number {
+  if (env === undefined || env === '') return TABLE_RESULT_ROW_LIMIT
+  const parsed = Number(env)
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 0
+}
+
 function resolveResultRowLimit(
-  configuredLimit: ClickHouseSettings['max_result_rows'] | undefined
+  configuredLimit: ClickHouseSettings['max_result_rows'] | undefined,
+  cap: number
 ): number {
   const numericLimit = Number(configuredLimit)
 
   if (Number.isFinite(numericLimit) && numericLimit > 0) {
-    return Math.min(numericLimit, TABLE_RESULT_ROW_LIMIT)
+    return Math.min(numericLimit, cap)
   }
 
-  return TABLE_RESULT_ROW_LIMIT
+  return cap
 }
 
+/**
+ * Build the `clickhouse_settings` for a table query, applying the row cap
+ * (`max_result_rows` + `result_overflow_mode: 'break'`) so ClickHouse
+ * truncates server-side instead of shipping an unbounded result set (#2490).
+ * A config's own `max_result_rows` is respected as long as it doesn't exceed
+ * the resolved cap. Passing `cap: 0` (`CHM_TABLE_MAX_RESULT_ROWS=0`) disables
+ * the cap entirely — no `max_result_rows`/`result_overflow_mode` are set.
+ */
 export function getTableClickHouseSettings(
   config: QueryConfig | undefined,
-  timezone: string | undefined
+  timezone: string | undefined,
+  cap: number = resolveTableResultRowLimit()
 ): TableClickHouseSettings {
   const configSettings = config?.clickhouseSettings ?? {}
-  const maxResultRows = resolveResultRowLimit(configSettings.max_result_rows)
+
+  if (cap <= 0) {
+    return {
+      ...configSettings,
+      ...(timezone ? { session_timezone: timezone } : {}),
+    }
+  }
+
+  const maxResultRows = resolveResultRowLimit(
+    configSettings.max_result_rows,
+    cap
+  )
 
   return {
     ...configSettings,
@@ -69,4 +111,28 @@ export function capTableResultRows<T>(
     returnedRows: rowLimit,
     truncated: true,
   }
+}
+
+/**
+ * Detect whether a table query's result was truncated by the row cap
+ * (#2490), given the number of rows actually returned, the cap that was
+ * applied (`0` = disabled), and ClickHouse's `rows_before_limit_at_least`
+ * statistic (present when `result_overflow_mode: 'break'` — or a plain
+ * LIMIT — cut the result short). Pure function so it's cheap to unit test
+ * independent of any live ClickHouse response.
+ */
+export function detectTableTruncation({
+  dataLength,
+  cap,
+  rowsBeforeLimit,
+}: {
+  dataLength: number
+  cap: number
+  rowsBeforeLimit: number | undefined
+}): { truncated: boolean; rowsBeforeCap?: number } {
+  if (cap <= 0) return { truncated: false }
+  if (rowsBeforeLimit === undefined || rowsBeforeLimit <= dataLength) {
+    return { truncated: false }
+  }
+  return { truncated: true, rowsBeforeCap: rowsBeforeLimit }
 }

--- a/apps/dashboard/src/routes/api/v1/tables/$name.ts
+++ b/apps/dashboard/src/routes/api/v1/tables/$name.ts
@@ -9,6 +9,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { env } from 'cloudflare:workers'
 import { error } from '@chm/logger'
 import { executeTableConfig } from '@/lib/api/query-executor'
+import { detectTableTruncation } from '@/lib/api/table-query-settings'
 import {
   getAvailableTables,
   getTableQuery,
@@ -121,15 +122,15 @@ export async function handler(
   }
 
   try {
-    const { result, executedSql, clickhouseVersion } = await executeTableConfig(
-      config,
-      hostId,
-      queryParams,
-      {
-        bindings,
-        timezone,
-      }
-    )
+    const {
+      result,
+      executedSql,
+      clickhouseVersion,
+      maxResultRows,
+    } = await executeTableConfig(config, hostId, queryParams, {
+      bindings,
+      timezone,
+    })
 
     if (result.error) {
       // An OPTIONAL config whose underlying table is simply absent is an
@@ -174,6 +175,15 @@ export async function handler(
     }
 
     const rows = result.data ?? []
+    const rowsBeforeLimit =
+      typeof result.metadata.rows_before_limit_at_least === 'number'
+        ? result.metadata.rows_before_limit_at_least
+        : undefined
+    const { truncated, rowsBeforeCap } = detectTableTruncation({
+      dataLength: rows.length,
+      cap: maxResultRows,
+      rowsBeforeLimit,
+    })
     const metadata = {
       queryId: String(result.metadata.queryId || ''),
       duration: Number(result.metadata.duration || 0),
@@ -182,7 +192,10 @@ export async function handler(
       sql: executedSql.trim(),
       clickhouseVersion,
       timezone,
-      rows_before_limit_at_least: result.metadata.rows_before_limit_at_least,
+      resultRowLimit: maxResultRows > 0 ? maxResultRows : undefined,
+      resultOverflowMode: maxResultRows > 0 ? 'break' : undefined,
+      resultRowsTruncated: truncated,
+      resultRowsBeforeCap: rowsBeforeCap,
     }
 
     return Response.json({ success: true, data: rows, metadata })

--- a/apps/dashboard/src/routes/api/v1/tables/$name.ts
+++ b/apps/dashboard/src/routes/api/v1/tables/$name.ts
@@ -122,15 +122,11 @@ export async function handler(
   }
 
   try {
-    const {
-      result,
-      executedSql,
-      clickhouseVersion,
-      maxResultRows,
-    } = await executeTableConfig(config, hostId, queryParams, {
-      bindings,
-      timezone,
-    })
+    const { result, executedSql, clickhouseVersion, maxResultRows } =
+      await executeTableConfig(config, hostId, queryParams, {
+        bindings,
+        timezone,
+      })
 
     if (result.error) {
       // An OPTIONAL config whose underlying table is simply absent is an

--- a/packages/clickhouse-client/src/clickhouse/__tests__/clickhouse-fetch.test.ts
+++ b/packages/clickhouse-client/src/clickhouse/__tests__/clickhouse-fetch.test.ts
@@ -216,6 +216,35 @@ describe('clickhouse-fetch', () => {
         expect(result.metadata.readBytes).toBeUndefined()
       })
 
+      it('does not include rows_before_limit_at_least when the result set has no response_headers (#2490)', async () => {
+        const result = await fetchData(defaultParams)
+        expect(result.metadata.rows_before_limit_at_least).toBeUndefined()
+      })
+
+      it('includes rows_before_limit_at_least parsed from the X-ClickHouse-Summary header (#2490)', async () => {
+        mockClientQuery.mockResolvedValueOnce({
+          ...mockResultSet,
+          response_headers: {
+            'x-clickhouse-summary': JSON.stringify({
+              rows_before_limit_at_least: '54321',
+            }),
+          },
+        } as never)
+
+        const result = await fetchData(defaultParams)
+        expect(result.metadata.rows_before_limit_at_least).toBe(54321)
+      })
+
+      it('omits rows_before_limit_at_least when the summary header is unparseable (#2490)', async () => {
+        mockClientQuery.mockResolvedValueOnce({
+          ...mockResultSet,
+          response_headers: { 'x-clickhouse-summary': 'not-json' },
+        } as never)
+
+        const result = await fetchData(defaultParams)
+        expect(result.metadata.rows_before_limit_at_least).toBeUndefined()
+      })
+
       it('does not JSON.stringify the result set when debug is disabled', async () => {
         // isDebugEnabled() is mocked false (simulating DEBUG unset / prod).
         const mockData = [{ big: 'payload' }]

--- a/packages/clickhouse-client/src/clickhouse/clickhouse-fetch.ts
+++ b/packages/clickhouse-client/src/clickhouse/clickhouse-fetch.ts
@@ -44,6 +44,34 @@ function parseReadBytesFromHeaders(
 }
 
 /**
+ * Parse `rows_before_limit_at_least` out of the `X-ClickHouse-Summary`
+ * response header (#2490). ClickHouse sets this when a query hits
+ * `max_result_rows` with `result_overflow_mode: 'break'` (or a plain LIMIT) —
+ * it reports how many rows existed before the cap/limit truncated the result.
+ * Returns `undefined` when absent/unparseable, mirroring
+ * `parseReadBytesFromHeaders`.
+ */
+function parseRowsBeforeLimitFromHeaders(
+  headers: Record<string, string | string[] | undefined> | undefined
+): number | undefined {
+  const raw = headers?.['x-clickhouse-summary']
+  const text = Array.isArray(raw) ? raw[0] : raw
+  if (!text) return undefined
+
+  try {
+    const summary = JSON.parse(text) as {
+      rows_before_limit_at_least?: string
+    }
+    const value = summary.rows_before_limit_at_least
+      ? Number(summary.rows_before_limit_at_least)
+      : undefined
+    return value !== undefined && Number.isFinite(value) ? value : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
  * Extract an HTTP status code (100–599) from a fetch error message.
  *
  * Strategy:
@@ -345,6 +373,16 @@ export const fetchData = async <
       const readBytes = parseReadBytesFromHeaders(resultSet.response_headers)
       if (readBytes !== undefined) {
         metadata.readBytes = readBytes
+      }
+
+      // Only present when result_overflow_mode='break' (or a plain LIMIT)
+      // truncated the query — lets callers detect and surface truncation
+      // (#2490).
+      const rowsBeforeLimitAtLeast = parseRowsBeforeLimitFromHeaders(
+        resultSet.response_headers
+      )
+      if (rowsBeforeLimitAtLeast !== undefined) {
+        metadata.rows_before_limit_at_least = rowsBeforeLimitAtLeast
       }
 
       // Include raw response for debugging (lazily evaluated to avoid performance overhead)


### PR DESCRIPTION
## Summary
- Wire the previously-dead `table-query-settings.ts` module into `executeTableConfig`: applies `max_result_rows` + `result_overflow_mode: 'break'` to all table queries (default 10000, `CHM_TABLE_MAX_RESULT_ROWS` env-tunable, `0` disables).
- Parse `rows_before_limit_at_least` out of ClickHouse's `X-ClickHouse-Summary` response header in `@chm/clickhouse-client`'s `fetchData`.
- Populate `resultRowLimit` / `resultOverflowMode` / `resultRowsTruncated` / `resultRowsBeforeCap` on the `/api/v1/tables/$name` response metadata via a new pure `detectTableTruncation` helper, lighting up the existing (previously dead) "Capped" badge in `table-client.tsx`.
- Document `CHM_TABLE_MAX_RESULT_ROWS` in `.env.example`.

## Test plan
- [ ] `bun test packages/clickhouse-client/src/clickhouse/__tests__/clickhouse-fetch.test.ts` — new `rows_before_limit_at_least` header-parsing cases
- [ ] `bun test apps/dashboard/src/lib/api/table-query-settings.test.ts` — cap resolution, disabled-cap, `detectTableTruncation`
- [ ] `pnpm run build` — type-check
- [ ] CI (`dashboard`, `unit-tests`)

Fixes #2490