### PR TITLE
fix(analytics): stitch upgrade_completed to the browser funnel distinct-id

### DIFF
--- a/apps/dashboard/src/lib/analytics/analytics.client.ts
+++ b/apps/dashboard/src/lib/analytics/analytics.client.ts
@@ -107,3 +107,14 @@ export function trackAnalyticsEvent(
   }
   if (pending.length < MAX_PENDING) pending.push({ event, props })
 }
+
+/**
+ * The browser's PostHog anonymous distinct-id, or undefined when analytics is
+ * disabled or PostHog hasn't finished initializing yet. Used to stitch
+ * server-side funnel events (e.g. `upgrade_completed` from the Polar webhook,
+ * #2478) onto the same distinct-id as the rest of the browser funnel.
+ */
+export function getAnalyticsDistinctId(): string | undefined {
+  if (disabled || !posthogInstance) return undefined
+  return posthogInstance.get_distinct_id()
+}

--- a/apps/dashboard/src/lib/analytics/analytics.ts
+++ b/apps/dashboard/src/lib/analytics/analytics.ts
@@ -40,3 +40,17 @@ export const captureException = createIsomorphicFn().client(
     )
   }
 )
+
+/**
+ * The browser's PostHog distinct-id, or undefined on the server / when
+ * analytics is disabled or not yet initialized. Awaited (unlike the
+ * fire-and-forget `trackEvent`) because callers need the value before making
+ * a request — see `startCheckout`, which attaches it to the Polar checkout so
+ * `upgrade_completed` can be stitched back onto this funnel (#2478).
+ */
+export const getDistinctId = createIsomorphicFn()
+  .server(async (): Promise<string | undefined> => undefined)
+  .client(async (): Promise<string | undefined> => {
+    const m = await import('./analytics.client')
+    return m.getAnalyticsDistinctId()
+  })

--- a/apps/dashboard/src/lib/billing/use-billing.ts
+++ b/apps/dashboard/src/lib/billing/use-billing.ts
@@ -8,7 +8,7 @@ import { useQuery } from '@tanstack/react-query'
 
 import type { PlanId } from '@/lib/billing/plans'
 
-import { trackEvent } from '@/lib/analytics/analytics'
+import { getDistinctId, trackEvent } from '@/lib/analytics/analytics'
 import { apiFetch } from '@/lib/swr/api-fetch'
 
 export interface BillingSubscription {
@@ -76,7 +76,17 @@ export async function startCheckout(
   planId: 'pro' | 'max',
   period: 'monthly' | 'yearly'
 ): Promise<void> {
-  const url = await postForUrl('/api/v1/billing/checkout', { planId, period })
+  // Attach the browser's PostHog distinct-id so the Polar webhook can stitch
+  // upgrade_completed onto the same funnel session (#2478) instead of the
+  // shared server id. Undefined (analytics disabled/DNT/not-yet-init) is
+  // dropped by postForUrl's JSON.stringify — the checkout route treats that
+  // as "absent" and falls back cleanly.
+  const posthogDistinctId = await getDistinctId()
+  const url = await postForUrl('/api/v1/billing/checkout', {
+    planId,
+    period,
+    posthogDistinctId,
+  })
   trackEvent('checkout_started', { plan_id: planId, billing_period: period })
   window.location.href = url
 }

--- a/apps/dashboard/src/routes/api/v1/billing/checkout.test.ts
+++ b/apps/dashboard/src/routes/api/v1/billing/checkout.test.ts
@@ -148,3 +148,40 @@ describe('POST /api/v1/billing/checkout — annual billing', () => {
     expect(logEventImpl).not.toHaveBeenCalled()
   })
 })
+
+// #2478 — posthogDistinctId (sent by the browser alongside checkout_started)
+// must be forwarded onto the Polar checkout metadata unchanged so the
+// subscription.created webhook can stitch upgrade_completed back onto the
+// same funnel distinct-id.
+describe('POST /api/v1/billing/checkout — funnel distinct-id stitching', () => {
+  test('posthogDistinctId in the body is forwarded to Polar checkout metadata', async () => {
+    const res = await handlePost(
+      makeRequest({
+        planId: 'pro',
+        period: 'monthly',
+        posthogDistinctId: 'ph_abc123',
+      })
+    )
+
+    expect(res.status).toBe(200)
+    expect(checkoutsCreate.mock.calls[0]?.[0]).toMatchObject({
+      metadata: {
+        planId: 'pro',
+        period: 'monthly',
+        posthogDistinctId: 'ph_abc123',
+      },
+    })
+  })
+
+  test('missing posthogDistinctId (analytics disabled/DNT) omits it from metadata cleanly', async () => {
+    const res = await handlePost(
+      makeRequest({ planId: 'pro', period: 'monthly' })
+    )
+
+    expect(res.status).toBe(200)
+    const metadata = checkoutsCreate.mock.calls[0]?.[0] as {
+      metadata: Record<string, unknown>
+    }
+    expect(metadata.metadata).not.toHaveProperty('posthogDistinctId')
+  })
+})

--- a/apps/dashboard/src/routes/api/v1/billing/checkout.ts
+++ b/apps/dashboard/src/routes/api/v1/billing/checkout.ts
@@ -1,7 +1,7 @@
 /**
  * POST /api/v1/billing/checkout — start a Polar checkout for a paid plan.
  *
- * Body: { planId: 'pro' | 'max', period: 'monthly' | 'yearly' }
+ * Body: { planId: 'pro' | 'max', period: 'monthly' | 'yearly', posthogDistinctId?: string }
  * Returns: { url } — the Polar-hosted checkout URL to redirect the customer to.
  *
  * `externalCustomerId` is set to the billing-owner id (Clerk org id when the
@@ -9,6 +9,14 @@
  * stamps every resulting webhook with `customer.externalId`. The `metadata`
  * always carries the actual Clerk userId so the webhook can lazily create a
  * Clerk org for the buyer on first payment.
+ *
+ * `posthogDistinctId` (optional, sent by the browser alongside `checkout_started`
+ * — see `useBilling`/`startCheckout`) is forwarded into the Polar checkout
+ * metadata unchanged. Polar propagates it onto the resulting subscription, so
+ * the `subscription.created` webhook can stitch `upgrade_completed` back onto
+ * the same PostHog distinct-id as the rest of the funnel (#2478) instead of the
+ * shared server id. Absent when analytics is disabled/DNT — the webhook falls
+ * back to the shared id in that case, never throwing.
  */
 import { createFileRoute } from '@tanstack/react-router'
 
@@ -40,9 +48,13 @@ async function handlePost(request: Request): Promise<Response> {
     )
   }
 
-  let body: { planId?: string; period?: string }
+  let body: { planId?: string; period?: string; posthogDistinctId?: string }
   try {
-    body = (await request.json()) as { planId?: string; period?: string }
+    body = (await request.json()) as {
+      planId?: string
+      period?: string
+      posthogDistinctId?: string
+    }
   } catch {
     return createApiErrorResponse(
       {
@@ -54,7 +66,7 @@ async function handlePost(request: Request): Promise<Response> {
     )
   }
 
-  const { planId, period } = body
+  const { planId, period, posthogDistinctId } = body
   if (!planId || !isPaidPlanId(planId)) {
     return createApiErrorResponse(
       {
@@ -103,7 +115,16 @@ async function handlePost(request: Request): Promise<Response> {
       successUrl: `${origin}/billing?status=success`,
       // userId in metadata lets the webhook lazily create a Clerk org for the
       // buyer when externalCustomerId was still a user id (first payment).
-      metadata: { userId, planId, period },
+      // posthogDistinctId (when present) stitches upgrade_completed back onto
+      // the browser's funnel distinct-id (#2478) — omitted entirely rather
+      // than sent as undefined/empty so the webhook's "absent" fallback path
+      // is unambiguous.
+      metadata: {
+        userId,
+        planId,
+        period,
+        ...(posthogDistinctId ? { posthogDistinctId } : {}),
+      },
     })
 
     // Best-effort audit trail — org-scoped only (a first-time upgrade with no

--- a/apps/dashboard/src/routes/api/v1/webhooks/polar.test.ts
+++ b/apps/dashboard/src/routes/api/v1/webhooks/polar.test.ts
@@ -28,6 +28,22 @@ mock.module('@/lib/audit/logEvent', () => ({
   logEvent: (e: unknown) => logEventImpl(e),
 }))
 
+// #2478 — captures the distinct id the webhook passes for `upgrade_completed`
+// so tests can assert the funnel-stitching fallback (metadata present →
+// browser distinct id; absent → shared default, no throw).
+let captureServerEventImpl = mock(
+  (_env: unknown, _event: string, _props?: unknown, _distinctId?: string) =>
+    Promise.resolve()
+)
+mock.module('@/lib/analytics/analytics.server', () => ({
+  captureServerEvent: (
+    env: unknown,
+    event: string,
+    props?: unknown,
+    distinctId?: string
+  ) => captureServerEventImpl(env, event, props, distinctId),
+}))
+
 let getOrganizationMembershipList = mock(async (_args: { userId: string }) => ({
   data: [] as Array<{ organization?: { id?: string | null } }>,
 }))
@@ -112,6 +128,7 @@ beforeEach(() => {
   upsertSubscription = mock(async () => {})
   invalidateNegativeCache = mock(() => {})
   logEventImpl = mock(() => Promise.resolve())
+  captureServerEventImpl = mock(() => Promise.resolve())
 })
 
 describe('applySubscription — org re-keying', () => {
@@ -248,5 +265,57 @@ describe('applySubscription — audit wiring', () => {
     await applySubscription(subData({ productId: 'prod_unknown' }))
 
     expect(logEventImpl).not.toHaveBeenCalled()
+  })
+})
+
+// #2478 — upgrade_completed must carry the browser's PostHog distinct id
+// (read off subscription.metadata.posthogDistinctId, propagated by Polar from
+// the checkout) so the funnel stitches through the webhook boundary instead of
+// reporting under the shared server id.
+describe('applySubscription — upgrade_completed funnel stitching', () => {
+  test('metadata.posthogDistinctId present → captureServerEvent uses it as the distinct id', async () => {
+    await applySubscription(
+      subData({ metadata: { posthogDistinctId: 'ph_abc123' } }),
+      null,
+      'subscription.created'
+    )
+
+    expect(captureServerEventImpl).toHaveBeenCalledTimes(1)
+    const [, event, props, distinctId] = captureServerEventImpl.mock
+      .calls[0] as [unknown, string, unknown, string | undefined]
+    expect(event).toBe('upgrade_completed')
+    expect(props).toMatchObject({ plan_id: 'pro' })
+    expect(distinctId).toBe('ph_abc123')
+  })
+
+  test('metadata absent → falls back to the shared default id without throwing', async () => {
+    await expect(
+      applySubscription(subData(), null, 'subscription.created')
+    ).resolves.toBeUndefined()
+
+    expect(captureServerEventImpl).toHaveBeenCalledTimes(1)
+    const distinctId = captureServerEventImpl.mock.calls[0]?.[3]
+    expect(distinctId).toBeUndefined()
+  })
+
+  test('a non-string metadata.posthogDistinctId is ignored, not passed through', async () => {
+    await applySubscription(
+      subData({ metadata: { posthogDistinctId: 12345 } }),
+      null,
+      'subscription.created'
+    )
+
+    const distinctId = captureServerEventImpl.mock.calls[0]?.[3]
+    expect(distinctId).toBeUndefined()
+  })
+
+  test('subscription.updated (renewal) never fires upgrade_completed at all', async () => {
+    await applySubscription(
+      subData({ metadata: { posthogDistinctId: 'ph_abc123' } }),
+      null,
+      'subscription.updated'
+    )
+
+    expect(captureServerEventImpl).not.toHaveBeenCalled()
   })
 })

--- a/apps/dashboard/src/routes/api/v1/webhooks/polar.ts
+++ b/apps/dashboard/src/routes/api/v1/webhooks/polar.ts
@@ -68,6 +68,15 @@ interface PolarSubscriptionData {
   productId: string
   customerId: string
   customer?: { externalId?: string | null } | null
+  /**
+   * Copied onto the subscription from the checkout's metadata at creation
+   * (Polar propagates checkout metadata to the resulting subscription).
+   * Carries `posthogDistinctId` when the browser attached one at checkout
+   * time (see `/api/v1/billing/checkout`) — stitches `upgrade_completed`
+   * onto the same PostHog distinct-id as the rest of the funnel instead of
+   * the shared server id, so the funnel's last step stops reporting 0%.
+   */
+  metadata?: Record<string, unknown> | null
 }
 
 function toUnixSeconds(value: Date | string | null | undefined): number | null {
@@ -289,10 +298,14 @@ async function applySubscription(
   // `checkout_started` events) because this is the only point that reflects
   // money actually moving, confirmed by Polar.
   if (isPaidPlan && eventType === 'subscription.created') {
+    const posthogDistinctId = data.metadata?.posthogDistinctId
     await captureServerEvent(
       process.env as Record<string, string | undefined>,
       'upgrade_completed',
-      { plan_id: mapped.planId, billing_period: mapped.period }
+      { plan_id: mapped.planId, billing_period: mapped.period },
+      typeof posthogDistinctId === 'string' && posthogDistinctId
+        ? posthogDistinctId
+        : undefined
     )
   }
 

--- a/docs/content/operate/advanced/product-analytics.mdx
+++ b/docs/content/operate/advanced/product-analytics.mdx
@@ -81,15 +81,16 @@ The core acquisition→conversion funnel these events trace: `landing_view` →
 `paywall_hit` → `upgrade_completed`. Build this as a PostHog funnel insight
 (Product analytics → Insights → Funnel) using these events in order.
 
-<Callout type="warn" title="upgrade_completed is not stitched to the same distinct_id">
 `upgrade_completed` fires from the Polar webhook (server-side, no browser
-context), so it's captured under the shared `server` distinct id rather than
-the browser's anonymous id used by every other dashboard event above. Treat it
-as an aggregate count (conversions per period), not as a per-user step in a
-PostHog funnel insight — a true per-user funnel across the webhook boundary
-would need passing the anonymous distinct id through checkout metadata and
-back, which is not implemented.
-</Callout>
+context), so it carries the browser's PostHog distinct id rather than the
+shared `server` one: `checkout_started` reads `posthog.get_distinct_id()` and
+forwards it as `posthogDistinctId` on the Polar checkout metadata, Polar
+propagates it onto the resulting subscription, and the
+`subscription.created` webhook reads it back off to stitch
+`upgrade_completed` onto that same distinct id (#2478). Older checkouts or a
+manually-created Polar subscription have no such metadata; the webhook falls
+back to the shared `server` id for those, so it stays a per-user funnel step
+for stitched conversions and an aggregate count otherwise.
 
 ## What is captured
 

--- a/docs/internal/2026h2-market/06-analytics-baseline.md
+++ b/docs/internal/2026h2-market/06-analytics-baseline.md
@@ -60,11 +60,12 @@ two PostHog Insights in the `chmonitor.dev` project, not new in-app code:
 
 1. **Funnel insight** — Product analytics → Insights → New → Funnel. Steps, in
    order: `landing_view`, `signup`, `cluster_connect`,
-   `advisor_recommendation_viewed`, `paywall_hit`, `upgrade_completed`. Note the
-   `upgrade_completed` distinct-id caveat in `product-analytics.mdx` — this step
-   is an aggregate count of the step before it, not a stitched per-user
-   conversion, since it's captured server-side from the Polar webhook with no
-   browser context.
+   `advisor_recommendation_viewed`, `paywall_hit`, `upgrade_completed`.
+   `upgrade_completed` is stitched to the same browser distinct-id as the
+   steps before it (#2478 — see `product-analytics.mdx`), so this is now a
+   real per-user conversion step, not just an aggregate count; the fallback to
+   the shared `server` id only applies to pre-#2478 checkouts and manually
+   created Polar subscriptions.
 2. **Trends insight** — `signup`, `cluster_connect`, `checkout_started`,
    `upgrade_completed` as separate trend lines, weekly, to eyeball week-over-week
    funnel health without waiting on the stitched funnel step above.
@@ -81,10 +82,6 @@ against the existing `chmonitor.dev` project and pin them to a dashboard there.
 - **Social followers are entirely unmeasured.** No X/LinkedIn account is wired
   into any repo tooling; this line item needs a human to check the account(s)
   directly, or a future task to pull an API if/when official accounts exist.
-- **`upgrade_completed` is not stitched to the rest of the funnel per-user** —
-  see the callout in `product-analytics.mdx`. Closing this gap would mean
-  passing the browser's anonymous PostHog distinct id through Polar checkout
-  metadata and reading it back out of the webhook payload.
 - **PostHog Insights themselves are not created by this change** — the funnel/
   trends config above is written as instructions for whoever has PostHog
   project access; no PostHog API credential was available in this session to


### PR DESCRIPTION
## Summary
- `checkout_started` now reads `posthog.get_distinct_id()` and forwards it as `posthogDistinctId` on the Polar checkout metadata.
- The `subscription.created` webhook reads it back off `data.metadata.posthogDistinctId` and passes it as `captureServerEvent`'s distinct id for `upgrade_completed`, instead of the shared server id — so the funnel no longer breaks at the last step.
- Falls back cleanly to the shared id when metadata is absent (older checkouts, manual Polar-dashboard subscriptions) — webhook never throws.
- Updated the caveat in `docs/content/operate/advanced/product-analytics.mdx` and `docs/internal/2026h2-market/06-analytics-baseline.md` now that stitching is implemented.
- Verified `posthog.identify()`/alias is never called anywhere in the app — distinct id stays anonymous end-to-end, so signup doesn't itself break stitching.

## Test plan
- [x] `bun test src/routes/api/v1/webhooks/polar.test.ts src/routes/api/v1/billing/checkout.test.ts` — 23 pass, including new cases: metadata present → distinct id used; metadata absent → shared-id fallback, no throw; non-string metadata ignored; `subscription.updated` never fires the event; checkout route forwards/omits `posthogDistinctId` correctly.
- [x] Existing billing webhook tests (signature auth, monotonic guard, org re-keying, D1 retry) stay green.

Fixes #2478