### PR TITLE
fix(cloud): detect build-time-vs-runtime cloud-mode split-brain (#2515)

### DIFF
--- a/.claude/skills/cloud-saas-mode/SKILL.md
+++ b/.claude/skills/cloud-saas-mode/SKILL.md
@@ -45,6 +45,15 @@ monitoring feature behind cloud mode. (Mirrors `lib/edition` fail-open design.)
 - Self-hosted uses the same names from `apps/dashboard/.env.example` (Docker
   `env_file`, Helm `values.yaml`). Secrets only via `set-secrets.ts` / K8s Secret.
 
+**Cloud mode is a BUILD-TIME contract (#2515).** The client bundle only sees the
+baked-in `VITE_CLOUD_MODE`; it never reads runtime env. Booting a **prebuilt OSS
+image** with runtime `CHM_DEPLOYMENT_MODE=cloud` / `CHM_CLOUD_MODE=true` splits
+the product — server enforces cloud (demo guard) while the client renders OSS UI.
+Enable cloud by setting `CHM_CLOUD_MODE` **before the build** (so the VITE
+derivation runs), not only at runtime. Guard: `detectCloudModeMismatch(env)` →
+`{server, clientBuild, mismatch}`; `/api/healthz` `warn`s and reports `cloudMode`
+on mismatch. The reverse (cloud build, runtime unset) is safe — fail-closed.
+
 ## Behaviour
 
 | | Self-hosted | Cloud |

--- a/apps/dashboard/src/lib/cloud/cloud-mode.test.ts
+++ b/apps/dashboard/src/lib/cloud/cloud-mode.test.ts
@@ -1,4 +1,8 @@
-import { isCloudModeServer, parseCloudMode } from './cloud-mode'
+import {
+  detectCloudModeMismatch,
+  isCloudModeServer,
+  parseCloudMode,
+} from './cloud-mode'
 import { describe, expect, test } from 'bun:test'
 
 // ---------------------------------------------------------------------------
@@ -49,5 +53,51 @@ describe('isCloudModeServer', () => {
 
   test('runtime junk → false (does not lock out self-hosted)', () => {
     expect(isCloudModeServer({ CHM_CLOUD_MODE: 'maybe' })).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// detectCloudModeMismatch — split-brain guard for prebuilt bundles.
+// The `clientBuildValue` arg stands in for the baked-in VITE_CLOUD_MODE so the
+// build-time half can be varied under test.
+// ---------------------------------------------------------------------------
+describe('detectCloudModeMismatch', () => {
+  test('OSS bundle + runtime cloud flag → mismatch (the reported defect)', () => {
+    const result = detectCloudModeMismatch(
+      { CHM_DEPLOYMENT_MODE: 'cloud' },
+      false // client bundle built without VITE_CLOUD_MODE
+    )
+    expect(result).toEqual({ server: true, clientBuild: false, mismatch: true })
+  })
+
+  test('runtime CHM_CLOUD_MODE=true on OSS bundle → mismatch', () => {
+    const result = detectCloudModeMismatch({ CHM_CLOUD_MODE: 'true' }, false)
+    expect(result.mismatch).toBe(true)
+  })
+
+  test('cloud bundle + matching runtime cloud → no mismatch', () => {
+    const result = detectCloudModeMismatch({ CHM_CLOUD_MODE: 'true' }, true)
+    expect(result).toEqual({ server: true, clientBuild: true, mismatch: false })
+  })
+
+  test('cloud bundle + runtime unset → no mismatch (fail-closed, both OSS)', () => {
+    // Server falls back to build-time (false in tests); a cloud bundle that
+    // forgot the runtime var degrades to OSS on BOTH halves — safe, not flagged.
+    const result = detectCloudModeMismatch({}, false)
+    expect(result).toEqual({
+      server: false,
+      clientBuild: false,
+      mismatch: false,
+    })
+  })
+
+  test('OSS bundle + no runtime flag → no mismatch', () => {
+    const result = detectCloudModeMismatch({}, false)
+    expect(result.mismatch).toBe(false)
+  })
+
+  test('runtime junk cloud flag on OSS bundle → no mismatch (junk = OSS)', () => {
+    const result = detectCloudModeMismatch({ CHM_CLOUD_MODE: 'maybe' }, false)
+    expect(result.mismatch).toBe(false)
   })
 })

--- a/apps/dashboard/src/lib/cloud/cloud-mode.ts
+++ b/apps/dashboard/src/lib/cloud/cloud-mode.ts
@@ -38,6 +38,54 @@ export function isCloudModeClient(): boolean {
 }
 
 /**
+ * The cloud-mode value BAKED INTO the client bundle at build time.
+ *
+ * The browser UI can only ever reflect this value — it never sees runtime env
+ * (`CHM_CLOUD_MODE` / `CHM_DEPLOYMENT_MODE`). Enabling cloud mode is therefore a
+ * BUILD-TIME contract: it requires a cloud build (VITE_CLOUD_MODE inlined from
+ * the canonical `CHM_CLOUD_MODE` in vite.config.ts), not just a runtime flag.
+ */
+export function clientBuildCloudMode(): boolean {
+  return parseCloudMode(import.meta.env.VITE_CLOUD_MODE)
+}
+
+export interface CloudModeConsistency {
+  /** Cloud mode the SERVER enforces (runtime-aware). */
+  server: boolean
+  /** Cloud mode baked into the CLIENT bundle at build time. */
+  clientBuild: boolean
+  /** True when the two disagree — a split-brain deployment. */
+  mismatch: boolean
+}
+
+/**
+ * Detect a split-brain deployment where the server-resolved cloud mode differs
+ * from the cloud mode baked into the prebuilt client bundle.
+ *
+ * This happens when a prebuilt OSS image (client built WITHOUT `VITE_CLOUD_MODE`)
+ * is booted with runtime `CHM_DEPLOYMENT_MODE=cloud` / `CHM_CLOUD_MODE=true`:
+ * the server then enforces cloud behaviour (demo-host guard, private-host
+ * blocking) while the client renders OSS UI (no demo badges, no welcome flow).
+ *
+ * The reverse (a cloud build with the runtime var unset) is SAFE — fail-closed
+ * means both halves degrade to OSS together, so it is not flagged.
+ *
+ * `clientBuildValue` is injected for testing; production callers use the default
+ * (the actual baked-in build constant).
+ */
+export function detectCloudModeMismatch(
+  runtimeEnv?: Record<string, string | undefined>,
+  clientBuildValue: boolean = clientBuildCloudMode()
+): CloudModeConsistency {
+  const server = isCloudModeServer(runtimeEnv)
+  return {
+    server,
+    clientBuild: clientBuildValue,
+    mismatch: server !== clientBuildValue,
+  }
+}
+
+/**
  * Server-side: runtime `CHM_CLOUD_MODE` wins, falling back to the build-time
  * `VITE_CLOUD_MODE`. Pass the Cloudflare `env` binding on the edge; defaults to
  * `process.env` on Node.

--- a/apps/dashboard/src/routes/api/healthz.ts
+++ b/apps/dashboard/src/routes/api/healthz.ts
@@ -6,8 +6,9 @@ import { env } from 'cloudflare:workers'
 // @clickhouse/client (node:os/node:stream/TCP) — excluded from the worker
 // bundle in vite.config.ts.
 import { getClient } from '@chm/clickhouse-client'
-import { error as logError } from '@chm/logger'
+import { error as logError, warn } from '@chm/logger'
 import { getClickHouseConfigsFromEnv } from '@/lib/api/clickhouse-config'
+import { detectCloudModeMismatch } from '@/lib/cloud/cloud-mode'
 
 // Mirrors @chm/clickhouse-client getClickHouseConfigs(), but sources the
 // comma-separated lists from the Cloudflare env binding (workerd does not map
@@ -25,9 +26,25 @@ export const Route = createFileRoute('/api/healthz')({
   server: {
     handlers: {
       GET: async () => {
-        const configs = getClickHouseConfigsFromEnv(
-          env as Record<string, string | undefined>
-        )
+        const runtimeEnv = env as Record<string, string | undefined>
+
+        // Split-brain guard: a prebuilt OSS bundle booted with a runtime cloud
+        // flag makes the server enforce cloud while the client renders OSS UI.
+        // Cloud mode is a build-time contract — surface the mismatch loudly.
+        const cloudMode = detectCloudModeMismatch(runtimeEnv)
+        if (cloudMode.mismatch) {
+          warn(
+            '[/api/healthz] cloud-mode split-brain: server=' +
+              `${cloudMode.server} but the client bundle was built with ` +
+              `cloud=${cloudMode.clientBuild}. Cloud mode is a BUILD-TIME ` +
+              'contract — set CHM_CLOUD_MODE/CHM_DEPLOYMENT_MODE before the ' +
+              'build (so VITE_CLOUD_MODE is inlined), not only at runtime. A ' +
+              'runtime flag alone splits the product (server guards demo hosts, ' +
+              'client shows OSS UI).'
+          )
+        }
+
+        const configs = getClickHouseConfigsFromEnv(runtimeEnv)
 
         if (configs.length === 0) {
           return Response.json(
@@ -35,6 +52,7 @@ export const Route = createFileRoute('/api/healthz')({
               ok: false,
               error: 'No ClickHouse hosts configured',
               hosts: [],
+              cloudMode,
               timestamp: new Date().toISOString(),
             },
             { status: 503 }
@@ -97,6 +115,7 @@ export const Route = createFileRoute('/api/healthz')({
           {
             ok: allUp,
             hosts,
+            cloudMode,
             timestamp: new Date().toISOString(),
           },
           { status: allUp ? 200 : 503 }

--- a/docs/content/reference/environment-variables.mdx
+++ b/docs/content/reference/environment-variables.mdx
@@ -33,6 +33,17 @@ A dual-surface setting must still be present at **both** build time (so vite
 inlines its `VITE_*`) and runtime (so the server reads it) — but it is the same
 single name in both places.
 
+<Callout type="warn">
+  **Cloud mode is a build-time contract.** `CHM_CLOUD_MODE` /
+  `CHM_DEPLOYMENT_MODE=cloud` must be set **before the build** so `VITE_CLOUD_MODE`
+  is inlined into the client bundle. Setting it only at runtime on a **prebuilt
+  OSS image** (e.g. the published Docker image) splits the product: the server
+  enforces cloud behaviour (demo-host guard) while the client still renders OSS
+  UI. `/api/healthz` detects and warns on this mismatch and reports a `cloudMode`
+  object. The reverse — a cloud build with the runtime var unset — is safe
+  (fail-closed: both halves degrade to OSS).
+</Callout>
+
 ### Client variable prefix by app
 
 Browser-exposed variables are **build-time inlined**. The prefix depends on which

--- a/docs/knowledge/cloud-saas-mode.md
+++ b/docs/knowledge/cloud-saas-mode.md
@@ -3,7 +3,7 @@ id: cloud-saas-mode
 title: Cloud (SaaS) mode — one codebase, two products
 type: spec
 status: active
-updated: 2026-07-04
+updated: 2026-07-10
 tags:
   - saas
   - cloud
@@ -28,6 +28,30 @@ FAIL-CLOSED to self-hosted. Unset/junk `CHM_CLOUD_MODE` (runtime) or
 `VITE_CLOUD_MODE` (build) → NOT cloud → OSS behaviour unchanged. Cloud is purely
 additive; it never removes a monitoring feature. Mirrors `lib/edition`'s
 fail-open design (edition already lists `cloud` as an enterprise feature).
+
+## Cloud mode is a BUILD-TIME contract (#2515)
+
+Enabling cloud mode requires a **cloud build**, not just a runtime flag. The
+client bundle only ever sees the baked-in `VITE_CLOUD_MODE` (inlined from the
+canonical `CHM_CLOUD_MODE` in `vite.config.ts` at build time); it never reads
+runtime env. So booting a **prebuilt OSS image** (e.g. the published Docker
+image, client built without `VITE_CLOUD_MODE`) with runtime
+`CHM_DEPLOYMENT_MODE=cloud` / `CHM_CLOUD_MODE=true` **splits the product**: the
+server enforces cloud (demo-host guard, private-host blocking) while the client
+renders OSS UI (no demo badges, no welcome flow). The correct way to enable
+cloud is to set `CHM_CLOUD_MODE` **before the build** so the VITE derivation
+runs — which is exactly what `dash.chmonitor.dev` does via committed
+`.env.production` + `CHM_BUILD_ENV=production`.
+
+The reverse (a cloud build with the runtime var unset) is safe — fail-closed
+degrades BOTH halves to OSS together.
+
+**Guard:** `detectCloudModeMismatch(runtimeEnv)` in `lib/cloud/cloud-mode.ts`
+returns `{ server, clientBuild, mismatch }`. `/api/healthz` computes it every
+readiness check, logs a prominent `warn(...)` on mismatch, and surfaces the
+result as `cloudMode` in its JSON so operators (and probes) can spot the
+split-brain. Detection is pure and unit-tested (`cloud-mode.test.ts`); the
+`clientBuildValue` arg is injected there to vary the build-time half.
 
 ## Behaviour matrix
 
@@ -57,7 +81,8 @@ Implemented in `lib/cloud/demo-hosts.ts` (`filterToDemoHosts`), applied at
 
 ## Files
 
-- `apps/dashboard/src/lib/cloud/cloud-mode.ts` — resolvers + `parseCloudMode`. Tested.
+- `apps/dashboard/src/lib/cloud/cloud-mode.ts` — resolvers + `parseCloudMode` + `detectCloudModeMismatch` (build-time-vs-runtime split-brain guard, #2515). Tested.
+- `apps/dashboard/src/routes/api/healthz.ts` — logs a `warn` and reports `cloudMode` (the mismatch result) on every readiness check.
 - `vite.config.ts` `loadDeployEnv` + CLIENT_ENV + `src/vite-env.d.ts` — client `VITE_CLOUD_MODE` DERIVES from canonical `CHM_CLOUD_MODE` (set once).
 - `apps/dashboard/.env.production` (+ `.env.preview` overlay) — **single source of truth** for the hosted product's non-secret config (`CHM_CLOUD_MODE=true`, `CHM_FEATURE_USER_CONNECTIONS_DB=true`, auth, LLM). `wrangler.toml` declares NO `[vars]`.
 - `scripts/patch-wrangler-env.ts` — reads `.env.production`/`.env.preview`, injects the non-`VITE_` keys as Worker runtime `[vars]` at deploy.

--- a/plans/README.md
+++ b/plans/README.md
@@ -236,7 +236,7 @@ it protects (76–78, 95).
 | 95 | [platform-adapter-tests](95-platform-adapter-tests.md) | tests | P2 | S | — | ⏳ TODO · [#2512](https://github.com/chmonitor/chmonitor/issues/2512) |
 | 96 | [opennext-context-replacement-spike](96-opennext-context-replacement-spike.md) | migration | P3 | M | 95 | ⏳ TODO · [#2513](https://github.com/chmonitor/chmonitor/issues/2513) |
 | 97 | [billing-cycle-metering-alignment](97-billing-cycle-metering-alignment.md) | business-logic | P2 | M | 76 (soft) | ✅ DONE · [#2514](https://github.com/chmonitor/chmonitor/issues/2514) |
-| 98 | [cloud-mode-runtime-consistency](98-cloud-mode-runtime-consistency.md) | investigate | P3 | S–M | — | ⏳ TODO · [#2515](https://github.com/chmonitor/chmonitor/issues/2515) |
+| 98 | [cloud-mode-runtime-consistency](98-cloud-mode-runtime-consistency.md) | investigate | P3 | S–M | — | ✅ DONE · build-time contract + `detectCloudModeMismatch` guard in `/api/healthz` · [#2515](https://github.com/chmonitor/chmonitor/issues/2515) |
 | 99 | [seat-precheck-pending-invites](99-seat-precheck-pending-invites.md) | business-logic | P3 | S | — | ⏳ TODO · [#2516](https://github.com/chmonitor/chmonitor/issues/2516) |
 | 100 | [ai-usage-reservation-release](100-ai-usage-reservation-release.md) | investigate | P3 | S | — | ⏳ TODO · [#2517](https://github.com/chmonitor/chmonitor/issues/2517) |
 | 101 | [chart-color-token-hygiene](101-chart-color-token-hygiene.md) | tech-debt | P3 | M | — | ⏳ TODO · [#2518](https://github.com/chmonitor/chmonitor/issues/2518) |


### PR DESCRIPTION
## Problem

`isCloudModeClient()` reads only the **build-time** inlined `VITE_CLOUD_MODE`, while `isCloudModeServer()` honors runtime `CHM_CLOUD_MODE` / `CHM_DEPLOYMENT_MODE`. Booting a **prebuilt OSS image** (client built without `VITE_CLOUD_MODE`) with runtime `CHM_DEPLOYMENT_MODE=cloud` therefore **splits the product**: the server enforces cloud behaviour (demo-host guard, private-host blocking) while the client renders OSS UI (no demo badges, no welcome flow).

## Determination (Step 1)

Runtime-only cloud enablement on a prebuilt bundle is **not a supported path**. Every doc presents cloud mode as build-time derived (`vite derives VITE_CLOUD_MODE`); the hosted product builds with committed `.env.production` + `CHM_BUILD_ENV=production`. The client bundle can only ever reflect the baked-in constant. So cloud mode is a **build-time contract** — the minimal remedy (detect + warn + surface), not the large client-runtime refactor.

## Change

- `detectCloudModeMismatch(runtimeEnv, clientBuildValue?)` in `lib/cloud/cloud-mode.ts` → `{ server, clientBuild, mismatch }` (pure, unit-tested; `clientBuildValue` injected to vary the build-time half under test).
- `/api/healthz` computes it each readiness check: logs a prominent `warn` and reports a `cloudMode` object in its JSON on mismatch.
- Preserves the **fail-closed-to-OSS** invariant — a cloud build with the runtime var unset degrades both halves to OSS and is **not** flagged.
- Unit tests for the resolution precedence.
- Docs (`docs/knowledge/cloud-saas-mode.md`, env-vars reference callout) + `cloud-saas-mode` skill + `plans/README.md` updated per the standing instruction.

Fixes #2515