### PR TITLE
feat(api): fleet-wide rate limiting via CF binding with in-memory fallback

### DIFF
--- a/apps/dashboard/src/lib/api/__tests__/rate-limiter.test.ts
+++ b/apps/dashboard/src/lib/api/__tests__/rate-limiter.test.ts
@@ -15,7 +15,10 @@ import {
   _MAX_BUCKETS_FOR_TEST,
   _resetBucketsForTest,
   checkRateLimit,
+  checkRateLimitDurable,
   clientIpKey,
+  getRateLimitBinding,
+  type RateLimitBinding,
   rateLimitResponse,
 } from '../rate-limiter'
 import { afterEach, describe, expect, test } from 'bun:test'
@@ -131,5 +134,90 @@ describe('clientIpKey', () => {
   test('returns "unknown" when no IP headers present', () => {
     const req = makeRequest({})
     expect(clientIpKey(req)).toBe('unknown')
+  })
+})
+
+describe('getRateLimitBinding / checkRateLimitDurable (adapter selection)', () => {
+  const BINDING = 'CHM_RATE_LIMIT_TEST'
+
+  afterEach(() => {
+    // Ensure no test leaks a binding onto the shared globalThis.
+    delete (globalThis as Record<string, unknown>)[BINDING]
+  })
+
+  test('getRateLimitBinding returns undefined when no binding on globalThis', () => {
+    expect(getRateLimitBinding(BINDING)).toBeUndefined()
+  })
+
+  test('getRateLimitBinding returns undefined when value lacks limit()', () => {
+    ;(globalThis as Record<string, unknown>)[BINDING] = { nope: true }
+    expect(getRateLimitBinding(BINDING)).toBeUndefined()
+  })
+
+  test('getRateLimitBinding resolves a well-formed binding', () => {
+    const stub: RateLimitBinding = {
+      limit: async () => ({ success: true }),
+    }
+    ;(globalThis as Record<string, unknown>)[BINDING] = stub
+    expect(getRateLimitBinding(BINDING)).toBe(stub)
+  })
+
+  test('delegates to the binding when present (allowed)', async () => {
+    let called = 0
+    const stub: RateLimitBinding = {
+      limit: async ({ key }) => {
+        called++
+        expect(key).toBe('durable-key')
+        return { success: true }
+      },
+    }
+    ;(globalThis as Record<string, unknown>)[BINDING] = stub
+
+    const result = await checkRateLimitDurable('durable-key', 5, BINDING)
+    expect(called).toBe(1)
+    expect(result.allowed).toBe(true)
+    expect(result.retryAfterSec).toBe(0)
+    // Binding path must NOT touch the in-memory bucket store.
+    expect(_bucketCountForTest()).toBe(0)
+  })
+
+  test('delegates to the binding when present (blocked → 429 backoff)', async () => {
+    const stub: RateLimitBinding = { limit: async () => ({ success: false }) }
+    ;(globalThis as Record<string, unknown>)[BINDING] = stub
+
+    const result = await checkRateLimitDurable('blocked-key', 5, BINDING)
+    expect(result.allowed).toBe(false)
+    expect(result.retryAfterSec).toBeGreaterThan(0)
+    expect(_bucketCountForTest()).toBe(0)
+  })
+
+  test('falls back to the in-memory limiter when binding is absent', async () => {
+    const result = await checkRateLimitDurable('fallback-key', 3, BINDING)
+    expect(result.allowed).toBe(true)
+    // In-memory path was used, so a bucket now exists for the key.
+    expect(_bucketCountForTest()).toBe(1)
+  })
+
+  test('in-memory fallback still enforces the limit across calls', async () => {
+    for (let i = 0; i < 3; i++) {
+      const r = await checkRateLimitDurable('fallback-burst', 3, BINDING)
+      expect(r.allowed).toBe(true)
+    }
+    const denied = await checkRateLimitDurable('fallback-burst', 3, BINDING)
+    expect(denied.allowed).toBe(false)
+  })
+
+  test('fails open to the in-memory limiter when the binding throws', async () => {
+    const stub: RateLimitBinding = {
+      limit: async () => {
+        throw new Error('edge counter unavailable')
+      },
+    }
+    ;(globalThis as Record<string, unknown>)[BINDING] = stub
+
+    const result = await checkRateLimitDurable('error-key', 4, BINDING)
+    expect(result.allowed).toBe(true)
+    // Fell through to the Map path.
+    expect(_bucketCountForTest()).toBe(1)
   })
 })

--- a/apps/dashboard/src/lib/api/rate-limiter.ts
+++ b/apps/dashboard/src/lib/api/rate-limiter.ts
@@ -126,6 +126,87 @@ export function checkRateLimit(
 }
 
 /**
+ * Cloudflare Rate Limiting binding surface (the "unsafe" ratelimit binding).
+ * `limit({ key })` resolves `{ success }` — success=false means the fleet-wide
+ * counter for that key has exceeded the configured limit/period. This counter
+ * lives in Cloudflare's edge (not the isolate), so it is enforced across every
+ * isolate — unlike the in-memory `buckets` Map above.
+ * @see https://developers.cloudflare.com/workers/runtime-apis/bindings/rate-limit/
+ */
+export interface RateLimitBinding {
+  limit(options: { key: string }): Promise<{ success: boolean }>
+}
+
+/**
+ * Cloudflare's rate-limit binding config uses a fixed `period` (10 or 60s).
+ * The binding does not report a precise retry time, so blocked callers get a
+ * conservative full-period backoff. Our declared bindings use a 60s period.
+ */
+const BINDING_PERIOD_SEC = 60
+
+/**
+ * Resolve a named Cloudflare rate-limit binding from the Worker runtime.
+ *
+ * Bindings are exposed on `globalThis` in the Worker (same detection pattern as
+ * `CHM_DASHBOARD_QUERY_KV` / `CHM_VERSION_CACHE_KV` in
+ * `lib/api/data/dashboard-query-kv-cache.ts`). Returns `undefined` on
+ * Node/Docker/K8s (self-hosted) where no such binding exists, so callers fall
+ * back to the in-memory limiter — preserving current OSS behaviour.
+ */
+export function getRateLimitBinding(
+  name: string
+): RateLimitBinding | undefined {
+  if (typeof globalThis === 'undefined' || !(name in globalThis)) {
+    return undefined
+  }
+  const candidate = (globalThis as Record<string, unknown>)[name]
+  if (candidate && typeof (candidate as RateLimitBinding).limit === 'function') {
+    return candidate as RateLimitBinding
+  }
+  return undefined
+}
+
+/** Binding names declared in wrangler.toml (`[[unsafe.bindings]]`). */
+export const RATE_LIMIT_BINDING_API = 'CHM_RATE_LIMIT_API'
+export const RATE_LIMIT_BINDING_AGENT = 'CHM_RATE_LIMIT_AGENT'
+
+/**
+ * Fleet-wide rate limit check with graceful fallback.
+ *
+ * When a Cloudflare rate-limit binding named `bindingName` is present (Cloud /
+ * Workers), the durable edge counter is authoritative — enforced across ALL
+ * isolates (fixing the per-isolate blind spot of the in-memory Map). When the
+ * binding is absent (self-hosted single-process Node/Docker/K8s) or errors,
+ * this falls back to the in-memory `checkRateLimit` token bucket, so behaviour
+ * is byte-identical to before on OSS deployments (fail-open to current).
+ *
+ * The `{ allowed, retryAfterSec, remaining }` contract is preserved; callers
+ * only swap the sync call for an awaited one.
+ *
+ * @param bucketKey    - Unique identifier (e.g. `charts:ip:1.2.3.4`)
+ * @param limitPerMin  - Fallback per-60s limit for the in-memory path
+ * @param bindingName  - Worker binding to use when present (e.g. `CHM_RATE_LIMIT_API`)
+ */
+export async function checkRateLimitDurable(
+  bucketKey: string,
+  limitPerMin: number,
+  bindingName: string
+): Promise<RateLimitResult> {
+  const binding = getRateLimitBinding(bindingName)
+  if (binding) {
+    try {
+      const { success } = await binding.limit({ key: bucketKey })
+      if (success) return { allowed: true, retryAfterSec: 0, remaining: 0 }
+      return { allowed: false, retryAfterSec: BINDING_PERIOD_SEC, remaining: 0 }
+    } catch {
+      // Fail open to the in-memory limiter on any binding error, rather than
+      // hard-blocking legitimate traffic when the edge counter is unavailable.
+    }
+  }
+  return checkRateLimit(bucketKey, limitPerMin)
+}
+
+/**
  * Build the 429 response with Retry-After header.
  */
 export function rateLimitResponse(retryAfterSec: number): Response {

--- a/apps/dashboard/src/routes/api/dashboards/share.$slug.ts
+++ b/apps/dashboard/src/routes/api/dashboards/share.$slug.ts
@@ -33,9 +33,10 @@ import {
   createInternalErrorResponse,
 } from '@/lib/api/error-handler'
 import {
-  checkRateLimit,
+  checkRateLimitDurable,
   clientIpKey,
   getApiRateLimitPerMin,
+  RATE_LIMIT_BINDING_API,
   rateLimitResponse,
 } from '@/lib/api/rate-limiter'
 import {
@@ -58,9 +59,10 @@ async function handleGet(request: Request, slug: string): Promise<Response> {
   // Rate-limit by client IP before doing any work — this is a public,
   // unauthenticated route, so it's the only abuse guard available.
   const ip = clientIpKey(request)
-  const rlResult = checkRateLimit(
+  const rlResult = await checkRateLimitDurable(
     `dashboards-share:ip:${ip}`,
-    getApiRateLimitPerMin()
+    getApiRateLimitPerMin(),
+    RATE_LIMIT_BINDING_API
   )
   if (!rlResult.allowed) return rateLimitResponse(rlResult.retryAfterSec)
 

--- a/apps/dashboard/src/routes/api/events/ingest.ts
+++ b/apps/dashboard/src/routes/api/events/ingest.ts
@@ -30,9 +30,10 @@ import { createFileRoute } from '@tanstack/react-router'
 import { error, log, warn } from '@chm/logger'
 import { getPlatformBindings } from '@chm/platform'
 import {
-  checkRateLimit,
+  checkRateLimitDurable,
   clientIpKey,
   getApiRateLimitPerMin,
+  RATE_LIMIT_BINDING_API,
   rateLimitResponse,
 } from '@/lib/api/rate-limiter'
 import { secretsMatch } from '@/lib/auth/providers/constant-time'
@@ -84,9 +85,10 @@ async function handlePost(
   const denied = authorizeIngest(request)
   if (denied) return denied
 
-  const rl = checkRateLimit(
+  const rl = await checkRateLimitDurable(
     `events-ingest:ip:${clientIpKey(request)}`,
-    getApiRateLimitPerMin()
+    getApiRateLimitPerMin(),
+    RATE_LIMIT_BINDING_API
   )
   if (!rl.allowed) return rateLimitResponse(rl.retryAfterSec)
 

--- a/apps/dashboard/src/routes/api/v1/agent.ts
+++ b/apps/dashboard/src/routes/api/v1/agent.ts
@@ -58,9 +58,10 @@ import {
   parseModelId,
 } from '@/lib/ai/providers'
 import {
-  checkRateLimit,
+  checkRateLimitDurable,
   clientIpKey,
   getAgentRateLimitPerMin,
+  RATE_LIMIT_BINDING_AGENT,
   rateLimitResponse,
 } from '@/lib/api/rate-limiter'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
@@ -304,7 +305,11 @@ async function handlePost(request: Request): Promise<Response> {
 
   // Rate-limit by IP first, then tighten per identity after auth resolves.
   const ip = clientIpKey(request)
-  const rlResult = checkRateLimit(`agent:ip:${ip}`, getAgentRateLimitPerMin())
+  const rlResult = await checkRateLimitDurable(
+    `agent:ip:${ip}`,
+    getAgentRateLimitPerMin(),
+    RATE_LIMIT_BINDING_AGENT
+  )
   if (!rlResult.allowed) return rateLimitResponse(rlResult.retryAfterSec)
 
   const authResponse = await authorizeAgentApiRequest(request)
@@ -505,9 +510,10 @@ async function handlePost(request: Request): Promise<Response> {
   // across many IPs to exceed its allowance. Anonymous callers keep the per-IP
   // bucket above as their identity, so this only adds a stricter per-user gate.
   if (userId !== 'guest') {
-    const identityRl = checkRateLimit(
+    const identityRl = await checkRateLimitDurable(
       `agent:user:${userId}`,
-      getAgentRateLimitPerMin()
+      getAgentRateLimitPerMin(),
+      RATE_LIMIT_BINDING_AGENT
     )
     if (!identityRl.allowed) return rateLimitResponse(identityRl.retryAfterSec)
   }

--- a/apps/dashboard/src/routes/api/v1/charts/$name.ts
+++ b/apps/dashboard/src/routes/api/v1/charts/$name.ts
@@ -26,9 +26,10 @@ import {
   isValidInterval,
 } from '@/lib/api/query-executor'
 import {
-  checkRateLimit,
+  checkRateLimitDurable,
   clientIpKey,
   getApiRateLimitPerMin,
+  RATE_LIMIT_BINDING_API,
   rateLimitResponse,
 } from '@/lib/api/rate-limiter'
 import {
@@ -51,7 +52,11 @@ export async function handler(
 ): Promise<Response> {
   // Rate-limit by client IP before doing any work
   const ip = clientIpKey(request)
-  const rlResult = checkRateLimit(`charts:ip:${ip}`, getApiRateLimitPerMin())
+  const rlResult = await checkRateLimitDurable(
+    `charts:ip:${ip}`,
+    getApiRateLimitPerMin(),
+    RATE_LIMIT_BINDING_API
+  )
   if (!rlResult.allowed) return rateLimitResponse(rlResult.retryAfterSec)
 
   const bindings = env as Record<string, string | undefined>

--- a/apps/dashboard/wrangler.toml
+++ b/apps/dashboard/wrangler.toml
@@ -98,6 +98,30 @@ preview_id = "1f8ab0acc6114802bf5c14d883dae341"
 # ─────────────────────────────────────────────────────────────────────────────
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Fleet-wide rate limiting (Cloudflare Rate Limiting API, "unsafe" binding).
+# Backs the public/anonymous abuse guards (share links, anon pageview inserts,
+# public chart GETs, agent burst guard). The in-memory token bucket in
+# lib/api/rate-limiter.ts is per-isolate, so Workers' isolate spread means
+# configured limits are not enforced fleet-wide — these edge counters are.
+# checkRateLimitDurable() delegates to these bindings when present and falls
+# back to the in-memory limiter when absent, so self-hosted Docker/K8s/Node
+# (no binding) keeps working unchanged. namespace_id is a stable per-binding
+# integer; period must be 10 or 60. See:
+# https://developers.cloudflare.com/workers/runtime-apis/bindings/rate-limit/
+[[unsafe.bindings]]
+name = "CHM_RATE_LIMIT_API"
+type = "ratelimit"
+namespace_id = "2001"
+simple = { limit = 100, period = 60 }
+
+[[unsafe.bindings]]
+name = "CHM_RATE_LIMIT_AGENT"
+type = "ratelimit"
+namespace_id = "2002"
+simple = { limit = 10, period = 60 }
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Inbound event bus (Cloudflare Queues) — EXAMPLE, NOT ACTIVE.
 # See plans/36-inbound-event-bus-queues.md. POST /api/events/ingest and the
 # consumer (lib/events/queue-consumer.ts processEventBatch) are implemented
@@ -217,6 +241,20 @@ preview_id = "44390b843ada46d8beb47c99bcf24115"
 binding = "CHM_VERSION_CACHE_KV"
 id = "f2efbec5955a4772a01e32e7e35c35f5"
 preview_id = "1f8ab0acc6114802bf5c14d883dae341"
+
+# Rate-limit bindings are not inherited by named environments — repeat the
+# top-level CHM_RATE_LIMIT_* unsafe bindings here (see top-level note).
+[[env.preview.unsafe.bindings]]
+name = "CHM_RATE_LIMIT_API"
+type = "ratelimit"
+namespace_id = "2001"
+simple = { limit = 100, period = 60 }
+
+[[env.preview.unsafe.bindings]]
+name = "CHM_RATE_LIMIT_AGENT"
+type = "ratelimit"
+namespace_id = "2002"
+simple = { limit = 10, period = 60 }
 
 # DO migrations are not inherited by named environments — repeat the chain that
 # drops the legacy preview worker's Durable Objects (see top-level note).

--- a/plans/README.md
+++ b/plans/README.md
@@ -221,7 +221,7 @@ it protects (76–78, 95).
 | 80 | [background-bar-companions](80-background-bar-companions.md) | bug | P2 | S | — | ⏳ TODO · [#2497](https://github.com/chmonitor/chmonitor/issues/2497) |
 | 81 | [tooltip-breakdown-fixes](81-tooltip-breakdown-fixes.md) | bug | P2 | S | — | ⏳ TODO · [#2498](https://github.com/chmonitor/chmonitor/issues/2498) |
 | 82 | [data-table-utility-columns-sorting](82-data-table-utility-columns-sorting.md) | bug | P2 | S | — | ⏳ TODO · [#2499](https://github.com/chmonitor/chmonitor/issues/2499) |
-| 83 | [fleet-wide-rate-limiting](83-fleet-wide-rate-limiting.md) | security | P2 | M | — | ⏳ TODO · [#2500](https://github.com/chmonitor/chmonitor/issues/2500) (closes #2467) |
+| 83 | [fleet-wide-rate-limiting](83-fleet-wide-rate-limiting.md) | security | P2 | M | — | ✅ DONE · [#2500](https://github.com/chmonitor/chmonitor/issues/2500) (closes #2467) |
 | 84 | [sanitize-500-error-responses](84-sanitize-500-error-responses.md) | security | P2 | S | — | ⏳ TODO · [#2501](https://github.com/chmonitor/chmonitor/issues/2501) |
 | 85 | [bug-handler-fail-closed-senders](85-bug-handler-fail-closed-senders.md) | security | P2 | S | — | ⏳ TODO · [#2502](https://github.com/chmonitor/chmonitor/issues/2502) |
 | 86 | [telemetry-event-insert-bounds](86-telemetry-event-insert-bounds.md) | security | P3 | S | — | ⏳ TODO · [#2503](https://github.com/chmonitor/chmonitor/issues/2503) |


### PR DESCRIPTION
## Summary

The public/anonymous abuse guards — public dashboard share links (`/api/dashboards/share/$slug`), anonymous pageview ClickHouse inserts (`/api/events/ingest`), public chart GETs (`/api/v1/charts/$name`), and the agent burst guard (`/api/v1/agent`) — were enforced only by a **per-isolate** in-memory token bucket (`lib/api/rate-limiter.ts`). Cloudflare Workers spread traffic across many short-lived isolates, each with a fresh bucket, so "N per minute" was never enforced fleet-wide.

## What changed

- **`checkRateLimitDurable(bucketKey, limitPerMin, bindingName)`** — new adapter seam. When a Cloudflare Rate Limiting binding is present in the Worker runtime (resolved off `globalThis`, same pattern as the KV caches), it delegates to the durable edge counter (`binding.limit({ key })`), enforced across **all** isolates. When the binding is absent (self-hosted Docker/K8s/Node) or throws, it **falls back to the existing bounded in-memory limiter** — OSS behaviour is byte-identical (fail-open to current).
- **`wrangler.toml`** — declares `CHM_RATE_LIMIT_API` (100/60s) and `CHM_RATE_LIMIT_AGENT` (10/60s) as `[[unsafe.bindings]]` (top-level + `[env.preview]`, since named envs don't inherit bindings). No `[vars]` touched.
- Wired the four public call sites to `await checkRateLimitDurable(...)`.
- Builds on top of the bounded fallback Map from #2547 (does not revert it) — so this also closes the unbounded-growth concern in #2467.

## Tests

Added adapter-selection unit tests: binding present → binding used and Map untouched; binding blocked → 429 backoff; binding absent → Map fallback still enforces the limit; binding throws → fails open to Map. `bun test src/lib/api` — 949 pass. `wrangler.toml` validated as parseable TOML with both bindings resolved.

## Notes

Self-hosted stays whole: no core feature gated; single-process Node keeps the in-memory path (adequate). Per Cloudflare's Rate Limiting API, one binding = one static limit/period, so API vs agent tiers use separate bindings.

Fixes #2500
Closes #2467

https://claude.ai/code/session_01GUKP6qY1efJkqPz6AgaxXh