### PR TITLE
perf(landing,blog): single themed screenshot per slot, no double download

### DIFF
--- a/apps/blog/src/content/blog/chmonitor-v0-3.md
+++ b/apps/blog/src/content/blog/chmonitor-v0-3.md
@@ -70,96 +70,80 @@ docker compose up -d
 
 v0.3 keeps shipping. Since the initial release:
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="/posts/v0.3/overview-dark.png">
-  <img data-shot="light" src="/posts/v0.3/overview-light.png" alt="Overview page with a GitHub-style query activity heatmap" />
-  <img data-shot="dark" src="/posts/v0.3/overview-dark.png" alt="Overview page with a GitHub-style query activity heatmap" />
-</picture>
+<img data-src-light="/posts/v0.3/overview-light.png" data-src-dark="/posts/v0.3/overview-dark.png" src="/posts/v0.3/overview-light.png" alt="Overview page with a GitHub-style query activity heatmap" width="1024" height="727" loading="lazy" />
 
 **A year of query activity, at a glance.** The Overview page now has a
 calendar heatmap of query volume, failures, memory and duration — the same
 glanceable pattern as a GitHub contribution graph.
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="/posts/v0.3/cluster-insights-dark.png">
-  <img data-shot="light" src="/posts/v0.3/cluster-insights-light.png" alt="Cluster Insights page with record breakers and detected findings" />
-  <img data-shot="dark" src="/posts/v0.3/cluster-insights-dark.png" alt="Cluster Insights page with record breakers and detected findings" />
-</picture>
+<img data-src-light="/posts/v0.3/cluster-insights-light.png" data-src-dark="/posts/v0.3/cluster-insights-dark.png" src="/posts/v0.3/cluster-insights-light.png" alt="Cluster Insights page with record breakers and detected findings" width="1024" height="664" loading="lazy" />
 
 **Cluster Insights**, a new page: auto-detected findings (error-rate spikes,
 latency regressions) plus record breakers — largest scan, fastest scan speed,
 longest query, total storage — surfaced without building a single dashboard.
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="/posts/v0.3/sql-console-dark.png">
-  <img data-shot="light" src="/posts/v0.3/sql-console-light.png" alt="SQL Console with query editor, results, EXPLAIN and scan analysis tabs" />
-  <img data-shot="dark" src="/posts/v0.3/sql-console-dark.png" alt="SQL Console with query editor, results, EXPLAIN and scan analysis tabs" />
-</picture>
+<img data-src-light="/posts/v0.3/sql-console-light.png" data-src-dark="/posts/v0.3/sql-console-dark.png" src="/posts/v0.3/sql-console-light.png" alt="SQL Console with query editor, results, EXPLAIN and scan analysis tabs" width="1024" height="644" loading="lazy" />
 
 **SQL Console**: run read-only SQL with history, one-click EXPLAIN, query log
 and scan analysis, without leaving the dashboard for a separate client.
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="/posts/v0.3/storage-dark.png">
-  <img data-shot="light" src="/posts/v0.3/storage-light.png" alt="Storage breakdown by database, table and part" />
-  <img data-shot="dark" src="/posts/v0.3/storage-dark.png" alt="Storage breakdown by database, table and part" />
-</picture>
+<img data-src-light="/posts/v0.3/storage-light.png" data-src-dark="/posts/v0.3/storage-dark.png" src="/posts/v0.3/storage-light.png" alt="Storage breakdown by database, table and part" width="1024" height="734" loading="lazy" />
 
 **Storage breakdown** by database, table and part, so you know exactly where
 the bytes go.
 
-<img src="/posts/v0.3/keeper.png" alt="Keeper page with session, watches, quorum role and per-node stats" />
+<img src="/posts/v0.3/keeper.png" alt="Keeper page with session, watches, quorum role and per-node stats" width="1024" height="953" loading="lazy" />
 
 **ClickHouse Keeper monitoring**: session state, watches, quorum role and
 per-node Raft stats for every Keeper node.
 
-<img src="/posts/v0.3/cluster-topology.png" alt="Cluster Topology diagram showing Keeper quorum, ClickHouse nodes and replication links" />
+<img src="/posts/v0.3/cluster-topology.png" alt="Cluster Topology diagram showing Keeper quorum, ClickHouse nodes and replication links" width="1942" height="1612" loading="lazy" />
 
 **Cluster Topology**: nodes, shards, replicas, and Keeper quorum drawn as a
 live diagram — click any node for an inspector panel with latency, znodes and
 virtual cluster membership.
 
-<img src="/posts/v0.3/ai-agent.png" alt="AI Agent chat with suggested questions, connected MCP server and skill toggles" />
+<img src="/posts/v0.3/ai-agent.png" alt="AI Agent chat with suggested questions, connected MCP server and skill toggles" width="2642" height="1980" loading="lazy" />
 
 **The AI agent**, wired straight into a host: suggested questions by category
 (insights, schema, storage, queries), live skill/tool toggles, and an MCP
 server already connected — ask about your cluster in plain language.
 
-<img src="/posts/v0.3/data-explorer.png" alt="Data Explorer rendering a table dependency graph with materialized view edges" />
+<img src="/posts/v0.3/data-explorer.png" alt="Data Explorer rendering a table dependency graph with materialized view edges" width="2732" height="1758" loading="lazy" />
 
 **Data Explorer**: every table in a database rendered as a dependency graph —
 materialized views, dictionaries and sources connected by typed edges (`TO`,
 `dictGet`, `joinGet`) instead of guessing from `SHOW CREATE TABLE`.
 
-<img src="/posts/v0.3/running-queries.png" alt="Running Queries page with live charts and a table of active queries" />
+<img src="/posts/v0.3/running-queries.png" alt="Running Queries page with live charts and a table of active queries" width="2680" height="1920" loading="lazy" />
 
 **Running Queries**, live: active count, memory and per-user breakdown as
 charts up top, the actual query table below, auto-refreshing every 5 seconds.
 
-<img src="/posts/v0.3/explain-tree.png" alt="EXPLAIN Query page showing the execution plan as an interactive tree" />
+<img src="/posts/v0.3/explain-tree.png" alt="EXPLAIN Query page showing the execution plan as an interactive tree" width="1878" height="1212" loading="lazy" />
 
 **EXPLAIN as a tree**: pick Plan, Pipeline, AST, Syntax or Estimate, and read
 the execution plan as a collapsible tree instead of a wall of text.
 
-<img src="/posts/v0.3/health-audit.png" alt="Generated audit prompt for a critical replication lag health check" />
+<img src="/posts/v0.3/health-audit.png" alt="Generated audit prompt for a critical replication lag health check" width="2680" height="1790" loading="lazy" />
 
 **Health → audit prompt**: a critical check (replication lag, in this case)
 turns into a ready-to-paste prompt with the metric, raw data row, system
 tables and common causes — hand it to any AI/coding agent for a diagnosis.
 
-<img src="/posts/v0.3/slow-queries.png" alt="Slow Queries page with an occurrence chart and a sortable table of the slowest finished queries" />
+<img src="/posts/v0.3/slow-queries.png" alt="Slow Queries page with an occurrence chart and a sortable table of the slowest finished queries" width="2662" height="1618" loading="lazy" />
 
 **Slow Queries**: the slowest finished queries from the query log, worst
 first, with an occurrence chart and a one-click "Explain top N" for the whole
 list.
 
-<img src="/posts/v0.3/peerdb-mirrors.png" alt="PeerDB Mirrors page with mirror status, peer topology and per-mirror pipeline phase" />
+<img src="/posts/v0.3/peerdb-mirrors.png" alt="PeerDB Mirrors page with mirror status, peer topology and per-mirror pipeline phase" width="2716" height="1780" loading="lazy" />
 
 **PeerDB Mirrors**: CDC/QRep mirror status, throughput and rows synced across
 every source-to-ClickHouse pipeline, plus a live peer topology and per-mirror
 pipeline phase breakdown.
 
-<img src="/posts/v0.3/mcp-server.png" alt="MCP Server page with endpoint URL and setup guides for Claude Desktop, Claude Code and Cursor" />
+<img src="/posts/v0.3/mcp-server.png" alt="MCP Server page with endpoint URL and setup guides for Claude Desktop, Claude Code and Cursor" width="2946" height="1956" loading="lazy" />
 
 **MCP Server**, self-serve: the endpoint URL plus copy-paste setup for Claude
 Desktop, Claude Code, Cursor or any Streamable HTTP MCP client — read-only

--- a/apps/blog/src/layouts/Base.astro
+++ b/apps/blog/src/layouts/Base.astro
@@ -55,6 +55,20 @@ const ogImage = new URL(image, Astro.site).toString()
         document.documentElement.setAttribute('data-theme', 'light')
       }
     })()
+    // Theme-aware post screenshots: a single <img data-src-light data-src-dark>
+    // per slot picks the right variant for the current theme, so only ONE
+    // image ever downloads (no display:none sibling to fetch on scroll).
+    // Mirrors apps/landing/src/layouts/Base.astro.
+    window.chmSyncThemedImages = function (root) {
+      var theme = document.documentElement.getAttribute('data-theme')
+      var imgs = (root || document).querySelectorAll('img[data-src-light]')
+      for (var i = 0; i < imgs.length; i++) {
+        var img = imgs[i]
+        var dark = img.getAttribute('data-src-dark')
+        var wanted = theme === 'dark' && dark ? dark : img.getAttribute('data-src-light')
+        if (wanted && img.getAttribute('src') !== wanted) img.setAttribute('src', wanted)
+      }
+    }
   </script>
   <style is:global>
     :root{
@@ -155,12 +169,9 @@ const ogImage = new URL(image, Astro.site).toString()
     :root[data-theme="dark"] .theme-toggle .i-moon{display:none}
 
     /* ── theme-aware post screenshots ──
-       Pair two <img data-shot="light"/"dark"> as siblings in post content;
-       only one is ever laid out (the other is display:none). Mirrors the
-       same pattern in apps/landing/src/layouts/Base.astro. */
-    img[data-shot="dark"]{display:none !important}
-    :root[data-theme="dark"] img[data-shot="light"]{display:none !important}
-    :root[data-theme="dark"] img[data-shot="dark"]{display:block !important}
+       A single <img data-src-light data-src-dark> per slot; `window.chmSyncThemedImages`
+       (defined in the head script) picks the right `src` for the current theme,
+       so only ONE variant ever downloads. */
 
     /* ── blog header ── */
     .blog-hero{padding:64px 0 36px;border-bottom:1px solid var(--border-soft);position:relative;overflow:hidden}
@@ -277,15 +288,18 @@ const ogImage = new URL(image, Astro.site).toString()
         var next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark'
         document.documentElement.setAttribute('data-theme', next)
         try { localStorage.setItem('chm-theme', next) } catch (e) {}
+        if (typeof window.chmSyncThemedImages === 'function') window.chmSyncThemedImages()
       })
     }
     try {
       window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function (e) {
         if (!localStorage.getItem('chm-theme')) {
           document.documentElement.setAttribute('data-theme', e.matches ? 'dark' : 'light')
+          if (typeof window.chmSyncThemedImages === 'function') window.chmSyncThemedImages()
         }
       })
     } catch (e) {}
+    if (typeof window.chmSyncThemedImages === 'function') window.chmSyncThemedImages()
   </script>
   <script>
     // Opt-in, off-by-default product analytics (PostHog) — see

--- a/apps/landing/src/components/DataExplorer.astro
+++ b/apps/landing/src/components/DataExplorer.astro
@@ -9,8 +9,7 @@
         <div class="de-card reveal">
           <div class="feat-shot">
             <div class="browser-bar"><span class="lights"><i></i><i></i><i></i></span></div>
-            <img src="/landing-assets/data-explorer-graph-light.png" data-shot="light" alt="chmonitor data explorer dependency graph: materialized views, dictionaries and sources wired between tables" width="1024" height="722" loading="lazy" decoding="async" />
-            <img src="/landing-assets/data-explorer-graph-dark.png" data-shot="dark" alt="chmonitor data explorer dependency graph: materialized views, dictionaries and sources wired between tables" width="1024" height="735" loading="lazy" decoding="async" />
+            <img src="/landing-assets/data-explorer-graph-dark.png" data-src-light="/landing-assets/data-explorer-graph-light.png" data-src-dark="/landing-assets/data-explorer-graph-dark.png" alt="chmonitor data explorer dependency graph: materialized views, dictionaries and sources wired between tables" width="1024" height="735" loading="lazy" decoding="async" />
           </div>
           <div class="de-cap">
             <span class="n">01</span>

--- a/apps/landing/src/components/Features.astro
+++ b/apps/landing/src/components/Features.astro
@@ -82,8 +82,7 @@
           <div class="carousel aspect-[16/9.7]" data-autoplay="4600">
             <div class="ctrack h-full">
               <div class="cslide h-full w-full">
-                <img src="/landing-assets/chmonitor-health-light.png" data-shot="light" alt="chmonitor health checks with editable warning and critical thresholds" width="1932" height="1322" loading="lazy" decoding="async" class="block h-full w-full object-cover object-top" />
-                <img src="/landing-assets/chmonitor-health-dark.png" data-shot="dark" alt="" aria-hidden="true" width="1934" height="1254" loading="lazy" decoding="async" class="block h-full w-full object-cover object-top" />
+                <img src="/landing-assets/chmonitor-health-dark.png" data-src-light="/landing-assets/chmonitor-health-light.png" data-src-dark="/landing-assets/chmonitor-health-dark.png" alt="chmonitor health checks with editable warning and critical thresholds" width="1934" height="1254" loading="lazy" decoding="async" class="block h-full w-full object-cover object-top" />
               </div>
               <div class="cslide h-full w-full"><img src="/landing-assets/health-audit.png" alt="chmonitor AI audit prompt generated from a critical replication lag alert" width="1024" height="684" loading="lazy" decoding="async" class="block h-full w-full object-cover object-top" /></div>
             </div>

--- a/apps/landing/src/components/Insights.astro
+++ b/apps/landing/src/components/Insights.astro
@@ -9,8 +9,7 @@
         <div class="de-card reveal">
           <div class="feat-shot">
             <div class="browser-bar"><span class="lights"><i></i><i></i><i></i></span></div>
-            <img src="/landing-assets/cluster-insights-light.png" data-shot="light" alt="chmonitor Cluster Insights: critical and warning findings, record-breaking queries and storage stats" width="1024" height="664" loading="lazy" decoding="async" />
-            <img src="/landing-assets/cluster-insights-dark.png" data-shot="dark" alt="chmonitor Cluster Insights: critical and warning findings, record-breaking queries and storage stats" width="1024" height="728" loading="lazy" decoding="async" />
+            <img src="/landing-assets/cluster-insights-dark.png" data-src-light="/landing-assets/cluster-insights-light.png" data-src-dark="/landing-assets/cluster-insights-dark.png" alt="chmonitor Cluster Insights: critical and warning findings, record-breaking queries and storage stats" width="1024" height="728" loading="lazy" decoding="async" />
           </div>
           <div class="de-cap">
             <span class="n">01</span>
@@ -23,12 +22,10 @@
             <div class="carousel" data-autoplay="4600">
               <div class="ctrack">
                 <div class="cslide">
-                  <img src="/landing-assets/overview-light.png" data-shot="light" alt="chmonitor Overview query activity heatmap, a year of query volume at a glance" width="1024" height="727" loading="lazy" decoding="async" />
-                  <img src="/landing-assets/overview-dark.png" data-shot="dark" alt="chmonitor Overview query activity heatmap, a year of query volume at a glance" width="1024" height="732" loading="lazy" decoding="async" />
+                  <img src="/landing-assets/overview-dark.png" data-src-light="/landing-assets/overview-light.png" data-src-dark="/landing-assets/overview-dark.png" alt="chmonitor Overview query activity heatmap, a year of query volume at a glance" width="1024" height="732" loading="lazy" decoding="async" />
                 </div>
                 <div class="cslide">
-                  <img src="/landing-assets/overview-charts-detailed-light.png" data-shot="light" alt="chmonitor Overview detailed charts: query count, duration and data written over time" width="1024" height="641" loading="lazy" decoding="async" />
-                  <img src="/landing-assets/overview-charts-detailed-dark.png" data-shot="dark" alt="chmonitor Overview detailed charts: query count, duration and data written over time" width="1024" height="640" loading="lazy" decoding="async" />
+                  <img src="/landing-assets/overview-charts-detailed-dark.png" data-src-light="/landing-assets/overview-charts-detailed-light.png" data-src-dark="/landing-assets/overview-charts-detailed-dark.png" alt="chmonitor Overview detailed charts: query count, duration and data written over time" width="1024" height="640" loading="lazy" decoding="async" />
                 </div>
               </div>
               <div class="cdots"></div>
@@ -42,8 +39,7 @@
         <div class="de-card reveal">
           <div class="feat-shot">
             <div class="browser-bar"><span class="lights"><i></i><i></i><i></i></span></div>
-            <img src="/landing-assets/sql-console-light.png" data-shot="light" alt="chmonitor SQL Console: run read-only SQL with history, EXPLAIN and scan analysis" width="1024" height="644" loading="lazy" decoding="async" />
-            <img src="/landing-assets/sql-console-dark.png" data-shot="dark" alt="chmonitor SQL Console: run read-only SQL with history, EXPLAIN and scan analysis" width="1024" height="727" loading="lazy" decoding="async" />
+            <img src="/landing-assets/sql-console-dark.png" data-src-light="/landing-assets/sql-console-light.png" data-src-dark="/landing-assets/sql-console-dark.png" alt="chmonitor SQL Console: run read-only SQL with history, EXPLAIN and scan analysis" width="1024" height="727" loading="lazy" decoding="async" />
           </div>
           <div class="de-cap">
             <span class="n">03</span>
@@ -53,8 +49,7 @@
         <div class="de-card reveal">
           <div class="feat-shot">
             <div class="browser-bar"><span class="lights"><i></i><i></i><i></i></span></div>
-            <img src="/landing-assets/storage-light.png" data-shot="light" alt="chmonitor storage breakdown by database and table" width="1024" height="734" loading="lazy" decoding="async" />
-            <img src="/landing-assets/storage-dark.png" data-shot="dark" alt="chmonitor storage breakdown by database and table" width="1024" height="729" loading="lazy" decoding="async" />
+            <img src="/landing-assets/storage-dark.png" data-src-light="/landing-assets/storage-light.png" data-src-dark="/landing-assets/storage-dark.png" alt="chmonitor storage breakdown by database and table" width="1024" height="729" loading="lazy" decoding="async" />
           </div>
           <div class="de-cap">
             <span class="n">04</span>

--- a/apps/landing/src/components/Nav.astro
+++ b/apps/landing/src/components/Nav.astro
@@ -144,6 +144,7 @@ import { btnOutline, btnOutlineBlock, btnPrimary, btnPrimaryBlock } from '../lib
         var next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark'
         document.documentElement.setAttribute('data-theme', next)
         try { localStorage.setItem('chm-theme', next) } catch (e) {}
+        if (typeof window.chmSyncThemedImages === 'function') window.chmSyncThemedImages()
       })
     })
 

--- a/apps/landing/src/components/ScreenshotShot.astro
+++ b/apps/landing/src/components/ScreenshotShot.astro
@@ -7,7 +7,6 @@ interface Props {
 }
 
 const { id, src, srcDark, alt } = Astro.props
-const paired = Boolean(srcDark)
 ---
 
 <button
@@ -21,23 +20,11 @@ const paired = Boolean(srcDark)
 >
   <img
     src={src}
-    {...(paired ? { 'data-shot': 'light' as const } : {})}
+    data-src-light={src}
+    data-src-dark={srcDark}
     alt={alt}
     loading="lazy"
     decoding="async"
     class="block h-auto w-full align-top"
   />
-  {
-    srcDark ? (
-      <img
-        src={srcDark}
-        data-shot="dark"
-        alt=""
-        aria-hidden="true"
-        loading="lazy"
-        decoding="async"
-        class="block h-auto w-full align-top"
-      />
-    ) : null
-  }
 </button>

--- a/apps/landing/src/components/ScreenshotZoom.test.ts
+++ b/apps/landing/src/components/ScreenshotZoom.test.ts
@@ -8,14 +8,14 @@ describe('ScreenshotShot theme pairing', () => {
     'utf8'
   )
 
-  test('only tags data-shot on the inline preview when a dark variant exists', () => {
-    expect(source).toContain(
-      "...(paired ? { 'data-shot': 'light' as const } : {})"
-    )
+  test('renders a single themed <img> per slot (no light/dark sibling pair)', () => {
     const previewBlock = source.slice(
       source.indexOf('data-screenshot-zoom'),
       source.indexOf('</button>')
     )
-    expect(previewBlock).not.toContain('data-shot="light"')
+    const imgCount = (previewBlock.match(/<img\b/g) || []).length
+    expect(imgCount).toBe(1)
+    expect(previewBlock).toContain('data-src-light={src}')
+    expect(previewBlock).toContain('data-src-dark={srcDark}')
   })
 })

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -88,6 +88,20 @@ const ogImage = new URL(image, Astro.site).toString()
         document.documentElement.setAttribute('data-theme', 'dark')
       }
     })()
+    // Theme-aware screenshots: a single <img data-src-light data-src-dark>
+    // per slot picks the right variant for the current theme, so only ONE
+    // image ever downloads (no display:none sibling to fetch on scroll).
+    // Exposed on window so the theme toggle (Nav.astro) can re-run it.
+    window.chmSyncThemedImages = function (root) {
+      var theme = document.documentElement.getAttribute('data-theme')
+      var imgs = (root || document).querySelectorAll('img[data-src-light]')
+      for (var i = 0; i < imgs.length; i++) {
+        var img = imgs[i]
+        var dark = img.getAttribute('data-src-dark')
+        var wanted = theme === 'dark' && dark ? dark : img.getAttribute('data-src-light')
+        if (wanted && img.getAttribute('src') !== wanted) img.setAttribute('src', wanted)
+      }
+    }
   </script>
   <style is:global>
     /* All of the legacy hand-authored global CSS lives in @layer base so that
@@ -277,13 +291,11 @@ const ogImage = new URL(image, Astro.site).toString()
     :root[data-theme="dark"] .theme-toggle .i-moon{display:none}
 
     /* ── theme-aware screenshots ──
-       Pair two <img data-shot="light"/"dark"> as siblings in any .gcard/.feat-shot/
-       .cslide/.de-card slot; only one is ever laid out (the other is display:none),
-       so no wrapper or positioning is needed. Screenshots with no dark variant
-       just omit data-shot and always show. */
-    img[data-shot="dark"]{display:none !important}
-    :root[data-theme="dark"] img[data-shot="light"]{display:none !important}
-    :root[data-theme="dark"] img[data-shot="dark"]{display:block !important}
+       A single <img data-src-light data-src-dark> per slot (no hidden sibling
+       to double-fetch). `src` is set to the light variant at build time so
+       no-JS/bots still render an image; the inline `chmSyncThemedImages()`
+       script (below) overwrites it with the dark variant when needed, before
+       lazy-loaded images enter the viewport. */
 
     /* ── screenshot zoom (native dialog) ── */
     .screenshot-zoom-dialog{position:fixed;inset:0;border:none;padding:0;background:transparent;max-width:min(96vw,1200px);width:100%;height:100%;margin:auto;outline:none}
@@ -292,9 +304,6 @@ const ogImage = new URL(image, Astro.site).toString()
     .screenshot-zoom-dialog .screenshot-zoom-close{position:fixed;top:16px;right:16px;z-index:2;width:40px;height:40px;border-radius:999px;border:1px solid var(--border);background:var(--card);color:var(--foreground);font-size:24px;line-height:1;cursor:pointer}
     .screenshot-zoom-body{max-height:90vh;max-width:100%;overflow:hidden;border-radius:var(--radius);border:1px solid var(--border);background:var(--card)}
     .screenshot-zoom-body img{display:block;max-width:100%;max-height:90vh;width:auto;height:auto;margin:auto;border-radius:var(--radius)}
-    .screenshot-zoom-body img[data-shot="dark"]{display:none !important}
-    :root[data-theme="dark"] .screenshot-zoom-body img[data-shot="light"]{display:none !important}
-    :root[data-theme="dark"] .screenshot-zoom-body img[data-shot="dark"]{display:block !important}
     html:has(.screenshot-zoom-dialog[open]){overflow:hidden}
 
     /* ── hero ── */
@@ -757,18 +766,12 @@ const ogImage = new URL(image, Astro.site).toString()
         var srcDark = btn.getAttribute('data-zoom-src-dark');
         var alt = btn.getAttribute('data-zoom-alt') || '';
         if(!src) return;
+        var theme = document.documentElement.getAttribute('data-theme');
+        var wanted = theme === 'dark' && srcDark ? srcDark : src;
         body.innerHTML = '';
-        if(srcDark){
-          var light = document.createElement('img');
-          light.src = src; light.alt = alt; light.setAttribute('data-shot','light');
-          var dark = document.createElement('img');
-          dark.src = srcDark; dark.alt = ''; dark.setAttribute('data-shot','dark'); dark.setAttribute('aria-hidden','true');
-          body.appendChild(light); body.appendChild(dark);
-        } else {
-          var img = document.createElement('img');
-          img.src = src; img.alt = alt;
-          body.appendChild(img);
-        }
+        var img = document.createElement('img');
+        img.src = wanted; img.alt = alt;
+        body.appendChild(img);
         if(typeof dlg.showModal === 'function') dlg.showModal();
       }
       document.addEventListener('click', function(e){
@@ -779,6 +782,8 @@ const ogImage = new URL(image, Astro.site).toString()
         dlg.close();
       });
     })();
+    // resolve theme-aware screenshot <img> src now that the DOM is parsed
+    if (typeof window.chmSyncThemedImages === 'function') window.chmSyncThemedImages()
     // reveal on scroll
     (function(){
       var els = document.querySelectorAll('.reveal');


### PR DESCRIPTION
## Summary
- Every landing/blog screenshot pair rendered TWO sibling `<img>` tags (light + dark); CSS hid one but both fetched when scrolled into view (~1MB wasted per page load).
- Replaces the light/dark `<img>` pairs in `Insights.astro`, `Features.astro`, `DataExplorer.astro`, `ScreenshotShot.astro` (zoom preview), the zoom modal, and the v0.3 blog post with a **single** `<img data-src-light data-src-dark>` per slot.
- A shared inline script (`window.chmSyncThemedImages`, in `Base.astro` for both apps) resolves `src` to the current theme right after DOM parse and re-runs on theme toggle — only the visible variant ever downloads. Landing defaults to dark (matches the recent redesign); blog keeps its existing light/OS-pref default.
- Blog post `chmonitor-v0-3.md`: replaced the `<picture>`+dual-`<img>` blocks the same way, and added `width`/`height`/`loading="lazy"` to the remaining ~10 raw screenshot `<img>` tags (previously no dimensions → CLS, eager-loaded).
- Updated `ScreenshotZoom.test.ts` to assert the single-`<img>` markup instead of the old paired pattern.

Visual output is unchanged in both themes (same PNGs, same layout/CSS); this is purely a network-transfer fix — no `astro:assets`/format conversion was in scope for this pass.

## Test plan
- [x] `cd apps/landing && pnpm install && pnpm run build` — green
- [x] `cd apps/blog && pnpm install && pnpm run build` — green
- [x] `bun test apps/landing/src/components/ScreenshotZoom.test.ts` — passes
- [x] `grep -rn data-shot apps/landing apps/blog` → 0 matches (old dual-image pattern fully removed)

Fixes #2507