### PR TITLE
fix(api): return sanitized messages instead of raw errors on 500s

### DIFF
--- a/apps/dashboard/src/lib/api/error-handler/error-response-builder.ts
+++ b/apps/dashboard/src/lib/api/error-handler/error-response-builder.ts
@@ -130,6 +130,78 @@ export function createValidationError(
 }
 
 /**
+ * Creates a sanitized 500 response for an internal/backend error.
+ *
+ * Unlike `createErrorResponse`, this NEVER echoes the raw `err.message` in the
+ * client-facing body — D1/ClickHouse/driver internals must not leak to
+ * clients (see issue #2501). The original error is still logged in full
+ * server-side (via `ErrorLogger` + console `error`) with an optional
+ * `requestId` so it can be correlated with client-side reports.
+ *
+ * @param err - The caught error (any type)
+ * @param context - Route context for logging
+ * @param requestId - Optional request id to surface to the client for correlation
+ * @returns 500 Internal Server Error response with a generic message
+ *
+ * @example
+ * ```ts
+ * } catch (err) {
+ *   return createInternalErrorResponse(err, ROUTE_CONTEXT, requestId)
+ * }
+ * ```
+ */
+export function createInternalErrorResponse(
+  err: unknown,
+  context?: RouteContext,
+  requestId?: string
+): Response {
+  const originalError = err instanceof Error ? err : new Error(String(err))
+
+  ErrorLogger.logError(originalError, {
+    component: `API:${context?.route || 'unknown'}`,
+    action: context?.method || 'unknown',
+    hostId: parseHostId(context?.hostId),
+    errorType: ApiErrorType.QueryError,
+  })
+
+  error(
+    `[API ${context?.method || ''} ${context?.route || ''}] Internal error`,
+    originalError,
+    {
+      component: `API:${context?.route || 'unknown'}`,
+      action: context?.method || 'unknown',
+      errorType: ApiErrorType.QueryError,
+      requestId,
+    }
+  )
+
+  const response: ApiResponse = {
+    success: false,
+    metadata: {
+      queryId: '',
+      duration: 0,
+      rows: 0,
+      host: String(context?.hostId || 'unknown'),
+    },
+    error: {
+      type: ApiErrorType.QueryError,
+      message: 'Internal error',
+      details: {
+        timestamp: new Date().toISOString(),
+        ...(requestId ? { requestId } : {}),
+      },
+    },
+  }
+
+  return Response.json(response, {
+    status: 500,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+}
+
+/**
  * Creates a not found error response (404 status)
  *
  * @param message - Not found error message

--- a/apps/dashboard/src/lib/api/error-handler/index.ts
+++ b/apps/dashboard/src/lib/api/error-handler/index.ts
@@ -37,6 +37,7 @@ export { classifyBillingLimit, classifyError } from './error-classifier'
 // Export error response builder functions
 export {
   createErrorResponse,
+  createInternalErrorResponse,
   createNotFoundError,
   createValidationError,
   getStatusCodeForErrorType,

--- a/apps/dashboard/src/lib/connection-store/api-errors.ts
+++ b/apps/dashboard/src/lib/connection-store/api-errors.ts
@@ -1,5 +1,8 @@
 import { ConnectionStoreError } from './types'
-import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
+import {
+  createErrorResponse as createApiErrorResponse,
+  createInternalErrorResponse,
+} from '@/lib/api/error-handler'
 import { ApiErrorType } from '@/lib/api/types'
 import { ConversationStoreError } from '@/lib/conversation-store/types'
 
@@ -23,6 +26,9 @@ export function mapConnectionApiError(
             : error.code === 'LIMIT_EXCEEDED'
               ? 402
               : 500
+    if (status === 500) {
+      return createInternalErrorResponse(error, context)
+    }
     return createApiErrorResponse(
       { type: ApiErrorType.PermissionError, message: error.message },
       status,
@@ -31,20 +37,15 @@ export function mapConnectionApiError(
   }
 
   if (error instanceof ConversationStoreError) {
-    const status = error.code === 'UNAUTHORIZED' ? 401 : 500
-    return createApiErrorResponse(
-      { type: ApiErrorType.PermissionError, message: error.message },
-      status,
-      context
-    )
+    if (error.code === 'UNAUTHORIZED') {
+      return createApiErrorResponse(
+        { type: ApiErrorType.PermissionError, message: error.message },
+        401,
+        context
+      )
+    }
+    return createInternalErrorResponse(error, context)
   }
 
-  return createApiErrorResponse(
-    {
-      type: ApiErrorType.QueryError,
-      message: error instanceof Error ? error.message : 'Unknown error',
-    },
-    500,
-    context
-  )
+  return createInternalErrorResponse(error, context)
 }

--- a/apps/dashboard/src/routes/api/dashboards/delete.ts
+++ b/apps/dashboard/src/routes/api/dashboards/delete.ts
@@ -8,7 +8,10 @@
 import { createFileRoute } from '@tanstack/react-router'
 
 import { debug, error, generateRequestId } from '@chm/logger'
-import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
+import {
+  createErrorResponse as createApiErrorResponse,
+  createInternalErrorResponse,
+} from '@/lib/api/error-handler'
 import {
   CacheControl,
   createSuccessResponse,
@@ -92,35 +95,21 @@ async function handleDelete(request: Request): Promise<Response> {
       headers,
     })
   } catch (err) {
-    const errorMessage =
-      err instanceof Error ? err.message : 'Unknown error occurred'
     error('[DELETE /api/dashboards/delete] Error:', err, { requestId })
 
-    if (err instanceof DashboardStoreError) {
-      const status = err.code === 'UNAUTHORIZED' ? 403 : 500
+    if (err instanceof DashboardStoreError && err.code === 'UNAUTHORIZED') {
       return createApiErrorResponse(
         {
-          type:
-            err.code === 'UNAUTHORIZED'
-              ? ApiErrorType.PermissionError
-              : ApiErrorType.QueryError,
+          type: ApiErrorType.PermissionError,
           message: err.message,
           details: { timestamp: new Date().toISOString() },
         },
-        status,
+        403,
         ROUTE_CONTEXT
       )
     }
 
-    return createApiErrorResponse(
-      {
-        type: ApiErrorType.QueryError,
-        message: errorMessage,
-        details: { timestamp: new Date().toISOString() },
-      },
-      500,
-      ROUTE_CONTEXT
-    )
+    return createInternalErrorResponse(err, ROUTE_CONTEXT, requestId)
   }
 }
 

--- a/apps/dashboard/src/routes/api/dashboards/list.ts
+++ b/apps/dashboard/src/routes/api/dashboards/list.ts
@@ -10,7 +10,10 @@
 import { createFileRoute } from '@tanstack/react-router'
 
 import { debug, error, generateRequestId } from '@chm/logger'
-import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
+import {
+  createErrorResponse as createApiErrorResponse,
+  createInternalErrorResponse,
+} from '@/lib/api/error-handler'
 import {
   CacheControl,
   createSuccessResponse,
@@ -69,35 +72,21 @@ async function handleGet(): Promise<Response> {
       headers,
     })
   } catch (err) {
-    const errorMessage =
-      err instanceof Error ? err.message : 'Unknown error occurred'
     error('[GET /api/dashboards/list] Error:', err, { requestId })
 
-    if (err instanceof DashboardStoreError) {
-      const status = err.code === 'UNAUTHORIZED' ? 403 : 500
+    if (err instanceof DashboardStoreError && err.code === 'UNAUTHORIZED') {
       return createApiErrorResponse(
         {
-          type:
-            err.code === 'UNAUTHORIZED'
-              ? ApiErrorType.PermissionError
-              : ApiErrorType.QueryError,
+          type: ApiErrorType.PermissionError,
           message: err.message,
           details: { timestamp: new Date().toISOString() },
         },
-        status,
+        403,
         ROUTE_CONTEXT
       )
     }
 
-    return createApiErrorResponse(
-      {
-        type: ApiErrorType.QueryError,
-        message: errorMessage,
-        details: { timestamp: new Date().toISOString() },
-      },
-      500,
-      ROUTE_CONTEXT
-    )
+    return createInternalErrorResponse(err, ROUTE_CONTEXT, requestId)
   }
 }
 

--- a/apps/dashboard/src/routes/api/dashboards/save.ts
+++ b/apps/dashboard/src/routes/api/dashboards/save.ts
@@ -14,7 +14,10 @@ import { createFileRoute } from '@tanstack/react-router'
 import type { DashboardLayout } from '@/types/dashboard-layout'
 
 import { debug, error, generateRequestId } from '@chm/logger'
-import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
+import {
+  createErrorResponse as createApiErrorResponse,
+  createInternalErrorResponse,
+} from '@/lib/api/error-handler'
 import {
   CacheControl,
   createSuccessResponse,
@@ -118,27 +121,21 @@ async function handlePost(request: Request): Promise<Response> {
       headers,
     })
   } catch (err) {
-    const errorMessage =
-      err instanceof Error ? err.message : 'Unknown error occurred'
     error('[POST /api/dashboards/save] Error:', err, { requestId })
 
-    if (err instanceof DashboardStoreError) {
-      const status = err.code === 'UNAUTHORIZED' ? 403 : 500
+    if (err instanceof DashboardStoreError && err.code === 'UNAUTHORIZED') {
       return createApiErrorResponse(
         {
-          type:
-            err.code === 'UNAUTHORIZED'
-              ? ApiErrorType.PermissionError
-              : ApiErrorType.QueryError,
+          type: ApiErrorType.PermissionError,
           message: err.message,
           details: { timestamp: new Date().toISOString() },
         },
-        status,
+        403,
         ROUTE_CONTEXT
       )
     }
 
-    if (err instanceof SyntaxError && errorMessage.includes('JSON')) {
+    if (err instanceof SyntaxError && err.message.includes('JSON')) {
       return createApiErrorResponse(
         {
           type: ApiErrorType.ValidationError,
@@ -150,15 +147,7 @@ async function handlePost(request: Request): Promise<Response> {
       )
     }
 
-    return createApiErrorResponse(
-      {
-        type: ApiErrorType.QueryError,
-        message: errorMessage,
-        details: { timestamp: new Date().toISOString() },
-      },
-      500,
-      ROUTE_CONTEXT
-    )
+    return createInternalErrorResponse(err, ROUTE_CONTEXT, requestId)
   }
 }
 

--- a/apps/dashboard/src/routes/api/dashboards/share.$slug.ts
+++ b/apps/dashboard/src/routes/api/dashboards/share.$slug.ts
@@ -28,7 +28,10 @@
 import { createFileRoute } from '@tanstack/react-router'
 
 import { debug, error, generateRequestId } from '@chm/logger'
-import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
+import {
+  createErrorResponse as createApiErrorResponse,
+  createInternalErrorResponse,
+} from '@/lib/api/error-handler'
 import {
   checkRateLimit,
   clientIpKey,
@@ -41,7 +44,6 @@ import {
 } from '@/lib/api/shared/response-builder'
 import { ApiErrorType } from '@/lib/api/types'
 import { D1DashboardStore } from '@/lib/dashboard-storage/d1-store'
-import { DashboardStoreError } from '@/lib/dashboard-storage/types'
 import { isFeatureEnabled } from '@/lib/feature-flags'
 import { autoMigrate } from '@/lib/migration/auto-migrate'
 
@@ -122,29 +124,7 @@ async function handleGet(request: Request, slug: string): Promise<Response> {
   } catch (err) {
     error('[GET /api/dashboards/share/$slug] Error:', err, { requestId })
 
-    if (err instanceof DashboardStoreError) {
-      return createApiErrorResponse(
-        {
-          type: ApiErrorType.QueryError,
-          message: err.message,
-          details: { timestamp: new Date().toISOString() },
-        },
-        500,
-        ROUTE_CONTEXT
-      )
-    }
-
-    const errorMessage =
-      err instanceof Error ? err.message : 'Unknown error occurred'
-    return createApiErrorResponse(
-      {
-        type: ApiErrorType.QueryError,
-        message: errorMessage,
-        details: { timestamp: new Date().toISOString() },
-      },
-      500,
-      ROUTE_CONTEXT
-    )
+    return createInternalErrorResponse(err, ROUTE_CONTEXT, requestId)
   }
 }
 

--- a/apps/dashboard/src/routes/api/dashboards/share.ts
+++ b/apps/dashboard/src/routes/api/dashboards/share.ts
@@ -12,7 +12,10 @@
 import { createFileRoute } from '@tanstack/react-router'
 
 import { debug, error, generateRequestId } from '@chm/logger'
-import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
+import {
+  createErrorResponse as createApiErrorResponse,
+  createInternalErrorResponse,
+} from '@/lib/api/error-handler'
 import {
   CacheControl,
   createSuccessResponse,
@@ -64,19 +67,18 @@ function storeErrorResponse(
   err: DashboardStoreError,
   context: { route: string; method: string }
 ): Response {
-  const status = err.code === 'UNAUTHORIZED' ? 403 : 500
-  return createApiErrorResponse(
-    {
-      type:
-        err.code === 'UNAUTHORIZED'
-          ? ApiErrorType.PermissionError
-          : ApiErrorType.QueryError,
-      message: err.message,
-      details: { timestamp: new Date().toISOString() },
-    },
-    status,
-    context
-  )
+  if (err.code === 'UNAUTHORIZED') {
+    return createApiErrorResponse(
+      {
+        type: ApiErrorType.PermissionError,
+        message: err.message,
+        details: { timestamp: new Date().toISOString() },
+      },
+      403,
+      context
+    )
+  }
+  return createInternalErrorResponse(err, context)
 }
 
 /** Enable read-only sharing; returns the (idempotent) public share slug. */
@@ -129,9 +131,7 @@ async function handlePost(request: Request): Promise<Response> {
     if (err instanceof DashboardStoreError) {
       return storeErrorResponse(err, ROUTE_CONTEXT_POST)
     }
-    const errorMessage =
-      err instanceof Error ? err.message : 'Unknown error occurred'
-    if (err instanceof SyntaxError && errorMessage.includes('JSON')) {
+    if (err instanceof SyntaxError && err.message.includes('JSON')) {
       return createApiErrorResponse(
         {
           type: ApiErrorType.ValidationError,
@@ -142,15 +142,7 @@ async function handlePost(request: Request): Promise<Response> {
         ROUTE_CONTEXT_POST
       )
     }
-    return createApiErrorResponse(
-      {
-        type: ApiErrorType.QueryError,
-        message: errorMessage,
-        details: { timestamp: new Date().toISOString() },
-      },
-      500,
-      ROUTE_CONTEXT_POST
-    )
+    return createInternalErrorResponse(err, ROUTE_CONTEXT_POST, requestId)
   }
 }
 
@@ -205,17 +197,7 @@ async function handleDelete(request: Request): Promise<Response> {
     if (err instanceof DashboardStoreError) {
       return storeErrorResponse(err, ROUTE_CONTEXT_DELETE)
     }
-    const errorMessage =
-      err instanceof Error ? err.message : 'Unknown error occurred'
-    return createApiErrorResponse(
-      {
-        type: ApiErrorType.QueryError,
-        message: errorMessage,
-        details: { timestamp: new Date().toISOString() },
-      },
-      500,
-      ROUTE_CONTEXT_DELETE
-    )
+    return createInternalErrorResponse(err, ROUTE_CONTEXT_DELETE, requestId)
   }
 }
 

--- a/apps/dashboard/src/routes/api/v1/browser-connections/charts/$name.ts
+++ b/apps/dashboard/src/routes/api/v1/browser-connections/charts/$name.ts
@@ -5,8 +5,10 @@
 
 import { createFileRoute } from '@tanstack/react-router'
 
+import { error as logError } from '@chm/logger'
 import { hasChart } from '@/lib/api/chart-registry'
 import { createValidationError } from '@/lib/api/error-handler'
+import { sanitizeClickHouseError } from '@/lib/api/error-handler/sanitize-error'
 import { isValidInterval } from '@/lib/api/query-executor'
 import {
   createErrorResponse,
@@ -87,10 +89,15 @@ async function handlePost(
 
     return createSuccessResponse(result.data, result.metadata)
   } catch (err) {
+    logError(
+      '[POST /api/v1/browser-connections/charts/$name] Query failed',
+      err
+    )
+    const rawMessage = err instanceof Error ? err.message : 'Chart query failed'
     return createErrorResponse(
       {
         type: ApiErrorType.QueryError,
-        message: err instanceof Error ? err.message : 'Chart query failed',
+        message: sanitizeClickHouseError(rawMessage),
       },
       500,
       ROUTE_CONTEXT

--- a/apps/dashboard/src/routes/api/v1/browser-connections/proxy.ts
+++ b/apps/dashboard/src/routes/api/v1/browser-connections/proxy.ts
@@ -17,8 +17,10 @@ import { createFileRoute } from '@tanstack/react-router'
 import type { DataFormat } from '@clickhouse/client'
 import { createClient } from '@clickhouse/client-web'
 
+import { error as logError } from '@chm/logger'
 import { validateSqlQuery } from '@chm/sql-builder'
 import { createValidationError } from '@/lib/api/error-handler'
+import { sanitizeClickHouseError } from '@/lib/api/error-handler/sanitize-error'
 import {
   createErrorResponse,
   createSuccessResponse,
@@ -153,12 +155,13 @@ async function handlePost(request: Request): Promise<Response> {
       queryId: result.query_id,
     })
   } catch (err) {
-    const message =
+    logError('[POST /api/v1/browser-connections/proxy] Query failed', err)
+    const rawMessage =
       err instanceof Error ? err.message : 'Query execution failed'
     return createErrorResponse(
       {
         type: ApiErrorType.QueryError,
-        message,
+        message: sanitizeClickHouseError(rawMessage),
         details: { timestamp: new Date().toISOString() },
       },
       500,

--- a/apps/dashboard/src/routes/api/v1/browser-connections/tables/$name.ts
+++ b/apps/dashboard/src/routes/api/v1/browser-connections/tables/$name.ts
@@ -5,7 +5,9 @@
 
 import { createFileRoute } from '@tanstack/react-router'
 
+import { error as logError } from '@chm/logger'
 import { createValidationError } from '@/lib/api/error-handler'
+import { sanitizeClickHouseError } from '@/lib/api/error-handler/sanitize-error'
 import {
   createErrorResponse,
   createSuccessResponse,
@@ -77,10 +79,15 @@ async function handlePost(
     )
     return createSuccessResponse(result.data, result.metadata)
   } catch (err) {
+    logError(
+      '[POST /api/v1/browser-connections/tables/$name] Query failed',
+      err
+    )
+    const rawMessage = err instanceof Error ? err.message : 'Table query failed'
     return createErrorResponse(
       {
         type: ApiErrorType.QueryError,
-        message: err instanceof Error ? err.message : 'Table query failed',
+        message: sanitizeClickHouseError(rawMessage),
       },
       500,
       ROUTE_CONTEXT

--- a/apps/dashboard/src/routes/api/v1/cluster-counts/$key.ts
+++ b/apps/dashboard/src/routes/api/v1/cluster-counts/$key.ts
@@ -24,6 +24,7 @@ import {
   hasClusterCountKey,
 } from '@/lib/api/cluster-count-registry'
 import { createErrorResponse } from '@/lib/api/error-handler'
+import { sanitizeClickHouseError } from '@/lib/api/error-handler/sanitize-error'
 import { HostIdSchema, MenuCountKeySchema } from '@/lib/api/schemas'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import {
@@ -268,7 +269,9 @@ async function handler(
     const errorResponse = createErrorResponse(
       {
         type: ApiErrorType.QueryError,
-        message: err instanceof Error ? err.message : 'Unknown error',
+        message: sanitizeClickHouseError(
+          err instanceof Error ? err.message : 'Unknown error'
+        ),
       },
       500,
       ROUTE_CONTEXT

--- a/apps/dashboard/src/routes/api/v1/cluster-topology.ts
+++ b/apps/dashboard/src/routes/api/v1/cluster-topology.ts
@@ -50,6 +50,7 @@ import { fetchData } from '@chm/clickhouse-client'
 import { debug, error, generateRequestId } from '@chm/logger'
 import { assembleTopology } from '@/components/cluster-topology/model'
 import { createErrorResponse } from '@/lib/api/error-handler'
+import { sanitizeClickHouseError } from '@/lib/api/error-handler/sanitize-error'
 import { HostIdSchema } from '@/lib/api/schemas'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import {
@@ -280,7 +281,9 @@ async function handleGet(request: Request): Promise<Response> {
     const errorResponse = createErrorResponse(
       {
         type: ApiErrorType.QueryError,
-        message: err instanceof Error ? err.message : 'Unknown error',
+        message: sanitizeClickHouseError(
+          err instanceof Error ? err.message : 'Unknown error'
+        ),
       },
       500,
       ROUTE_CONTEXT

--- a/apps/dashboard/src/routes/api/v1/conversations.ts
+++ b/apps/dashboard/src/routes/api/v1/conversations.ts
@@ -18,7 +18,10 @@ import type {
 } from '@/lib/conversation-store/types'
 
 import { debug, error, generateRequestId } from '@chm/logger'
-import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
+import {
+  createErrorResponse as createApiErrorResponse,
+  createInternalErrorResponse,
+} from '@/lib/api/error-handler'
 import {
   CacheControl,
   createSuccessResponse,
@@ -148,39 +151,25 @@ async function handleGet(request: Request): Promise<Response> {
       headers: newHeaders,
     })
   } catch (err) {
-    const errorMessage =
-      err instanceof Error ? err.message : 'Unknown error occurred'
-
     error('[GET /api/v1/conversations] Error:', err, { requestId })
 
     // Handle conversation store errors
-    if (err instanceof ConversationStoreError) {
-      const errorType =
-        err.code === 'UNAUTHORIZED'
-          ? ApiErrorType.PermissionError
-          : ApiErrorType.QueryError
-
+    if (err instanceof ConversationStoreError && err.code === 'UNAUTHORIZED') {
       return createApiErrorResponse(
         {
-          type: errorType,
+          type: ApiErrorType.PermissionError,
           message: err.message,
           details: { timestamp: new Date().toISOString() },
         },
-        err.code === 'UNAUTHORIZED' ? 403 : 500,
+        403,
         ROUTE_CONTEXT_GET
       )
     }
 
-    const errorResponse = createApiErrorResponse(
-      {
-        type: ApiErrorType.QueryError,
-        message: errorMessage,
-        details: {
-          timestamp: new Date().toISOString(),
-        },
-      },
-      500,
-      ROUTE_CONTEXT_GET
+    const errorResponse = createInternalErrorResponse(
+      err,
+      ROUTE_CONTEXT_GET,
+      requestId
     )
 
     // Add request ID header to error response
@@ -324,40 +313,29 @@ async function handlePost(request: Request): Promise<Response> {
       headers: newHeaders,
     })
   } catch (err) {
-    const errorMessage =
-      err instanceof Error ? err.message : 'Unknown error occurred'
-
     error('[POST /api/v1/conversations] Error:', err, { requestId })
 
     // Handle conversation store errors
-    if (err instanceof ConversationStoreError) {
-      const errorType =
-        err.code === 'VALIDATION_ERROR'
-          ? ApiErrorType.ValidationError
-          : err.code === 'UNAUTHORIZED'
-            ? ApiErrorType.PermissionError
-            : ApiErrorType.QueryError
-
-      const statusCode =
-        err.code === 'VALIDATION_ERROR'
-          ? 400
-          : err.code === 'UNAUTHORIZED'
-            ? 403
-            : 500
-
+    if (
+      err instanceof ConversationStoreError &&
+      (err.code === 'VALIDATION_ERROR' || err.code === 'UNAUTHORIZED')
+    ) {
       return createApiErrorResponse(
         {
-          type: errorType,
+          type:
+            err.code === 'VALIDATION_ERROR'
+              ? ApiErrorType.ValidationError
+              : ApiErrorType.PermissionError,
           message: err.message,
           details: { timestamp: new Date().toISOString() },
         },
-        statusCode,
+        err.code === 'VALIDATION_ERROR' ? 400 : 403,
         ROUTE_CONTEXT_POST
       )
     }
 
     // Handle JSON parsing errors
-    if (err instanceof SyntaxError && errorMessage.includes('JSON')) {
+    if (err instanceof SyntaxError && err.message.includes('JSON')) {
       return createApiErrorResponse(
         {
           type: ApiErrorType.ValidationError,
@@ -369,16 +347,10 @@ async function handlePost(request: Request): Promise<Response> {
       )
     }
 
-    const errorResponse = createApiErrorResponse(
-      {
-        type: ApiErrorType.QueryError,
-        message: errorMessage,
-        details: {
-          timestamp: new Date().toISOString(),
-        },
-      },
-      500,
-      ROUTE_CONTEXT_POST
+    const errorResponse = createInternalErrorResponse(
+      err,
+      ROUTE_CONTEXT_POST,
+      requestId
     )
 
     // Add request ID header to error response

--- a/apps/dashboard/src/routes/api/v1/conversations/$id.follow-ups.ts
+++ b/apps/dashboard/src/routes/api/v1/conversations/$id.follow-ups.ts
@@ -10,7 +10,10 @@
 import { createFileRoute } from '@tanstack/react-router'
 
 import { debug, error, generateRequestId } from '@chm/logger'
-import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
+import {
+  createErrorResponse as createApiErrorResponse,
+  createInternalErrorResponse,
+} from '@/lib/api/error-handler'
 import {
   CacheControl,
   createSuccessResponse,
@@ -110,46 +113,33 @@ async function handleGet(id: string): Promise<Response> {
       headers: newHeaders,
     })
   } catch (err) {
-    const errorMessage =
-      err instanceof Error ? err.message : 'Unknown error occurred'
-
     error('[GET /api/v1/conversations/$id/follow-ups] Error:', err, {
       requestId,
     })
 
     // Handle conversation store errors
-    if (err instanceof ConversationStoreError) {
-      const errorType =
-        err.code === 'NOT_FOUND'
-          ? ApiErrorType.ValidationError
-          : err.code === 'UNAUTHORIZED'
-            ? ApiErrorType.PermissionError
-            : ApiErrorType.QueryError
-
-      const statusCode =
-        err.code === 'NOT_FOUND' || err.code === 'UNAUTHORIZED' ? 404 : 500
-
+    if (
+      err instanceof ConversationStoreError &&
+      (err.code === 'NOT_FOUND' || err.code === 'UNAUTHORIZED')
+    ) {
       return createApiErrorResponse(
         {
-          type: errorType,
+          type:
+            err.code === 'NOT_FOUND'
+              ? ApiErrorType.ValidationError
+              : ApiErrorType.PermissionError,
           message: err.message,
           details: { timestamp: new Date().toISOString() },
         },
-        statusCode,
+        404,
         ROUTE_CONTEXT_GET
       )
     }
 
-    const errorResponse = createApiErrorResponse(
-      {
-        type: ApiErrorType.QueryError,
-        message: errorMessage,
-        details: {
-          timestamp: new Date().toISOString(),
-        },
-      },
-      500,
-      ROUTE_CONTEXT_GET
+    const errorResponse = createInternalErrorResponse(
+      err,
+      ROUTE_CONTEXT_GET,
+      requestId
     )
 
     // Add request ID header to error response

--- a/apps/dashboard/src/routes/api/v1/conversations/$id.ts
+++ b/apps/dashboard/src/routes/api/v1/conversations/$id.ts
@@ -17,7 +17,10 @@ import type { UIMessage } from 'ai'
 import type { StoredConversation } from '@/lib/conversation-store/types'
 
 import { debug, error, generateRequestId } from '@chm/logger'
-import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
+import {
+  createErrorResponse as createApiErrorResponse,
+  createInternalErrorResponse,
+} from '@/lib/api/error-handler'
 import {
   CacheControl,
   createSuccessResponse,
@@ -137,44 +140,31 @@ async function handleGet(id: string): Promise<Response> {
       headers: newHeaders,
     })
   } catch (err) {
-    const errorMessage =
-      err instanceof Error ? err.message : 'Unknown error occurred'
-
     error('[GET /api/v1/conversations/$id] Error:', err, { requestId })
 
     // Handle conversation store errors
-    if (err instanceof ConversationStoreError) {
-      const errorType =
-        err.code === 'NOT_FOUND'
-          ? ApiErrorType.ValidationError
-          : err.code === 'UNAUTHORIZED'
-            ? ApiErrorType.PermissionError
-            : ApiErrorType.QueryError
-
-      const statusCode =
-        err.code === 'NOT_FOUND' || err.code === 'UNAUTHORIZED' ? 404 : 500
-
+    if (
+      err instanceof ConversationStoreError &&
+      (err.code === 'NOT_FOUND' || err.code === 'UNAUTHORIZED')
+    ) {
       return createApiErrorResponse(
         {
-          type: errorType,
+          type:
+            err.code === 'NOT_FOUND'
+              ? ApiErrorType.ValidationError
+              : ApiErrorType.PermissionError,
           message: err.message,
           details: { timestamp: new Date().toISOString() },
         },
-        statusCode,
+        404,
         ROUTE_CONTEXT_GET
       )
     }
 
-    const errorResponse = createApiErrorResponse(
-      {
-        type: ApiErrorType.QueryError,
-        message: errorMessage,
-        details: {
-          timestamp: new Date().toISOString(),
-        },
-      },
-      500,
-      ROUTE_CONTEXT_GET
+    const errorResponse = createInternalErrorResponse(
+      err,
+      ROUTE_CONTEXT_GET,
+      requestId
     )
 
     // Add request ID header to error response
@@ -332,42 +322,31 @@ async function handlePut(request: Request, id: string): Promise<Response> {
       headers: newHeaders,
     })
   } catch (err) {
-    const errorMessage =
-      err instanceof Error ? err.message : 'Unknown error occurred'
-
     error('[PUT /api/v1/conversations/$id] Error:', err, { requestId })
 
     // Handle conversation store errors
-    if (err instanceof ConversationStoreError) {
-      const errorType =
-        err.code === 'NOT_FOUND'
-          ? ApiErrorType.ValidationError
-          : err.code === 'VALIDATION_ERROR'
-            ? ApiErrorType.ValidationError
-            : err.code === 'UNAUTHORIZED'
-              ? ApiErrorType.PermissionError
-              : ApiErrorType.QueryError
-
-      const statusCode =
-        err.code === 'NOT_FOUND' ||
+    if (
+      err instanceof ConversationStoreError &&
+      (err.code === 'NOT_FOUND' ||
         err.code === 'VALIDATION_ERROR' ||
-        err.code === 'UNAUTHORIZED'
-          ? 404
-          : 500
-
+        err.code === 'UNAUTHORIZED')
+    ) {
       return createApiErrorResponse(
         {
-          type: errorType,
+          type:
+            err.code === 'UNAUTHORIZED'
+              ? ApiErrorType.PermissionError
+              : ApiErrorType.ValidationError,
           message: err.message,
           details: { timestamp: new Date().toISOString() },
         },
-        statusCode,
+        404,
         ROUTE_CONTEXT_PUT
       )
     }
 
     // Handle JSON parsing errors
-    if (err instanceof SyntaxError && errorMessage.includes('JSON')) {
+    if (err instanceof SyntaxError && err.message.includes('JSON')) {
       return createApiErrorResponse(
         {
           type: ApiErrorType.ValidationError,
@@ -379,16 +358,10 @@ async function handlePut(request: Request, id: string): Promise<Response> {
       )
     }
 
-    const errorResponse = createApiErrorResponse(
-      {
-        type: ApiErrorType.QueryError,
-        message: errorMessage,
-        details: {
-          timestamp: new Date().toISOString(),
-        },
-      },
-      500,
-      ROUTE_CONTEXT_PUT
+    const errorResponse = createInternalErrorResponse(
+      err,
+      ROUTE_CONTEXT_PUT,
+      requestId
     )
 
     // Add request ID header to error response
@@ -492,44 +465,31 @@ async function handleDelete(id: string): Promise<Response> {
       headers: newHeaders,
     })
   } catch (err) {
-    const errorMessage =
-      err instanceof Error ? err.message : 'Unknown error occurred'
-
     error('[DELETE /api/v1/conversations/$id] Error:', err, { requestId })
 
     // Handle conversation store errors
-    if (err instanceof ConversationStoreError) {
-      const errorType =
-        err.code === 'NOT_FOUND'
-          ? ApiErrorType.ValidationError
-          : err.code === 'UNAUTHORIZED'
-            ? ApiErrorType.PermissionError
-            : ApiErrorType.QueryError
-
-      const statusCode =
-        err.code === 'NOT_FOUND' || err.code === 'UNAUTHORIZED' ? 404 : 500
-
+    if (
+      err instanceof ConversationStoreError &&
+      (err.code === 'NOT_FOUND' || err.code === 'UNAUTHORIZED')
+    ) {
       return createApiErrorResponse(
         {
-          type: errorType,
+          type:
+            err.code === 'NOT_FOUND'
+              ? ApiErrorType.ValidationError
+              : ApiErrorType.PermissionError,
           message: err.message,
           details: { timestamp: new Date().toISOString() },
         },
-        statusCode,
+        404,
         ROUTE_CONTEXT_DELETE
       )
     }
 
-    const errorResponse = createApiErrorResponse(
-      {
-        type: ApiErrorType.QueryError,
-        message: errorMessage,
-        details: {
-          timestamp: new Date().toISOString(),
-        },
-      },
-      500,
-      ROUTE_CONTEXT_DELETE
+    const errorResponse = createInternalErrorResponse(
+      err,
+      ROUTE_CONTEXT_DELETE,
+      requestId
     )
 
     // Add request ID header to error response

--- a/apps/dashboard/src/routes/api/v1/health/ack.ts
+++ b/apps/dashboard/src/routes/api/v1/health/ack.ts
@@ -26,6 +26,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 
 import { error } from '@chm/logger'
+import { createInternalErrorResponse } from '@/lib/api/error-handler'
 import { createErrorResponse } from '@/lib/api/shared/response-builder'
 import { ApiErrorType } from '@/lib/api/types'
 import { resolveBillingOwner } from '@/lib/billing/billing-owner'
@@ -129,14 +130,10 @@ async function handlePost(request: Request): Promise<Response> {
     return Response.json({ success: true, ack }, { status: 200 })
   } catch (err) {
     error('[POST /api/v1/health/ack] Failed to record ACK', err as Error)
-    return createErrorResponse(
-      {
-        type: ApiErrorType.QueryError,
-        message: err instanceof Error ? err.message : 'Failed to record ACK',
-      },
-      500,
-      { ...ROUTE_CONTEXT, method: 'POST' }
-    )
+    return createInternalErrorResponse(err, {
+      ...ROUTE_CONTEXT,
+      method: 'POST',
+    })
   }
 }
 

--- a/apps/dashboard/src/routes/api/v1/health/findings.ts
+++ b/apps/dashboard/src/routes/api/v1/health/findings.ts
@@ -12,6 +12,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 
 import { error } from '@chm/logger'
+import { sanitizeClickHouseError } from '@/lib/api/error-handler/sanitize-error'
 import { getCurrentFindings } from '@/lib/health/current-findings'
 
 export const Route = createFileRoute('/api/v1/health/findings')({
@@ -37,7 +38,9 @@ export const Route = createFileRoute('/api/v1/health/findings')({
               success: false,
               error: {
                 type: 'query_error',
-                message: err instanceof Error ? err.message : 'Unknown error',
+                message: sanitizeClickHouseError(
+                  err instanceof Error ? err.message : 'Unknown error'
+                ),
               },
             },
             { status: 500 }

--- a/apps/dashboard/src/routes/api/v1/health/snapshot.ts
+++ b/apps/dashboard/src/routes/api/v1/health/snapshot.ts
@@ -16,6 +16,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { env } from 'cloudflare:workers'
 import { error } from '@chm/logger'
+import { sanitizeClickHouseError } from '@/lib/api/error-handler/sanitize-error'
 import { isDemoHostBlockedForRequest } from '@/lib/cloud/reject-demo-host'
 import { captureIncidentSnapshot } from '@/lib/health/incident-snapshot'
 
@@ -80,7 +81,9 @@ export const Route = createFileRoute('/api/v1/health/snapshot')({
               success: false,
               error: {
                 type: 'query_error',
-                message: err instanceof Error ? err.message : 'Unknown error',
+                message: sanitizeClickHouseError(
+                  err instanceof Error ? err.message : 'Unknown error'
+                ),
               },
             },
             { status: 500 }

--- a/apps/dashboard/src/routes/api/v1/insights/query-patterns/$hash.ts
+++ b/apps/dashboard/src/routes/api/v1/insights/query-patterns/$hash.ts
@@ -18,6 +18,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { env } from 'cloudflare:workers'
 import { error } from '@chm/logger'
+import { sanitizeClickHouseError } from '@/lib/api/error-handler/sanitize-error'
 import {
   buildPatternDetailConfig,
   buildPatternExecutionsConfig,
@@ -180,7 +181,9 @@ export async function handler(
         success: false,
         error: {
           type: 'query_error',
-          message: err instanceof Error ? err.message : 'Unknown error',
+          message: sanitizeClickHouseError(
+            err instanceof Error ? err.message : 'Unknown error'
+          ),
         },
       },
       { status: 500 }

--- a/apps/dashboard/src/routes/api/v1/menu-counts/$key.ts
+++ b/apps/dashboard/src/routes/api/v1/menu-counts/$key.ts
@@ -16,6 +16,7 @@ import { fetchData } from '@chm/clickhouse-client'
 import { getClickHouseVersion } from '@chm/clickhouse-client/clickhouse-version'
 import { debug, error, generateRequestId } from '@chm/logger'
 import { createErrorResponse } from '@/lib/api/error-handler'
+import { sanitizeClickHouseError } from '@/lib/api/error-handler/sanitize-error'
 import {
   getMenuCountQuery,
   hasMenuCountKey,
@@ -254,7 +255,9 @@ async function handler(
     const errorResponse = createErrorResponse(
       {
         type: ApiErrorType.QueryError,
-        message: err instanceof Error ? err.message : 'Unknown error',
+        message: sanitizeClickHouseError(
+          err instanceof Error ? err.message : 'Unknown error'
+        ),
       },
       500,
       ROUTE_CONTEXT

--- a/apps/dashboard/src/routes/api/v1/menu-counts/index.ts
+++ b/apps/dashboard/src/routes/api/v1/menu-counts/index.ts
@@ -21,6 +21,7 @@ import { fetchData } from '@chm/clickhouse-client'
 import { getClickHouseVersion } from '@chm/clickhouse-client/clickhouse-version'
 import { debug, error, generateRequestId } from '@chm/logger'
 import { createErrorResponse } from '@/lib/api/error-handler'
+import { sanitizeClickHouseError } from '@/lib/api/error-handler/sanitize-error'
 import {
   getAvailableMenuCountKeys,
   getMenuCountQuery,
@@ -257,7 +258,9 @@ export async function handler(request: Request): Promise<Response> {
     const errorResponse = createErrorResponse(
       {
         type: ApiErrorType.QueryError,
-        message: err instanceof Error ? err.message : 'Unknown error',
+        message: sanitizeClickHouseError(
+          err instanceof Error ? err.message : 'Unknown error'
+        ),
       },
       500,
       ROUTE_CONTEXT

--- a/apps/dashboard/src/routes/api/v1/table-availability.ts
+++ b/apps/dashboard/src/routes/api/v1/table-availability.ts
@@ -20,6 +20,7 @@ import { env } from 'cloudflare:workers'
 import { checkTableExists } from '@chm/clickhouse-client/table-existence-cache'
 import { debug, error, generateRequestId } from '@chm/logger'
 import { createErrorResponse } from '@/lib/api/error-handler'
+import { sanitizeClickHouseError } from '@/lib/api/error-handler/sanitize-error'
 import { HostIdSchema } from '@/lib/api/schemas'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import {
@@ -185,7 +186,9 @@ export const Route = createFileRoute('/api/v1/table-availability')({
           const errorResponse = createErrorResponse(
             {
               type: ApiErrorType.QueryError,
-              message: err instanceof Error ? err.message : 'Unknown error',
+              message: sanitizeClickHouseError(
+                err instanceof Error ? err.message : 'Unknown error'
+              ),
             },
             500,
             ROUTE_CONTEXT

--- a/apps/dashboard/src/routes/api/v1/tables/$name.ts
+++ b/apps/dashboard/src/routes/api/v1/tables/$name.ts
@@ -8,6 +8,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { env } from 'cloudflare:workers'
 import { error } from '@chm/logger'
+import { sanitizeClickHouseError } from '@/lib/api/error-handler/sanitize-error'
 import { executeTableConfig } from '@/lib/api/query-executor'
 import {
   getAvailableTables,
@@ -193,7 +194,9 @@ export async function handler(
         success: false,
         error: {
           type: 'query_error',
-          message: err instanceof Error ? err.message : 'Unknown error',
+          message: sanitizeClickHouseError(
+            err instanceof Error ? err.message : 'Unknown error'
+          ),
         },
       },
       { status: 500 }


### PR DESCRIPTION
## Summary
- Several API catch-blocks (including the unauthenticated `share.$slug` route) returned raw D1/ClickHouse/driver `err.message` strings to clients on 500 responses.
- Added `createInternalErrorResponse(err, context, requestId?)` to `lib/api/error-handler` — returns a generic `Internal error` message + optional `requestId` while logging the full original error server-side.
- Converted the named routes (`share.$slug.ts`, `browser-connections/proxy.ts`, `user-connections.ts` via the shared `mapConnectionApiError`) and swept other generic 500 sites (dashboards save/list/delete/share, conversations, menu-counts, cluster-counts, cluster-topology, table-availability, health ack/findings/snapshot, insights/query-patterns/$hash, tables/$name).
- ClickHouse query-execution error sites (browser-connections proxy/tables/charts, tables/$name, menu/cluster counts, health findings/snapshot, insights) use the existing `sanitizeClickHouseError` classifier instead, so useful classification (not found / permission / timeout / syntax) is preserved without leaking raw driver text.
- Left 4xx validation messages and the connection-error classifier (`lib/connection-errors.ts`) untouched, per scope.

## Test plan
- [x] `pnpm run type-check` (apps/dashboard) — clean
- [x] `bun test src/lib/api/error-handler src/lib/connection-store` — 78 pass
- [x] `bun test src/routes/api/v1/browser-connections/__tests__/proxy.test.ts` — 8 pass
- [x] Full pre-push suite (960 tests) — pass

Fixes #2501