### PR TITLE
perf(dashboard): stabilize useMergedHosts, dedupe query-key serialization, parallelize topology

### DIFF
--- a/apps/dashboard/src/lib/query/query-keys.test.ts
+++ b/apps/dashboard/src/lib/query/query-keys.test.ts
@@ -1,5 +1,10 @@
 import { hostConnectionKey } from './host-query-key'
-import { chartQueryKey, tableQueryKey } from './query-keys'
+import {
+  chartQueryKey,
+  serializeChartParams,
+  serializeTableSearchParams,
+  tableQueryKey,
+} from './query-keys'
 import { describe, expect, test } from 'bun:test'
 
 describe('chartQueryKey', () => {
@@ -9,7 +14,7 @@ describe('chartQueryKey', () => {
     const prefetchKey = chartQueryKey({
       chartName: 'overview-cpu',
       hostId,
-      params: null,
+      paramsKey: serializeChartParams(null),
       connectionKey: hostConnectionKey(hostId, null),
     })
 
@@ -22,7 +27,7 @@ describe('chartQueryKey', () => {
       hostId,
       interval: undefined,
       lastHours: undefined,
-      params: undefined,
+      paramsKey: serializeChartParams(undefined),
       timezone: undefined,
       connectionKey: hostConnectionKey(hostId, null),
     })
@@ -46,7 +51,7 @@ describe('chartQueryKey', () => {
       hostId: 2,
       interval: '1 HOUR',
       lastHours: 24,
-      params: { database: 'default' },
+      paramsKey: serializeChartParams({ database: 'default' }),
       timezone: 'UTC',
       connectionKey: 'conn-a',
     })
@@ -71,7 +76,7 @@ describe('tableQueryKey', () => {
     const prefetchKey = tableQueryKey({
       queryConfigName: 'tables',
       hostId,
-      searchParams: {},
+      searchParamsKey: serializeTableSearchParams({}),
       connectionKey: hostConnectionKey(hostId, null),
     })
 
@@ -80,7 +85,7 @@ describe('tableQueryKey', () => {
     const hookKey = tableQueryKey({
       queryConfigName: 'tables',
       hostId,
-      searchParams: undefined,
+      searchParamsKey: serializeTableSearchParams(undefined),
       timezone: undefined,
       connectionKey: hostConnectionKey(hostId, null),
     })
@@ -100,7 +105,7 @@ describe('tableQueryKey', () => {
     const key = tableQueryKey({
       queryConfigName: 'tables',
       hostId: 3,
-      searchParams: { search: 'foo', page: 2 },
+      searchParamsKey: serializeTableSearchParams({ search: 'foo', page: 2 }),
       timezone: 'Asia/Ho_Chi_Minh',
       connectionKey: 'conn-b',
     })

--- a/apps/dashboard/src/lib/query/query-keys.ts
+++ b/apps/dashboard/src/lib/query/query-keys.ts
@@ -10,12 +10,25 @@
  * prefetch again.
  */
 
+/**
+ * Canonical serialization of chart `params` for the cache key. Callers
+ * (`useChartData`, `prefetch`) serialize ONCE via this helper and pass the
+ * result as `paramsKey`, so the byte-identical-key contract holds without
+ * stringifying the same object twice per render.
+ */
+export function serializeChartParams(
+  params?: Record<string, unknown> | null
+): string {
+  return JSON.stringify(params ?? null)
+}
+
 export interface ChartQueryKeyParams {
   chartName: string
   hostId?: number | string
   interval?: string
   lastHours?: number
-  params?: Record<string, unknown> | null
+  /** Precompute via `serializeChartParams(params)`. */
+  paramsKey: string
   timezone?: string
   /** Precompute via `hostConnectionKey(numericHostId, browserConnection)`. */
   connectionKey: string | undefined
@@ -26,7 +39,7 @@ export function chartQueryKey({
   hostId,
   interval,
   lastHours,
-  params,
+  paramsKey,
   timezone,
   connectionKey,
 }: ChartQueryKeyParams) {
@@ -36,16 +49,28 @@ export function chartQueryKey({
     hostId,
     interval,
     lastHours,
-    JSON.stringify(params ?? null),
+    paramsKey,
     timezone,
     connectionKey,
   ] as const
 }
 
+/**
+ * Canonical serialization of table `searchParams` for the cache key. Callers
+ * (`useTableData`, `prefetch`) serialize ONCE via this helper and pass the
+ * result as `searchParamsKey`.
+ */
+export function serializeTableSearchParams(
+  searchParams?: Record<string, unknown> | null
+): string {
+  return JSON.stringify(searchParams ?? {})
+}
+
 export interface TableQueryKeyParams {
   queryConfigName: string
   hostId?: number
-  searchParams?: Record<string, unknown> | null
+  /** Precompute via `serializeTableSearchParams(searchParams)`. */
+  searchParamsKey: string
   timezone?: string
   /** Precompute via `hostConnectionKey(hostId, browserConnection)`. */
   connectionKey: string | undefined
@@ -54,7 +79,7 @@ export interface TableQueryKeyParams {
 export function tableQueryKey({
   queryConfigName,
   hostId,
-  searchParams,
+  searchParamsKey,
   timezone,
   connectionKey,
 }: TableQueryKeyParams) {
@@ -62,7 +87,7 @@ export function tableQueryKey({
     '/api/v1/tables',
     queryConfigName,
     hostId,
-    JSON.stringify(searchParams ?? {}),
+    searchParamsKey,
     timezone,
     connectionKey,
   ] as const

--- a/apps/dashboard/src/lib/query/use-chart-data.ts
+++ b/apps/dashboard/src/lib/query/use-chart-data.ts
@@ -8,7 +8,7 @@ import {
   isCustomHost,
 } from '@/lib/host-fetch/resolve-host-fetch'
 import { hostConnectionKey } from '@/lib/query/host-query-key'
-import { chartQueryKey } from '@/lib/query/query-keys'
+import { chartQueryKey, serializeChartParams } from '@/lib/query/query-keys'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { REFRESH_INTERVAL, type RefreshInterval } from '@/lib/swr/config'
 import { throwIfNotOk } from '@/lib/swr/fetch-error'
@@ -75,29 +75,32 @@ export function useChartData<T extends ChartDataPoint = ChartDataPoint>({
       ? getConnectionByHostId(numericHostId)
       : null
 
-  // Serialize params so the memo key is value-stable: a parent passing an
-  // inline `params` object literal changes its reference every render, which
-  // would otherwise defeat this memo (re-running on every render).
-  const paramsKey = params ? JSON.stringify(params) : ''
+  // Serialize params once so it's value-stable for both the memo key and the
+  // query key: a parent passing an inline `params` object literal changes its
+  // reference every render, which would otherwise defeat this memo. Reusing the
+  // single serialized string also avoids stringifying `params` twice per render
+  // (URL + cache key).
+  const paramsKey = serializeChartParams(params)
+  const hasParams = params != null
   const url = useMemo(() => {
     const searchParams = new URLSearchParams()
     if (hostId !== undefined) searchParams.append('hostId', String(hostId))
     if (interval) searchParams.append('interval', interval)
     if (lastHours !== undefined)
       searchParams.append('lastHours', String(lastHours))
-    if (paramsKey) searchParams.append('params', paramsKey)
+    if (hasParams) searchParams.append('params', paramsKey)
     if (timezone) searchParams.append('timezone', timezone)
 
     const queryString = searchParams.toString()
     return `/api/v1/charts/${chartName}${queryString ? `?${queryString}` : ''}`
-  }, [chartName, hostId, interval, lastHours, paramsKey, timezone])
+  }, [chartName, hostId, interval, lastHours, hasParams, paramsKey, timezone])
 
   const queryKey = chartQueryKey({
     chartName,
     hostId,
     interval,
     lastHours,
-    params,
+    paramsKey,
     timezone,
     connectionKey: hostConnectionKey(numericHostId, browserConnection),
   })

--- a/apps/dashboard/src/lib/query/use-table-data.ts
+++ b/apps/dashboard/src/lib/query/use-table-data.ts
@@ -9,7 +9,10 @@ import {
   isCustomHost,
 } from '@/lib/host-fetch/resolve-host-fetch'
 import { hostConnectionKey } from '@/lib/query/host-query-key'
-import { tableQueryKey } from '@/lib/query/query-keys'
+import {
+  serializeTableSearchParams,
+  tableQueryKey,
+} from '@/lib/query/query-keys'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { throwIfNotOk } from '@/lib/swr/fetch-error'
 import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
@@ -42,9 +45,11 @@ export function useTableData<T = unknown>(
   const browserConnection =
     hostId !== undefined && hostId < 0 ? getConnectionByHostId(hostId) : null
 
-  // Serialize searchParams so the memo key is value-stable even when a parent
-  // recreates the object each render (inline literal / derived state).
-  const searchParamsKey = searchParams ? JSON.stringify(searchParams) : ''
+  // Serialize searchParams once so it's value-stable for both the memo key and
+  // the query key, even when a parent recreates the object each render (inline
+  // literal / derived state). Reusing the single serialized string also avoids
+  // stringifying `searchParams` twice per render.
+  const searchParamsKey = serializeTableSearchParams(searchParams)
   // biome-ignore lint/correctness/useExhaustiveDependencies: searchParams is read inside but keyed via the value-stable searchParamsKey
   const url = useMemo(() => {
     const params = new URLSearchParams()
@@ -66,7 +71,7 @@ export function useTableData<T = unknown>(
   const queryKey = tableQueryKey({
     queryConfigName,
     hostId,
-    searchParams,
+    searchParamsKey,
     timezone,
     connectionKey: hostConnectionKey(hostId, browserConnection),
   })

--- a/apps/dashboard/src/lib/swr/prefetch.ts
+++ b/apps/dashboard/src/lib/swr/prefetch.ts
@@ -5,7 +5,12 @@ import type { PrefetchConfig } from './route-prefetch-map'
 import { apiFetch } from './api-fetch'
 import { routePrefetchMap } from './route-prefetch-map'
 import { hostConnectionKey } from '@/lib/query/host-query-key'
-import { chartQueryKey, tableQueryKey } from '@/lib/query/query-keys'
+import {
+  chartQueryKey,
+  serializeChartParams,
+  serializeTableSearchParams,
+  tableQueryKey,
+} from '@/lib/query/query-keys'
 
 /**
  * Prefetch chart data and seed the TanStack Query cache.
@@ -28,7 +33,7 @@ function prefetchChart(
   const queryKey = chartQueryKey({
     chartName,
     hostId,
-    params: null,
+    paramsKey: serializeChartParams(null),
     connectionKey: hostConnectionKey(hostId, null),
   })
 
@@ -61,7 +66,7 @@ function prefetchTable(
   const queryKey = tableQueryKey({
     queryConfigName: tableName,
     hostId,
-    searchParams: {},
+    searchParamsKey: serializeTableSearchParams({}),
     connectionKey: hostConnectionKey(hostId, null),
   })
 

--- a/apps/dashboard/src/lib/swr/use-merged-hosts.ts
+++ b/apps/dashboard/src/lib/swr/use-merged-hosts.ts
@@ -1,5 +1,7 @@
 import type { HostInfo } from '@chm/types/host-info'
 
+import { useMemo } from 'react'
+
 import { useHosts } from './use-hosts'
 import { isCloudModeClient } from '@/lib/cloud/cloud-mode'
 import { useBrowserConnections } from '@/lib/hooks/use-browser-connections'
@@ -72,38 +74,53 @@ export function useMergedHosts() {
   const envSource: MergedHostInfo['source'] = cloudMode ? 'demo' : 'env'
   const showEnvHosts = !(cloudMode && isSignedIn)
 
-  const mergedHosts: MergedHostInfo[] = [
-    ...(showEnvHosts
-      ? envHosts.map(
-          (h): MergedHostInfo => ({
-            ...h,
-            source: envSource,
-            readOnly: cloudMode,
-          })
-        )
-      : []),
-    ...connections.map(
-      (c): MergedHostInfo => ({
-        id: c.hostId,
-        name: c.name,
-        host: c.host,
-        user: c.user,
-        source: 'browser',
-      })
-    ),
-    ...(dbFeatureEnabled && isSignedIn
-      ? dbConnections.map(
-          (c): MergedHostInfo => ({
-            id: c.hostId,
-            name: c.name,
-            host: c.host,
-            user: c.user,
-            source: 'database',
-            connectionId: c.id,
-          })
-        )
-      : []),
-  ]
+  // Memoize the derived array so the reference is stable across renders. This
+  // hook is called by every chart/table data hook, so an unstable array here
+  // would ripple into their memo/query-key deps and defeat those memos.
+  const mergedHosts: MergedHostInfo[] = useMemo(
+    () => [
+      ...(showEnvHosts
+        ? envHosts.map(
+            (h): MergedHostInfo => ({
+              ...h,
+              source: envSource,
+              readOnly: cloudMode,
+            })
+          )
+        : []),
+      ...connections.map(
+        (c): MergedHostInfo => ({
+          id: c.hostId,
+          name: c.name,
+          host: c.host,
+          user: c.user,
+          source: 'browser',
+        })
+      ),
+      ...(dbFeatureEnabled && isSignedIn
+        ? dbConnections.map(
+            (c): MergedHostInfo => ({
+              id: c.hostId,
+              name: c.name,
+              host: c.host,
+              user: c.user,
+              source: 'database',
+              connectionId: c.id,
+            })
+          )
+        : []),
+    ],
+    [
+      showEnvHosts,
+      envHosts,
+      envSource,
+      cloudMode,
+      connections,
+      dbFeatureEnabled,
+      isSignedIn,
+      dbConnections,
+    ]
+  )
 
   return {
     hosts: mergedHosts,

--- a/apps/dashboard/src/routes/api/v1/cluster-topology.ts
+++ b/apps/dashboard/src/routes/api/v1/cluster-topology.ts
@@ -138,6 +138,22 @@ async function handleGet(request: Request): Promise<Response> {
       hostId,
     })
 
+    // Keeper presence + info (steps 2 & 3) don't depend on the structural rows,
+    // so kick them off now to overlap with the structural query below instead of
+    // serializing behind it. They're optional and must never fail the batch.
+    const presencePromise = fetchData<KeeperPresenceRow[]>({
+      query: '',
+      hostId,
+      format: 'JSONEachRow',
+      queryConfig: keeperPresenceConfig,
+    }).catch(() => ({ data: [], error: undefined }) as never)
+    const keeperPromise = fetchData<KeeperInfoRow[]>({
+      query: '',
+      hostId,
+      format: 'JSONEachRow',
+      queryConfig: keeperInfoConfig,
+    }).catch(() => ({ data: [], error: undefined }) as never)
+
     // ── 1. STRUCTURAL truth (must succeed) ──
     const structural = await fetchData<ClusterTopologyRow[]>({
       query: '',
@@ -177,20 +193,10 @@ async function handleGet(request: Request): Promise<Response> {
 
     const clusterRows = (structural.data ?? []) as ClusterTopologyRow[]
 
-    // ── 2 & 3. Keeper presence + info (optional; never fail the batch) ──
+    // ── 2 & 3. Keeper presence + info (started above; awaited here) ──
     const [presenceResult, keeperResult] = await Promise.all([
-      fetchData<KeeperPresenceRow[]>({
-        query: '',
-        hostId,
-        format: 'JSONEachRow',
-        queryConfig: keeperPresenceConfig,
-      }).catch(() => ({ data: [], error: undefined }) as never),
-      fetchData<KeeperInfoRow[]>({
-        query: '',
-        hostId,
-        format: 'JSONEachRow',
-        queryConfig: keeperInfoConfig,
-      }).catch(() => ({ data: [], error: undefined }) as never),
+      presencePromise,
+      keeperPromise,
     ])
 
     const presenceRows = (


### PR DESCRIPTION
Fixes the three sub-findings in #2519.

## Changes
- **`useMergedHosts`** (`lib/swr/use-merged-hosts.ts`): memoize the derived merged-hosts array so its reference stays stable across renders. Since this hook is called by every chart/table data hook, an unstable array previously rippled into their memo/query-key deps and defeated those memos.
- **Query-key serialization** (`lib/query/query-keys.ts`, `use-chart-data.ts`, `use-table-data.ts`, `swr/prefetch.ts`): removed the double `JSON.stringify` per key. The hooks already serialize params once (for URL + memo stability); they now pass that serialized string straight into the key factory via new `serializeChartParams` / `serializeTableSearchParams` helpers. The byte-identical-key contract with `prefetch` is preserved (all callers route through the same helpers).
- **Cluster topology API** (`routes/api/v1/cluster-topology.ts`): the keeper presence + info queries don't depend on the structural rows, so they now start concurrently with the structural query instead of serializing behind it.

## Verification
- `bun test src/lib/query/query-keys.test.ts` — 4 pass (updated to new factory signature).
- Biome lint + format clean on all changed files.

Fixes #2519