### PR TITLE
feat(blog): category-card homepage + 6 SEO posts

### DIFF
--- a/apps/blog/CONTENT-CALENDAR.md
+++ b/apps/blog/CONTENT-CALENDAR.md
@@ -45,6 +45,22 @@ published (`draft: false`, merged to main)
 | 12 | release | (scaffold from the next GitHub release when it ships) | — | `/reference/releases` | planned |
 | 13 | troubleshooting | ClickHouse disk is full — what to do right now | clickhouse disk full emergency | `/guide/features` | done (`clickhouse-disk-full-emergency.md`, published 2026-09-11) |
 
+## Published this cycle (homepage redesign + SEO expansion)
+
+The blog homepage was redesigned into category cards grouped by `tag`, with the
+Release category highlighted full-width and the rest rendered as compact
+post-title lists. Alongside it, six SEO posts were added (all reusing verified
+`system.*` SQL from the docs guides, with bidirectional cross-links):
+
+| Date | Type | Title | Target keyword | Cross-link (docs page) |
+|---|---|---|---|---|
+| 2026-10-02 | 5 min | ClickHouse skip indices that actually prune | clickhouse skip index / data skipping index | `/guide/guides/skip-indices-guide` |
+| 2026-10-09 | 5 min | Spill GROUP BY to disk instead of OOMing | clickhouse external group by / memory limit exceeded | `/guide/guides/external-group-by` |
+| 2026-10-16 | 5 min | Fix "Memory limit (total) exceeded" | clickhouse memory limit total exceeded | `/guide/guides/memory-limit-total-exceeded` |
+| 2026-10-23 | 5 min | Connect a firewalled ClickHouse to chmonitor Cloud | clickhouse behind firewall cloudflare tunnel | `/guide/guides/connect-firewalled-clickhouse` |
+| 2026-10-30 | 5 min | Upgrade ClickHouse safely while chmonitor stays connected | upgrade clickhouse safely | `/guide/guides/upgrade-clickhouse` |
+| 2026-11-06 | how-to | The 6 root causes of slow ClickHouse | clickhouse query optimization | `/guide/guides/clickhouse-query-optimization` |
+
 ## Post-type mix (per 12-week cycle)
 
 - Release: 2 (as releases actually ship — do not invent a cadence releases

--- a/apps/blog/src/content/blog/clickhouse-external-group-by.md
+++ b/apps/blog/src/content/blog/clickhouse-external-group-by.md
@@ -1,0 +1,72 @@
+---
+title: "5 min of ClickHouse: spill GROUP BY to disk instead of OOMing"
+description: "A high-cardinality GROUP BY can blow past max_memory_usage and die with MEMORY_LIMIT_EXCEEDED. Here's the setting that spills it to disk, the cheaper fixes to try first, and the query that proves a spill happened."
+date: 2026-10-09
+tag: 5 min of ClickHouse
+---
+
+Five minutes, one real diagnostic, no fluff. A `GROUP BY` on a high-cardinality key builds an in-memory hash table — one entry per distinct key. On a big enough table that hash table outgrows `max_memory_usage` and the query dies with `MEMORY_LIMIT_EXCEEDED` (code 241) instead of finishing slowly. Today: the safety valve, and the cheaper options.
+
+## The safety valve
+
+`max_bytes_before_external_group_by` sets a per-query memory threshold. Cross it and ClickHouse writes the partial aggregation state to a temp file on disk, frees the memory, and keeps going — merging the spilled chunks at the end.
+
+```sql
+SET max_bytes_before_external_group_by = 10000000000; -- 10 GB, e.g. half of max_memory_usage
+```
+
+Same pattern covers two siblings — too low causes needless disk I/O, too high risks OOM:
+
+| Setting | Applies to | Guidance |
+|---|---|---|
+| `max_bytes_before_external_group_by` | `GROUP BY` | Session-level; common start is half of `max_memory_usage`. `0` disables spilling. |
+| `max_bytes_before_external_sort` | `ORDER BY` | Same ratio guidance. |
+| `max_bytes_before_external_join` | Hash joins | Same ratio, applied to the join's build side. |
+
+Spilling is strictly slower than staying in RAM — treat it as a safety valve, not a substitute for a correct `max_memory_usage`.
+
+## Try these first (cheaper than spilling)
+
+1. **Pre-aggregate.** If the same aggregation runs repeatedly, a materialized view pre-aggregates on insert so each query scans far fewer rows. See [projections vs materialized views](https://docs.chmonitor.dev/guide/guides/projections-vs-materialized-views).
+2. **Two-level aggregation.** `group_by_two_level_threshold` / `group_by_two_level_threshold_bytes` split the hash table into buckets that merge in parallel across threads — lower peak memory without touching disk.
+3. **Check the scan first.** A `GROUP BY` reading too many rows because of a missing skip index or partition problem always uses more memory than it should — see the [skip indices guide](https://docs.chmonitor.dev/guide/guides/skip-indices-guide).
+4. **Raise `max_memory_usage`** if the cluster genuinely has headroom — RAM is usually faster than spilling to disk.
+
+## Diagnose OOM-killed queries
+
+```sql
+SELECT
+    event_time, query_id, user, exception_code,
+    formatReadableSize(memory_usage) AS memory_usage,
+    normalizeQuery(query) AS normalized_query
+FROM system.query_log
+WHERE event_time > now() - INTERVAL 1 HOUR
+  AND type IN ('ExceptionWhileProcessing', 'ExceptionBeforeStart')
+  AND (exception_code = 241 OR exception LIKE '%MEMORY_LIMIT_EXCEEDED%')
+ORDER BY event_time DESC
+LIMIT 50;
+```
+
+## Confirm a spill actually happened
+
+```sql
+SELECT
+    query_id,
+    ProfileEvents['ExternalAggregationWrittenRows']     AS spilled_rows,
+    ProfileEvents['ExternalAggregationCompressedBytes'] AS spilled_bytes
+FROM system.query_log
+WHERE query_id = 'your-query-id'
+  AND type = 'QueryFinish';
+```
+
+Nonzero `spilled_rows` means it spilled; zero means it finished in memory and the threshold wasn't the bottleneck.
+
+## How chmonitor surfaces this
+
+The Health page's **OOM-Killed Queries** check runs the diagnostic query above continuously and alerts when the rate crosses a threshold, with `read_rows`, `memory_usage`, and the query text linked from Expensive Queries. The AI agent's `query-optimization` skill watches for exactly this pattern — high `memory_usage` on an aggregation step.
+
+## Related
+
+- Docs: [External GROUP BY guide](https://docs.chmonitor.dev/guide/guides/external-group-by) — full spill reference
+- Docs: [Query optimization pillar](https://docs.chmonitor.dev/guide/guides/clickhouse-query-optimization)
+- Live demo: [dash.chmonitor.dev/metrics](https://dash.chmonitor.dev/metrics)

--- a/apps/blog/src/content/blog/clickhouse-firewalled-cloud.md
+++ b/apps/blog/src/content/blog/clickhouse-firewalled-cloud.md
@@ -1,0 +1,35 @@
+---
+title: "5 min of ClickHouse: connect a firewalled ClickHouse to chmonitor Cloud"
+description: "chmonitor Cloud runs on Cloudflare Workers with no fixed egress IP, so allowlisting Cloudflare's ranges is not a real allowlist. Here's the tunnel that works with zero inbound ports opened."
+date: 2026-10-23
+tag: 5 min of ClickHouse
+---
+
+Five minutes, one real setup, no fluff. chmonitor **Cloud** runs entirely on Cloudflare Workers. When your ClickHouse sits behind a firewall, the Worker has to reach it — and because Workers have **no single fixed public IP by default**, a plain "allowlist our IP" doesn't work. Self-hosted chmonitor doesn't have this problem (it runs inside your network and reaches ClickHouse directly). This is the Cloud path.
+
+## The default: Cloudflare Tunnel
+
+A [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-tunnel/) runs a small `cloudflared` connector next to ClickHouse. It makes only **outbound** connections to Cloudflare, so you open **no inbound ports and allowlist no IPs**. You then protect the tunnel's hostname with [Access](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/) and hand chmonitor a **service token**.
+
+```bash
+cloudflared tunnel create chmonitor
+cloudflared tunnel route dns chmonitor ch.example.com
+```
+
+Then add the host with URL `https://ch.example.com` and paste the service-token Client ID / Secret into the connection's headers (`CF-Access-Client-Id` / `CF-Access-Client-Secret`). No inbound hole, per-connection revocable token, end-to-end TLS — and it works today on free/standard Zero Trust tiers.
+
+## Don't do this
+
+> **Do not allowlist Cloudflare's public IP ranges.** Worker egress over those ranges is shared by *every* Cloudflare customer. Allowlisting them authorizes the entire fleet — not a real allowlist. Use a tunnel or dedicated egress IPs.
+
+If a security team **requires** a literal firewall allowlist, chmonitor talks to ClickHouse over HTTP (`fetch()`), so Cloudflare's [Dedicated Egress IPs](https://developers.cloudflare.com/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/) (enterprise add-on) apply and give the Worker a stable source IP you can allowlist. Or run a reverse proxy (nginx/HAProxy) on a static-IP VM and allowlist only that.
+
+## How chmonitor surfaces this
+
+The [Connection errors](https://docs.chmonitor.dev/guide/guides/connection-errors) guide classifies "Test connection" failures (host not allowed / SSRF, invalid URL, auth failed, access denied, DNS/refused/TLS/timeout) so you know which leg of the tunnel is broken.
+
+## Related
+
+- Docs: [Connection errors](https://docs.chmonitor.dev/guide/guides/connection-errors) — diagnose failures kind by kind
+- Docs: [Proxy & SSO auth setup](https://docs.chmonitor.dev/guide/guides/proxy-auth-setup)
+- Docs: [Self-host](https://docs.chmonitor.dev/operate/deploy/self-host) — run inside your network, no tunnel needed

--- a/apps/blog/src/content/blog/clickhouse-memory-limit-total-exceeded.md
+++ b/apps/blog/src/content/blog/clickhouse-memory-limit-total-exceeded.md
@@ -1,0 +1,63 @@
+---
+title: "5 min of ClickHouse: fix 'Memory limit (total) exceeded' (it's not one query)"
+description: "The server-wide 'Memory limit (total) exceeded' error is tripped by every concurrent query, merge, and cache combined — not one query's budget. Here are the queries that show what's eating RAM."
+date: 2026-10-16
+tag: 5 min of ClickHouse
+---
+
+Five minutes, one real diagnostic, no fluff. `Code: 241. Memory limit (total) exceeded` looks exactly like the per-query [Memory limit (for query) exceeded](/clickhouse-memory-limit-exceeded/), but the `(total)` wording is the whole story: this is the **server-wide** cap (`max_server_memory_usage`, ~90% of RAM by default), tripped by the sum of every concurrent query, merge, mutation, and cache — not one query's own budget. It can fire when no single query looks expensive.
+
+## Why it happens
+
+- **Too many concurrent queries.** Each moderate, but the sum crosses the cap.
+- **Oversized caches.** `mark_cache_size` / `uncompressed_cache_size` set too large for the box.
+- **Merges and mutations competing** for the same budget — a merge storm or a large `ALTER … UPDATE/DELETE`.
+- **Replication buffers** queueing in-flight data on a busy replica.
+
+## Diagnose
+
+```sql
+-- Current total memory tracked by the server
+SELECT value AS current_memory_bytes, formatReadableSize(value) AS current_memory
+FROM system.metrics
+WHERE metric = 'MemoryTracking';
+```
+```sql
+-- Trend over the last few hours (sampled periodically)
+SELECT event_time, value AS memory_bytes
+FROM system.asynchronous_metric_log
+WHERE metric = 'MemoryTracking' AND event_time > now() - INTERVAL 6 HOUR
+ORDER BY event_time;
+```
+```sql
+-- Everything currently holding memory, heaviest first
+SELECT
+    query_id, user, elapsed,
+    formatReadableSize(memory_usage) AS current_memory,
+    query
+FROM system.processes
+ORDER BY memory_usage DESC
+LIMIT 20;
+```
+
+Confirm the ceiling: `SELECT * FROM system.server_settings WHERE name = 'max_server_memory_usage'` (24.x+), or check `max_server_memory_usage` / `max_server_memory_usage_to_ram_ratio` in `config.xml` on older versions.
+
+## Fix
+
+- **Limit concurrency** — cap `max_concurrent_queries` and per-user `max_memory_usage_for_user`.
+- **Shrink caches** if oversized — they count against the same total.
+- **Raise `max_server_memory_usage`** only if the host has spare RAM the default 90% isn't using.
+- **Spread load** across more replicas or shards.
+- **Address merge/mutation pressure** — see [Merges slower than inserts](https://docs.chmonitor.dev/guide/guides/merges-slower-than-inserts).
+
+**Don't just raise the ceiling.** Without taming runaway concurrency, the Linux OOM killer may take down the whole `clickhouse-server` process — a much worse outage. (Altinity's [Rescuing ClickHouse from the Linux OOM Killer](https://altinity.com/blog/rescuing-clickhouse-from-the-linux-oom-killer) covers the failure mode.)
+
+## How chmonitor surfaces this
+
+The [Metrics](https://docs.chmonitor.dev/guide/features/metrics) page tracks `MemoryTracking` live, and [Health](https://docs.chmonitor.dev/guide/features/health) rolls memory pressure into the at-a-glance status grid so you see it trending up before the server rejects a query.
+
+## Related
+
+- Docs: [Memory limit (for query) exceeded](https://docs.chmonitor.dev/guide/guides/memory-limit-exceeded)
+- Docs: [Merges slower than inserts](https://docs.chmonitor.dev/guide/guides/merges-slower-than-inserts)
+- Docs: [Metrics](https://docs.chmonitor.dev/guide/features/metrics)

--- a/apps/blog/src/content/blog/clickhouse-query-optimization-pillars.md
+++ b/apps/blog/src/content/blog/clickhouse-query-optimization-pillars.md
@@ -1,0 +1,58 @@
+---
+title: "The 6 root causes of slow ClickHouse (and the query that rules out each)"
+description: "Most ClickHouse slowness traces to one of six things: partition key, granularity, PREWHERE, skip index, projection vs MV, or GROUP BY memory. A diagnostic map with the system-table query to start at."
+date: 2026-11-06
+tag: How-to
+---
+
+This is for anyone who has stared at a slow ClickHouse query and not known whether to touch the partition key, add an index, or just throw RAM at it. The truth: almost every "ClickHouse is slow" problem is one of six things, and there's a cheap order to rule them out. chmonitor runs this whole diagnosis automatically — this is the map so you understand it.
+
+## The six areas
+
+1. **Partition key** — a bad `PARTITION BY` (high cardinality) causes a too-many-parts spiral.
+2. **Partition granularity** — fine vs coarse trade-offs; size partitions correctly.
+3. **PREWHERE vs WHERE** — column-level filter pushdown that cuts I/O.
+4. **Projections vs materialized views** — which acceleration mechanism fits the query shape.
+5. **Skip indices** — minmax / set / bloom_filter / tokenbf_v1, and how to confirm one fires.
+6. **External GROUP BY** — spill aggregation to disk instead of `MEMORY_LIMIT_EXCEEDED`.
+
+## Start at the top — part and partition health
+
+A bad partition key or wrong granularity causes symptoms everywhere else. Rule it out first:
+
+```sql
+SELECT
+    database, table,
+    count() AS active_parts,
+    uniqExact(partition) AS partitions,
+    formatReadableSize(sum(data_compressed_bytes)) AS compressed_size
+FROM system.parts
+WHERE active
+GROUP BY database, table
+ORDER BY active_parts DESC
+LIMIT 20;
+```
+
+More than a few hundred active parts on one table, or fewer than ~10 MB compressed per part, is a partitioning problem. See the [partition key best practices](https://docs.chmonitor.dev/guide/guides/partition-key-best-practices) and [granularity](https://docs.chmonitor.dev/guide/guides/partition-granularity) guides.
+
+## Then: is the filter doing its job?
+
+For a specific slow query, run `EXPLAIN indexes = 1 <query>` and compare `Granules: N/M`. If `N` ≈ `M`, the query scans almost everything — the filter isn't pruning. That's a [PREWHERE](https://docs.chmonitor.dev/guide/guides/prewhere-vs-where) or [skip index](https://docs.chmonitor.dev/guide/guides/skip-indices-guide) problem.
+
+## Then: how to accelerate the repeated shape
+
+If the same `GROUP BY`/`WHERE` shape runs often, decide between a [projection or a materialized view](https://docs.chmonitor.dev/guide/guides/projections-vs-materialized-views) to pre-compute it instead of re-scanning raw data.
+
+## Only then: tune memory
+
+If the query genuinely needs to scan a lot (a high-cardinality aggregation), see [external GROUP BY](https://docs.chmonitor.dev/guide/guides/external-group-by) for spill settings — but only after the steps above, since fixing the index or partition is usually cheaper than spilling to disk.
+
+## How chmonitor surfaces this
+
+Ask the AI agent "why is my ClickHouse cluster slow?" and it works through `list_slow_query_patterns` → `explain_query` → `get_optimization_recommendations`, then proposes ranked skip-index, projection, partition-key, and `PREWHERE` fixes as DDL you review and run — it never applies anything itself.
+
+## Related
+
+- Docs: [Query optimization pillar](https://docs.chmonitor.dev/guide/guides/clickhouse-query-optimization) — the full map with links to every guide
+- Docs: [AI Agent capabilities](https://docs.chmonitor.dev/guide/ai-agent/capabilities) — the diagnose loop and ranked recommendations
+- Docs: [Queries](https://docs.chmonitor.dev/guide/features/queries) — live, historical, failed, and slow query pages

--- a/apps/blog/src/content/blog/clickhouse-skip-indices-guide.md
+++ b/apps/blog/src/content/blog/clickhouse-skip-indices-guide.md
@@ -1,0 +1,68 @@
+---
+title: "5 min of ClickHouse: skip indices that actually prune your scans"
+description: "ClickHouse secondary indices skip whole granule blocks instead of indexing rows. Here are the four index types, when each fires, and the EXPLAIN query that proves it's working."
+date: 2026-10-02
+tag: 5 min of ClickHouse
+---
+
+Five minutes, one real diagnostic, no fluff. Skip indices are the ClickHouse feature most people add once and assume is helping — and then never check. Today: what each type is for, and how to confirm it actually prunes.
+
+## The mental model
+
+A ClickHouse "secondary index" is not a B-tree. It's a **data-skipping index**: for each block of granules it stores a tiny summary (a min/max range, a set of values, or a bloom filter), and at query time ClickHouse uses that summary to skip entire granule blocks that can't match — without reading the underlying column.
+
+## The four types
+
+| Type | Good for | How it works |
+|---|---|---|
+| `minmax` | Range queries on numeric/date columns not in `ORDER BY` | Stores min/max per block; skips blocks outside the range |
+| `set(N)` | Equality / `IN` on low-cardinality columns | Stores up to `N` distinct values per block; over `N` distinct → reads everything |
+| `bloom_filter` | Equality on higher-cardinality strings | Probabilistic membership per block; false positives only |
+| `tokenbf_v1` | Substring search (`LIKE '%error%'`) | Tokenized bloom filter over the column text |
+
+```sql
+ALTER TABLE events ADD INDEX idx_amount amount TYPE minmax GRANULARITY 4;
+ALTER TABLE events ADD INDEX idx_status status TYPE set(100) GRANULARITY 4;
+ALTER TABLE events ADD INDEX idx_request_id request_id TYPE bloom_filter GRANULARITY 4;
+ALTER TABLE events ADD INDEX idx_message message TYPE tokenbf_v1(4096, 3, 0) GRANULARITY 4;
+```
+
+`GRANULARITY N` groups N index granules into one index block — bigger index but coarser skipping. Start at `4`.
+
+**Adding an index does not backfill existing parts.** Run `ALTER TABLE … MATERIALIZE INDEX idx_name` to build it for data already on disk, or wait for the natural merge cycle.
+
+## Verify it fires
+
+Don't trust that it works — prove it:
+
+```sql
+EXPLAIN indexes = 1
+SELECT count()
+FROM events
+WHERE request_id = '3f9c1a2e-...';
+```
+
+Find your index name in the plan and confirm `Granules: N/M` shows `N` well below `M`. If the index never appears, the query expression doesn't match (index on `amount` but the filter uses `round(amount, 2)`), or the column is already a prefix of `ORDER BY` — in which case the primary key already prunes for free.
+
+## Audit for dead indices
+
+An index with zero compressed bytes was never built, or was built and never touched. Drop the dead weight — every index is maintained on every insert and merge:
+
+```sql
+SELECT
+    database, table, name, type, expr, granularity,
+    formatReadableSize(data_compressed_bytes) AS compressed_size,
+    if(data_compressed_bytes = 0, 'dead', 'active') AS status
+FROM system.data_skipping_indices
+ORDER BY data_compressed_bytes DESC;
+```
+
+## How chmonitor surfaces this
+
+The Data Explorer's per-table **Skip Indexes** panel lists every index with type, expression, granularity, and compression ratio — the same `system.data_skipping_indices` data without SQL. The AI agent's `get_optimization_recommendations` proposes specific skip-index DDL (type and expression already chosen) when it profiles a slow query.
+
+## Related
+
+- Docs: [Skip indices guide](https://docs.chmonitor.dev/guide/guides/skip-indices-guide) — the full secondary-index reference
+- Docs: [PREWHERE vs WHERE](https://docs.chmonitor.dev/guide/guides/prewhere-vs-where) — filter pushdown that works alongside indices
+- Docs: [Query optimization pillar](https://docs.chmonitor.dev/guide/guides/clickhouse-query-optimization) — the six areas that make ClickHouse slow

--- a/apps/blog/src/content/blog/clickhouse-upgrade-safely.md
+++ b/apps/blog/src/content/blog/clickhouse-upgrade-safely.md
@@ -1,0 +1,62 @@
+---
+title: "5 min of ClickHouse: upgrade safely while chmonitor stays connected"
+description: "Pre-upgrade checks, the system-table changes that light up new dashboard pages at each version, and the post-upgrade grants sanity queries — so you upgrade ClickHouse without losing monitoring."
+date: 2026-10-30
+tag: 5 min of ClickHouse
+---
+
+Five minutes, one real runbook, no fluff. chmonitor stays connected through a ClickHouse upgrade — it uses versioned SQL (`since` per query config) to automatically pick the right query for the connected version. But a few pre/post checks keep the dashboard fully lit.
+
+## Before you upgrade
+
+```bash
+curl -s "https://your-ch-host:8443?query=SELECT+version()" -u monitoring:password
+```
+
+chmonitor supports 22.x+, with full coverage recommended from **23.8 LTS**. Back up the settings you'll compare afterward, and clear the backlog that blocks a clean replica upgrade:
+
+```sql
+-- Save merge-tree + server settings for comparison
+SELECT * FROM system.merge_tree_settings INTO OUTFILE 'merge_tree_settings_before.csv' FORMAT CSV;
+SELECT * FROM system.settings INTO OUTFILE 'settings_before.csv' FORMAT CSV;
+
+-- Any stuck mutations (wait or cancel before upgrading a replica)?
+SELECT database, table, command, parts_to_do, is_done
+FROM system.mutations WHERE is_done = 0 ORDER BY create_time DESC;
+
+-- Long-running merges?
+SELECT database, table, round(progress * 100, 2) AS pct, elapsed
+FROM system.merges ORDER BY elapsed DESC;
+
+-- Replication health: no read-only replicas, drains should be small
+SELECT database, table, replica_name, is_leader, is_readonly, future_parts, queue_size
+FROM system.replicas WHERE is_readonly = 1 OR queue_size > 10;
+```
+
+## What lights up at each version
+
+- **22.x → 23.x**: Query Views Log, Moves, Dropped Tables, Session Log (Login Attempts/Sessions), Processors Profile Log.
+- **23.x → 24.x**: per-user `system.user_processes`, `system.part_log` (Merge Performance), `system.query_metric_log`, `system.query_cache`, `system.data_skipping_indices` (Explorer skip-index panel), `system.view_refreshes`.
+- **24.x → 25.x**: `system.distributed_ddl_queue`, extra async-metrics, `system.replicated_merge_tree_settings`.
+
+## After the upgrade
+
+Open `/overview` — if it shows data, the connection and grants are intact. Re-check grants if you upgraded users; ClickHouse sometimes changes system-table visibility across majors:
+
+```sql
+SELECT count() FROM system.query_log LIMIT 1;
+SELECT count() FROM system.processes LIMIT 1;
+SELECT count() FROM system.replicas LIMIT 1;
+```
+
+Then roll forward one replica at a time, confirming each rejoins replication (`is_readonly = 0`, `queue_size` draining) before touching the next.
+
+## How chmonitor surfaces this
+
+The AI agent can compare the system tables available now against what the dashboard expects and flag optional tables still missing. The [Health](https://docs.chmonitor.dev/guide/features/health) page rolls cluster status into one grid so you see regressions immediately after cutover.
+
+## Related
+
+- Docs: [ClickHouse User & Grants](https://docs.chmonitor.dev/guide/getting-started/clickhouse-requirements) — re-apply least-privilege grants
+- Docs: [Troubleshooting](https://docs.chmonitor.dev/guide/guides/troubleshooting)
+- Docs: [Health probes (K8s)](https://docs.chmonitor.dev/operate/deploy/k8s#health-probes)

--- a/apps/blog/src/layouts/Base.astro
+++ b/apps/blog/src/layouts/Base.astro
@@ -182,27 +182,32 @@ const ogImage = new URL(image, Astro.site).toString()
     .sec-eyebrow{display:flex;align-items:center;gap:9px}
     .sec-eyebrow::before{content:"";width:18px;height:1.5px;background:var(--amber);border-radius:2px}
 
-    /* ── post list ── */
-    .post-list{padding:8px 0 80px;display:flex;flex-direction:column;gap:20px}
-    .post-card{display:grid;grid-template-columns:170px 1fr;gap:32px;padding:28px 32px;
-      border:none;border-radius:var(--radius);background:#f6f8fb;align-items:start;transition:.22s cubic-bezier(0.16, 1, 0.3, 1)}
-    :root[data-theme="dark"] .post-card{background:#111217}
-    .post-card:hover{background:#edf2f9;transform:translateY(-2px);box-shadow:var(--shadow-card)}
-    :root[data-theme="dark"] .post-card:hover{background:#161821}
-    .post-card:hover h2{color:var(--orange)}
-    .post-meta{display:flex;flex-direction:column;gap:8px}
-    .post-tag{display:inline-flex;align-items:center;height:26px;padding:0 12px;border-radius:999px;
-      background:var(--muted);font-size:12.5px;font-weight:600;font-family:'JetBrains Mono',monospace;
-      color:var(--fg-soft);width:fit-content}
-    .post-date{font-size:13px;color:var(--muted-fg)}
-    .post-body h2{font-size:23px;font-weight:700;letter-spacing:-.02em;line-height:1.2;transition:color .15s}
-    .post-body p{margin-top:10px;font-size:15.5px;color:var(--muted-fg);line-height:1.6;text-wrap:pretty;max-width:62ch}
-    .post-more{margin-top:14px;display:inline-flex;align-items:center;gap:6px;font-size:14px;font-weight:600;color:var(--fg)}
-    .post-more svg{width:15px;height:15px;transition:transform .16s}
-    .post-card:hover .post-more svg{transform:translateX(3px)}
-    @media (max-width:680px){
-      .post-card{grid-template-columns:1fr;gap:14px;padding:24px 20px}
-    }
+    /* ── category grid (homepage) ── */
+    .cat-grid{padding:8px 0 80px;display:grid;grid-template-columns:repeat(2,1fr);gap:20px;align-items:start}
+    .cat-card{border:1px solid var(--border);border-radius:var(--radius);background:var(--card);
+      padding:24px 26px;transition:.22s cubic-bezier(0.16, 1, 0.3, 1)}
+    .cat-card:hover{border-color:var(--border-hover);box-shadow:var(--shadow-card)}
+    .cat-card.is-featured{grid-column:1 / -1;background:linear-gradient(180deg,#fff8f1 0%,var(--card) 60%);
+      border-color:rgba(249,115,22,.35)}
+    :root[data-theme="dark"] .cat-card.is-featured{background:linear-gradient(180deg,#1d160f 0%,var(--card) 60%);
+      border-color:rgba(249,115,22,.30)}
+    .cat-head{display:flex;align-items:center;gap:10px}
+    .cat-head h2{font-size:17px;font-weight:700;letter-spacing:-.01em}
+    .cat-count{font-size:12px;font-weight:600;color:var(--muted-fg);background:var(--muted);
+      border-radius:999px;padding:1px 9px;font-family:'JetBrains Mono',monospace}
+    .cat-tagline{margin-top:8px;font-size:13.5px;color:var(--muted-fg);line-height:1.5;text-wrap:pretty}
+    .cat-list{margin-top:16px;list-style:none;display:flex;flex-direction:column;gap:2px;
+      border-top:1px solid var(--border-soft);padding-top:6px}
+    .cat-item{display:flex;flex-direction:column;gap:2px;padding:11px 0;border-bottom:1px solid var(--border-soft)}
+    .cat-item:last-child{border-bottom:none}
+    .cat-link{display:flex;align-items:baseline;justify-content:space-between;gap:14px;
+      text-decoration:none;transition:color .15s}
+    .cat-title{font-size:15px;font-weight:550;letter-spacing:-.01em;color:var(--fg)}
+    .cat-link:hover .cat-title{color:var(--orange)}
+    .cat-date{font-size:12.5px;color:var(--muted-fg);white-space:nowrap;flex:0 0 auto;
+      font-family:'JetBrains Mono',monospace}
+    .cat-desc{font-size:14px;color:var(--muted-fg);line-height:1.55;margin-top:4px;text-wrap:pretty;max-width:72ch}
+    @media (max-width:720px){.cat-grid{grid-template-columns:1fr}}
 
     /* ── article ── */
     .article-wrap{max-width:var(--maxw-prose);margin:0 auto;padding:0 24px;width:100%}

--- a/apps/blog/src/pages/index.astro
+++ b/apps/blog/src/pages/index.astro
@@ -12,34 +12,79 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
 function fmtDate(d: Date) {
   return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
 }
+
+// Category display order + blurbs. "Release" is the highlighted category; the
+// rest render as compact title lists. Categories not in this list fall back to
+// alphabetical order so a new tag always gets a card.
+const CATEGORY_ORDER = [
+  'Release',
+  'How-to',
+  'Troubleshooting',
+  'Case study',
+  '5 min of ClickHouse',
+]
+
+const CATEGORY_TAGLINE = {
+  Release: 'New versions, features, and fixes shipped to chmonitor.',
+  Howto: 'Step-by-step guides to get more from your dashboard.',
+  Troubleshooting: 'Diagnose ClickHouse errors with copy-paste system-table queries.',
+  'Case study': 'Real incidents, diagnosed end to end with chmonitor.',
+  '5 min of ClickHouse': 'One diagnostic query, five minutes, no fluff.',
+}
+
+const seen = {}
+for (const p of posts) seen[p.data.tag] = true
+const extraTags = Object.keys(seen)
+  .filter((t) => !CATEGORY_ORDER.includes(t))
+  .sort()
+
+const allTags = [...CATEGORY_ORDER, ...extraTags]
+
+const groups = allTags
+  .map((tag) => ({
+    tag: tag,
+    tagline: CATEGORY_TAGLINE[tag] || '',
+    items: posts.filter((p) => p.data.tag === tag),
+    featured: tag === 'Release',
+  }))
+  .filter((g) => g.items.length > 0)
 ---
-<Base title="chmonitor blog — release notes & product updates" image="/og/blog/index.png">
+<Base title="chmonitor blog — release notes, guides & ClickHouse diagnostics" image="/og/blog/index.png">
   <Nav />
   <main>
     <section class="blog-hero">
       <div class="wrap">
         <span class="eyebrow sec-eyebrow">Blog</span>
         <h1>What's new in chmonitor</h1>
-        <p>Release notes, product updates and engineering notes from the team building the open-source ClickHouse monitoring dashboard.</p>
+        <p>Release notes, product updates, how-to guides, and ClickHouse diagnostic deep-dives from the team building the open-source ClickHouse monitoring dashboard.</p>
       </div>
     </section>
     <section class="wrap">
-      <div class="post-list">
-        {posts.map((post) => (
-          <a class="post-card" href={`/${postSlug(post)}/`}>
-            <div class="post-meta">
-              <span class="post-tag">{post.data.version ?? post.data.tag}</span>
-              <span class="post-date">{fmtDate(post.data.date)}</span>
-            </div>
-            <div class="post-body">
-              <h2>{post.data.title}</h2>
-              <p>{post.data.description}</p>
-              <span class="post-more">
-                Read more
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
-              </span>
-            </div>
-          </a>
+      <div class="cat-grid">
+        {groups.map((group) => (
+          <section class={`cat-card${group.featured ? ' is-featured' : ''}`}>
+            <header class="cat-head">
+              <h2>{group.tag}</h2>
+              <span class="cat-count">{group.items.length}</span>
+            </header>
+            <p class="cat-tagline">{group.tagline}</p>
+            <ul class="cat-list">
+              {group.items.map((post) => (
+                <li class="cat-item">
+                  <a class="cat-link" href={`/${postSlug(post)}/`}>
+                    <span class="cat-title">{post.data.title}</span>
+                    {!group.featured && <span class="cat-date">{fmtDate(post.data.date)}</span>}
+                  </a>
+                  {group.featured && (
+                    <span class="cat-date">{fmtDate(post.data.date)}</span>
+                  )}
+                  {group.featured && post.data.description && (
+                    <p class="cat-desc">{post.data.description}</p>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
         ))}
       </div>
     </section>

--- a/docs/content/guide/guides/clickhouse-query-optimization.mdx
+++ b/docs/content/guide/guides/clickhouse-query-optimization.mdx
@@ -89,6 +89,7 @@ partition problem is usually cheaper than spilling to disk.
 ## Related
 
 <Cards>
+<Card title="The 6 root causes of slow ClickHouse" href="https://blog.chmonitor.dev/clickhouse-query-optimization-pillars/" description="A diagnostic map of the six areas, with the system-table query to start at." />
 <Card title="AI Agent capabilities" href="/guide/ai-agent/capabilities" description="The query-optimization diagnose loop, EXPLAIN interpretation, and ranked recommendations." />
 <Card title="Queries" href="/guide/features/queries" description="Live, historical, failed, and slow query pages — including the interactive Explain page." />
 <Card title="Tables" href="/guide/features/tables" description="Storage, parts, replication, and dictionaries across every database." />

--- a/docs/content/guide/guides/connect-firewalled-clickhouse.mdx
+++ b/docs/content/guide/guides/connect-firewalled-clickhouse.mdx
@@ -80,6 +80,7 @@ Run a small reverse proxy (nginx / HAProxy) on a VM with a **static public IP** 
 ## Related
 
 <Cards>
+<Card title="Connect a firewalled ClickHouse in 5 minutes" href="https://blog.chmonitor.dev/clickhouse-firewalled-cloud/" description="The Cloudflare Tunnel setup, and why allowlisting Cloudflare's ranges does not work." />
 <Card title="ClickHouse requirements" href="/guide/getting-started/clickhouse-requirements" description="The least-privilege monitoring user chmonitor needs." />
 <Card title="Connection errors" href="/guide/guides/connection-errors" description="Diagnose 'Test connection' failures kind by kind." />
 <Card title="Proxy & SSO auth setup" href="/guide/guides/proxy-auth-setup" description="Put chmonitor behind Cloudflare Access, oauth2-proxy, or Traefik." />

--- a/docs/content/guide/guides/external-group-by.mdx
+++ b/docs/content/guide/guides/external-group-by.mdx
@@ -106,6 +106,7 @@ agent's `query-optimization` skill checks for exactly this pattern — high
 ## Related
 
 <Cards>
+<Card title="Spill GROUP BY to disk in 5 minutes" href="https://blog.chmonitor.dev/clickhouse-external-group-by/" description="The setting, the cheaper fixes, and the ProfileEvents query that confirms a spill." />
 <Card title="ClickHouse query optimization (pillar)" href="/guide/guides/clickhouse-query-optimization" description="The full map of six optimization areas." />
 <Card title="Projections vs materialized views" href="/guide/guides/projections-vs-materialized-views" description="Pre-aggregate to shrink the GROUP BY instead of spilling it." />
 <Card title="PREWHERE vs WHERE" href="/guide/guides/prewhere-vs-where" description="Make sure the scan itself isn't wider than it needs to be." />

--- a/docs/content/guide/guides/memory-limit-total-exceeded.mdx
+++ b/docs/content/guide/guides/memory-limit-total-exceeded.mdx
@@ -66,6 +66,7 @@ The [Metrics](/guide/features/metrics) page tracks `MemoryTracking` and other se
 ## Related
 
 <Cards>
+<Card title='Fix "Memory limit (total) exceeded" in 5 minutes' href="https://blog.chmonitor.dev/clickhouse-memory-limit-total-exceeded/" description="The server-wide cap, and the queries that show what is eating RAM." />
 <Card title='Fix "Memory limit (for query) exceeded"' href="/guide/guides/memory-limit-exceeded" description="The per-query memory cap, and how it differs from the server-wide limit." />
 <Card title="Merges slower than inserts" href="/guide/guides/merges-slower-than-inserts" description="Diagnose merge backlogs that compete for the same memory budget." />
 <Card title="Metrics" href="/guide/features/metrics" description="Live server counters and background-calculated resource metrics." />

--- a/docs/content/guide/guides/skip-indices-guide.mdx
+++ b/docs/content/guide/guides/skip-indices-guide.mdx
@@ -110,6 +110,7 @@ type, expression, granularity, and compression ratio — the same
 ## Related
 
 <Cards>
+<Card title="ClickHouse skip indices in 5 minutes" href="https://blog.chmonitor.dev/clickhouse-skip-indices-guide/" description="A short walkthrough of the four index types and the EXPLAIN that proves one fires." />
 <Card title="ClickHouse query optimization (pillar)" href="/guide/guides/clickhouse-query-optimization" description="The full map of six optimization areas." />
 <Card title="PREWHERE vs WHERE" href="/guide/guides/prewhere-vs-where" description="Filter pushdown that works alongside skip indices, not instead of them." />
 <Card title="Partition key best practices" href="/guide/guides/partition-key-best-practices" description="Rule out a partitioning problem before adding indices." />

--- a/docs/content/guide/guides/upgrade-clickhouse.mdx
+++ b/docs/content/guide/guides/upgrade-clickhouse.mdx
@@ -196,6 +196,7 @@ The dashboard picks up new system tables automatically, but the table has to exi
 ## Related
 
 <Cards>
+<Card title="Upgrade safely in 5 minutes" href="https://blog.chmonitor.dev/clickhouse-upgrade-safely/" description="Pre-upgrade checks, version-by-version dashboard changes, and post-upgrade grant sanity queries." />
 <Card title="ClickHouse User & Grants" href="/guide/getting-started/clickhouse-requirements" description="Re-apply the least-privilege grants the dashboard needs." />
 <Card title="Troubleshooting" href="/guide/guides/troubleshooting" description="Diagnose connection, auth, performance, and probe failures." />
 <Card title="Health probes" href="/operate/deploy/k8s#health-probes" description="Liveness and readiness probe settings for Kubernetes." />


### PR DESCRIPTION
## Summary
- Redesign the blog homepage into **category cards** grouped by post `tag`, mirroring the docs homepage section grid.
  - **Release** category highlighted full-width (featured card with title + date + description).
  - All other categories (**How-to, Troubleshooting, Case study, 5 min of ClickHouse**) render as compact post-title lists (title + date only) for a dense, scannable index.
  - New `tag:` values auto-create a card (alphabetical fallback) so the layout never breaks.
- Add **6 SEO posts** reusing verified `system.*` SQL from the docs guides:
  - `clickhouse-skip-indices-guide` (5 min)
  - `clickhouse-external-group-by` (5 min)
  - `clickhouse-memory-limit-total-exceeded` (5 min)
  - `clickhouse-firewalled-cloud` (5 min)
  - `clickhouse-upgrade-safely` (5 min)
  - `clickhouse-query-optimization-pillars` (how-to)
- Add **bidirectional docs↔blog cross-links** (the new posts link to their canonical docs pages; the docs guides link back to the posts).
- Update `CONTENT-CALENDAR.md` with the published-this-cycle table.

## Verification
- `pnpm run build` in `apps/blog` passes — 25 pages built, all six new posts rendered.
- Homepage HTML confirmed: 1 featured `cat-card is-featured` + 4 compact `cat-card`, all 5 categories present.

🤖 Generated with [Command Code](https://commandcode.ai)