### PR TITLE
feat(landing): x.ai-style dark redesign

### DIFF
--- a/apps/landing/src/components/Capabilities.astro
+++ b/apps/landing/src/components/Capabilities.astro
@@ -1,7 +1,7 @@
   <section id="capabilities" class="py-20 sm:py-24">
     <div class="mx-auto max-w-6xl px-6">
       <div class="reveal mx-auto max-w-2xl text-center">
-        <p class="text-sm font-medium text-primary">Full coverage</p>
+        <p class="font-mono text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">Full coverage</p>
         <h2 class="mt-3 text-balance font-semibold text-3xl sm:text-4xl tracking-tight">One dashboard for the whole cluster</h2>
         <p class="mt-4 text-pretty text-muted-foreground">From a high-level overview down to ZooKeeper logs and replication mirrors, every system table you reach for, already laid out.</p>
       </div>

--- a/apps/landing/src/components/Comparison.astro
+++ b/apps/landing/src/components/Comparison.astro
@@ -6,7 +6,7 @@ const partialSvg = `<svg class="inline-block size-[18px] shrink-0 align-middle t
 <section id="comparison" class="bg-muted/30 py-14 sm:py-20 md:py-24">
   <div class="mx-auto max-w-6xl px-4 sm:px-6">
     <div class="reveal mx-auto max-w-2xl text-center">
-      <p class="text-sm font-medium text-primary">Why chmonitor</p>
+      <p class="font-mono text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">Why chmonitor</p>
       <h2 class="mt-3 text-balance font-semibold text-2xl sm:text-3xl md:text-4xl tracking-tight">Purpose-built for ClickHouse</h2>
       <p class="mt-4 text-pretty text-sm sm:text-base text-muted-foreground">General-purpose tools treat ClickHouse as one data source among many. chmonitor reads its system tables directly and tracks nothing else. Here's how it stacks up against the most common alternatives.</p>
     </div>

--- a/apps/landing/src/components/FAQ.astro
+++ b/apps/landing/src/components/FAQ.astro
@@ -49,7 +49,7 @@ const faqJsonLd = {
 <section id="faq" class="py-14 sm:py-20 md:py-24">
   <div class="mx-auto max-w-6xl px-4 sm:px-6">
     <div class="reveal mx-auto max-w-2xl text-center">
-      <p class="text-sm font-medium text-primary">FAQ</p>
+      <p class="font-mono text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">FAQ</p>
       <h2 class="mt-3 text-balance font-extrabold text-2xl sm:text-4xl md:text-5xl tracking-[-0.04em]">
         Questions &amp; answers
       </h2>

--- a/apps/landing/src/components/FeatureShowcase.astro
+++ b/apps/landing/src/components/FeatureShowcase.astro
@@ -46,7 +46,7 @@ const icons: Record<string, string> = {
               }
             >
               <span set:html={icons[section.icon]} />
-              <p class="mt-4 font-medium text-primary text-sm">
+              <p class="mt-4 font-mono text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
                 {section.eyebrow}
               </p>
               <h3 class="mt-2 text-balance font-semibold text-2xl tracking-tight sm:text-3xl">

--- a/apps/landing/src/components/Features.astro
+++ b/apps/landing/src/components/Features.astro
@@ -1,7 +1,7 @@
   <section id="features" class="border-y border-border bg-muted/30 py-20 sm:py-24">
     <div class="mx-auto max-w-6xl px-6">
       <div class="reveal mx-auto max-w-2xl text-center">
-        <p class="text-sm font-medium text-primary">What you get</p>
+        <p class="font-mono text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">What you get</p>
         <h2 class="mt-3 text-balance font-semibold text-3xl sm:text-4xl tracking-tight">Everything about your cluster, in one place</h2>
         <p class="mt-4 text-pretty text-muted-foreground">chmonitor reads ClickHouse system tables directly, no exporters, no extra storage. Each view is purpose-built so you can spot the problem and move on.</p>
       </div>

--- a/apps/landing/src/components/Pricing.astro
+++ b/apps/landing/src/components/Pricing.astro
@@ -34,7 +34,7 @@ const cardColors = [
   <div class="mx-auto max-w-6xl px-4 sm:px-6">
     {!compact && (
     <div class="reveal mx-auto max-w-2xl text-center">
-      <p class="text-sm font-medium text-primary">Pricing</p>
+      <p class="font-mono text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">Pricing</p>
       <h2 class="mt-3 text-balance font-extrabold text-2xl sm:text-3xl md:text-4xl tracking-[-0.04em]">Self-host free. Cloud for teams.</h2>
       <p class="mt-4 text-pretty text-sm sm:text-base text-muted-foreground">chmonitor is open source — self-hosting is always free under GPL-3.0, with every feature and unlimited clusters. The hosted cloud connects a cluster in minutes when you'd rather not run anything yourself.</p>
     </div>

--- a/apps/landing/src/components/SocialProof.astro
+++ b/apps/landing/src/components/SocialProof.astro
@@ -14,7 +14,7 @@ const commitIcon = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" s
 <section class="py-16">
   <div class="mx-auto max-w-6xl px-6">
     <div class="reveal mx-auto flex max-w-xl flex-col items-center gap-5 rounded-xl border border-border bg-card p-9 text-center shadow-sm">
-      <p class="text-sm font-medium text-primary">Community</p>
+      <p class="font-mono text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">Community</p>
       <h2 class="text-balance font-semibold text-2xl tracking-tight sm:text-3xl">Open source, built in public</h2>
 
       <div class="flex flex-wrap items-center justify-center gap-2.5">

--- a/apps/landing/src/components/UseCaseLinks.astro
+++ b/apps/landing/src/components/UseCaseLinks.astro
@@ -16,7 +16,7 @@ const { items, eyebrow, heading, soft = false } = Astro.props
 <section class:list={['py-14 sm:py-20 md:py-24', soft && 'border-y border-border bg-muted/30']}>
   <div class="mx-auto max-w-6xl px-4 sm:px-6">
     <div class="reveal mx-auto max-w-2xl text-center">
-      <p class="text-sm font-medium text-primary">{eyebrow}</p>
+      <p class="font-mono text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">{eyebrow}</p>
       <h2 class="mt-3 text-balance font-semibold text-2xl sm:text-3xl md:text-4xl tracking-tight">{heading}</h2>
     </div>
     <div class="mt-8 sm:mt-12 grid grid-cols-1 gap-3 sm:gap-4 sm:grid-cols-2 lg:grid-cols-4">

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -77,14 +77,15 @@ const ogImage = new URL(image, Astro.site).toString()
     :root{--serif:'Geist',ui-sans-serif,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif}
   </style>
   <script is:inline>
-    // Resolve theme before paint (no flash): saved choice wins, else OS pref.
+    // Resolve theme before paint (no flash): the landing commits to a dark
+    // (x.ai-style) canvas by default. A saved choice still wins so the toggle
+    // works, but there is no light default and OS light preference is ignored.
     (function () {
       try {
         var saved = localStorage.getItem('chm-theme')
-        var theme = saved || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-        document.documentElement.setAttribute('data-theme', theme)
+        document.documentElement.setAttribute('data-theme', saved || 'dark')
       } catch (e) {
-        document.documentElement.setAttribute('data-theme', 'light')
+        document.documentElement.setAttribute('data-theme', 'dark')
       }
     })()
   </script>
@@ -120,8 +121,8 @@ const ogImage = new URL(image, Astro.site).toString()
       --emerald:#171717;
       --violet:#666666;
       --blue:#171717;
-      /* Geist everyday radius */
-      --radius:6px;
+      /* x.ai sharp corners */
+      --radius:2px;
       --maxw:1200px;
       --shadow-card:0 2px 2px rgba(0,0,0,.04);
       --shadow-float:0 1px 1px rgba(0,0,0,.02), 0 4px 8px -4px rgba(0,0,0,.04), 0 16px 24px -8px rgba(0,0,0,.06);
@@ -165,7 +166,7 @@ const ogImage = new URL(image, Astro.site).toString()
     a{color:inherit;text-decoration:none}
     .mono{font-family:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,monospace}
     .wrap{max-width:var(--maxw);margin:0 auto;padding:0 24px}
-    .eyebrow{font-size:12px;font-weight:600;letter-spacing:.10em;text-transform:uppercase;color:var(--muted-fg)}
+    .eyebrow{font-family:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,monospace;font-size:11.5px;font-weight:500;letter-spacing:.14em;text-transform:uppercase;color:var(--muted-fg)}
 
     /* ── buttons (Geist: 40px height, 6px radius, no lift) ── */
     .btn{display:inline-flex;align-items:center;gap:8px;height:40px;padding:0 14px;border-radius:var(--radius);

--- a/apps/landing/src/styles/globals.css
+++ b/apps/landing/src/styles/globals.css
@@ -16,8 +16,8 @@
 /* shadcn tokens — Geist (Vercel design.md) + x.ai monochrome. Light: near-white
    surfaces, gray-1000 primary. Dark: pure black field, white primary (x.ai). */
 :root {
-  /* Geist shape: 6px everyday radius */
-  --radius: 0.375rem;
+  /* x.ai shape: sharp corners — 2px everyday radius (max rounded-sm feel) */
+  --radius: 0.125rem;
   --background: #ffffff;
   --foreground: #171717;
   --card: #ffffff;


### PR DESCRIPTION
Re-skins the marketing landing (`apps/landing`, Astro + Tailwind) toward the x.ai visual language. This is a re-skin plus typography/spacing overhaul — all existing content, sections, links, SEO meta, and screenshots are preserved. Addresses the direction of #2472.

## Token / theme changes
- **Commit to a dark canvas.** The pre-paint theme resolver now defaults to the dark, near-black x.ai field instead of OS/light preference. A saved toggle choice still wins so the theme switch keeps working; there is no light default.
- **Sharp corners.** Everyday radius dropped to 2px (max rounded-sm feel) in both token sources — `Base.astro` (`--radius`, hand-authored CSS) and `globals.css` (`--radius`, cascades to all shadcn `rounded-*` utilities).

## Type changes
- `.eyebrow` and all `text-primary` section eyebrows (Capabilities, Comparison, FAQ, Features, Pricing, SocialProof, UseCaseLinks, FeatureShowcase) are now monospace, uppercase, wider-tracked, muted — the x.ai mono-accent treatment.

## Notes
- The landing already carried a strong x.ai monochrome base (pure-black dark tokens, ambient grid hero, white-on-black primary buttons); this PR closes the remaining gaps: dark as the committed default, sharper radii, and mono eyebrows.
- Verified with `pnpm install` + `pnpm run build` inside `apps/landing` (15 pages built clean).

https://claude.ai/code/session_01GUKP6qY1efJkqPz6AgaxXh