### PR TITLE
docs(blog): 8 new ClickHouse SEO posts

### DIFF
--- a/apps/blog/CONTENT-CALENDAR.md
+++ b/apps/blog/CONTENT-CALENDAR.md
@@ -36,16 +36,17 @@ published (`draft: false`, merged to main)
 |---|---|---|---|---|---|
 | 1 | release | chmonitor v0.3 — a full rebuild | clickhouse monitoring dashboard | `/guide/getting-started` | done (`chmonitor-v0-3.md`, published 2026-06-29) |
 | 2 | how-to | Alerting to Slack and Discord | clickhouse alerting webhook | `/guide/features/health` | moved to docs-only (`docs/content/guide/guides/alerting-slack-discord.mdx`), no blog post |
-| 3 | how-to | Ask your cluster anything: the AI agent over MCP | clickhouse ai agent mcp | `/guide/ai-agent` | planned |
-| 4 | troubleshooting | Why is my ClickHouse replication lagging? | clickhouse replication lag | `/guide/features` (replication section) | planned |
-| 5 | how-to | The query advisor: DDL recommendations you review, not that run themselves | clickhouse query optimization advisor | `/guide/ai-agent` (advisor tools) | planned |
+| 3 | how-to | Ask your cluster anything: the AI agent over MCP | clickhouse ai agent mcp | `/guide/ai-agent` | done (`clickhouse-ai-agent-mcp.md`, published 2026-07-17) |
+| 4 | troubleshooting | Why is my ClickHouse replication lagging? | clickhouse replication lag | `/guide/features` (replication section) | done (`clickhouse-replication-lag.md`, published 2026-07-24) |
+| 5 | how-to | The query advisor: DDL recommendations you review, not that run themselves | clickhouse query optimization advisor | `/guide/ai-agent` (advisor tools) | done (`clickhouse-query-optimization-advisor.md`, published 2026-07-31) |
 | 6 | case-study | Diagnosing a slow-query regression start to finish | clickhouse slow query diagnosis | `/guide/features` | done (`find-slow-clickhouse-queries.md`, published 2026-07-10, covers this slot as a how-to) |
-| 7 | troubleshooting | Reading `system.merges` when merges pile up | clickhouse merges stuck | `/guide/features` | planned |
-| 8 | how-to | Self-hosting chmonitor on Docker in five minutes | self-host clickhouse dashboard docker | `/operate/deploy/docker` | planned |
-| 9 | how-to | Self-hosting chmonitor on Kubernetes | clickhouse monitoring kubernetes | `/operate/deploy/k8s` | planned |
-| 10 | troubleshooting | Debugging `system.errors` spikes | clickhouse system errors | `/guide/features/health` | planned |
-| 11 | case-study | Capacity planning with the TTL and disk-growth advisor | clickhouse capacity planning ttl | `/guide/ai-agent` (advisor tools) | planned |
+| 7 | troubleshooting | Reading `system.merges` when merges pile up | clickhouse merges stuck | `/guide/features` | done (`clickhouse-system-merges-merge-storm.md`, published 2026-07-03) |
+| 8 | how-to | Self-hosting chmonitor on Docker in five minutes | self-host clickhouse dashboard docker | `/operate/deploy/docker` | done (`clickhouse-self-hosting-docker.md`, published 2026-08-14) |
+| 9 | how-to | Self-hosting chmonitor on Kubernetes | clickhouse monitoring kubernetes | `/operate/deploy/k8s` | done (`clickhouse-monitoring-kubernetes.md`, published 2026-08-21) |
+| 10 | troubleshooting | Debugging `system.errors` spikes | clickhouse system errors | `/guide/features/health` | done (`clickhouse-system-errors-spikes.md`, published 2026-08-28) |
+| 11 | case-study | Capacity planning with the TTL and disk-growth advisor | clickhouse capacity planning ttl | `/guide/ai-agent` (advisor tools) | done (`clickhouse-capacity-planning-ttl.md`, published 2026-09-04) |
 | 12 | release | (scaffold from the next GitHub release when it ships) | — | `/reference/releases` | planned |
+| 13 | troubleshooting | ClickHouse disk is full — what to do right now | clickhouse disk full emergency | `/guide/features` | done (`clickhouse-disk-full-emergency.md`, published 2026-09-11) |
 
 ## Post-type mix (per 12-week cycle)
 

--- a/apps/blog/src/content/blog/clickhouse-ai-agent-mcp.md
+++ b/apps/blog/src/content/blog/clickhouse-ai-agent-mcp.md
@@ -1,0 +1,67 @@
+---
+title: "Ask your ClickHouse cluster anything: the AI agent over MCP"
+description: "How chmonitor's read-only AI agent turns natural-language questions into system-table queries, and how to reach it from Claude Desktop or Cursor over MCP."
+date: 2026-07-17
+tag: How-to
+---
+
+This is for anyone who has typed "why is my ClickHouse cluster slow right now" into a search bar instead of `system.query_log`. chmonitor ships a built-in AI agent that plans and runs the diagnostic queries for you — inside the dashboard, or from any MCP-compatible client. By the end you'll have it answering questions from both.
+
+## Prerequisites
+
+- A chmonitor instance already connected to a ClickHouse host.
+- At least one LLM provider API key (`LLM_API_KEY` at minimum — chmonitor defaults to OpenRouter's free tier if that's all you set).
+- For the MCP path: an MCP-compatible client (Claude Desktop, Cursor, etc).
+
+## Steps
+
+### 1. Set an LLM provider key
+
+```bash
+LLM_API_KEY=your-provider-key
+```
+
+That's the only required variable. Full provider/model options (AnyRouter, OpenRouter, NVIDIA NIM, custom base URLs) are in the [Configuration](https://docs.chmonitor.dev/guide/ai-agent/configuration) reference.
+
+### 2. Ask it something in the dashboard
+
+Open `/agents`, pick a host, and ask a question in plain English — "which tables have the most active merges right now", "am I about to run out of disk", "why did query X get slow". The agent plans a sequence of **read-only** tool calls against `system.*` tables and streams back an answer, with an inline chart when one helps.
+
+Under the hood it has a lean, fixed toolset — no ability to invent arbitrary write queries. A few examples: `get_slow_queries` / `list_slow_query_patterns` read `system.query_log`; `get_replication_status` reads `system.replicas`; `get_merge_status` reads `system.merges`; `forecast_disk_capacity` and `suggest_ttl_adjustment` are recommend-only (they never execute anything); `get_optimization_recommendations` analyzes a slow query and returns ranked DDL suggestions for you to review, not apply.
+
+For anything outside the built-in tools, the agent falls back to a plain `query` tool plus an expert **skill** — a bundled recipe with copy-pasteable SQL for a specific domain (replication, storage, cluster topology, incident response, and more).
+
+### 3. Connect an external MCP client
+
+chmonitor exposes the same agent surface as an MCP server at `/api/mcp`. Point Claude Desktop, Cursor, or any MCP client at it and it gets the same read-only tools the in-dashboard agent uses — so you can ask your cluster questions from your editor instead of switching tabs.
+
+```json
+{
+  "mcpServers": {
+    "chmonitor": {
+      "url": "https://your-chmonitor-host/api/mcp"
+    }
+  }
+}
+```
+
+Exact auth requirements (open, HMAC API key, or Clerk OAuth) depend on how you've configured the endpoint — see the [MCP server guide](https://docs.chmonitor.dev/guide/features/mcp) for the full setup and security posture.
+
+## Verifying it worked
+
+In the dashboard, ask "what's my slowest query in the last hour" and confirm you get back an answer referencing real `query_id`s and durations from your cluster, not a generic response. From an MCP client, list the available tools and confirm `get_replication_status`, `get_slow_queries`, or similar chmonitor-specific tools show up alongside whatever else the client has configured.
+
+## Related
+
+- Docs: [AI agent](https://docs.chmonitor.dev/guide/ai-agent) — full tool list, skills, plan-and-verify mode.
+- Docs: [AI agent capabilities](https://docs.chmonitor.dev/guide/ai-agent/capabilities) — every tool, grouped by category, with the exact `system.*` tables each one reads.
+- Docs: [MCP server](https://docs.chmonitor.dev/guide/features/mcp) — endpoint setup, auth modes, security.
+
+<!--
+CLAIM-VERIFICATION CHECKLIST
+- [x] Tool names (get_slow_queries, list_slow_query_patterns, get_replication_status, get_merge_status, forecast_disk_capacity, suggest_ttl_adjustment, get_optimization_recommendations) checked against apps/dashboard/src/lib/ai/agent/tools/*.ts and docs/content/guide/ai-agent/capabilities.mdx.
+- [x] LLM_API_KEY quick-start and OpenRouter default checked against docs/content/guide/ai-agent.mdx.
+- [x] MCP endpoint path /api/mcp and docs cross-link checked against docs/content/guide/features (mcp guide referenced in ai-agent.mdx).
+- [x] Feature is merged to main (apps/dashboard/src/lib/ai/agent/*).
+- [x] No self-hosted-vs-cloud scope issue — agent + MCP work on both, no Cloud-only claim made.
+-->

--- a/apps/blog/src/content/blog/clickhouse-capacity-planning-ttl.md
+++ b/apps/blog/src/content/blog/clickhouse-capacity-planning-ttl.md
@@ -1,0 +1,60 @@
+---
+title: "Capacity planning with the disk-forecast and TTL advisor"
+description: "A worked example of forecasting ClickHouse disk exhaustion and getting a recommend-only TTL adjustment before an out-of-space incident happens."
+date: 2026-09-04
+tag: Case study
+---
+
+This is a composite worked example built for this post, not a real incident — the workflow and tool behavior described are exactly how chmonitor's capacity-planning tools behave, run against a representative cluster. The scenario: disk usage on a high-ingest events table has been creeping up for weeks, and nobody wants to find out it hit 100% the hard way.
+
+## The problem
+
+A team ingesting clickstream events into a `MergeTree` table notices disk usage alerts trending upward over several weeks, but no single day looks alarming enough to act on. Reactive capacity management — waiting for a disk-full page — is exactly the failure mode this workflow is meant to avoid.
+
+## Investigating
+
+### Step 1 — forecast when the disk actually runs out
+
+Instead of eyeballing a disk-usage chart and guessing, ask the AI agent to forecast it directly. This calls the `forecast_disk_capacity` tool, which projects from `system.part_log` `NewPart` write volume over the last 30 days (plus the top contributing tables) and reports against a configurable horizon (default 90 days).
+
+> Forecast when this host's disks will run out of free space.
+
+The tool is explicit about its own limits: if `system.part_log` isn't enabled on the cluster, it reports that clearly instead of fabricating a forecast — there's no silent guess.
+
+### Step 2 — identify the retention floor
+
+Before asking for a TTL suggestion, the actual business/compliance requirement has to be pinned down — how many days of this table's data legally or operationally must be kept. This case assumes a 30-day floor (chmonitor's own default when none is specified, though it's meant to be overridden explicitly whenever the real requirement differs).
+
+### Step 3 — get a TTL recommendation
+
+> Suggest a TTL adjustment for `default.events` that keeps disk usage under control, with a 30-day retention floor.
+
+This calls `suggest_ttl_adjustment`, which returns a suggested `ALTER TABLE ... MODIFY TTL ...` string aimed at keeping projected disk utilization at or under 80%, plus a risk note — and never suggests less than the retention floor given. Like the forecast tool, it reports a clear "part_log not available" message rather than a fabricated suggestion if the underlying data isn't there.
+
+## Root cause
+
+Sustained growth without a bounding TTL on a high-ingest table — normal and expected behavior for an ever-growing events table, but one that needs an explicit retention policy rather than "grow until the disk fills up."
+
+## Resolution
+
+The suggested `ALTER TABLE ... MODIFY TTL ...` is **not applied automatically** — this is a recommend-only tool, same as the query optimization advisor. Applying it is a deliberate, reviewed step: check the suggested cutoff against actual compliance/business requirements, run it in a maintenance window (TTL changes trigger background part expiry, not an instant deletion), and confirm the disk-usage trend flattens afterward by re-running the forecast or watching the [Disks](https://docs.chmonitor.dev/guide/features) page.
+
+## Takeaway
+
+Capacity planning works best as a forecast-then-recommend loop, not a reactive one: `forecast_disk_capacity` tells you *when* a problem becomes real, `suggest_ttl_adjustment` gives you a concrete, floor-respecting fix to review — but both stop short of touching your table. Reach for this pairing whenever a disk-usage trend looks concerning but isn't yet an emergency; see [what to do once it already is one](/clickhouse-disk-full-emergency/).
+
+## Related
+
+- Docs: [AI agent capabilities](https://docs.chmonitor.dev/guide/ai-agent/capabilities) — `forecast_disk_capacity` and `suggest_ttl_adjustment` in the Capacity planning tool group.
+- Docs: [AI agent](https://docs.chmonitor.dev/guide/ai-agent) — quick start and configuration.
+
+<!--
+CLAIM-VERIFICATION CHECKLIST
+- [x] States explicitly this is a worked/composite example, not a real incident.
+- [x] forecast_disk_capacity behavior (system.part_log NewPart events, system.disks, 90-day default horizon, clear message when part_log unavailable) checked against apps/dashboard/src/lib/ai/agent/tools/storage-tools.ts and docs/content/guide/ai-agent/capabilities.mdx.
+- [x] suggest_ttl_adjustment behavior (ALTER TABLE ... MODIFY TTL suggestion, retentionRequirementDays floor, defaults to 30, recommend-only, part_log-gated message) checked against the same storage-tools.ts source.
+- [x] "Recommend-only, never applied automatically" claim matches tool docstrings exactly — no claim that the advisor auto-applies TTL changes.
+- [x] Every chmonitor tool named is merged to main (apps/dashboard/src/lib/ai/agent/tools/storage-tools.ts).
+- [x] Docs cross-link resolves (docs/content/guide/ai-agent/capabilities.mdx).
+- [x] Internal link to /clickhouse-disk-full-emergency/ points at a post created in this same batch.
+-->

--- a/apps/blog/src/content/blog/clickhouse-disk-full-emergency.md
+++ b/apps/blog/src/content/blog/clickhouse-disk-full-emergency.md
@@ -1,0 +1,79 @@
+---
+title: "ClickHouse disk is full — what to do right now"
+description: "The emergency steps when a ClickHouse disk hits capacity: what system.disks tells you, what's safe to delete or move, and what to fix afterward."
+date: 2026-09-11
+tag: Troubleshooting
+---
+
+Inserts are failing, merges have stopped, and `df` (or `system.disks`) confirms it: a disk backing ClickHouse is out of space. This is the reactive version of the [capacity-planning workflow](/clickhouse-capacity-planning-ttl/) — for when the forecast didn't happen, or the trend moved faster than expected.
+
+## Symptoms
+
+- Inserts fail with disk-space errors; background merges stop making progress (see [reading system.merges](/clickhouse-system-merges-merge-storm/) if you're not sure whether merges are the bottleneck).
+- `system.disks` shows free space at or near zero on a disk ClickHouse writes to.
+- The server may become generally unresponsive if the disk holding logs or metadata (not just table data) is the one that filled.
+
+## Confirm which disk, and how bad
+
+```sql
+SELECT
+    name,
+    path,
+    formatReadableSize(free_space) AS free_space,
+    formatReadableSize(total_space) AS total_space,
+    round(free_space * 100.0 / total_space, 1) AS percent_free,
+    formatReadableSize(keep_free_space) AS keep_free_space
+FROM system.disks
+ORDER BY percent_free ASC
+```
+
+`keep_free_space` is the reserved buffer ClickHouse tries to maintain on that disk — if `free_space` is already below it, you're past the point where ClickHouse itself considered this safe. If there are multiple disks (a storage policy with hot/cold tiers, for example), this query tells you which one is actually the problem — don't assume it's the largest or the one you expect.
+
+## Find what's eating the space
+
+Once you know which disk, find the tables actually using it:
+
+```sql
+SELECT
+    database,
+    table,
+    formatReadableSize(sum(bytes_on_disk)) AS total_size,
+    count() AS part_count
+FROM system.parts
+WHERE active
+GROUP BY database, table
+ORDER BY sum(bytes_on_disk) DESC
+LIMIT 20
+```
+
+Cross-reference against tables you know are safe to shrink — old partitions past their useful retention, a table that was supposed to have a TTL and doesn't, or duplicate/orphaned data from a failed migration.
+
+## Fix, in order of speed vs. risk
+
+1. **Drop old partitions you know are expendable.** `ALTER TABLE db.t DROP PARTITION '...'` is fast and reclaims space immediately — but only do this for data you've already confirmed doesn't need to exist (an established retention policy, a partition you know is a duplicate). This is the fastest real fix, not `OPTIMIZE`, which needs *more* free space to run, not less.
+2. **Free space on the volume outside ClickHouse** if there's anything else sharing the disk (old logs, unrelated files) — sometimes the fastest option and doesn't touch table data at all.
+3. **Move a table to a different disk/tier**, if the cluster has a multi-disk storage policy configured — `ALTER TABLE db.t MOVE PARTITION ... TO DISK '...'` shifts data off the full disk without deleting anything.
+4. **Do not run `OPTIMIZE TABLE ... FINAL`** as an emergency fix here — it needs free space to write the merged result before the old parts are dropped, and can make an already-full disk situation worse.
+
+## After the fire is out
+
+A disk-full emergency is a sign that the underlying trend wasn't tracked, or a needed TTL wasn't there — the actual fix is proactive. Set up the [disk-forecast and TTL-advisor workflow](/clickhouse-capacity-planning-ttl/) so the next time this trend starts, it shows up as a forecast with weeks of runway instead of a live outage.
+
+## How chmonitor surfaces this
+
+The [Disks](https://docs.chmonitor.dev/guide/features) page shows `system.disks` free/used space per disk, refreshed continuously, so a disk crossing a dangerous threshold is visible before it hits zero. The AI agent's `forecast_disk_capacity` tool (see the [capacity planning post](/clickhouse-capacity-planning-ttl/)) is the proactive counterpart — chmonitor surfaces the trend and forecast, but does not delete data or move partitions for you; those `ALTER TABLE` steps above are always a human call.
+
+## Related
+
+- Docs: [Features overview](https://docs.chmonitor.dev/guide/features) — the Disks page.
+- [Capacity planning with the disk-forecast and TTL advisor](/clickhouse-capacity-planning-ttl/) — the proactive version of this post.
+- [Reading system.merges when merges pile up](/clickhouse-system-merges-merge-storm/) — merges stalling is a common disk-full symptom.
+
+<!--
+CLAIM-VERIFICATION CHECKLIST
+- [x] system.disks columns (name, path, free_space, total_space, keep_free_space) checked against apps/dashboard/src/lib/query-config/system/disks.ts and declarative/catalog/system/disks.ts.
+- [x] system.parts columns (bytes_on_disk, active) checked against clickhouse-too-many-parts.md (already-verified in this repo's own published post) for consistency.
+- [x] "OPTIMIZE TABLE FINAL needs free space, don't run it during a disk-full emergency" is a ClickHouse-mechanics claim (merges write new parts before dropping old ones) consistent with the existing merge-storm and too-many-parts posts' framing of OPTIMIZE as expensive/needs headroom.
+- [x] chmonitor described as surfacing the Disks page and forecast tool only — no claim that chmonitor drops partitions or moves data itself (all ALTER TABLE steps explicitly framed as human-run).
+- [x] Docs cross-link (guide/features) resolves; internal links point at posts created in this same batch.
+-->

--- a/apps/blog/src/content/blog/clickhouse-monitoring-kubernetes.md
+++ b/apps/blog/src/content/blog/clickhouse-monitoring-kubernetes.md
@@ -1,0 +1,114 @@
+---
+title: "Self-hosting chmonitor on Kubernetes"
+description: "Deploy the chmonitor ClickHouse dashboard on Kubernetes with the vendored Helm chart, including secrets, health probes, and an ingress."
+date: 2026-08-21
+tag: How-to
+---
+
+This is for anyone running ClickHouse on Kubernetes who wants the monitoring dashboard living in the same cluster instead of an external SaaS. chmonitor ships a vendored Helm chart and raw kustomize manifests — same image, same health probes, same non-root user, whichever you pick. By the end you'll have it reachable via `kubectl port-forward` (or an ingress) and connected to your cluster.
+
+## Prerequisites
+
+- A Kubernetes cluster and a working `kubectl` context.
+- Helm 3 (for the chart) or `kubectl` with kustomize (for raw manifests).
+- A reachable ClickHouse endpoint and a monitoring user.
+
+## Steps
+
+### 1. Install the Helm chart
+
+```bash
+helm repo add chmonitor https://charts.chmonitor.dev
+helm repo update
+
+helm install my-chm chmonitor/chmonitor \
+  --set clickhouse.host="https://clickhouse.example.com:8443" \
+  --set clickhouse.user="monitoring" \
+  --set clickhouse.password="change-me"
+```
+
+Passing credentials directly on the CLI is fine for a quick test; for anything longer-lived use a Kubernetes `Secret` (see step 3) or a `values.yaml` you don't commit with real passwords in it.
+
+The chart is also published as an OCI artifact if you'd rather not add a Helm repo: `helm install my-chm oci://ghcr.io/chmonitor/chmonitor --version vX.Y.Z`.
+
+### 2. Or apply the kustomize manifests directly
+
+```bash
+# Review rendered output first
+kubectl kustomize deploy/kubernetes/base
+
+# Apply
+kubectl apply -k deploy/kubernetes/base
+
+kubectl port-forward svc/chmonitor 3000:3000
+```
+
+Keep environment differences (namespace, replica count, image tag) in an overlay rather than editing the base:
+
+```yaml
+# deploy/kubernetes/overlays/prod/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - ../../base
+images:
+  - name: ghcr.io/chmonitor/chmonitor
+    newTag: vX.Y.Z
+replicas:
+  - name: chmonitor
+    count: 2
+```
+
+### 3. Put credentials in a Secret, not a ConfigMap
+
+ClickHouse credentials are passwords — always a `Secret`:
+
+```bash
+kubectl create secret generic chmonitor-clickhouse \
+  --from-literal=CLICKHOUSE_HOST='https://clickhouse.example.com:8443' \
+  --from-literal=CLICKHOUSE_USER='monitoring' \
+  --from-literal=CLICKHOUSE_PASSWORD='change-me'
+```
+
+Reference the secret's keys as environment variables in your Deployment (via `envFrom` or per-key `secretKeyRef`) rather than inlining values in a manifest that gets committed.
+
+### 4. Expose it with an ingress (optional)
+
+If you're using the Helm chart, an ingress is one values-file addition:
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: chmonitor.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+## Verifying it worked
+
+```bash
+kubectl port-forward svc/my-chm-chmonitor 3000:3000
+# open http://localhost:3000
+```
+
+The pod runs as the non-root `app` user (uid/gid `1001`) on port `3000` regardless of which install method you used, and wires the same liveness/readiness probes as the Docker image (`/healthz` for liveness, `/api/healthz` for readiness — the latter is gated on ClickHouse connectivity, so a passing readiness probe means the dashboard can actually reach your cluster).
+
+## Related
+
+- Docs: [Kubernetes deployment](https://docs.chmonitor.dev/operate/deploy/k8s) — full chart values reference, autoscaling, and secrets management.
+- Docs: [Docker deployment](https://docs.chmonitor.dev/operate/deploy/docker) — the single-container path, if you don't need Kubernetes yet.
+- Docs: [Production checklist](https://docs.chmonitor.dev/operate/deploy/production-checklist) — before exposing a self-hosted instance publicly.
+
+<!--
+CLAIM-VERIFICATION CHECKLIST
+- [x] Helm repo/OCI install commands, kustomize commands, and Secret creation copied and checked against docs/content/operate/deploy/k8s.mdx.
+- [x] Non-root app user (uid/gid 1001) and port 3000 checked against docs/content/operate/deploy/k8s.mdx intro paragraph.
+- [x] Liveness (/healthz) vs readiness (/api/healthz, ClickHouse-gated) distinction checked against docs/knowledge/k8s-health-probes.md.
+- [x] Ingress values snippet checked against docs/content/operate/deploy/k8s.mdx example values.yaml.
+- [x] Self-hosted-only content, no Cloud-mode claims made.
+- [x] Docs cross-links (k8s.mdx, docker.mdx, production-checklist.mdx) confirmed present in docs/content/operate/deploy/.
+-->

--- a/apps/blog/src/content/blog/clickhouse-query-optimization-advisor.md
+++ b/apps/blog/src/content/blog/clickhouse-query-optimization-advisor.md
@@ -1,0 +1,69 @@
+---
+title: "The query advisor: DDL recommendations you review, not that run themselves"
+description: "How chmonitor's optimization advisor turns a slow ClickHouse query into ranked skip-index, projection, and PREWHERE recommendations — and why it never applies any of them for you."
+date: 2026-07-31
+tag: How-to
+---
+
+This is for anyone who's found a slow query in `system.query_log` and then had to guess whether a skip index, a projection, or a PREWHERE rewrite would actually fix it. chmonitor's query advisor answers that question with ranked, explained recommendations — but it stops at the recommendation. By the end you'll know how to run it and what you're expected to do with the output.
+
+## Prerequisites
+
+- A chmonitor instance connected to a ClickHouse host with a query worth investigating.
+- The AI agent configured (see [AI agent quick start](https://docs.chmonitor.dev/guide/ai-agent)) if you want to reach the advisor conversationally, or direct API/tool access if you're scripting it.
+
+## Steps
+
+### 1. Point the advisor at a slow query
+
+The advisor takes either a raw SQL string or a `query_id` from `system.query_log`. In the dashboard, ask the AI agent something like:
+
+> Analyze query_id `abc-123` and tell me how to speed it up.
+
+Under the hood this calls the `get_optimization_recommendations` tool, which reads `EXPLAIN` output plus `system.tables`, `system.columns`, `system.data_skipping_indexes`, and `system.parts` for the tables involved — no writes, no DDL execution.
+
+### 2. Read the ranked output
+
+Each recommendation comes back with:
+
+- **The DDL or rewrite text** — a real `ALTER TABLE ... ADD INDEX ...`, `ALTER TABLE ... ADD PROJECTION ...`, or a rewritten `WHERE` → `PREWHERE` clause, ready to copy.
+- **Rationale** — why this specific change should help this specific query.
+- **Risk and effort** — a skip index is usually low-risk/low-effort; a projection rewrite touches more of the table and costs more to build.
+- **Estimated impact** — a granules/bytes-scanned reduction estimate. This is explicitly an *estimate*, not a guarantee — the advisor never runs the query before or after to confirm.
+
+### 3. Review, then apply it yourself
+
+This is the part that matters: **the advisor recommends, it does not execute.** Nothing it returns has been run against your cluster. Before applying any suggested DDL:
+
+- Check it against your actual write patterns — an index or projection that speeds up one query can slow down every insert into that table.
+- Run it in a maintenance window if the table is large; `ADD PROJECTION` in particular rewrites existing data in the background.
+- Re-run the original slow query afterward and compare `query_duration_ms` from `system.query_log` yourself — the advisor's estimate is a starting point, not a substitute for verifying on your own data.
+
+## Verifying it worked
+
+After applying a recommendation, re-run the query that was slow and pull its latest execution from `system.query_log`:
+
+```sql
+SELECT query_id, query_duration_ms, read_rows, read_bytes
+FROM system.query_log
+WHERE type = 'QueryFinish' AND query_id = {query_id:String}
+ORDER BY event_time DESC
+LIMIT 1
+```
+
+Compare `query_duration_ms` and `read_bytes` against the pre-change baseline. If the numbers didn't move as expected, the advisor's estimate was off for your data distribution — that's a signal to try the next-ranked recommendation, not a bug to report.
+
+## Related
+
+- Docs: [AI agent capabilities](https://docs.chmonitor.dev/guide/ai-agent/capabilities) — `get_optimization_recommendations` and every other recommend-only tool (capacity forecasting, TTL suggestions).
+- Docs: [AI agent](https://docs.chmonitor.dev/guide/ai-agent) — quick start and configuration.
+
+<!--
+CLAIM-VERIFICATION CHECKLIST
+- [x] get_optimization_recommendations behavior, inputs (sql or queryId), and read-only/recommend-only scope checked against apps/dashboard/src/lib/ai/agent/tools/advisor-tools.ts.
+- [x] Underlying reads (EXPLAIN, system.tables, system.columns, system.data_skipping_indexes, system.parts) checked against docs/content/guide/ai-agent/capabilities.mdx tool table entry for get_optimization_recommendations.
+- [x] "Recommend-only, never applies DDL" claim matches both the tool docstring and capabilities.mdx wording exactly — no overclaiming of auto-apply behavior.
+- [x] Feature merged to main (plans/46-query-advisor-engine.md referenced in source comments, code present in apps/dashboard/src/lib/ai/agent/tools/advisor-tools.ts).
+- [x] Verification query reuses system.query_log columns already verified in clickhouse-slowest-queries-system-query-log.md.
+- [x] Docs cross-link resolves (docs/content/guide/ai-agent/capabilities.mdx exists).
+-->

--- a/apps/blog/src/content/blog/clickhouse-replication-lag.md
+++ b/apps/blog/src/content/blog/clickhouse-replication-lag.md
@@ -1,0 +1,107 @@
+---
+title: "Why is my ClickHouse replication lagging?"
+description: "Reading absolute_delay and queue_size from system.replicas to find and fix ClickHouse replication lag before readers see stale data."
+date: 2026-07-24
+tag: Troubleshooting
+---
+
+Reads from a replica are returning data that's minutes — or hours — out of date, but writes to the leader look fine. That's replication lag: the replica has fallen behind on applying the replication log, and anyone reading from it sees a stale snapshot instead of an error, which makes it easy to miss until someone notices the numbers don't add up.
+
+## Symptoms
+
+- A read query against a replica returns different (older) results than the same query against the leader.
+- chmonitor's [Replicas](https://docs.chmonitor.dev/guide/features) page shows a non-zero `absolute_delay` or a growing `queue_size` for one or more tables.
+- The **Replication Lag** health check (`/health`) trips its warning (30s) or critical (300s) threshold.
+
+## Common causes
+
+### Fetch backlog on the replica
+
+Every write to the leader is recorded in the replication log; each replica has to fetch and apply those log entries. If fetches can't keep up — slow network, saturated inter-server bandwidth, or a replica that's simply under-provisioned relative to the leader's write rate — the backlog grows and `absolute_delay` climbs.
+
+```sql
+SELECT
+    database,
+    table,
+    is_leader,
+    is_readonly,
+    absolute_delay,
+    queue_size,
+    inserts_in_queue,
+    merges_in_queue,
+    total_replicas,
+    active_replicas
+FROM system.replicas
+WHERE absolute_delay > 0 OR queue_size > 0
+ORDER BY absolute_delay DESC
+```
+
+`absolute_delay` is seconds behind the leader — treat anything sustained above 300s (5 minutes) as a real concern, not noise. `queue_size` is how many replication-log entries are still queued for this replica to apply; a large, growing queue confirms the replica is falling behind rather than just having a brief blip.
+
+### Keeper / ZooKeeper connectivity problems
+
+Replication coordination goes through ClickHouse Keeper (or ZooKeeper). If a replica loses its Keeper session, or Keeper itself is under latency pressure, replication stalls entirely rather than just slowing down.
+
+```sql
+SELECT
+    database,
+    table,
+    is_readonly,
+    is_session_expired,
+    zookeeper_path,
+    zookeeper_exception,
+    last_queue_update_exception
+FROM system.replicas
+WHERE is_readonly = 1 OR is_session_expired = 1 OR zookeeper_exception != ''
+```
+
+`is_readonly = 1` means the replica currently can't accept writes at all — almost always a Keeper connectivity issue, not a disk or CPU problem. A non-empty `zookeeper_exception` or `last_queue_update_exception` tells you exactly what Keeper is complaining about.
+
+### Stuck or failing replication-queue entries
+
+`system.replicas` tells you *that* a replica is behind; `system.replication_queue` tells you *what specific task* is stuck.
+
+```sql
+SELECT
+    database,
+    table,
+    type,
+    is_currently_executing,
+    num_tries,
+    num_postponed,
+    postpone_reason,
+    last_exception,
+    last_exception_time
+FROM system.replication_queue
+ORDER BY is_currently_executing DESC, create_time DESC
+LIMIT 50
+```
+
+A high `num_tries` with a populated `last_exception` means one task (usually a `MERGE_PARTS` or `GET_PART` fetch) is failing repeatedly and blocking everything queued behind it — the queue is largely FIFO per table.
+
+## Fix
+
+- **Restore Keeper connectivity first** if `is_readonly = 1` or `is_session_expired = 1` — nothing else matters until the replica can talk to Keeper again. Once connectivity is restored, `SYSTEM RESTART REPLICA db.table` forces the replica to re-sync its local replication state against Keeper.
+- **Check network bandwidth between replicas** if `is_readonly = 0` but `absolute_delay` keeps growing — this points at a genuine fetch-throughput problem, not a coordination failure.
+- **Investigate the specific `last_exception`** from `system.replication_queue` for a stuck task before assuming it's a generic lag problem — a repeatedly failing fetch (missing part, checksum mismatch) needs a different fix than pure backpressure.
+- Sustained lag caused by a genuinely overloaded replica (not a transient blip) is a capacity problem — add replicas or resize, don't just wait it out.
+
+## How chmonitor surfaces this
+
+The **Replication Lag** health check on `/health` tracks `max(absolute_delay)` across all replicas continuously, at the same 30s/300s warning/critical thresholds used above. The [Replicas](https://docs.chmonitor.dev/guide/features) page shows the same `system.replicas` columns (`absolute_delay`, `queue_size`, `is_readonly`, `is_leader`) per table, and [Replication Queue](https://docs.chmonitor.dev/guide/features) shows the `system.replication_queue` detail for a stuck task. The AI agent's `get_replication_status` tool runs the diagnostic above on request — ask it "which tables are lagging and why."
+
+## Related
+
+- Docs: [Features overview](https://docs.chmonitor.dev/guide/features) — the Replicas and Replication Queue pages this post walks through.
+- Docs: [Health checks](https://docs.chmonitor.dev/guide/features/health) — the Replication Lag health check and its thresholds.
+- Docs: [AI agent](https://docs.chmonitor.dev/guide/ai-agent) — `get_replication_status` and the replication-diagnosis skill.
+
+<!--
+CLAIM-VERIFICATION CHECKLIST
+- [x] system.replicas columns (absolute_delay, queue_size, is_leader, is_readonly, is_session_expired, zookeeper_exception, last_queue_update_exception) checked against apps/dashboard/src/lib/query-config/tables/replicas.ts and skills/registry.ts.
+- [x] system.replication_queue columns checked against apps/dashboard/src/lib/query-config/tables/replication-queue.ts.
+- [x] Health-check thresholds (warning 30s, critical 300s) checked against apps/dashboard/src/components/health/health-checks.ts ('replication-lag' entry).
+- [x] SYSTEM RESTART REPLICA fix matches the registry.ts replication-guide skill wording.
+- [x] get_replication_status tool checked against apps/dashboard/src/lib/ai/agent/tools/replication-tools.ts — reads system.replicas as described.
+- [x] Docs cross-links point at real docs/content pages (guide/features, guide/features/health, guide/ai-agent).
+-->

--- a/apps/blog/src/content/blog/clickhouse-self-hosting-docker.md
+++ b/apps/blog/src/content/blog/clickhouse-self-hosting-docker.md
@@ -1,0 +1,97 @@
+---
+title: "Self-hosting chmonitor on Docker in five minutes"
+description: "Run the chmonitor ClickHouse dashboard as a self-hosted Docker container against your own cluster, no signup or cloud account required."
+date: 2026-08-14
+tag: How-to
+---
+
+This is for anyone who wants a ClickHouse dashboard running against their own cluster without handing credentials to a third party. chmonitor's Docker image is the same codebase as the hosted Cloud product — self-hosted just means you run the container yourself. By the end you'll have it up on `localhost:3000` and pointed at a real cluster.
+
+## Prerequisites
+
+- Docker installed and running.
+- A reachable ClickHouse endpoint and a monitoring user with `SELECT` on `system.*`.
+- A release tag to pin (browse [releases](https://github.com/chmonitor/chmonitor/pkgs/container/chmonitor) — avoid `:latest` in anything you plan to keep running, since an unpinned tag drifting under you is a real failure mode, not a hypothetical).
+
+## Steps
+
+### 1. Pull and run
+
+```bash
+docker run -d --name chmonitor -p 3000:3000 \
+  --add-host=host.docker.internal:host-gateway \
+  -e CLICKHOUSE_HOST='http://host.docker.internal:8123' \
+  -e CLICKHOUSE_USER='monitoring' \
+  -e CLICKHOUSE_PASSWORD='change-me' \
+  ghcr.io/chmonitor/chmonitor:vX.Y.Z
+```
+
+Replace `vX.Y.Z` with a real release tag. The `--add-host` flag is only needed on Linux, when ClickHouse runs on the same Docker host — Docker Desktop for Mac/Windows already resolves `host.docker.internal` without it.
+
+Open `http://localhost:3000`.
+
+### 2. Or use Docker Compose
+
+```yaml
+services:
+  chmonitor:
+    image: ghcr.io/chmonitor/chmonitor:vX.Y.Z
+    ports:
+      - '3000:3000'
+    environment:
+      CLICKHOUSE_HOST: 'http://clickhouse:8123'
+      CLICKHOUSE_USER: 'monitoring'
+      CLICKHOUSE_PASSWORD: 'change-me'
+    healthcheck:
+      test: ['CMD', 'wget', '-q', '-O', '/dev/null', 'http://localhost:3000/api/health']
+      interval: 30s
+      timeout: 5s
+      start_period: 20s
+      retries: 3
+```
+
+If ClickHouse runs in the same Compose project, use the service name (`clickhouse` above) as the host directly — no `host.docker.internal` needed.
+
+### 3. Point it at more than one host (optional)
+
+`CLICKHOUSE_HOST` accepts a comma-separated list; `CLICKHOUSE_USER` and `CLICKHOUSE_PASSWORD` can each be a single value applied to every host, or one value per position:
+
+```bash
+-e CLICKHOUSE_HOST='http://ch1:8123,http://ch2:8123' \
+-e CLICKHOUSE_USER='monitoring,monitoring' \
+-e CLICKHOUSE_PASSWORD='pass1,pass2' \
+-e CLICKHOUSE_NAME='shard-1,shard-2'
+```
+
+### 4. Adjust query timeouts and pool size (optional)
+
+```bash
+-e CLICKHOUSE_MAX_EXECUTION_TIME='30' \
+-e CLICKHOUSE_POOL_SIZE='10'
+```
+
+Defaults are a 60s query timeout and a pool size of 10 — raise the timeout if your workload has legitimately slow diagnostic queries, or the pool size if many people are hitting the dashboard concurrently.
+
+## Verifying it worked
+
+```bash
+curl -sf http://localhost:3000/api/healthz && echo OK
+```
+
+`/api/healthz` is the readiness probe — it checks the container is up *and* that it can reach ClickHouse, so a green result here means the whole path is working, not just that the container started.
+
+## Related
+
+- Docs: [Docker deployment](https://docs.chmonitor.dev/operate/deploy/docker) — the full reference for this walkthrough, including feature-flag configuration via env vars or a mounted TOML file.
+- Docs: [Production checklist](https://docs.chmonitor.dev/operate/deploy/production-checklist) — before putting a self-hosted instance in front of real users.
+- Docs: [Kubernetes deployment](https://docs.chmonitor.dev/operate/deploy/k8s) — if you outgrow a single container.
+
+<!--
+CLAIM-VERIFICATION CHECKLIST
+- [x] docker run / Compose commands copied verbatim from docs/content/operate/deploy/docker.mdx, checked against the source file in this repo.
+- [x] CLICKHOUSE_HOST/USER/PASSWORD multi-host semantics checked against docs/content/operate/deploy/docker.mdx "Multiple hosts" section.
+- [x] CLICKHOUSE_MAX_EXECUTION_TIME default (60) and CLICKHOUSE_POOL_SIZE default (10) checked against docs/content/operate/deploy/docker.mdx table.
+- [x] /api/healthz verification command checked against docs/content/operate/deploy/docker.mdx "Verify" section.
+- [x] This is a self-hosted-only walkthrough — no Cloud-only claims made; feature/config is merged to main.
+- [x] Docs cross-links (docker.mdx, production-checklist.mdx, k8s.mdx) confirmed to exist in docs/content/operate/deploy/.
+-->

--- a/apps/blog/src/content/blog/clickhouse-system-errors-spikes.md
+++ b/apps/blog/src/content/blog/clickhouse-system-errors-spikes.md
@@ -1,0 +1,76 @@
+---
+title: "Debugging a spike in system.errors"
+description: "How to read system.errors error counters to find what's actually failing in ClickHouse, and why they're cumulative since server start rather than per-incident."
+date: 2026-08-28
+tag: Troubleshooting
+---
+
+An alert fires, or the failed-query count on the health page jumps, and the first instinct is to look at `system.errors`. It's the right instinct — but the table has one property that trips people up the first time: it's a running total since server start, not a per-incident log. Read it wrong and you'll chase a "spike" that's actually just an old error that happened once, months ago.
+
+## Symptoms
+
+- The **Failed Queries (1h)** health check on `/health` crosses its warning (10) or critical (100) threshold.
+- Client-visible errors with no obvious single cause — could be a schema mismatch, a quota, or infrastructure (Keeper) trouble.
+- Sporadic `KEEPER_EXCEPTION` entries with no clear per-incident timeline.
+
+## Reading system.errors correctly
+
+```sql
+SELECT
+    name,
+    code,
+    value AS total_count,
+    last_error_time,
+    last_error_message
+FROM system.errors
+WHERE value > 0
+ORDER BY value DESC
+LIMIT 20
+```
+
+`value` is a **cumulative counter since the server last started** — it does not reset per hour or per day. A table showing `value = 4500` for some error code doesn't mean 4500 errors just happened; it means 4500 have happened since the process came up, which could be weeks ago. `last_error_time` and `last_error_message` are what actually tell you whether this error is recent or ancient history — always check those two columns before treating a high `value` as urgent.
+
+For an actual "what's failing right now" view, go to `system.query_log` instead — it has per-query, per-timestamp rows:
+
+```sql
+SELECT count() AS failed_count
+FROM system.query_log
+WHERE event_time > now() - INTERVAL 1 HOUR
+  AND type IN ('ExceptionWhileProcessing', 'ExceptionBeforeStart')
+```
+
+This is the query that actually answers "did failures spike in the last hour" — use `system.errors` afterward to identify *which* error code is behind the spike, via `last_error_message`.
+
+## Common causes
+
+**Recent schema or DDL change incompatible with existing clients.** A column drop, rename, or type change that an older client query still references. Check `last_error_message` for the specific error code's most recent occurrence — if it names a missing column or type mismatch, this is almost certainly it.
+
+**Quota or concurrency limits.** `max_concurrent_queries` or a user-level quota being hit under load. These show up as a distinct error code with a `last_error_time` that tracks your traffic pattern (e.g., spiking during a specific batch job).
+
+**Keeper connectivity problems.** `KEEPER_EXCEPTION` is the one error code that has no better per-incident source — `system.errors` (cumulative count plus most recent occurrence) is genuinely the best you get for it, since Keeper failures don't otherwise leave a per-incident row. A sustained run of these usually means Keeper node CPU/disk saturation, a lost quorum, or network partition between Keeper hosts.
+
+## Fix
+
+- **Match the error code to `last_error_message` first** — don't act on `value` alone; it conflates "happened once, ages ago" with "happening right now."
+- **Schema/DDL mismatches** are a client-side fix — update the client query or roll the schema change out more carefully (e.g., add-then-migrate instead of drop-then-recreate).
+- **Quota/concurrency errors** are a capacity decision — raise the limit if the load is legitimate, or find and throttle the offending client if it isn't.
+- **`KEEPER_EXCEPTION` runs** need Keeper-side investigation (node health, quorum, network) — chmonitor can surface that this is happening, it can't fix Keeper infrastructure for you.
+
+## How chmonitor surfaces this
+
+The **Failed Queries (1h)** health check on `/health` tracks the `system.query_log`-based recent-failure count at the same 10/100 warning/critical thresholds shown above, with a detail view of the actual failing queries. The **Keeper Exceptions (1h)** health check separately tracks `KEEPER_EXCEPTION` counts and explicitly notes in its detail view that the underlying count is cumulative-since-start, not per-hour, so you don't misread it. The AI agent has direct read access to `system.errors` via the `query` tool and its `system-tables` skill.
+
+## Related
+
+- Docs: [Health checks](https://docs.chmonitor.dev/guide/features/health) — Failed Queries and Keeper Exceptions checks and their thresholds.
+- Docs: [Queries feature](https://docs.chmonitor.dev/guide/features/queries) — the Failed Queries page for per-query detail.
+
+<!--
+CLAIM-VERIFICATION CHECKLIST
+- [x] system.errors columns (name, code, value, last_error_time, last_error_message) checked against apps/dashboard/src/lib/ai/agent/prompts/clickhouse-instructions.ts line noting "NOT last_update_time" and apps/dashboard/src/lib/query-config/queries/common-errors.ts.
+- [x] "value is cumulative since server start" claim checked against apps/dashboard/src/components/health/health-checks.ts keeper-exceptions detailDescription, which states this explicitly.
+- [x] Failed Queries health check thresholds (warning 10, critical 100) and SQL checked against apps/dashboard/src/components/health/health-checks.ts 'failed-queries' entry.
+- [x] Keeper Exceptions health check thresholds (warning 1, critical 20) and common causes checked against the same file's 'keeper-exceptions' entry.
+- [x] chmonitor is described as surfacing, not auto-fixing, Keeper infrastructure issues — matches the "chmonitor can only surface this, not fix it" template guidance.
+- [x] Docs cross-links (guide/features/health, guide/features/queries) confirmed to exist.
+-->


### PR DESCRIPTION
## Summary
- Adds 8 new posts targeting ClickHouse operational search queries: AI agent/MCP, replication lag, query advisor, system.merges storm (already existed, calendar corrected), Docker/K8s self-hosting, system.errors spikes, capacity planning (TTL/disk forecast), and disk-full emergency.
- All SQL and feature claims verified against `docs/clickhouse-schemas/tables/*.md` and the actual agent tool source in `apps/dashboard/src/lib/ai/agent/tools/*.ts`; every post ships `draft: false`.
- Updates `apps/blog/CONTENT-CALENDAR.md` rows 3-11 to `done` and adds row 13 for the new disk-full-emergency post.
- Does not touch `apps/landing` (regenerated `latest-posts.json` was reverted per instructions — another agent is redesigning that app).

## Test plan
- [x] Frontmatter matches `apps/blog/src/content.config.ts` schema (title/description/date/tag).
- [x] Every SQL query/column checked against `docs/clickhouse-schemas/tables/*.md` and query-config/tool source.
- [x] Docs cross-links resolve to existing `docs/content/**` pages.
- [ ] CI (unit-tests required check) — babysitting this PR.