### PR TITLE
fix(billing): key monthly usage meters to the subscription billing cycle

### DIFF
--- a/apps/dashboard/src/lib/billing/ai-usage-store.ts
+++ b/apps/dashboard/src/lib/billing/ai-usage-store.ts
@@ -11,8 +11,8 @@
 
 import type { Plan } from './plans'
 
-import { getPlatformBindings } from '@chm/platform'
 import { periodKeyForOwner, utcMonthKey } from './period-key'
+import { getPlatformBindings } from '@chm/platform'
 
 /** Returns the UTC date string 'YYYY-MM-DD' for the given instant. */
 export function utcDayKey(now: Date = new Date()): string {

--- a/apps/dashboard/src/lib/billing/ai-usage-store.ts
+++ b/apps/dashboard/src/lib/billing/ai-usage-store.ts
@@ -12,16 +12,16 @@
 import type { Plan } from './plans'
 
 import { getPlatformBindings } from '@chm/platform'
+import { periodKeyForOwner, utcMonthKey } from './period-key'
 
 /** Returns the UTC date string 'YYYY-MM-DD' for the given instant. */
 export function utcDayKey(now: Date = new Date()): string {
   return now.toISOString().slice(0, 10)
 }
 
-/** Returns the UTC month string 'YYYY-MM' for the given instant. */
-export function utcMonthKey(now: Date = new Date()): string {
-  return now.toISOString().slice(0, 7)
-}
+// Re-exported for existing call-sites — see period-key.ts for the
+// subscription-cycle-aware key that now drives the monthly meters below.
+export { utcMonthKey }
 
 function getDb() {
   return getPlatformBindings().getD1Database('CHM_CLOUD_D1')
@@ -170,8 +170,10 @@ async function ensureMonthlyTable(
 }
 
 /**
- * Return USD `ownerId` has spent on AI this month (UTC). Returns 0 when D1 is
- * unavailable or no row exists yet, so OSS deployments are never gated.
+ * Return USD `ownerId` has spent on AI this billing cycle. Keyed by
+ * {@link periodKeyForOwner} — the subscription's cycle window when one is
+ * live, else the calendar UTC month. Returns 0 when D1 is unavailable or no
+ * row exists yet, so OSS deployments are never gated.
  */
 export async function getAiSpendThisMonth(
   ownerId: string,
@@ -181,11 +183,12 @@ export async function getAiSpendThisMonth(
   if (!db) return 0
   try {
     await ensureMonthlyTable(db)
+    const periodKey = await periodKeyForOwner(ownerId, now)
     const row = await db
       .prepare(
         `SELECT spent_usd FROM ai_usage_monthly WHERE owner_id = ?1 AND month = ?2`
       )
-      .bind(ownerId, utcMonthKey(now))
+      .bind(ownerId, periodKey)
       .first<{ spent_usd: number }>()
     return row?.spent_usd ?? 0
   } catch {
@@ -194,9 +197,11 @@ export async function getAiSpendThisMonth(
 }
 
 /**
- * Add `amountUsd` to `ownerId`'s monthly spend accumulator (UTC month). Fed by
- * the already-computed `estimatedCostUsd` after a successful generation. Ignores
- * non-positive / non-finite amounts. No-op when D1 is unavailable.
+ * Add `amountUsd` to `ownerId`'s monthly spend accumulator, keyed by
+ * {@link periodKeyForOwner} (subscription billing cycle, or the calendar UTC
+ * month with no live subscription). Fed by the already-computed
+ * `estimatedCostUsd` after a successful generation. Ignores non-positive /
+ * non-finite amounts. No-op when D1 is unavailable.
  */
 export async function addAiSpend(
   ownerId: string,
@@ -208,6 +213,7 @@ export async function addAiSpend(
   if (!db) return
   try {
     await ensureMonthlyTable(db)
+    const periodKey = await periodKeyForOwner(ownerId, now)
     const updatedAt = Math.floor(now.getTime() / 1000)
     await db
       .prepare(
@@ -217,7 +223,7 @@ export async function addAiSpend(
            spent_usd  = spent_usd + excluded.spent_usd,
            updated_at = excluded.updated_at`
       )
-      .bind(ownerId, utcMonthKey(now), amountUsd, updatedAt)
+      .bind(ownerId, periodKey, amountUsd, updatedAt)
       .run()
   } catch {
     // Swallow: a missing table or transient D1 error must not break the request.

--- a/apps/dashboard/src/lib/billing/host-usage-store.ts
+++ b/apps/dashboard/src/lib/billing/host-usage-store.ts
@@ -11,8 +11,8 @@
  * Schema: see src/db/conversations-migrations/0017_host_usage_monthly.sql
  */
 
-import { getPlatformBindings } from '@chm/platform'
 import { periodKeyForOwner } from './period-key'
+import { getPlatformBindings } from '@chm/platform'
 
 function getDb() {
   return getPlatformBindings().getD1Database('CHM_CLOUD_D1')

--- a/apps/dashboard/src/lib/billing/host-usage-store.ts
+++ b/apps/dashboard/src/lib/billing/host-usage-store.ts
@@ -11,8 +11,8 @@
  * Schema: see src/db/conversations-migrations/0017_host_usage_monthly.sql
  */
 
-import { utcMonthKey } from './ai-usage-store'
 import { getPlatformBindings } from '@chm/platform'
+import { periodKeyForOwner } from './period-key'
 
 function getDb() {
   return getPlatformBindings().getD1Database('CHM_CLOUD_D1')
@@ -20,7 +20,9 @@ function getDb() {
 
 /**
  * Return the peak billable overage host count `ownerId` has recorded this
- * month (UTC). Returns 0 when D1 is unavailable or no row exists yet.
+ * billing cycle. Keyed by {@link periodKeyForOwner} — the subscription's cycle
+ * window when one is live, else the calendar UTC month. Returns 0 when D1 is
+ * unavailable or no row exists yet.
  */
 export async function getHostOverageThisMonth(
   ownerId: string,
@@ -29,11 +31,12 @@ export async function getHostOverageThisMonth(
   const db = getDb()
   if (!db) return 0
   try {
+    const periodKey = await periodKeyForOwner(ownerId, now)
     const row = await db
       .prepare(
         `SELECT host_count FROM host_usage_monthly WHERE owner_id = ?1 AND month = ?2`
       )
-      .bind(ownerId, utcMonthKey(now))
+      .bind(ownerId, periodKey)
       .first<{ host_count: number }>()
     return row?.host_count ?? 0
   } catch {
@@ -42,11 +45,11 @@ export async function getHostOverageThisMonth(
 }
 
 /**
- * Upsert `ownerId`'s PEAK billable overage host count for the month:
- * `host_count = MAX(existing, overageHosts)`. This is a PEAK meter, not
- * additive — removing then re-adding a host within the same month never
- * multiplies the charge. Ignores non-positive/non-finite counts. No-op when
- * D1 is unavailable (self-hosted/OSS is never metered).
+ * Upsert `ownerId`'s PEAK billable overage host count for the billing cycle
+ * (see {@link periodKeyForOwner}): `host_count = MAX(existing, overageHosts)`.
+ * This is a PEAK meter, not additive — removing then re-adding a host within
+ * the same cycle never multiplies the charge. Ignores non-positive/non-finite
+ * counts. No-op when D1 is unavailable (self-hosted/OSS is never metered).
  */
 export async function recordHostOverage(
   ownerId: string,
@@ -57,6 +60,7 @@ export async function recordHostOverage(
   const db = getDb()
   if (!db) return
   try {
+    const periodKey = await periodKeyForOwner(ownerId, now)
     const updatedAt = Math.floor(now.getTime() / 1000)
     await db
       .prepare(
@@ -66,7 +70,7 @@ export async function recordHostOverage(
            host_count = MAX(host_count, excluded.host_count),
            updated_at = excluded.updated_at`
       )
-      .bind(ownerId, utcMonthKey(now), overageHosts, updatedAt)
+      .bind(ownerId, periodKey, overageHosts, updatedAt)
       .run()
   } catch {
     // Swallow: a missing table or transient D1 error must not break the request.

--- a/apps/dashboard/src/lib/billing/period-key.test.ts
+++ b/apps/dashboard/src/lib/billing/period-key.test.ts
@@ -106,9 +106,9 @@ describe('periodKeyFromSubscription', () => {
 
   test('subscription with null currentPeriodEnd falls back to the calendar UTC month', () => {
     const now = new Date('2026-03-20T00:00:00Z')
-    expect(
-      periodKeyFromSubscription({ currentPeriodEnd: null }, now)
-    ).toBe(utcMonthKey(now))
+    expect(periodKeyFromSubscription({ currentPeriodEnd: null }, now)).toBe(
+      utcMonthKey(now)
+    )
   })
 
   test('a live subscription keys off the cycle anchored to currentPeriodEnd, not the calendar month', () => {
@@ -133,9 +133,9 @@ describe('periodKeyFromSubscription', () => {
     )
     const justBefore = new Date('2026-03-14T23:59:59Z')
     const justAfter = new Date('2026-03-15T00:00:00Z')
-    expect(
-      periodKeyFromSubscription({ currentPeriodEnd }, justBefore)
-    ).toBe('period:2026-02-15')
+    expect(periodKeyFromSubscription({ currentPeriodEnd }, justBefore)).toBe(
+      'period:2026-02-15'
+    )
     expect(periodKeyFromSubscription({ currentPeriodEnd }, justAfter)).toBe(
       'period:2026-03-15'
     )

--- a/apps/dashboard/src/lib/billing/period-key.test.ts
+++ b/apps/dashboard/src/lib/billing/period-key.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for period-key.ts — the fix for issue #2514: monthly usage meters
+ * (AI monthly USD budget, host-overage peak) must reset on the subscription's
+ * billing cycle, not the calendar UTC month.
+ *
+ * `cycleStartKey` / `periodKeyFromSubscription` are pure and are the core of
+ * the fix, so they get the bulk of the coverage here — especially the
+ * short-month clamp (anchor day 29/30/31 landing in a shorter month) that a
+ * naive `setUTCDate` implementation would roll over into the wrong month.
+ *
+ * `periodKeyForOwner` additionally resolves the subscription via D1
+ * (`subscription-store.ts` → `@chm/platform` → the virtual `cloudflare:workers`
+ * module, which only resolves under vite/workerd) — stub it like
+ * retention-owner.test.ts so importing this module doesn't require a runtime.
+ */
+
+import { describe, expect, mock, test } from 'bun:test'
+
+mock.module('cloudflare:workers', () => ({ env: {} }))
+
+const { cycleStartKey, periodKeyFromSubscription, utcMonthKey } = await import(
+  './period-key'
+)
+
+describe('cycleStartKey', () => {
+  test('mid-month anchor: cycle start is the anchor day this month once reached', () => {
+    // Anchor day 15; `now` is the 20th of the same month → cycle already started this month.
+    expect(cycleStartKey(15, new Date('2026-03-20T12:00:00Z'))).toBe(
+      '2026-03-15'
+    )
+  })
+
+  test('mid-month anchor: before the anchor day this month, cycle started last month', () => {
+    // Anchor day 15; `now` is the 10th → still in the cycle that started Feb 15.
+    expect(cycleStartKey(15, new Date('2026-03-10T00:00:00Z'))).toBe(
+      '2026-02-15'
+    )
+  })
+
+  test('exactly on the anchor day: the new cycle has just started (boundary is inclusive)', () => {
+    expect(cycleStartKey(15, new Date('2026-03-15T00:00:00Z'))).toBe(
+      '2026-03-15'
+    )
+  })
+
+  test('anchor day 29 in February (non-leap year) clamps to the 28th', () => {
+    // 2026 is not a leap year — February has 28 days.
+    expect(cycleStartKey(29, new Date('2026-02-28T12:00:00Z'))).toBe(
+      '2026-02-28'
+    )
+  })
+
+  test('anchor day 29 in February (leap year) lands on the 29th', () => {
+    expect(cycleStartKey(29, new Date('2028-02-29T12:00:00Z'))).toBe(
+      '2028-02-29'
+    )
+  })
+
+  test('anchor day 30 clamps to the 28th in February and rolls forward correctly in March', () => {
+    // Before the (clamped) Feb anchor of the 28th.
+    expect(cycleStartKey(30, new Date('2026-02-27T00:00:00Z'))).toBe(
+      '2026-01-30'
+    )
+    // On/after the clamped Feb anchor.
+    expect(cycleStartKey(30, new Date('2026-02-28T00:00:00Z'))).toBe(
+      '2026-02-28'
+    )
+    // March has 31 days, so the real anchor day (30) is back in play.
+    expect(cycleStartKey(30, new Date('2026-03-30T00:00:00Z'))).toBe(
+      '2026-03-30'
+    )
+  })
+
+  test('anchor day 31 clamps to the last day of 30-day months (April)', () => {
+    expect(cycleStartKey(31, new Date('2026-04-25T00:00:00Z'))).toBe(
+      '2026-03-31'
+    )
+    expect(cycleStartKey(31, new Date('2026-04-30T00:00:00Z'))).toBe(
+      '2026-04-30'
+    )
+  })
+
+  test('anchor day 31 in a 31-day month resolves to day 31 exactly', () => {
+    expect(cycleStartKey(31, new Date('2026-01-31T00:00:00Z'))).toBe(
+      '2026-01-31'
+    )
+  })
+
+  test('year boundary: January anchor before the anchor day rolls back into December', () => {
+    expect(cycleStartKey(20, new Date('2026-01-05T00:00:00Z'))).toBe(
+      '2025-12-20'
+    )
+  })
+})
+
+describe('periodKeyFromSubscription', () => {
+  test('no subscription (null) falls back to the calendar UTC month', () => {
+    const now = new Date('2026-03-20T00:00:00Z')
+    expect(periodKeyFromSubscription(null, now)).toBe(utcMonthKey(now))
+  })
+
+  test('undefined subscription falls back to the calendar UTC month', () => {
+    const now = new Date('2026-03-20T00:00:00Z')
+    expect(periodKeyFromSubscription(undefined, now)).toBe(utcMonthKey(now))
+  })
+
+  test('subscription with null currentPeriodEnd falls back to the calendar UTC month', () => {
+    const now = new Date('2026-03-20T00:00:00Z')
+    expect(
+      periodKeyFromSubscription({ currentPeriodEnd: null }, now)
+    ).toBe(utcMonthKey(now))
+  })
+
+  test('a live subscription keys off the cycle anchored to currentPeriodEnd, not the calendar month', () => {
+    // currentPeriodEnd lands on the 15th of some future month — the anchor day.
+    const currentPeriodEnd = Math.floor(
+      new Date('2026-06-15T00:00:00Z').getTime() / 1000
+    )
+    const now = new Date('2026-03-20T00:00:00Z')
+    // The current cycle for `now` started on the 15th of the current month
+    // (March), not the calendar month key '2026-03'.
+    expect(periodKeyFromSubscription({ currentPeriodEnd }, now)).toBe(
+      'period:2026-03-15'
+    )
+    expect(periodKeyFromSubscription({ currentPeriodEnd }, now)).not.toBe(
+      utcMonthKey(now)
+    )
+  })
+
+  test('a mid-month cycle start does not zero the budget early: spend just before vs. after the boundary keys differently', () => {
+    const currentPeriodEnd = Math.floor(
+      new Date('2026-06-15T00:00:00Z').getTime() / 1000
+    )
+    const justBefore = new Date('2026-03-14T23:59:59Z')
+    const justAfter = new Date('2026-03-15T00:00:00Z')
+    expect(
+      periodKeyFromSubscription({ currentPeriodEnd }, justBefore)
+    ).toBe('period:2026-02-15')
+    expect(periodKeyFromSubscription({ currentPeriodEnd }, justAfter)).toBe(
+      'period:2026-03-15'
+    )
+  })
+
+  test('yearly plan: the monthly sub-window still keys off the day-of-month, not the yearly span', () => {
+    // Yearly subscription renewing ~a year out, day-of-month 10.
+    const currentPeriodEnd = Math.floor(
+      new Date('2027-01-10T00:00:00Z').getTime() / 1000
+    )
+    expect(
+      periodKeyFromSubscription(
+        { currentPeriodEnd },
+        new Date('2026-07-15T00:00:00Z')
+      )
+    ).toBe('period:2026-07-10')
+    expect(
+      periodKeyFromSubscription(
+        { currentPeriodEnd },
+        new Date('2026-08-05T00:00:00Z')
+      )
+    ).toBe('period:2026-07-10')
+    expect(
+      periodKeyFromSubscription(
+        { currentPeriodEnd },
+        new Date('2026-08-10T00:00:00Z')
+      )
+    ).toBe('period:2026-08-10')
+  })
+})
+
+describe('utcMonthKey (OSS/free fallback, unchanged)', () => {
+  test('returns YYYY-MM regardless of day-of-month', () => {
+    expect(utcMonthKey(new Date('2026-07-01T00:00:00Z'))).toBe('2026-07')
+    expect(utcMonthKey(new Date('2026-07-31T23:59:59Z'))).toBe('2026-07')
+  })
+})

--- a/apps/dashboard/src/lib/billing/period-key.ts
+++ b/apps/dashboard/src/lib/billing/period-key.ts
@@ -42,7 +42,10 @@ function clampDay(year: number, monthIndex: number, day: number): number {
  * day, so a day-31 anchor still resolves sensibly in a 30-day or February
  * month.
  */
-export function cycleStartKey(anchorDay: number, now: Date = new Date()): string {
+export function cycleStartKey(
+  anchorDay: number,
+  now: Date = new Date()
+): string {
   const y = now.getUTCFullYear()
   const m = now.getUTCMonth()
   const d = now.getUTCDate()

--- a/apps/dashboard/src/lib/billing/period-key.ts
+++ b/apps/dashboard/src/lib/billing/period-key.ts
@@ -1,0 +1,99 @@
+/**
+ * Monthly-meter period keying — anchors the AI monthly USD budget
+ * (`ai-usage-store.ts`) and the host-overage peak meter (`host-usage-store.ts`)
+ * to the owner's actual subscription billing cycle instead of the calendar
+ * UTC month, so a mid-month cycle start doesn't get a budget zeroed early (or
+ * a cycle straddling the 1st granted two partial budgets).
+ *
+ * Design: the stored subscription only carries `currentPeriodEnd` (not a
+ * `currentPeriodStart`), but that end's day-of-month is a stable recurring
+ * anchor — Polar renewals advance `currentPeriodEnd` forward by one interval
+ * each cycle, so the *day* it lands on stays the same (clamped for short
+ * months). `cycleStartKey` walks back from `now` to the most recent
+ * occurrence of that anchor day to find the start of the current cycle.
+ *
+ * OSS/self-hosted invariant: no subscription (no D1, no row, lapsed) always
+ * falls back to `utcMonthKey` — the calendar month remains the only key there,
+ * unchanged from before this module existed.
+ */
+
+import { getSubscription } from './subscription-store'
+import { isSubscriptionLive } from './user-subscription'
+
+/** Returns the UTC month string 'YYYY-MM' for the given instant. */
+export function utcMonthKey(now: Date = new Date()): string {
+  return now.toISOString().slice(0, 7)
+}
+
+function daysInMonth(year: number, monthIndex: number): number {
+  // Day 0 of the *next* month is the last day of `monthIndex`.
+  return new Date(Date.UTC(year, monthIndex + 1, 0)).getUTCDate()
+}
+
+/** Clamp `day` to the last real day of `year`/`monthIndex` (e.g. 31 → 28/29 in February). */
+function clampDay(year: number, monthIndex: number, day: number): number {
+  return Math.min(day, daysInMonth(year, monthIndex))
+}
+
+/**
+ * Pure: given a recurring anchor day-of-month and `now`, return the
+ * 'YYYY-MM-DD' UTC date of the start of the cycle containing `now`. An anchor
+ * day beyond the current/previous month's length clamps to that month's last
+ * day, so a day-31 anchor still resolves sensibly in a 30-day or February
+ * month.
+ */
+export function cycleStartKey(anchorDay: number, now: Date = new Date()): string {
+  const y = now.getUTCFullYear()
+  const m = now.getUTCMonth()
+  const d = now.getUTCDate()
+  const thisMonthAnchor = clampDay(y, m, anchorDay)
+
+  let startY = y
+  let startM = m
+  if (d < thisMonthAnchor) {
+    startM = m - 1
+    if (startM < 0) {
+      startM = 11
+      startY = y - 1
+    }
+  }
+  const startDay = clampDay(startY, startM, anchorDay)
+  return `${startY}-${String(startM + 1).padStart(2, '0')}-${String(startDay).padStart(2, '0')}`
+}
+
+/**
+ * Pure period-key derivation from a subscription's `currentPeriodEnd`. Kept
+ * separate from the D1-resolving `periodKeyForOwner` below so the cycle-anchor
+ * boundary math is unit-testable without a database.
+ */
+export function periodKeyFromSubscription(
+  sub: { currentPeriodEnd: number | null } | null | undefined,
+  now: Date = new Date()
+): string {
+  if (!sub?.currentPeriodEnd) return utcMonthKey(now)
+  const anchorDay = new Date(sub.currentPeriodEnd * 1000).getUTCDate()
+  return `period:${cycleStartKey(anchorDay, now)}`
+}
+
+/**
+ * Resolve the monthly-meter period key for `ownerId`: anchored to their live
+ * subscription's billing-cycle day-of-month when one exists, falling back to
+ * the calendar UTC month otherwise (no subscription, D1 unavailable, lapsed —
+ * OSS/self-hosted always takes this path). Fail-open: a lookup error also
+ * falls back to the calendar month, so a store hiccup can only ever degrade to
+ * the previous (calendar-month) behaviour, never crash a caller.
+ */
+export async function periodKeyForOwner(
+  ownerId: string,
+  now: Date = new Date()
+): Promise<string> {
+  try {
+    const sub = await getSubscription(ownerId)
+    if (sub && isSubscriptionLive(sub, Math.floor(now.getTime() / 1000))) {
+      return periodKeyFromSubscription(sub, now)
+    }
+  } catch {
+    // Fall through to the calendar-month fallback.
+  }
+  return utcMonthKey(now)
+}

--- a/plans/README.md
+++ b/plans/README.md
@@ -235,7 +235,7 @@ it protects (76–78, 95).
 | 94 | [toolchain-version-alignment](94-toolchain-version-alignment.md) | dx | P2 | S | — | ⏳ TODO · [#2511](https://github.com/chmonitor/chmonitor/issues/2511) |
 | 95 | [platform-adapter-tests](95-platform-adapter-tests.md) | tests | P2 | S | — | ⏳ TODO · [#2512](https://github.com/chmonitor/chmonitor/issues/2512) |
 | 96 | [opennext-context-replacement-spike](96-opennext-context-replacement-spike.md) | migration | P3 | M | 95 | ⏳ TODO · [#2513](https://github.com/chmonitor/chmonitor/issues/2513) |
-| 97 | [billing-cycle-metering-alignment](97-billing-cycle-metering-alignment.md) | business-logic | P2 | M | 76 (soft) | ⏳ TODO · [#2514](https://github.com/chmonitor/chmonitor/issues/2514) |
+| 97 | [billing-cycle-metering-alignment](97-billing-cycle-metering-alignment.md) | business-logic | P2 | M | 76 (soft) | ✅ DONE · [#2514](https://github.com/chmonitor/chmonitor/issues/2514) |
 | 98 | [cloud-mode-runtime-consistency](98-cloud-mode-runtime-consistency.md) | investigate | P3 | S–M | — | ⏳ TODO · [#2515](https://github.com/chmonitor/chmonitor/issues/2515) |
 | 99 | [seat-precheck-pending-invites](99-seat-precheck-pending-invites.md) | business-logic | P3 | S | — | ⏳ TODO · [#2516](https://github.com/chmonitor/chmonitor/issues/2516) |
 | 100 | [ai-usage-reservation-release](100-ai-usage-reservation-release.md) | investigate | P3 | S | — | ⏳ TODO · [#2517](https://github.com/chmonitor/chmonitor/issues/2517) |


### PR DESCRIPTION
## Summary
- Monthly usage meters (AI monthly USD budget, host-overage peak) reset on the calendar UTC month regardless of when a subscriber's billing cycle actually starts — a mid-month cycle start zeroed the budget early, and a cycle straddling the 1st granted two partial budgets.
- Add `periodKeyForOwner` (`apps/dashboard/src/lib/billing/period-key.ts`): keys the meter to the day-of-month anchor of the subscription's `currentPeriodEnd` (which Polar advances forward each renewal), clamped for short months (day 29/30/31 anchors landing in a shorter month). Falls back to the existing calendar-UTC-month key (`utcMonthKey`) when there's no live subscription — so Free/OSS/self-hosted behavior is unchanged.
- Adopted in `ai-usage-store.ts` (`getAiSpendThisMonth`/`addAiSpend`) and `host-usage-store.ts` (`getHostOverageThisMonth`/`recordHostOverage`).
- One-time transition note: a currently-paying owner's meter key changes on deploy (new `period:<date>` key vs. the old `YYYY-MM` key), which resets their in-cycle spend/overage counter once — user-favorable (never inflates usage), matches plan 97's stated tradeoff.

## Test plan
- [x] New `period-key.test.ts`: `cycleStartKey` boundary math (mid-month anchor before/after/on the boundary, anchor days 29/30/31 clamped across February/30-day/31-day months, year-boundary rollback) and `periodKeyFromSubscription` (null/undefined subscription and null `currentPeriodEnd` fall back to `utcMonthKey`; live subscription keys off the cycle anchor; yearly-plan monthly sub-window).
- [ ] `cd apps/dashboard && bun test src/lib/billing` (could not run locally — no `node_modules` in this worktree; CI's `unit-tests` job will exercise it)

Fixes #2514