### PR TITLE
fix(security): apply demo-host guard to 10 unguarded hostId API routes

### DIFF
--- a/apps/dashboard/src/lib/cloud/reject-demo-host.ts
+++ b/apps/dashboard/src/lib/cloud/reject-demo-host.ts
@@ -55,3 +55,19 @@ export async function isDemoHostBlockedForRequest(
   if (hostId < 0) return false
   return isSignedInServer()
 }
+
+/**
+ * Shared "demo hidden" payload for routes that reject a blocked hostId
+ * (#2172 / #2488). Every guarded route embeds this under its own
+ * `unavailable` field alongside a route-specific empty data shape — kept as
+ * a shared constant so the reason code / message aren't duplicated per route.
+ */
+export function demoHiddenUnavailable(): {
+  reason: 'demo_hidden'
+  message: string
+} {
+  return {
+    reason: 'demo_hidden',
+    message: 'The demo host is hidden for signed-in accounts.',
+  }
+}

--- a/apps/dashboard/src/routes/api/v1/advisor.ts
+++ b/apps/dashboard/src/routes/api/v1/advisor.ts
@@ -21,6 +21,10 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { env } from 'cloudflare:workers'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import {
+  demoHiddenUnavailable,
+  isDemoHostBlockedForRequest,
+} from '@/lib/cloud/reject-demo-host'
 
 const ROUTE_CONTEXT = { route: '/api/v1/advisor' }
 const MAX_QUERY_LENGTH = 100000
@@ -127,6 +131,27 @@ async function runAdvisor(
         ...ROUTE_CONTEXT,
       },
       { status: 400 }
+    )
+  }
+
+  // Cloud demo-hiding invariant (#2172 / #2488): user connections always use
+  // negative hostIds, so a non-negative id from a signed-in cloud principal
+  // can only be the hidden env/demo host. No-op for OSS and anonymous cloud
+  // callers (both legitimately use hostId=0).
+  if (
+    await isDemoHostBlockedForRequest(
+      hostId,
+      env as Record<string, string | undefined>
+    )
+  ) {
+    return Response.json(
+      {
+        success: true,
+        recommendations: [],
+        ...ROUTE_CONTEXT,
+        unavailable: demoHiddenUnavailable(),
+      },
+      { status: 200 }
     )
   }
 

--- a/apps/dashboard/src/routes/api/v1/cluster-counts/$key.ts
+++ b/apps/dashboard/src/routes/api/v1/cluster-counts/$key.ts
@@ -31,6 +31,10 @@ import {
   createSuccessResponse,
 } from '@/lib/api/shared/response-builder'
 import { ApiErrorType } from '@/lib/api/types'
+import {
+  demoHiddenUnavailable,
+  isDemoHostBlockedForRequest,
+} from '@/lib/cloud/reject-demo-host'
 
 const ROUTE_CONTEXT = { route: '/api/v1/cluster-counts/$key', method: 'GET' }
 
@@ -151,6 +155,32 @@ async function handler(
     }
 
     const hostId = hostIdResult.data
+
+    // Cloud demo-hiding invariant (#2172 / #2488): reject a non-negative
+    // hostId for an authenticated cloud principal (the hidden env/demo host).
+    if (
+      await isDemoHostBlockedForRequest(
+        hostId,
+        env as Record<string, string | undefined>
+      )
+    ) {
+      const headers = new Headers({ 'Content-Type': 'application/json' })
+      headers.set('X-Request-ID', requestId)
+      return Response.json(
+        {
+          success: true,
+          data: { count: null } satisfies ClusterCountResponse,
+          metadata: {
+            queryId: `cluster-count-${countKey}`,
+            duration: 0,
+            rows: 0,
+            host: String(hostId),
+            unavailable: demoHiddenUnavailable(),
+          },
+        },
+        { headers }
+      )
+    }
 
     debug('[GET /api/v1/cluster-counts] Fetching count', {
       requestId,

--- a/apps/dashboard/src/routes/api/v1/cluster-topology.ts
+++ b/apps/dashboard/src/routes/api/v1/cluster-topology.ts
@@ -57,6 +57,10 @@ import {
   createSuccessResponse,
 } from '@/lib/api/shared/response-builder'
 import { ApiErrorType } from '@/lib/api/types'
+import {
+  demoHiddenUnavailable,
+  isDemoHostBlockedForRequest,
+} from '@/lib/cloud/reject-demo-host'
 import { keeperInfoConfig } from '@/lib/query-config/keeper/keeper-info'
 import { keeperPresenceConfig } from '@/lib/query-config/keeper/keeper-presence'
 import {
@@ -132,6 +136,32 @@ async function handleGet(request: Request): Promise<Response> {
     }
     const hostId = hostIdResult.data
     const timezone = searchParams.get('timezone') || undefined
+
+    // Cloud demo-hiding invariant (#2172 / #2488): reject a non-negative
+    // hostId for an authenticated cloud principal (the hidden env/demo host).
+    if (
+      await isDemoHostBlockedForRequest(
+        hostId,
+        env as Record<string, string | undefined>
+      )
+    ) {
+      const headers = new Headers({ 'Content-Type': 'application/json' })
+      headers.set('X-Request-ID', requestId)
+      return Response.json(
+        {
+          success: true,
+          data: null,
+          metadata: {
+            queryId: 'cluster-topology',
+            duration: 0,
+            rows: 0,
+            host: String(hostId),
+            unavailable: demoHiddenUnavailable(),
+          },
+        },
+        { headers }
+      )
+    }
 
     debug('[GET /api/v1/cluster-topology] Assembling topology', {
       requestId,

--- a/apps/dashboard/src/routes/api/v1/data.ts
+++ b/apps/dashboard/src/routes/api/v1/data.ts
@@ -44,6 +44,10 @@ import {
 } from '@/lib/api/shared/validators'
 import { getTableConfig } from '@/lib/api/table-registry'
 import { ApiErrorType } from '@/lib/api/types'
+import {
+  demoHiddenUnavailable,
+  isDemoHostBlockedForRequest,
+} from '@/lib/cloud/reject-demo-host'
 
 const ROUTE_CONTEXT = { route: '/api/v1/data' } as const
 
@@ -84,6 +88,26 @@ function createSuccessResponse<T>(
     headers: {
       'Content-Type': 'application/json',
       ...SUCCESS_CACHE_HEADERS,
+    },
+  })
+}
+
+/**
+ * Cloud demo-hiding invariant (#2172 / #2488): user connections always use
+ * negative hostIds, so a non-negative id from a signed-in cloud principal can
+ * only be the hidden env/demo host. No-op for OSS and anonymous cloud callers
+ * (both legitimately use hostId=0).
+ */
+function createDemoHiddenResponse(hostId: number): Response {
+  return Response.json({
+    success: true,
+    data: null,
+    metadata: {
+      queryId: '',
+      duration: 0,
+      rows: 0,
+      host: String(hostId),
+      unavailable: demoHiddenUnavailable(),
     },
   })
 }
@@ -190,6 +214,15 @@ const handleGet = withApiHandler(async (request: Request) => {
   }
   const hostId = hostIdResult
 
+  if (
+    await isDemoHostBlockedForRequest(
+      hostId,
+      env as Record<string, string | undefined>
+    )
+  ) {
+    return createDemoHiddenResponse(hostId)
+  }
+
   debug('[GET /api/v1/data]', {
     hostId,
     format: format || 'JSONEachRow',
@@ -281,6 +314,15 @@ const handlePost = withApiHandler(async (request: Request) => {
     queryConfigName,
     timezone,
   })
+
+  if (
+    await isDemoHostBlockedForRequest(
+      Number(hostId),
+      env as Record<string, string | undefined>
+    )
+  ) {
+    return createDemoHiddenResponse(Number(hostId))
+  }
 
   // SECURITY: Reject client-supplied QueryConfig objects to prevent SQL override attacks.
   if (

--- a/apps/dashboard/src/routes/api/v1/explain.ts
+++ b/apps/dashboard/src/routes/api/v1/explain.ts
@@ -21,6 +21,10 @@ import { QUERY_COMMENT } from '@chm/clickhouse-client/constants'
 import { debug, error as logError } from '@chm/logger'
 import { stripTrailingFormat, validateSqlQuery } from '@chm/sql-builder'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import {
+  demoHiddenUnavailable,
+  isDemoHostBlockedForRequest,
+} from '@/lib/cloud/reject-demo-host'
 
 const ROUTE_CONTEXT = { route: '/api/v1/explain' }
 
@@ -156,6 +160,31 @@ async function runExplain(
   modeParam: string,
   planSettingsRaw: string
 ): Promise<Response> {
+  // Cloud demo-hiding invariant (#2172 / #2488): user connections always use
+  // negative hostIds, so a non-negative id from a signed-in cloud principal
+  // can only be the hidden env/demo host. No-op for OSS and anonymous cloud
+  // callers (both legitimately use hostId=0).
+  if (
+    await isDemoHostBlockedForRequest(
+      hostId,
+      env as Record<string, string | undefined>
+    )
+  ) {
+    return Response.json(
+      {
+        success: true,
+        data: [],
+        metadata: {
+          sql: '',
+          rows: 0,
+          queryId: '',
+          unavailable: demoHiddenUnavailable(),
+        },
+      },
+      { status: 200 }
+    )
+  }
+
   if (!query || query.trim() === '') {
     return Response.json(
       {

--- a/apps/dashboard/src/routes/api/v1/management.ts
+++ b/apps/dashboard/src/routes/api/v1/management.ts
@@ -12,6 +12,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { env } from 'cloudflare:workers'
 import { fetchData } from '@chm/clickhouse-client'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { isDemoHostBlockedForRequest } from '@/lib/cloud/reject-demo-host'
 import { ACTIONS_FEATURE_PERMISSION } from '@/lib/feature-permissions/permissions'
 import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
 import {
@@ -251,6 +252,26 @@ export const Route = createFileRoute('/api/v1/management')({
               error: 'Invalid parameter: hostId must be a non-negative integer',
             },
             { status: 400 }
+          )
+        }
+
+        // Cloud demo-hiding invariant (#2172 / #2488): user connections
+        // always use negative hostIds, so a non-negative id from a
+        // signed-in cloud principal can only be the hidden env/demo host.
+        // This is a mutation endpoint (DDL), so reject outright rather than
+        // returning structured-empty data.
+        if (
+          await isDemoHostBlockedForRequest(
+            hostId,
+            env as Record<string, string | undefined>
+          )
+        ) {
+          return Response.json(
+            {
+              success: false,
+              error: 'The demo host is hidden for signed-in accounts.',
+            },
+            { status: 403 }
           )
         }
 

--- a/apps/dashboard/src/routes/api/v1/menu-counts/index.ts
+++ b/apps/dashboard/src/routes/api/v1/menu-counts/index.ts
@@ -33,6 +33,10 @@ import {
   createSuccessResponse,
 } from '@/lib/api/shared/response-builder'
 import { ApiErrorType } from '@/lib/api/types'
+import {
+  demoHiddenUnavailable,
+  isDemoHostBlockedForRequest,
+} from '@/lib/cloud/reject-demo-host'
 
 const ROUTE_CONTEXT = { route: '/api/v1/menu-counts', method: 'GET' }
 
@@ -130,6 +134,33 @@ export async function handler(request: Request): Promise<Response> {
     }
 
     const hostId = hostIdResult.data
+
+    // Cloud demo-hiding invariant (#2172 / #2488): reject a non-negative
+    // hostId for an authenticated cloud principal (the hidden env/demo host).
+    if (
+      await isDemoHostBlockedForRequest(
+        hostId,
+        env as Record<string, string | undefined>
+      )
+    ) {
+      const headers = new Headers({ 'Content-Type': 'application/json' })
+      headers.set('X-Request-ID', requestId)
+      headers.set('Cache-Control', CacheControl.MEDIUM)
+      return Response.json(
+        {
+          success: true,
+          data: { counts: {} } satisfies MenuCountsResponse,
+          metadata: {
+            queryId: 'menu-counts-batch',
+            duration: 0,
+            rows: 0,
+            host: String(hostId),
+            unavailable: demoHiddenUnavailable(),
+          },
+        },
+        { headers }
+      )
+    }
 
     debug('[GET /api/v1/menu-counts] Fetching batched counts', {
       requestId,

--- a/apps/dashboard/src/routes/api/v1/settings-diff.ts
+++ b/apps/dashboard/src/routes/api/v1/settings-diff.ts
@@ -14,6 +14,10 @@ import { env } from 'cloudflare:workers'
 import { fetchData } from '@chm/clickhouse-client'
 import { getClickHouseConfigsFromEnv } from '@/lib/api/clickhouse-config'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import {
+  demoHiddenUnavailable,
+  isDemoHostBlockedForRequest,
+} from '@/lib/cloud/reject-demo-host'
 
 const SETTINGS_QUERY = `
   SELECT name, value, changed, description, default AS defaultValue
@@ -61,6 +65,25 @@ export const Route = createFileRoute('/api/v1/settings-diff')({
             { success: false, error: 'No ClickHouse hosts configured' },
             { status: 503 }
           )
+        }
+
+        // Cloud demo-hiding invariant (#2172 / #2488): this endpoint fans out
+        // over every env-configured host, which in cloud mode is exactly the
+        // hidden demo host (there is no per-request hostId param — env hosts
+        // ARE hostId 0..N-1). Probing hostId 0 mirrors the other routes'
+        // guard: true only for an authenticated cloud principal.
+        if (
+          await isDemoHostBlockedForRequest(
+            0,
+            env as Record<string, string | undefined>
+          )
+        ) {
+          return Response.json({
+            success: true,
+            hosts: [],
+            rows: [],
+            unavailable: demoHiddenUnavailable(),
+          })
         }
 
         // Fan out: for each host × each table, fire one query. That's 2×N promises.

--- a/apps/dashboard/src/routes/api/v1/table-availability.ts
+++ b/apps/dashboard/src/routes/api/v1/table-availability.ts
@@ -27,6 +27,10 @@ import {
   createSuccessResponse,
 } from '@/lib/api/shared/response-builder'
 import { ApiErrorType } from '@/lib/api/types'
+import {
+  demoHiddenUnavailable,
+  isDemoHostBlockedForRequest,
+} from '@/lib/cloud/reject-demo-host'
 
 const ROUTE_CONTEXT = { route: '/api/v1/table-availability', method: 'GET' }
 
@@ -122,6 +126,35 @@ export const Route = createFileRoute('/api/v1/table-availability')({
           }
 
           const hostId = hostIdResult.data
+
+          // Cloud demo-hiding invariant (#2172 / #2488): reject a
+          // non-negative hostId for an authenticated cloud principal (the
+          // hidden env/demo host).
+          if (
+            await isDemoHostBlockedForRequest(
+              hostId,
+              env as Record<string, string | undefined>
+            )
+          ) {
+            const headers = new Headers({ 'Content-Type': 'application/json' })
+            headers.set('X-Request-ID', requestId)
+            headers.set('Cache-Control', CacheControl.MEDIUM)
+            return Response.json(
+              {
+                success: true,
+                data: { available: {} } satisfies TableAvailabilityResponse,
+                metadata: {
+                  queryId: 'table-availability-batch',
+                  duration: 0,
+                  rows: 0,
+                  host: String(hostId),
+                  unavailable: demoHiddenUnavailable(),
+                },
+              },
+              { headers }
+            )
+          }
+
           bridgeClickHouseEnv(env as Record<string, string | undefined>)
 
           debug(

--- a/apps/dashboard/src/routes/api/v1/tables/index.ts
+++ b/apps/dashboard/src/routes/api/v1/tables/index.ts
@@ -14,6 +14,7 @@ import { env } from 'cloudflare:workers'
 import { fetchData } from '@chm/clickhouse-client'
 import { debug, error } from '@chm/logger'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { isDemoHostBlockedForRequest } from '@/lib/cloud/reject-demo-host'
 
 const DEFAULT_LIMIT = 500
 const MAX_LIMIT = 1000
@@ -45,6 +46,32 @@ export const Route = createFileRoute('/api/v1/tables/')({
             : DEFAULT_LIMIT
 
         debug('[GET /api/v1/tables]', { hostId, limit })
+
+        // Cloud demo-hiding invariant (#2172 / #2488): user connections
+        // always use negative hostIds, so a non-negative id from a
+        // signed-in cloud principal can only be the hidden env/demo host.
+        // No-op for OSS and anonymous cloud callers (both legitimately use
+        // hostId=0).
+        if (
+          await isDemoHostBlockedForRequest(
+            hostId,
+            env as Record<string, string | undefined>
+          )
+        ) {
+          return Response.json({
+            success: true,
+            data: [],
+            metadata: {
+              queryId: '',
+              duration: 0,
+              rows: 0,
+              host: String(hostId),
+              unavailable: true,
+              unavailableReason:
+                'The demo host is hidden for signed-in accounts.',
+            },
+          })
+        }
 
         const result = await fetchData<TableRow[]>({
           query: `


### PR DESCRIPTION
## Summary

`isDemoHostBlockedForRequest()` enforces the cloud demo-hiding invariant (#2172) on ~22 routes, but 10 hostId-accepting routes skipped it — a signed-in cloud user with a stale `?host=0` URL or a hand-crafted request could still read the hidden demo host.

This wires the same guard into all 10:

- `api/v1/data.ts` (GET + POST)
- `api/v1/cluster-topology.ts`
- `api/v1/menu-counts/index.ts`
- `api/v1/cluster-counts/$key.ts`
- `api/v1/settings-diff.ts` (fans out over env hosts; probes hostId 0)
- `api/v1/management.ts` (mutation route — rejects with 403 instead of structured-empty)
- `api/v1/advisor.ts` (guard in `runAdvisor`, shared by GET/POST, before billing reservation)
- `api/v1/explain.ts` (guard in `runExplain`, shared by GET/POST)
- `api/v1/table-availability.ts`
- `api/v1/tables/index.ts`

Shared helper `demoHiddenUnavailable()` added to `lib/cloud/reject-demo-host.ts` so the `demo_hidden` reason/message isn't duplicated per route.

## OSS unaffected

The guard early-returns when not cloud mode (`isCloudModeServer` fail-closed) and for anonymous cloud callers — both keep using `hostId=0` as before. No OSS/self-hosted functionality is gated.

Fixes #2488