### PR TITLE
fix(rate-limiter): bound in-memory bucket store to a fixed cap

### DIFF
--- a/apps/dashboard/src/lib/api/__tests__/rate-limiter.test.ts
+++ b/apps/dashboard/src/lib/api/__tests__/rate-limiter.test.ts
@@ -7,9 +7,12 @@
  *  - Bucket refills over time
  *  - rateLimitResponse returns a 429 with Retry-After
  *  - clientIpKey extraction from various headers
+ *  - Bucket store stays bounded and evicts old entries under high cardinality
  */
 
 import {
+  _bucketCountForTest,
+  _MAX_BUCKETS_FOR_TEST,
   _resetBucketsForTest,
   checkRateLimit,
   clientIpKey,
@@ -64,6 +67,16 @@ describe('checkRateLimit', () => {
   test('limit=1 allows exactly one request', () => {
     expect(checkRateLimit('tight-key', 1).allowed).toBe(true)
     expect(checkRateLimit('tight-key', 1).allowed).toBe(false)
+  })
+
+  test('bucket store stays bounded and evicts oldest entries past the cap', () => {
+    const cap = _MAX_BUCKETS_FOR_TEST
+    for (let i = 0; i < cap + 50; i++) {
+      checkRateLimit(`bounded-key-${i}`, 5)
+    }
+    expect(_bucketCountForTest()).toBeLessThanOrEqual(cap)
+    // The earliest keys should have been evicted (oldest-first eviction).
+    expect(checkRateLimit('bounded-key-0', 5).remaining).toBe(4)
   })
 })
 

--- a/apps/dashboard/src/lib/api/rate-limiter.ts
+++ b/apps/dashboard/src/lib/api/rate-limiter.ts
@@ -29,6 +29,34 @@ interface Bucket {
 const buckets = new Map<string, Bucket>()
 
 /**
+ * Hard cap on distinct bucket keys (e.g. distinct client IPs) kept in memory.
+ * Without this, high-cardinality public traffic (scrapers, bot sweeps) would
+ * grow `buckets` without bound for the isolate's lifetime.
+ */
+const MAX_BUCKETS = 5_000
+/** Sweep every N calls rather than on every call — cheap amortized cost. */
+const SWEEP_INTERVAL = 500
+/** Buckets idle longer than this (10x the refill window) are stale. */
+const STALE_MS = 600_000
+let callsSinceSweep = 0
+
+/**
+ * Drop stale buckets and enforce the size cap (oldest-first). Map preserves
+ * insertion order, and `checkRateLimit` re-inserts a key on every touch (see
+ * below), so the oldest entries are also the least-recently-used ones.
+ */
+function pruneBuckets(nowMs: number): void {
+  for (const [key, bucket] of buckets) {
+    if (nowMs - bucket.lastRefillMs >= STALE_MS) buckets.delete(key)
+  }
+  while (buckets.size > MAX_BUCKETS) {
+    const oldest = buckets.keys().next().value
+    if (oldest === undefined) break
+    buckets.delete(oldest)
+  }
+}
+
+/**
  * Read a positive-integer env var; fall back to `defaultValue`.
  * Checking process.env is correct here — bridgeClickHouseEnv() copies Worker
  * bindings onto process.env before any API handler runs, so env vars are
@@ -55,11 +83,21 @@ export function checkRateLimit(
   const nowMs = Date.now()
   const windowMs = 60_000 // 1 minute
 
+  callsSinceSweep += 1
+  if (callsSinceSweep >= SWEEP_INTERVAL) {
+    callsSinceSweep = 0
+    pruneBuckets(nowMs)
+  }
+
   let bucket = buckets.get(bucketKey)
   if (!bucket) {
     bucket = { tokens: limitPerMin, lastRefillMs: nowMs }
-    buckets.set(bucketKey, bucket)
+  } else {
+    // Re-insert to move this key to the end of Map iteration order, so
+    // `pruneBuckets`'s oldest-first eviction approximates least-recently-used.
+    buckets.delete(bucketKey)
   }
+  buckets.set(bucketKey, bucket)
 
   // Refill tokens proportional to elapsed time
   const elapsedMs = nowMs - bucket.lastRefillMs
@@ -68,6 +106,8 @@ export function checkRateLimit(
     bucket.tokens = Math.min(limitPerMin, bucket.tokens + refill)
     bucket.lastRefillMs = nowMs
   }
+
+  if (buckets.size > MAX_BUCKETS) pruneBuckets(nowMs)
 
   if (bucket.tokens >= 1) {
     bucket.tokens -= 1
@@ -139,4 +179,13 @@ export function getApiRateLimitPerMin(): number {
  */
 export function _resetBucketsForTest(): void {
   buckets.clear()
+  callsSinceSweep = 0
 }
+
+/** Current number of distinct bucket keys held in memory (for testing only). */
+export function _bucketCountForTest(): number {
+  return buckets.size
+}
+
+/** The hard cap on distinct bucket keys (for testing only). */
+export const _MAX_BUCKETS_FOR_TEST = MAX_BUCKETS


### PR DESCRIPTION
## Summary

The in-memory token-bucket rate limiter's `buckets` Map grew without bound for the lifetime of the Worker isolate, keyed by client IP on public routes (charts, agent, share-link, events-ingest). Diverse public traffic accumulated one permanent `Bucket` per unique IP.

## Changes

- Cap the store at `MAX_BUCKETS = 5000`, evicting oldest-first when over the cap (LRU-approximate: `checkRateLimit` re-inserts keys on touch so Map insertion order tracks recency).
- Opportunistic stale sweep: buckets idle > 10 minutes (10x the refill window) are dropped, amortized every 500 calls — no background timer needed on Workers.
- Immediate prune when the cap is exceeded, so `buckets.size` never stays above the cap.
- Token refill math and `allowed`/`retryAfterSec` behavior unchanged for keys within the cap.
- Test: N+50 distinct keys stay bounded at the cap; oldest entries are evicted (fresh bucket on re-check).

Mirrors the bounded-cache pattern already used in `peerdb-config.ts` / `polar-subscription.ts`.

## Test plan

- `bun test src/lib/api/__tests__/rate-limiter.test.ts` — 14 pass (13 existing + 1 new eviction test)

Fixes #2467