### PR TITLE
fix(agent): release daily-usage reservation on the onError stream path

### DIFF
--- a/apps/dashboard/src/lib/billing/ai-usage-store.test.ts
+++ b/apps/dashboard/src/lib/billing/ai-usage-store.test.ts
@@ -18,7 +18,10 @@ type UsageStore = Map<string, number>
 
 function makeFakeD1(store: UsageStore) {
   function prepare(sql: string) {
-    const isSelect = sql.trimStart().toUpperCase().startsWith('SELECT')
+    const upper = sql.trimStart().toUpperCase()
+    const isSelect = upper.startsWith('SELECT')
+    // releaseAiUsage: UPDATE ... SET count = MAX(0, count - 1) — floors at 0.
+    const isRelease = upper.startsWith('UPDATE')
 
     return {
       bind(...values: unknown[]) {
@@ -26,18 +29,28 @@ function makeFakeD1(store: UsageStore) {
         const day = values[1] as string
         const key = `${ownerId}::${day}`
 
+        function applyWrite() {
+          if (isRelease) {
+            store.set(key, Math.max(0, (store.get(key) ?? 0) - 1))
+          } else {
+            // INSERT ... ON CONFLICT DO UPDATE SET count = count + 1
+            store.set(key, (store.get(key) ?? 0) + 1)
+          }
+        }
+
         return {
           async first<T>() {
-            if (!isSelect) return null
-            const count = store.get(key)
-            if (count == null) return null
-            return { count } as unknown as T
+            if (isSelect) {
+              const count = store.get(key)
+              if (count == null) return null
+              return { count } as unknown as T
+            }
+            // reserveAiUsage: INSERT ... RETURNING count
+            applyWrite()
+            return { count: store.get(key) } as unknown as T
           },
           async run() {
-            if (!isSelect) {
-              // INSERT ... ON CONFLICT DO UPDATE SET count = count + 1
-              store.set(key, (store.get(key) ?? 0) + 1)
-            }
+            if (!isSelect) applyWrite()
             return { success: true, results: [], meta: {} }
           },
         }
@@ -116,6 +129,8 @@ const {
   utcDayKey,
   getAiUsageToday,
   incrementAiUsage,
+  reserveAiUsage,
+  releaseAiUsage,
   getAiSpendThisMonth,
   meterAiOverage,
 } = await import('./ai-usage-store')
@@ -200,6 +215,49 @@ describe('incrementAiUsage + getAiUsageToday round-trip', () => {
     currentDb = null
     // Must not throw
     await incrementAiUsage('user_abc', FIXED_DATE)
+  })
+})
+
+describe('reserveAiUsage + releaseAiUsage lifecycle', () => {
+  let store: UsageStore
+
+  beforeEach(() => {
+    store = new Map()
+    currentDb = makeFakeD1(store)
+  })
+
+  test('reserve returns the post-increment count', async () => {
+    expect(await reserveAiUsage('user_abc', FIXED_DATE)).toBe(1)
+    expect(await reserveAiUsage('user_abc', FIXED_DATE)).toBe(2)
+    expect(await getAiUsageToday('user_abc', FIXED_DATE)).toBe(2)
+  })
+
+  test('reserve returns null when D1 is unavailable (self-hosted skips gating)', async () => {
+    currentDb = null
+    expect(await reserveAiUsage('user_abc', FIXED_DATE)).toBeNull()
+  })
+
+  test('release rolls back a reservation (aborted request consumes no quota)', async () => {
+    await reserveAiUsage('user_abc', FIXED_DATE)
+    await releaseAiUsage('user_abc', FIXED_DATE)
+    expect(await getAiUsageToday('user_abc', FIXED_DATE)).toBe(0)
+  })
+
+  test('release floors at 0 — a double release never over-refunds below zero', async () => {
+    // Simulates the leak-fix guard's worst case: a failure observed by BOTH the
+    // inner execute catch and the onError callback. The store floors at 0 so the
+    // counter cannot go negative even if the release-once guard were bypassed.
+    await reserveAiUsage('user_abc', FIXED_DATE)
+    await releaseAiUsage('user_abc', FIXED_DATE)
+    await releaseAiUsage('user_abc', FIXED_DATE)
+    expect(await getAiUsageToday('user_abc', FIXED_DATE)).toBe(0)
+  })
+
+  test('release is a no-op when D1 is unavailable', async () => {
+    currentDb = null
+    await expect(
+      releaseAiUsage('user_abc', FIXED_DATE)
+    ).resolves.toBeUndefined()
   })
 })
 

--- a/apps/dashboard/src/routes/api/v1/agent.ts
+++ b/apps/dashboard/src/routes/api/v1/agent.ts
@@ -721,6 +721,20 @@ async function handlePost(request: Request): Promise<Response> {
   // Populated synchronously in onStepEnd so it is available after consumeStream().
   let lastStepModelId: string | undefined
 
+  // Roll back the daily reservation exactly once. Both the inner `execute`
+  // catch and the SDK's separate `onError` callback can observe a failure that
+  // produced no output (e.g. an error thrown inside the merged/piped stream
+  // surfaces via onError, outside the inner try/catch), and releaseAiUsage
+  // floors at 0 — so without this guard a double-observed failure would
+  // over-refund a slot. Idempotent: releases at most one reserved slot.
+  let usageReleased = false
+  const releaseReservationOnce = async (): Promise<void> => {
+    if (usageReleased) return
+    if (!billingOwnerId || !reservedDailyUsage) return
+    usageReleased = true
+    await releaseAiUsage(billingOwnerId)
+  }
+
   const stream = createUIMessageStream({
     execute: async ({ writer }) => {
       let modelMessages: ModelMessage[] = []
@@ -856,10 +870,10 @@ async function handlePost(request: Request): Promise<Response> {
               stats.estimatedCostUsd
             )
           }
-        } else if (billingOwnerId && reservedDailyUsage) {
+        } else {
           // Generation failed before producing any output — release the daily
           // reservation so aborted requests don't consume the user's quota.
-          await releaseAiUsage(billingOwnerId)
+          await releaseReservationOnce()
         }
       }
     },
@@ -869,6 +883,15 @@ async function handlePost(request: Request): Promise<Response> {
         provider: requestedProvider,
       })
       console.error('[Agent API] Classified error:', classified)
+      // A failure can surface here (rather than the inner execute catch) when it
+      // is thrown inside the merged/piped stream after the reservation. If no
+      // output was produced, release the daily reservation so the user is not
+      // charged for a request that yielded nothing. Best-effort + idempotent:
+      // releaseReservationOnce guards against a double release if the inner
+      // catch already released.
+      if (usageSteps.length === 0) {
+        void releaseReservationOnce()
+      }
       return JSON.stringify(classified)
     },
     onEnd: () => {


### PR DESCRIPTION
## Problem

`apps/dashboard/src/routes/api/v1/agent.ts` reserves a daily message slot (`reserveAiUsage`) before generation and promises that *aborted requests never consume quota* by releasing the reservation when generation produced no output.

That release only ran in the **inner `execute` catch** (`usageSteps.length === 0` branch). The AI SDK's separate `onError` stream callback merely classified the error and returned it — **without releasing**.

## Reachability (verified real)

`execute` does `writer.merge(createJsonRenderPatchGuardStream(pipeJsonRender(result.toUIMessageStream())))` and then `await result.consumeStream()`. The inner `try/catch` wraps `consumeStream()`, but the **merged/piped transform stream runs on the SDK's stream machinery**. An error thrown there (or any failure the SDK routes to the stream) surfaces via the top-level `onError` callback, **outside** the inner try/catch. In that path the reservation was held and never released → the user was charged a daily message for a request that produced nothing.

## Fix

- Hoist `let usageReleased = false` + a `releaseReservationOnce()` helper next to the reservation state.
- Call it from **both** the inner no-output catch and `onError` (only when `usageSteps.length === 0`).
- Idempotent: `releaseAiUsage` floors at 0, so without the once-guard a failure observed by both paths would over-refund a slot. The guard releases at most one reserved slot.

## Tests

Added `reserveAiUsage` / `releaseAiUsage` lifecycle tests to `ai-usage-store.test.ts`: reserve returns post-increment count, release rolls back, and a double release floors at 0 (the store-level defense the once-guard relies on).

Fixes #2517

https://claude.ai/code/session_01GUKP6qY1efJkqPz6AgaxXh