### PR TITLE
feat(agent): pass current dashboard page as context to the chat agent

### DIFF
--- a/apps/dashboard/src/components/assistant-ui/agent-runtime-provider.tsx
+++ b/apps/dashboard/src/components/assistant-ui/agent-runtime-provider.tsx
@@ -22,12 +22,14 @@ import {
 } from '@assistant-ui/react'
 import { useChatRuntime } from '@assistant-ui/react-ai-sdk'
 import { DefaultChatTransport } from 'ai'
-import { type ReactNode, useMemo } from 'react'
+import { type ReactNode, useMemo, useRef } from 'react'
+import { buildPageContext } from '@/lib/ai/agent/page-context'
 import { trackEvent } from '@/lib/analytics/analytics'
 import { resolveThreadListAdapter } from '@/lib/conversation-store/adapter/resolve-thread-list-adapter'
 import { useAgentModel } from '@/lib/hooks/use-agent-model'
 import { useMcpConfig } from '@/lib/hooks/use-mcp-config'
 import { useToolConfig } from '@/lib/hooks/use-tool-config'
+import { usePathname } from '@/lib/next-compat'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { useHostId } from '@/lib/swr/use-host'
 
@@ -54,6 +56,7 @@ function useAgentChatRuntime() {
   const { model } = useAgentModel()
   const sessionId = useMemo(() => crypto.randomUUID(), [])
   const { customServers, disabledServers } = useMcpConfig()
+  const pathname = usePathname()
 
   // Only pass enabled custom servers to the agent route. Derive from the stable
   // `customServers` + `disabledServers` arrays (not `isServerEnabled`, which is a
@@ -67,17 +70,53 @@ function useAgentChatRuntime() {
     [customServers, disabledServers]
   )
 
+  // Grounds an ambiguous question ("why is this slow?") in the page the user
+  // was on when they sent it. Sent only on the first message of a thread, or
+  // when the page changed since the last message that carried it — never on
+  // every turn, so a long-running conversation doesn't keep re-asserting
+  // stale page context after the user navigated away.
+  const lastSentPathnameRef = useRef<string | null>(null)
+
   const transport = useMemo(
     () =>
       new DefaultChatTransport({
         api: '/api/v1/agent',
         fetch: trackedAgentFetch as typeof globalThis.fetch,
         body: { hostId, model, disabledTools, sessionId, mcpServers },
+        prepareSendMessagesRequest: ({
+          id,
+          messages,
+          body,
+          trigger,
+          messageId,
+        }) => {
+          const isNewThread = messages.length <= 1
+          const pageChanged = lastSentPathnameRef.current !== pathname
+          const shouldSendPageContext =
+            Boolean(pathname) && (isNewThread || pageChanged)
+
+          if (shouldSendPageContext) {
+            lastSentPathnameRef.current = pathname
+          }
+
+          return {
+            body: {
+              ...body,
+              id,
+              messages,
+              trigger,
+              messageId,
+              ...(shouldSendPageContext
+                ? { pageContext: buildPageContext(pathname) }
+                : {}),
+            },
+          }
+        },
       }),
     // mcpServers is a derived array — include it directly so the transport
     // re-creates when the user toggles or adds custom servers.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [hostId, model, disabledTools, sessionId, mcpServers]
+    [hostId, model, disabledTools, sessionId, mcpServers, pathname]
   )
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/dashboard/src/lib/ai/agent/page-context.ts
+++ b/apps/dashboard/src/lib/ai/agent/page-context.ts
@@ -1,0 +1,32 @@
+/**
+ * Client-side helper for deriving the "page context" hint sent to the chat
+ * agent (`pageContext` on `/api/v1/agent`'s request body — see
+ * `routes/api/v1/agent.ts`'s `sanitizePageContext` / `buildPageContextLine`).
+ *
+ * Kept in its own module (rather than inline in the runtime provider) so it
+ * has no React dependency and can be unit tested directly.
+ */
+
+import { getBreadcrumbPath } from '@/lib/menu/breadcrumb'
+
+export type PageContext = {
+  route: string
+  label?: string
+}
+
+/**
+ * Resolve a human-readable page label for a pathname via the menu hierarchy
+ * (same lookup the breadcrumb uses), falling back to `undefined` when the
+ * route isn't registered — the server falls back to the raw route in that
+ * case.
+ */
+export function getPageLabel(pathname: string): string | undefined {
+  const breadcrumbs = getBreadcrumbPath(pathname)
+  if (breadcrumbs.length === 0) return undefined
+  return breadcrumbs[breadcrumbs.length - 1]?.title
+}
+
+/** Build the `pageContext` hint for the given pathname. */
+export function buildPageContext(pathname: string): PageContext {
+  return { route: pathname, label: getPageLabel(pathname) }
+}

--- a/apps/dashboard/src/routes/api/v1/agent-page-context.test.ts
+++ b/apps/dashboard/src/routes/api/v1/agent-page-context.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for the `pageContext` request-body hint (issue #2457): grounding
+ * an ambiguous chat message in the dashboard page it was sent from ("the user
+ * is currently viewing the Merges page"), without perturbing the byte-stable
+ * cached system prompt (`AGENT_JSON_RENDER_INLINE_PROMPT`).
+ *
+ * Exercises the two pure helpers exported from `./agent` — `sanitizePageContext`
+ * (validates/clamps the client-supplied hint; missing/malformed input must
+ * behave exactly like a request that omits `pageContext` entirely) and
+ * `buildPageContextLine` (the short synthetic line threaded ahead of the
+ * user's turn as its own message, per `docs/content/guide/ai-agent.mdx`).
+ *
+ * `cloudflare:workers` is stubbed because `./agent` imports `env` from it at
+ * module top — same convention as `routes/api/v1/advisor.test.ts` and
+ * `routes/api/v1/__tests__/actions.test.ts`.
+ */
+
+import { describe, expect, mock, test } from 'bun:test'
+
+mock.module('cloudflare:workers', () => ({ env: {} }))
+
+import { buildPageContextLine, sanitizePageContext } from './agent'
+
+describe('sanitizePageContext', () => {
+  test('returns undefined when pageContext is omitted', () => {
+    expect(sanitizePageContext(undefined)).toBeUndefined()
+  })
+
+  test('returns undefined for malformed input (not an object)', () => {
+    expect(sanitizePageContext('nope' as any)).toBeUndefined()
+    expect(sanitizePageContext(null as any)).toBeUndefined()
+  })
+
+  test('returns undefined when route is missing or not a string', () => {
+    expect(sanitizePageContext({ label: 'Merges' } as any)).toBeUndefined()
+    expect(
+      sanitizePageContext({ route: 42, label: 'Merges' } as any)
+    ).toBeUndefined()
+  })
+
+  test('returns undefined when route is blank/whitespace-only', () => {
+    expect(sanitizePageContext({ route: '   ' })).toBeUndefined()
+  })
+
+  test('accepts a valid route with no label', () => {
+    expect(sanitizePageContext({ route: '/merges' })).toEqual({
+      route: '/merges',
+    })
+  })
+
+  test('accepts a valid route + label pair', () => {
+    expect(sanitizePageContext({ route: '/merges', label: 'Merges' })).toEqual({
+      route: '/merges',
+      label: 'Merges',
+    })
+  })
+
+  test('drops a non-string label but keeps the route', () => {
+    expect(
+      sanitizePageContext({ route: '/merges', label: 123 as any })
+    ).toEqual({ route: '/merges' })
+  })
+
+  test('drops a blank label but keeps the route', () => {
+    expect(sanitizePageContext({ route: '/merges', label: '   ' })).toEqual({
+      route: '/merges',
+    })
+  })
+
+  test('clamps an oversized route/label instead of rejecting the request', () => {
+    const hugeRoute = `/${'a'.repeat(5_000)}`
+    const hugeLabel = 'b'.repeat(5_000)
+    const result = sanitizePageContext({ route: hugeRoute, label: hugeLabel })
+    expect(result).toBeDefined()
+    expect(result?.route.length).toBeLessThan(hugeRoute.length)
+    expect(result?.label?.length).toBeLessThan(hugeLabel.length)
+  })
+})
+
+describe('buildPageContextLine', () => {
+  test('prefers the label over the raw route', () => {
+    const line = buildPageContextLine({ route: '/merges', label: 'Merges' }, 0)
+    expect(line).toContain('"Merges"')
+    expect(line).toContain('host 0')
+  })
+
+  test('falls back to the route when there is no label', () => {
+    const line = buildPageContextLine({ route: '/merges' }, 2)
+    expect(line).toContain('"/merges"')
+    expect(line).toContain('host 2')
+  })
+})

--- a/apps/dashboard/src/routes/api/v1/agent.ts
+++ b/apps/dashboard/src/routes/api/v1/agent.ts
@@ -102,6 +102,9 @@ const AGENT_MAX_MESSAGES = 64
 const AGENT_MAX_MESSAGE_PARTS = 64
 const AGENT_MAX_USER_MESSAGE_LENGTH = 8_192
 const AGENT_MAX_PART_TEXT_LENGTH = 2_048
+// Page-context is a short grounding hint ("user is on the Merges page"), not
+// a message body — cap it much tighter than a chat message.
+const AGENT_MAX_PAGE_CONTEXT_FIELD_LENGTH = 200
 const textEncoder = new TextEncoder()
 const textDecoder = new TextDecoder()
 
@@ -116,6 +119,58 @@ type AgentRequestBody = {
   disabledTools?: string[]
   sessionId?: string
   mcpServers?: Array<{ id?: unknown; name?: unknown; endpoint?: unknown }>
+  /**
+   * Optional hint about the dashboard page the chat was opened/sent from
+   * (e.g. `{ route: '/merges', label: 'Merges' }`). Purely additive — a
+   * request omitting this field behaves exactly as before. See
+   * `sanitizePageContext` / `buildPageContextLine`.
+   */
+  pageContext?: { route?: unknown; label?: unknown }
+}
+
+/** Sanitized, safe-to-use page-context hint. */
+export type SafePageContext = {
+  readonly route: string
+  readonly label?: string
+}
+
+/**
+ * Validate and clamp the client-supplied `pageContext` hint.
+ *
+ * Returns `undefined` for anything malformed/empty so callers can simply
+ * treat a missing hint and an invalid one the same way (no page context).
+ */
+export function sanitizePageContext(
+  raw: AgentRequestBody['pageContext']
+): SafePageContext | undefined {
+  if (!isObject(raw) || typeof raw.route !== 'string') {
+    return undefined
+  }
+
+  const route = clampText(raw.route.trim(), AGENT_MAX_PAGE_CONTEXT_FIELD_LENGTH)
+  if (!route) {
+    return undefined
+  }
+
+  const label =
+    typeof raw.label === 'string' && raw.label.trim().length > 0
+      ? clampText(raw.label.trim(), AGENT_MAX_PAGE_CONTEXT_FIELD_LENGTH)
+      : undefined
+
+  return label ? { route, label } : { route }
+}
+
+/**
+ * Build the short synthetic context line describing the page the user is on.
+ * Kept out of the (byte-stable, cached) system prompt on purpose — this is
+ * threaded in as a separate message ahead of the user's turn instead.
+ */
+export function buildPageContextLine(
+  pageContext: SafePageContext,
+  hostId: number
+): string {
+  const page = pageContext.label ?? pageContext.route
+  return `Context: the user is currently viewing the "${page}" page (host ${hostId}).`
 }
 
 type SanitizeIncomingMessagesResult =
@@ -709,6 +764,34 @@ async function handlePost(request: Request): Promise<Response> {
       role: 'user',
       parts: [{ type: 'text' as const, text: userMessage }],
     })
+  }
+
+  // Thread a lightweight "the user is looking at page X" hint ahead of the
+  // user's turn — only on the first message of a (new) thread, so a
+  // long-running conversation doesn't keep re-asserting page context after
+  // the user has navigated away. The client only sends `pageContext` on the
+  // first turn or when the page changed; this is a server-side belt-and-
+  // braces check against the same signal (a single user turn in the incoming
+  // history). Deliberately NOT folded into `AGENT_JSON_RENDER_INLINE_PROMPT`
+  // (the cached system prompt) — inserted as its own message instead, so
+  // provider prompt caching on the system prompt is unaffected.
+  const safePageContext = sanitizePageContext(body.pageContext)
+  const isFirstThreadMessage =
+    safeIncomingMessages.filter((m) => m.role === 'user').length <= 1
+  if (safePageContext && isFirstThreadMessage) {
+    const lastMessageIndex = uiMessages.length - 1
+    if (lastMessageIndex >= 0 && uiMessages[lastMessageIndex].role === 'user') {
+      uiMessages.splice(lastMessageIndex, 0, {
+        id: crypto.randomUUID(),
+        role: 'system',
+        parts: [
+          {
+            type: 'text' as const,
+            text: buildPageContextLine(safePageContext, hostId),
+          },
+        ],
+      })
+    }
   }
 
   if (AGENT_DEBUG_LOGS) {

--- a/docs/content/guide/ai-agent.mdx
+++ b/docs/content/guide/ai-agent.mdx
@@ -226,6 +226,17 @@ curl -X POST https://your-host/api/v1/agent \
 
 `hostId` is a zero-based numeric index; defaults to `0`.
 
+**Page context (optional).** The dashboard chat sends an optional
+`pageContext: { route, label? }` field grounding an ambiguous question in the
+page the user was on when they sent it (e.g. "the user is currently viewing
+the Merges page"). It's only included on the first message of a new thread, or
+when the page changed since it was last sent — never on every turn, so a
+long-running conversation doesn't keep asserting stale context after the user
+navigated away. It's threaded in as its own message ahead of the user's turn,
+not baked into the (byte-stable, cached) system prompt. Purely additive:
+omitting it (MCP and API-token callers have no "page") behaves exactly as
+before.
+
 ## MCP Server
 
 The dashboard exposes an MCP (Model Context Protocol) endpoint at `/api/mcp`. The same implementation runs in the standalone Cloudflare MCP Worker (`apps/mcp`). All tools are read-only by design — write and DDL statements are rejected.


### PR DESCRIPTION
## Summary
- Add an optional `pageContext?: { route, label? }` field to the `/api/v1/agent` request body (`sanitizePageContext` / `buildPageContextLine` in `apps/dashboard/src/routes/api/v1/agent.ts`), clamped like other request fields. Omitting it (MCP / API-token callers) behaves exactly as before.
- Client sends it via a new `prepareSendMessagesRequest` on the chat transport (`agent-runtime-provider.tsx`), derived from `usePathname()` + the menu-based breadcrumb label (`lib/ai/agent/page-context.ts`) — only on the first message of a thread or when the page changed since it was last sent.
- Server threads it in as its own message ahead of the user's turn (not folded into the cached `AGENT_JSON_RENDER_INLINE_PROMPT` system prompt, so provider prompt caching is unaffected).
- Docs: noted the new field in `docs/content/guide/ai-agent.mdx`.

## Test plan
- [x] Unit tests for `sanitizePageContext` / `buildPageContextLine` (`apps/dashboard/src/routes/api/v1/agent-page-context.test.ts`) — malformed/oversized input, label fallback.
- [x] `pnpm exec tsc --noEmit` on the touched files (no new errors; pre-existing `routeTree.gen`-related errors are unrelated to this change).
- [x] `pnpm exec biome check` clean on touched files.

Fixes #2457