### PR TITLE
feat(blog): category-card homepage + landing brand accents

### DIFF
--- a/apps/blog/CONTENT-CALENDAR.md
+++ b/apps/blog/CONTENT-CALENDAR.md
@@ -45,6 +45,22 @@ published (`draft: false`, merged to main)
 | 12 | release | (scaffold from the next GitHub release when it ships) | — | `/reference/releases` | planned |
 | 13 | troubleshooting | ClickHouse disk is full — what to do right now | clickhouse disk full emergency | `/guide/features` | done (`clickhouse-disk-full-emergency.md`, published 2026-09-11) |
 
+## Published this cycle (homepage redesign + SEO expansion)
+
+The blog homepage was redesigned into category cards grouped by `tag`, with the
+Release category highlighted full-width and the rest rendered as compact
+post-title lists. Alongside it, six SEO posts were added (all reusing verified
+`system.*` SQL from the docs guides, with bidirectional cross-links):
+
+| Date | Type | Title | Target keyword | Cross-link (docs page) |
+|---|---|---|---|---|
+| 2026-10-02 | 5 min | ClickHouse skip indices that actually prune | clickhouse skip index / data skipping index | `/guide/guides/skip-indices-guide` |
+| 2026-10-09 | 5 min | Spill GROUP BY to disk instead of OOMing | clickhouse external group by / memory limit exceeded | `/guide/guides/external-group-by` |
+| 2026-10-16 | 5 min | Fix "Memory limit (total) exceeded" | clickhouse memory limit total exceeded | `/guide/guides/memory-limit-total-exceeded` |
+| 2026-10-23 | 5 min | Connect a firewalled ClickHouse to chmonitor Cloud | clickhouse behind firewall cloudflare tunnel | `/guide/guides/connect-firewalled-clickhouse` |
+| 2026-10-30 | 5 min | Upgrade ClickHouse safely while chmonitor stays connected | upgrade clickhouse safely | `/guide/guides/upgrade-clickhouse` |
+| 2026-11-06 | how-to | The 6 root causes of slow ClickHouse | clickhouse query optimization | `/guide/guides/clickhouse-query-optimization` |
+
 ## Post-type mix (per 12-week cycle)
 
 - Release: 2 (as releases actually ship — do not invent a cadence releases

--- a/apps/blog/src/content/blog/clickhouse-external-group-by.md
+++ b/apps/blog/src/content/blog/clickhouse-external-group-by.md
@@ -1,0 +1,72 @@
+---
+title: "5 min of ClickHouse: spill GROUP BY to disk instead of OOMing"
+description: "A high-cardinality GROUP BY can blow past max_memory_usage and die with MEMORY_LIMIT_EXCEEDED. Here's the setting that spills it to disk, the cheaper fixes to try first, and the query that proves a spill happened."
+date: 2026-10-09
+tag: 5 min of ClickHouse
+---
+
+Five minutes, one real diagnostic, no fluff. A `GROUP BY` on a high-cardinality key builds an in-memory hash table — one entry per distinct key. On a big enough table that hash table outgrows `max_memory_usage` and the query dies with `MEMORY_LIMIT_EXCEEDED` (code 241) instead of finishing slowly. Today: the safety valve, and the cheaper options.
+
+## The safety valve
+
+`max_bytes_before_external_group_by` sets a per-query memory threshold. Cross it and ClickHouse writes the partial aggregation state to a temp file on disk, frees the memory, and keeps going — merging the spilled chunks at the end.
+
+```sql
+SET max_bytes_before_external_group_by = 10000000000; -- 10 GB, e.g. half of max_memory_usage
+```
+
+Same pattern covers two siblings — too low causes needless disk I/O, too high risks OOM:
+
+| Setting | Applies to | Guidance |
+|---|---|---|
+| `max_bytes_before_external_group_by` | `GROUP BY` | Session-level; common start is half of `max_memory_usage`. `0` disables spilling. |
+| `max_bytes_before_external_sort` | `ORDER BY` | Same ratio guidance. |
+| `max_bytes_before_external_join` | Hash joins | Same ratio, applied to the join's build side. |
+
+Spilling is strictly slower than staying in RAM — treat it as a safety valve, not a substitute for a correct `max_memory_usage`.
+
+## Try these first (cheaper than spilling)
+
+1. **Pre-aggregate.** If the same aggregation runs repeatedly, a materialized view pre-aggregates on insert so each query scans far fewer rows. See [projections vs materialized views](https://docs.chmonitor.dev/guide/guides/projections-vs-materialized-views).
+2. **Two-level aggregation.** `group_by_two_level_threshold` / `group_by_two_level_threshold_bytes` split the hash table into buckets that merge in parallel across threads — lower peak memory without touching disk.
+3. **Check the scan first.** A `GROUP BY` reading too many rows because of a missing skip index or partition problem always uses more memory than it should — see the [skip indices guide](https://docs.chmonitor.dev/guide/guides/skip-indices-guide).
+4. **Raise `max_memory_usage`** if the cluster genuinely has headroom — RAM is usually faster than spilling to disk.
+
+## Diagnose OOM-killed queries
+
+```sql
+SELECT
+    event_time, query_id, user, exception_code,
+    formatReadableSize(memory_usage) AS memory_usage,
+    normalizeQuery(query) AS normalized_query
+FROM system.query_log
+WHERE event_time > now() - INTERVAL 1 HOUR
+  AND type IN ('ExceptionWhileProcessing', 'ExceptionBeforeStart')
+  AND (exception_code = 241 OR exception LIKE '%MEMORY_LIMIT_EXCEEDED%')
+ORDER BY event_time DESC
+LIMIT 50;
+```
+
+## Confirm a spill actually happened
+
+```sql
+SELECT
+    query_id,
+    ProfileEvents['ExternalAggregationWrittenRows']     AS spilled_rows,
+    ProfileEvents['ExternalAggregationCompressedBytes'] AS spilled_bytes
+FROM system.query_log
+WHERE query_id = 'your-query-id'
+  AND type = 'QueryFinish';
+```
+
+Nonzero `spilled_rows` means it spilled; zero means it finished in memory and the threshold wasn't the bottleneck.
+
+## How chmonitor surfaces this
+
+The Health page's **OOM-Killed Queries** check runs the diagnostic query above continuously and alerts when the rate crosses a threshold, with `read_rows`, `memory_usage`, and the query text linked from Expensive Queries. The AI agent's `query-optimization` skill watches for exactly this pattern — high `memory_usage` on an aggregation step.
+
+## Related
+
+- Docs: [External GROUP BY guide](https://docs.chmonitor.dev/guide/guides/external-group-by) — full spill reference
+- Docs: [Query optimization pillar](https://docs.chmonitor.dev/guide/guides/clickhouse-query-optimization)
+- Live demo: [dash.chmonitor.dev/metrics](https://dash.chmonitor.dev/metrics)

--- a/apps/blog/src/content/blog/clickhouse-firewalled-cloud.md
+++ b/apps/blog/src/content/blog/clickhouse-firewalled-cloud.md
@@ -1,0 +1,35 @@
+---
+title: "5 min of ClickHouse: connect a firewalled ClickHouse to chmonitor Cloud"
+description: "chmonitor Cloud runs on Cloudflare Workers with no fixed egress IP, so allowlisting Cloudflare's ranges is not a real allowlist. Here's the tunnel that works with zero inbound ports opened."
+date: 2026-10-23
+tag: 5 min of ClickHouse
+---
+
+Five minutes, one real setup, no fluff. chmonitor **Cloud** runs entirely on Cloudflare Workers. When your ClickHouse sits behind a firewall, the Worker has to reach it — and because Workers have **no single fixed public IP by default**, a plain "allowlist our IP" doesn't work. Self-hosted chmonitor doesn't have this problem (it runs inside your network and reaches ClickHouse directly). This is the Cloud path.
+
+## The default: Cloudflare Tunnel
+
+A [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-tunnel/) runs a small `cloudflared` connector next to ClickHouse. It makes only **outbound** connections to Cloudflare, so you open **no inbound ports and allowlist no IPs**. You then protect the tunnel's hostname with [Access](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/) and hand chmonitor a **service token**.
+
+```bash
+cloudflared tunnel create chmonitor
+cloudflared tunnel route dns chmonitor ch.example.com
+```
+
+Then add the host with URL `https://ch.example.com` and paste the service-token Client ID / Secret into the connection's headers (`CF-Access-Client-Id` / `CF-Access-Client-Secret`). No inbound hole, per-connection revocable token, end-to-end TLS — and it works today on free/standard Zero Trust tiers.
+
+## Don't do this
+
+> **Do not allowlist Cloudflare's public IP ranges.** Worker egress over those ranges is shared by *every* Cloudflare customer. Allowlisting them authorizes the entire fleet — not a real allowlist. Use a tunnel or dedicated egress IPs.
+
+If a security team **requires** a literal firewall allowlist, chmonitor talks to ClickHouse over HTTP (`fetch()`), so Cloudflare's [Dedicated Egress IPs](https://developers.cloudflare.com/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/) (enterprise add-on) apply and give the Worker a stable source IP you can allowlist. Or run a reverse proxy (nginx/HAProxy) on a static-IP VM and allowlist only that.
+
+## How chmonitor surfaces this
+
+The [Connection errors](https://docs.chmonitor.dev/guide/guides/connection-errors) guide classifies "Test connection" failures (host not allowed / SSRF, invalid URL, auth failed, access denied, DNS/refused/TLS/timeout) so you know which leg of the tunnel is broken.
+
+## Related
+
+- Docs: [Connection errors](https://docs.chmonitor.dev/guide/guides/connection-errors) — diagnose failures kind by kind
+- Docs: [Proxy & SSO auth setup](https://docs.chmonitor.dev/guide/guides/proxy-auth-setup)
+- Docs: [Self-host](https://docs.chmonitor.dev/operate/deploy/self-host) — run inside your network, no tunnel needed

--- a/apps/blog/src/content/blog/clickhouse-memory-limit-total-exceeded.md
+++ b/apps/blog/src/content/blog/clickhouse-memory-limit-total-exceeded.md
@@ -1,0 +1,63 @@
+---
+title: "5 min of ClickHouse: fix 'Memory limit (total) exceeded' (it's not one query)"
+description: "The server-wide 'Memory limit (total) exceeded' error is tripped by every concurrent query, merge, and cache combined — not one query's budget. Here are the queries that show what's eating RAM."
+date: 2026-10-16
+tag: 5 min of ClickHouse
+---
+
+Five minutes, one real diagnostic, no fluff. `Code: 241. Memory limit (total) exceeded` looks exactly like the per-query [Memory limit (for query) exceeded](/clickhouse-memory-limit-exceeded/), but the `(total)` wording is the whole story: this is the **server-wide** cap (`max_server_memory_usage`, ~90% of RAM by default), tripped by the sum of every concurrent query, merge, mutation, and cache — not one query's own budget. It can fire when no single query looks expensive.
+
+## Why it happens
+
+- **Too many concurrent queries.** Each moderate, but the sum crosses the cap.
+- **Oversized caches.** `mark_cache_size` / `uncompressed_cache_size` set too large for the box.
+- **Merges and mutations competing** for the same budget — a merge storm or a large `ALTER … UPDATE/DELETE`.
+- **Replication buffers** queueing in-flight data on a busy replica.
+
+## Diagnose
+
+```sql
+-- Current total memory tracked by the server
+SELECT value AS current_memory_bytes, formatReadableSize(value) AS current_memory
+FROM system.metrics
+WHERE metric = 'MemoryTracking';
+```
+```sql
+-- Trend over the last few hours (sampled periodically)
+SELECT event_time, value AS memory_bytes
+FROM system.asynchronous_metric_log
+WHERE metric = 'MemoryTracking' AND event_time > now() - INTERVAL 6 HOUR
+ORDER BY event_time;
+```
+```sql
+-- Everything currently holding memory, heaviest first
+SELECT
+    query_id, user, elapsed,
+    formatReadableSize(memory_usage) AS current_memory,
+    query
+FROM system.processes
+ORDER BY memory_usage DESC
+LIMIT 20;
+```
+
+Confirm the ceiling: `SELECT * FROM system.server_settings WHERE name = 'max_server_memory_usage'` (24.x+), or check `max_server_memory_usage` / `max_server_memory_usage_to_ram_ratio` in `config.xml` on older versions.
+
+## Fix
+
+- **Limit concurrency** — cap `max_concurrent_queries` and per-user `max_memory_usage_for_user`.
+- **Shrink caches** if oversized — they count against the same total.
+- **Raise `max_server_memory_usage`** only if the host has spare RAM the default 90% isn't using.
+- **Spread load** across more replicas or shards.
+- **Address merge/mutation pressure** — see [Merges slower than inserts](https://docs.chmonitor.dev/guide/guides/merges-slower-than-inserts).
+
+**Don't just raise the ceiling.** Without taming runaway concurrency, the Linux OOM killer may take down the whole `clickhouse-server` process — a much worse outage. (Altinity's [Rescuing ClickHouse from the Linux OOM Killer](https://altinity.com/blog/rescuing-clickhouse-from-the-linux-oom-killer) covers the failure mode.)
+
+## How chmonitor surfaces this
+
+The [Metrics](https://docs.chmonitor.dev/guide/features/metrics) page tracks `MemoryTracking` live, and [Health](https://docs.chmonitor.dev/guide/features/health) rolls memory pressure into the at-a-glance status grid so you see it trending up before the server rejects a query.
+
+## Related
+
+- Docs: [Memory limit (for query) exceeded](https://docs.chmonitor.dev/guide/guides/memory-limit-exceeded)
+- Docs: [Merges slower than inserts](https://docs.chmonitor.dev/guide/guides/merges-slower-than-inserts)
+- Docs: [Metrics](https://docs.chmonitor.dev/guide/features/metrics)

--- a/apps/blog/src/content/blog/clickhouse-query-optimization-pillars.md
+++ b/apps/blog/src/content/blog/clickhouse-query-optimization-pillars.md
@@ -1,0 +1,58 @@
+---
+title: "The 6 root causes of slow ClickHouse (and the query that rules out each)"
+description: "Most ClickHouse slowness traces to one of six things: partition key, granularity, PREWHERE, skip index, projection vs MV, or GROUP BY memory. A diagnostic map with the system-table query to start at."
+date: 2026-11-06
+tag: How-to
+---
+
+This is for anyone who has stared at a slow ClickHouse query and not known whether to touch the partition key, add an index, or just throw RAM at it. The truth: almost every "ClickHouse is slow" problem is one of six things, and there's a cheap order to rule them out. chmonitor runs this whole diagnosis automatically — this is the map so you understand it.
+
+## The six areas
+
+1. **Partition key** — a bad `PARTITION BY` (high cardinality) causes a too-many-parts spiral.
+2. **Partition granularity** — fine vs coarse trade-offs; size partitions correctly.
+3. **PREWHERE vs WHERE** — column-level filter pushdown that cuts I/O.
+4. **Projections vs materialized views** — which acceleration mechanism fits the query shape.
+5. **Skip indices** — minmax / set / bloom_filter / tokenbf_v1, and how to confirm one fires.
+6. **External GROUP BY** — spill aggregation to disk instead of `MEMORY_LIMIT_EXCEEDED`.
+
+## Start at the top — part and partition health
+
+A bad partition key or wrong granularity causes symptoms everywhere else. Rule it out first:
+
+```sql
+SELECT
+    database, table,
+    count() AS active_parts,
+    uniqExact(partition) AS partitions,
+    formatReadableSize(sum(data_compressed_bytes)) AS compressed_size
+FROM system.parts
+WHERE active
+GROUP BY database, table
+ORDER BY active_parts DESC
+LIMIT 20;
+```
+
+More than a few hundred active parts on one table, or fewer than ~10 MB compressed per part, is a partitioning problem. See the [partition key best practices](https://docs.chmonitor.dev/guide/guides/partition-key-best-practices) and [granularity](https://docs.chmonitor.dev/guide/guides/partition-granularity) guides.
+
+## Then: is the filter doing its job?
+
+For a specific slow query, run `EXPLAIN indexes = 1 <query>` and compare `Granules: N/M`. If `N` ≈ `M`, the query scans almost everything — the filter isn't pruning. That's a [PREWHERE](https://docs.chmonitor.dev/guide/guides/prewhere-vs-where) or [skip index](https://docs.chmonitor.dev/guide/guides/skip-indices-guide) problem.
+
+## Then: how to accelerate the repeated shape
+
+If the same `GROUP BY`/`WHERE` shape runs often, decide between a [projection or a materialized view](https://docs.chmonitor.dev/guide/guides/projections-vs-materialized-views) to pre-compute it instead of re-scanning raw data.
+
+## Only then: tune memory
+
+If the query genuinely needs to scan a lot (a high-cardinality aggregation), see [external GROUP BY](https://docs.chmonitor.dev/guide/guides/external-group-by) for spill settings — but only after the steps above, since fixing the index or partition is usually cheaper than spilling to disk.
+
+## How chmonitor surfaces this
+
+Ask the AI agent "why is my ClickHouse cluster slow?" and it works through `list_slow_query_patterns` → `explain_query` → `get_optimization_recommendations`, then proposes ranked skip-index, projection, partition-key, and `PREWHERE` fixes as DDL you review and run — it never applies anything itself.
+
+## Related
+
+- Docs: [Query optimization pillar](https://docs.chmonitor.dev/guide/guides/clickhouse-query-optimization) — the full map with links to every guide
+- Docs: [AI Agent capabilities](https://docs.chmonitor.dev/guide/ai-agent/capabilities) — the diagnose loop and ranked recommendations
+- Docs: [Queries](https://docs.chmonitor.dev/guide/features/queries) — live, historical, failed, and slow query pages

--- a/apps/blog/src/content/blog/clickhouse-skip-indices-guide.md
+++ b/apps/blog/src/content/blog/clickhouse-skip-indices-guide.md
@@ -1,0 +1,68 @@
+---
+title: "5 min of ClickHouse: skip indices that actually prune your scans"
+description: "ClickHouse secondary indices skip whole granule blocks instead of indexing rows. Here are the four index types, when each fires, and the EXPLAIN query that proves it's working."
+date: 2026-10-02
+tag: 5 min of ClickHouse
+---
+
+Five minutes, one real diagnostic, no fluff. Skip indices are the ClickHouse feature most people add once and assume is helping — and then never check. Today: what each type is for, and how to confirm it actually prunes.
+
+## The mental model
+
+A ClickHouse "secondary index" is not a B-tree. It's a **data-skipping index**: for each block of granules it stores a tiny summary (a min/max range, a set of values, or a bloom filter), and at query time ClickHouse uses that summary to skip entire granule blocks that can't match — without reading the underlying column.
+
+## The four types
+
+| Type | Good for | How it works |
+|---|---|---|
+| `minmax` | Range queries on numeric/date columns not in `ORDER BY` | Stores min/max per block; skips blocks outside the range |
+| `set(N)` | Equality / `IN` on low-cardinality columns | Stores up to `N` distinct values per block; over `N` distinct → reads everything |
+| `bloom_filter` | Equality on higher-cardinality strings | Probabilistic membership per block; false positives only |
+| `tokenbf_v1` | Substring search (`LIKE '%error%'`) | Tokenized bloom filter over the column text |
+
+```sql
+ALTER TABLE events ADD INDEX idx_amount amount TYPE minmax GRANULARITY 4;
+ALTER TABLE events ADD INDEX idx_status status TYPE set(100) GRANULARITY 4;
+ALTER TABLE events ADD INDEX idx_request_id request_id TYPE bloom_filter GRANULARITY 4;
+ALTER TABLE events ADD INDEX idx_message message TYPE tokenbf_v1(4096, 3, 0) GRANULARITY 4;
+```
+
+`GRANULARITY N` groups N index granules into one index block — bigger index but coarser skipping. Start at `4`.
+
+**Adding an index does not backfill existing parts.** Run `ALTER TABLE … MATERIALIZE INDEX idx_name` to build it for data already on disk, or wait for the natural merge cycle.
+
+## Verify it fires
+
+Don't trust that it works — prove it:
+
+```sql
+EXPLAIN indexes = 1
+SELECT count()
+FROM events
+WHERE request_id = '3f9c1a2e-...';
+```
+
+Find your index name in the plan and confirm `Granules: N/M` shows `N` well below `M`. If the index never appears, the query expression doesn't match (index on `amount` but the filter uses `round(amount, 2)`), or the column is already a prefix of `ORDER BY` — in which case the primary key already prunes for free.
+
+## Audit for dead indices
+
+An index with zero compressed bytes was never built, or was built and never touched. Drop the dead weight — every index is maintained on every insert and merge:
+
+```sql
+SELECT
+    database, table, name, type, expr, granularity,
+    formatReadableSize(data_compressed_bytes) AS compressed_size,
+    if(data_compressed_bytes = 0, 'dead', 'active') AS status
+FROM system.data_skipping_indices
+ORDER BY data_compressed_bytes DESC;
+```
+
+## How chmonitor surfaces this
+
+The Data Explorer's per-table **Skip Indexes** panel lists every index with type, expression, granularity, and compression ratio — the same `system.data_skipping_indices` data without SQL. The AI agent's `get_optimization_recommendations` proposes specific skip-index DDL (type and expression already chosen) when it profiles a slow query.
+
+## Related
+
+- Docs: [Skip indices guide](https://docs.chmonitor.dev/guide/guides/skip-indices-guide) — the full secondary-index reference
+- Docs: [PREWHERE vs WHERE](https://docs.chmonitor.dev/guide/guides/prewhere-vs-where) — filter pushdown that works alongside indices
+- Docs: [Query optimization pillar](https://docs.chmonitor.dev/guide/guides/clickhouse-query-optimization) — the six areas that make ClickHouse slow

--- a/apps/blog/src/content/blog/clickhouse-upgrade-safely.md
+++ b/apps/blog/src/content/blog/clickhouse-upgrade-safely.md
@@ -1,0 +1,62 @@
+---
+title: "5 min of ClickHouse: upgrade safely while chmonitor stays connected"
+description: "Pre-upgrade checks, the system-table changes that light up new dashboard pages at each version, and the post-upgrade grants sanity queries — so you upgrade ClickHouse without losing monitoring."
+date: 2026-10-30
+tag: 5 min of ClickHouse
+---
+
+Five minutes, one real runbook, no fluff. chmonitor stays connected through a ClickHouse upgrade — it uses versioned SQL (`since` per query config) to automatically pick the right query for the connected version. But a few pre/post checks keep the dashboard fully lit.
+
+## Before you upgrade
+
+```bash
+curl -s "https://your-ch-host:8443?query=SELECT+version()" -u monitoring:password
+```
+
+chmonitor supports 22.x+, with full coverage recommended from **23.8 LTS**. Back up the settings you'll compare afterward, and clear the backlog that blocks a clean replica upgrade:
+
+```sql
+-- Save merge-tree + server settings for comparison
+SELECT * FROM system.merge_tree_settings INTO OUTFILE 'merge_tree_settings_before.csv' FORMAT CSV;
+SELECT * FROM system.settings INTO OUTFILE 'settings_before.csv' FORMAT CSV;
+
+-- Any stuck mutations (wait or cancel before upgrading a replica)?
+SELECT database, table, command, parts_to_do, is_done
+FROM system.mutations WHERE is_done = 0 ORDER BY create_time DESC;
+
+-- Long-running merges?
+SELECT database, table, round(progress * 100, 2) AS pct, elapsed
+FROM system.merges ORDER BY elapsed DESC;
+
+-- Replication health: no read-only replicas, drains should be small
+SELECT database, table, replica_name, is_leader, is_readonly, future_parts, queue_size
+FROM system.replicas WHERE is_readonly = 1 OR queue_size > 10;
+```
+
+## What lights up at each version
+
+- **22.x → 23.x**: Query Views Log, Moves, Dropped Tables, Session Log (Login Attempts/Sessions), Processors Profile Log.
+- **23.x → 24.x**: per-user `system.user_processes`, `system.part_log` (Merge Performance), `system.query_metric_log`, `system.query_cache`, `system.data_skipping_indices` (Explorer skip-index panel), `system.view_refreshes`.
+- **24.x → 25.x**: `system.distributed_ddl_queue`, extra async-metrics, `system.replicated_merge_tree_settings`.
+
+## After the upgrade
+
+Open `/overview` — if it shows data, the connection and grants are intact. Re-check grants if you upgraded users; ClickHouse sometimes changes system-table visibility across majors:
+
+```sql
+SELECT count() FROM system.query_log LIMIT 1;
+SELECT count() FROM system.processes LIMIT 1;
+SELECT count() FROM system.replicas LIMIT 1;
+```
+
+Then roll forward one replica at a time, confirming each rejoins replication (`is_readonly = 0`, `queue_size` draining) before touching the next.
+
+## How chmonitor surfaces this
+
+The AI agent can compare the system tables available now against what the dashboard expects and flag optional tables still missing. The [Health](https://docs.chmonitor.dev/guide/features/health) page rolls cluster status into one grid so you see regressions immediately after cutover.
+
+## Related
+
+- Docs: [ClickHouse User & Grants](https://docs.chmonitor.dev/guide/getting-started/clickhouse-requirements) — re-apply least-privilege grants
+- Docs: [Troubleshooting](https://docs.chmonitor.dev/guide/guides/troubleshooting)
+- Docs: [Health probes (K8s)](https://docs.chmonitor.dev/operate/deploy/k8s#health-probes)

--- a/apps/blog/src/layouts/Base.astro
+++ b/apps/blog/src/layouts/Base.astro
@@ -182,27 +182,32 @@ const ogImage = new URL(image, Astro.site).toString()
     .sec-eyebrow{display:flex;align-items:center;gap:9px}
     .sec-eyebrow::before{content:"";width:18px;height:1.5px;background:var(--amber);border-radius:2px}
 
-    /* ── post list ── */
-    .post-list{padding:8px 0 80px;display:flex;flex-direction:column;gap:20px}
-    .post-card{display:grid;grid-template-columns:170px 1fr;gap:32px;padding:28px 32px;
-      border:none;border-radius:var(--radius);background:#f6f8fb;align-items:start;transition:.22s cubic-bezier(0.16, 1, 0.3, 1)}
-    :root[data-theme="dark"] .post-card{background:#111217}
-    .post-card:hover{background:#edf2f9;transform:translateY(-2px);box-shadow:var(--shadow-card)}
-    :root[data-theme="dark"] .post-card:hover{background:#161821}
-    .post-card:hover h2{color:var(--orange)}
-    .post-meta{display:flex;flex-direction:column;gap:8px}
-    .post-tag{display:inline-flex;align-items:center;height:26px;padding:0 12px;border-radius:999px;
-      background:var(--muted);font-size:12.5px;font-weight:600;font-family:'JetBrains Mono',monospace;
-      color:var(--fg-soft);width:fit-content}
-    .post-date{font-size:13px;color:var(--muted-fg)}
-    .post-body h2{font-size:23px;font-weight:700;letter-spacing:-.02em;line-height:1.2;transition:color .15s}
-    .post-body p{margin-top:10px;font-size:15.5px;color:var(--muted-fg);line-height:1.6;text-wrap:pretty;max-width:62ch}
-    .post-more{margin-top:14px;display:inline-flex;align-items:center;gap:6px;font-size:14px;font-weight:600;color:var(--fg)}
-    .post-more svg{width:15px;height:15px;transition:transform .16s}
-    .post-card:hover .post-more svg{transform:translateX(3px)}
-    @media (max-width:680px){
-      .post-card{grid-template-columns:1fr;gap:14px;padding:24px 20px}
-    }
+    /* ── category grid (homepage) ── */
+    .cat-grid{padding:8px 0 80px;display:grid;grid-template-columns:repeat(2,1fr);gap:20px;align-items:start}
+    .cat-card{border:1px solid var(--border);border-radius:var(--radius);background:var(--card);
+      padding:24px 26px;transition:.22s cubic-bezier(0.16, 1, 0.3, 1)}
+    .cat-card:hover{border-color:var(--border-hover);box-shadow:var(--shadow-card)}
+    .cat-card.is-featured{grid-column:1 / -1;background:linear-gradient(180deg,#fff8f1 0%,var(--card) 60%);
+      border-color:rgba(249,115,22,.35)}
+    :root[data-theme="dark"] .cat-card.is-featured{background:linear-gradient(180deg,#1d160f 0%,var(--card) 60%);
+      border-color:rgba(249,115,22,.30)}
+    .cat-head{display:flex;align-items:center;gap:10px}
+    .cat-head h2{font-size:17px;font-weight:700;letter-spacing:-.01em}
+    .cat-count{font-size:12px;font-weight:600;color:var(--muted-fg);background:var(--muted);
+      border-radius:999px;padding:1px 9px;font-family:'JetBrains Mono',monospace}
+    .cat-tagline{margin-top:8px;font-size:13.5px;color:var(--muted-fg);line-height:1.5;text-wrap:pretty}
+    .cat-list{margin-top:16px;list-style:none;display:flex;flex-direction:column;gap:2px;
+      border-top:1px solid var(--border-soft);padding-top:6px}
+    .cat-item{display:flex;flex-direction:column;gap:2px;padding:11px 0;border-bottom:1px solid var(--border-soft)}
+    .cat-item:last-child{border-bottom:none}
+    .cat-link{display:flex;align-items:baseline;justify-content:space-between;gap:14px;
+      text-decoration:none;transition:color .15s}
+    .cat-title{font-size:15px;font-weight:550;letter-spacing:-.01em;color:var(--fg)}
+    .cat-link:hover .cat-title{color:var(--orange)}
+    .cat-date{font-size:12.5px;color:var(--muted-fg);white-space:nowrap;flex:0 0 auto;
+      font-family:'JetBrains Mono',monospace}
+    .cat-desc{font-size:14px;color:var(--muted-fg);line-height:1.55;margin-top:4px;text-wrap:pretty;max-width:72ch}
+    @media (max-width:720px){.cat-grid{grid-template-columns:1fr}}
 
     /* ── article ── */
     .article-wrap{max-width:var(--maxw-prose);margin:0 auto;padding:0 24px;width:100%}

--- a/apps/blog/src/pages/index.astro
+++ b/apps/blog/src/pages/index.astro
@@ -12,34 +12,79 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
 function fmtDate(d: Date) {
   return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
 }
+
+// Category display order + blurbs. "Release" is the highlighted category; the
+// rest render as compact title lists. Categories not in this list fall back to
+// alphabetical order so a new tag always gets a card.
+const CATEGORY_ORDER = [
+  'Release',
+  'How-to',
+  'Troubleshooting',
+  'Case study',
+  '5 min of ClickHouse',
+]
+
+const CATEGORY_TAGLINE = {
+  Release: 'New versions, features, and fixes shipped to chmonitor.',
+  Howto: 'Step-by-step guides to get more from your dashboard.',
+  Troubleshooting: 'Diagnose ClickHouse errors with copy-paste system-table queries.',
+  'Case study': 'Real incidents, diagnosed end to end with chmonitor.',
+  '5 min of ClickHouse': 'One diagnostic query, five minutes, no fluff.',
+}
+
+const seen = {}
+for (const p of posts) seen[p.data.tag] = true
+const extraTags = Object.keys(seen)
+  .filter((t) => !CATEGORY_ORDER.includes(t))
+  .sort()
+
+const allTags = [...CATEGORY_ORDER, ...extraTags]
+
+const groups = allTags
+  .map((tag) => ({
+    tag: tag,
+    tagline: CATEGORY_TAGLINE[tag] || '',
+    items: posts.filter((p) => p.data.tag === tag),
+    featured: tag === 'Release',
+  }))
+  .filter((g) => g.items.length > 0)
 ---
-<Base title="chmonitor blog — release notes & product updates" image="/og/blog/index.png">
+<Base title="chmonitor blog — release notes, guides & ClickHouse diagnostics" image="/og/blog/index.png">
   <Nav />
   <main>
     <section class="blog-hero">
       <div class="wrap">
         <span class="eyebrow sec-eyebrow">Blog</span>
         <h1>What's new in chmonitor</h1>
-        <p>Release notes, product updates and engineering notes from the team building the open-source ClickHouse monitoring dashboard.</p>
+        <p>Release notes, product updates, how-to guides, and ClickHouse diagnostic deep-dives from the team building the open-source ClickHouse monitoring dashboard.</p>
       </div>
     </section>
     <section class="wrap">
-      <div class="post-list">
-        {posts.map((post) => (
-          <a class="post-card" href={`/${postSlug(post)}/`}>
-            <div class="post-meta">
-              <span class="post-tag">{post.data.version ?? post.data.tag}</span>
-              <span class="post-date">{fmtDate(post.data.date)}</span>
-            </div>
-            <div class="post-body">
-              <h2>{post.data.title}</h2>
-              <p>{post.data.description}</p>
-              <span class="post-more">
-                Read more
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
-              </span>
-            </div>
-          </a>
+      <div class="cat-grid">
+        {groups.map((group) => (
+          <section class={`cat-card${group.featured ? ' is-featured' : ''}`}>
+            <header class="cat-head">
+              <h2>{group.tag}</h2>
+              <span class="cat-count">{group.items.length}</span>
+            </header>
+            <p class="cat-tagline">{group.tagline}</p>
+            <ul class="cat-list">
+              {group.items.map((post) => (
+                <li class="cat-item">
+                  <a class="cat-link" href={`/${postSlug(post)}/`}>
+                    <span class="cat-title">{post.data.title}</span>
+                    {!group.featured && <span class="cat-date">{fmtDate(post.data.date)}</span>}
+                  </a>
+                  {group.featured && (
+                    <span class="cat-date">{fmtDate(post.data.date)}</span>
+                  )}
+                  {group.featured && post.data.description && (
+                    <p class="cat-desc">{post.data.description}</p>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
         ))}
       </div>
     </section>

--- a/apps/dashboard/src/lib/api/rate-limiter.ts
+++ b/apps/dashboard/src/lib/api/rate-limiter.ts
@@ -160,7 +160,10 @@ export function getRateLimitBinding(
     return undefined
   }
   const candidate = (globalThis as Record<string, unknown>)[name]
-  if (candidate && typeof (candidate as RateLimitBinding).limit === 'function') {
+  if (
+    candidate &&
+    typeof (candidate as RateLimitBinding).limit === 'function'
+  ) {
     return candidate as RateLimitBinding
   }
   return undefined

--- a/apps/landing/src/components/Comparison.astro
+++ b/apps/landing/src/components/Comparison.astro
@@ -6,7 +6,7 @@ const partialSvg = `<svg class="inline-block size-[18px] shrink-0 align-middle t
 <section id="comparison" class="bg-muted/30 py-14 sm:py-20 md:py-24">
   <div class="mx-auto max-w-6xl px-4 sm:px-6">
     <div class="reveal mx-auto max-w-2xl text-center">
-      <p class="font-mono text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">Why chmonitor</p>
+      <p class="font-mono text-xs font-medium uppercase tracking-[0.14em] text-[var(--brand-emerald)]">Why chmonitor</p>
       <h2 class="mt-3 text-balance font-semibold text-2xl sm:text-3xl md:text-4xl tracking-tight">Purpose-built for ClickHouse</h2>
       <p class="mt-4 text-pretty text-sm sm:text-base text-muted-foreground">General-purpose tools treat ClickHouse as one data source among many. chmonitor reads its system tables directly and tracks nothing else. Here's how it stacks up against the most common alternatives.</p>
     </div>
@@ -21,7 +21,7 @@ const partialSvg = `<svg class="inline-block size-[18px] shrink-0 align-middle t
           <thead>
             <tr class="bg-muted">
               <th class="min-w-[160px] whitespace-nowrap px-5 py-3.5 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground"></th>
-              <th class="whitespace-nowrap bg-primary/5 px-5 py-3.5 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">chmonitor</th>
+              <th class="whitespace-nowrap bg-[var(--brand-orange-soft)] px-5 py-3.5 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">chmonitor</th>
               <th class="whitespace-nowrap px-5 py-3.5 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">Grafana + CH plugin</th>
               <th class="whitespace-nowrap px-5 py-3.5 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">Datadog</th>
               <th class="whitespace-nowrap px-5 py-3.5 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">CH native /dashboard</th>
@@ -30,56 +30,56 @@ const partialSvg = `<svg class="inline-block size-[18px] shrink-0 align-middle t
           <tbody>
             <tr class="border-t border-border">
               <td class="whitespace-nowrap px-5 py-3.5 font-medium text-foreground">Setup time</td>
-              <td class="bg-primary/5 px-5 py-3.5 text-pretty text-muted-foreground">~5 min (Docker or CF Workers)</td>
+              <td class="bg-[var(--brand-orange-soft)] px-5 py-3.5 text-pretty text-muted-foreground">~5 min (Docker or CF Workers)</td>
               <td class="px-5 py-3.5 text-pretty text-muted-foreground">Grafana + datasource plugin install</td>
               <td class="px-5 py-3.5 text-pretty text-muted-foreground">Agent on each ClickHouse node</td>
               <td class="px-5 py-3.5 text-pretty text-muted-foreground">Enable in ClickHouse config, restart</td>
             </tr>
             <tr class="border-t border-border">
               <td class="whitespace-nowrap px-5 py-3.5 font-medium text-foreground">No exporters / agents needed</td>
-              <td class="bg-primary/5 px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={checkSvg} /> reads system tables directly</span></td>
+              <td class="bg-[var(--brand-orange-soft)] px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={checkSvg} /> reads system tables directly</span></td>
               <td class="px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={partialSvg} /> optional CH datasource plugin</span></td>
               <td class="px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={crossSvg} /> agent required on each node</span></td>
               <td class="px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={checkSvg} /> built into CH</span></td>
             </tr>
             <tr class="border-t border-border">
               <td class="whitespace-nowrap px-5 py-3.5 font-medium text-foreground">ClickHouse-specific depth</td>
-              <td class="bg-primary/5 px-5 py-3.5 text-pretty text-muted-foreground">Purpose-built: merges, parts, replication, query log, system health</td>
+              <td class="bg-[var(--brand-orange-soft)] px-5 py-3.5 text-pretty text-muted-foreground">Purpose-built: merges, parts, replication, query log, system health</td>
               <td class="px-5 py-3.5 text-pretty text-muted-foreground">Generic SQL panels, you write the queries</td>
               <td class="px-5 py-3.5 text-pretty text-muted-foreground">Generic agent metrics; limited CH specifics</td>
               <td class="px-5 py-3.5 text-pretty text-muted-foreground">Basic built-in panel; minimal detail</td>
             </tr>
             <tr class="border-t border-border">
               <td class="whitespace-nowrap px-5 py-3.5 font-medium text-foreground">AI agent + MCP</td>
-              <td class="bg-primary/5 px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={checkSvg} /> built-in AI agent; MCP server at /api/mcp</span></td>
+              <td class="bg-[var(--brand-orange-soft)] px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={checkSvg} /> built-in AI agent; MCP server at /api/mcp</span></td>
               <td class="px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={crossSvg} /> none</span></td>
               <td class="px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={partialSvg} /> AI Advisor on paid plans</span></td>
               <td class="px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={crossSvg} /> none</span></td>
             </tr>
             <tr class="border-t border-border">
               <td class="whitespace-nowrap px-5 py-3.5 font-medium text-foreground">Alert rules &amp; channels</td>
-              <td class="bg-primary/5 px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={checkSvg} /> Built-in health checks, editable thresholds; one webhook &rarr; Slack or Discord + full alert history</span></td>
+              <td class="bg-[var(--brand-orange-soft)] px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={checkSvg} /> Built-in health checks, editable thresholds; one webhook &rarr; Slack or Discord + full alert history</span></td>
               <td class="px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={checkSvg} /> Grafana Alerting: many channels and routing rules, once you've built the CH panels</span></td>
               <td class="px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={checkSvg} /> Datadog Monitors: broad integrations, mature escalation policies</span></td>
               <td class="px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={crossSvg} /> none</span></td>
             </tr>
             <tr class="border-t border-border">
               <td class="whitespace-nowrap px-5 py-3.5 font-medium text-foreground">Version-aware queries</td>
-              <td class="bg-primary/5 px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={checkSvg} /> SQL adapts to CH schema by version</span></td>
+              <td class="bg-[var(--brand-orange-soft)] px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={checkSvg} /> SQL adapts to CH schema by version</span></td>
               <td class="px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={crossSvg} /> you manage query compatibility</span></td>
               <td class="px-5 py-3.5 text-pretty text-muted-foreground">N/A</td>
               <td class="px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={crossSvg} /> fixed to bundled version</span></td>
             </tr>
             <tr class="border-t border-border">
               <td class="whitespace-nowrap px-5 py-3.5 font-medium text-foreground">Cost</td>
-              <td class="bg-primary/5 px-5 py-3.5 text-pretty text-muted-foreground">Free self-host; cloud in early access</td>
+              <td class="bg-[var(--brand-orange-soft)] px-5 py-3.5 text-pretty text-muted-foreground">Free self-host; cloud in early access</td>
               <td class="px-5 py-3.5 text-pretty text-muted-foreground">Grafana OSS free; Grafana Cloud paid</td>
               <td class="px-5 py-3.5 text-pretty text-muted-foreground">~$15–23 per host per month (varies)</td>
               <td class="px-5 py-3.5 text-pretty text-muted-foreground">Free (bundled with ClickHouse)</td>
             </tr>
             <tr class="border-t border-border">
               <td class="whitespace-nowrap px-5 py-3.5 font-medium text-foreground">Open source / self-host</td>
-              <td class="bg-primary/5 px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={checkSvg} /> GPL-3.0; Docker, CF Workers, K8s Helm</span></td>
+              <td class="bg-[var(--brand-orange-soft)] px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={checkSvg} /> GPL-3.0; Docker, CF Workers, K8s Helm</span></td>
               <td class="px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={checkSvg} /> Grafana OSS (AGPL-3.0)</span></td>
               <td class="px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={crossSvg} /> SaaS only</span></td>
               <td class="px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={checkSvg} /> within ClickHouse</span></td>

--- a/apps/landing/src/components/FAQ.astro
+++ b/apps/landing/src/components/FAQ.astro
@@ -49,7 +49,7 @@ const faqJsonLd = {
 <section id="faq" class="py-14 sm:py-20 md:py-24">
   <div class="mx-auto max-w-6xl px-4 sm:px-6">
     <div class="reveal mx-auto max-w-2xl text-center">
-      <p class="font-mono text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">FAQ</p>
+      <p class="font-mono text-xs font-medium uppercase tracking-[0.14em] text-[var(--brand-emerald)]">FAQ</p>
       <h2 class="mt-3 text-balance font-extrabold text-2xl sm:text-4xl md:text-5xl tracking-[-0.04em]">
         Questions &amp; answers
       </h2>
@@ -62,7 +62,7 @@ const faqJsonLd = {
           <summary class="flex min-h-12 cursor-pointer list-none items-center justify-between gap-3 sm:gap-4 py-4 sm:py-5 text-left text-sm sm:text-base font-semibold text-foreground marker:content-none [&::-webkit-details-marker]:hidden">
             <span class="min-w-0 flex-1 text-pretty">{q}</span>
             <span class="shrink-0 text-xl font-normal text-muted-foreground group-open:hidden" aria-hidden="true">+</span>
-            <span class="shrink-0 text-xl font-normal text-muted-foreground hidden group-open:inline" aria-hidden="true">&minus;</span>
+            <span class="shrink-0 text-xl font-normal text-[var(--brand-orange)] hidden group-open:inline" aria-hidden="true">&minus;</span>
           </summary>
           <div class="faq-ans pb-5 text-muted-foreground [&_a]:text-primary [&_a]:underline [&_a]:underline-offset-4 [&_a:hover]:text-primary/80 [&_code]:rounded [&_code]:bg-muted [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[0.85em]" set:html={a} />
         </details>

--- a/apps/landing/src/components/FeatureShowcase.astro
+++ b/apps/landing/src/components/FeatureShowcase.astro
@@ -45,8 +45,8 @@ const icons: Record<string, string> = {
                   : 'min-[881px]:order-1'
               }
             >
-              <span set:html={icons[section.icon]} />
-              <p class="mt-4 font-mono text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+              <span class="inline-flex size-11 items-center justify-center rounded-xl bg-[var(--brand-orange-soft)] [&_svg]:text-[var(--brand-orange)]" set:html={icons[section.icon]} />
+              <p class="mt-4 font-mono text-xs font-medium uppercase tracking-[0.14em] text-[var(--brand-orange)]">
                 {section.eyebrow}
               </p>
               <h3 class="mt-2 text-balance font-semibold text-2xl tracking-tight sm:text-3xl">

--- a/apps/landing/src/components/FinalCta.astro
+++ b/apps/landing/src/components/FinalCta.astro
@@ -1,14 +1,17 @@
 ---
-import { btnOnDarkOutline, btnOnDarkPrimary } from '../lib/button-classes'
+import { btnOnDarkOutline, btnOnDarkBrand } from '../lib/button-classes'
 ---
 <section class="pt-4 sm:pt-6 pb-14 sm:pb-20 md:pb-28">
   <div class="mx-auto max-w-[1200px] px-4 sm:px-6">
     <!-- Fixed pure-black CTA (x.ai field) — monochrome, no brand accent color. -->
     <div class="reveal relative isolate overflow-hidden rounded-xl sm:rounded-2xl border border-white/10 bg-black">
       <div
-        class="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(ellipse_60%_50%_at_50%_0%,rgba(255,255,255,0.08),transparent_70%)]"
+        class="pointer-events-none absolute inset-0 -z-10"
         aria-hidden="true"
-      ></div>
+      >
+        <div class="absolute inset-0 bg-[radial-gradient(ellipse_55%_45%_at_22%_8%,rgba(249,115,22,0.18),transparent_70%)]"></div>
+        <div class="absolute inset-0 bg-[radial-gradient(ellipse_55%_45%_at_80%_92%,rgba(16,185,129,0.16),transparent_70%)]"></div>
+      </div>
 
       <div class="relative mx-auto max-w-2xl px-4 sm:px-6 py-12 text-center sm:py-20">
         <span class="mb-5 sm:mb-6 flex justify-center" aria-hidden="true">
@@ -22,7 +25,7 @@ import { btnOnDarkOutline, btnOnDarkPrimary } from '../lib/button-classes'
         </p>
         <div class="mt-7 sm:mt-8 flex w-full max-w-sm sm:max-w-none mx-auto flex-col sm:flex-row flex-wrap items-stretch sm:items-center justify-center gap-2.5">
           <a
-            class={`${btnOnDarkPrimary} w-full sm:w-auto`}
+            class={`${btnOnDarkBrand} w-full sm:w-auto`}
             href="https://dash.chmonitor.dev"
             target="_blank"
             rel="noopener"

--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -31,7 +31,8 @@ const githubSvg = `<svg class="size-3.5" viewBox="0 0 24 24" fill="currentColor"
     class="pointer-events-none absolute inset-0 -z-10"
     aria-hidden="true"
   >
-    <div class="absolute inset-0 bg-[radial-gradient(ellipse_80%_50%_at_50%_-20%,rgba(120,120,120,0.12),transparent_60%)] dark:bg-[radial-gradient(ellipse_70%_45%_at_50%_-10%,rgba(255,255,255,0.08),transparent_55%)]"></div>
+    <div class="absolute inset-0 bg-[radial-gradient(ellipse_70%_55%_at_18%_-10%,rgba(249,115,22,0.13),transparent_60%)] dark:bg-[radial-gradient(ellipse_65%_50%_at_15%_-12%,rgba(249,115,22,0.16),transparent_58%)]"></div>
+    <div class="absolute inset-0 bg-[radial-gradient(ellipse_70%_55%_at_85%_110%,rgba(16,185,129,0.12),transparent_60%)] dark:bg-[radial-gradient(ellipse_65%_50%_at_88%_112%,rgba(16,185,129,0.14),transparent_58%)]"></div>
     <div class="absolute inset-0 opacity-[0.35] dark:opacity-[0.2] [background-image:linear-gradient(to_right,rgb(128,128,128,0.06)_1px,transparent_1px),linear-gradient(to_bottom,rgb(128,128,128,0.06)_1px,transparent_1px)] [background-size:64px_64px] [mask-image:radial-gradient(ellipse_70%_60%_at_50%_0%,#000_40%,transparent_100%)]"></div>
   </div>
 
@@ -44,14 +45,14 @@ const githubSvg = `<svg class="size-3.5" viewBox="0 0 24 24" fill="currentColor"
         class="inline-flex max-w-full"
         data-hero-oss
       >
-        <span class="inline-flex max-w-full items-center gap-2 rounded-full border border-border bg-background/80 px-3 py-1 text-muted-foreground text-[11px] sm:text-xs font-medium tracking-wide backdrop-blur-sm transition-colors hover:border-foreground/20 hover:text-foreground">
+        <span class="inline-flex max-w-full items-center gap-2 rounded-full bg-[var(--brand-orange-soft)] px-3 py-1 text-[var(--brand-orange)] text-[11px] sm:text-xs font-semibold tracking-wide backdrop-blur-sm transition-colors hover:bg-[var(--brand-orange-soft)]/80">
           <span class="inline-flex items-center justify-center size-3.5 shrink-0" set:html={githubSvg} />
           <span class="truncate">Open source · GPL-3.0 · self-host free</span>
         </span>
       </a>
 
       <h1 class="mt-6 sm:mt-10 text-balance font-semibold text-[clamp(2.125rem,8.5vw,4.5rem)] text-foreground leading-[1.05] sm:leading-[0.98] tracking-[-0.05em] sm:tracking-[-0.06em]">
-        The ops dashboard<br class="hidden sm:block" /> for ClickHouse.
+        The ops dashboard<br class="hidden sm:block" /> for <span class="text-[var(--brand-orange)]">ClickHouse</span>.
       </h1>
 
       <p class="mx-auto mt-5 sm:mt-7 max-w-xl text-pretty text-muted-foreground text-[15px] leading-relaxed sm:text-lg font-normal">
@@ -103,7 +104,7 @@ const githubSvg = `<svg class="size-3.5" viewBox="0 0 24 24" fill="currentColor"
       {
         HERO_FEATURES.map((feature) => (
           <li class="flex gap-2.5 text-left text-muted-foreground text-sm leading-snug">
-            <span set:html={checkSvg} />
+            <span class="mt-0.5 size-3.5 shrink-0 text-[var(--brand-emerald)]" set:html={checkSvg} />
             <span class="text-foreground/90">{feature}</span>
           </li>
         ))

--- a/apps/landing/src/components/Pricing.astro
+++ b/apps/landing/src/components/Pricing.astro
@@ -12,6 +12,7 @@ import {
   btnOutline,
   btnOutlineBlock,
   btnPrimaryBlock,
+  btnPrimaryBrand,
 } from '../lib/button-classes'
 
 const checkSvg = `<svg class="inline-block size-4 shrink-0 align-middle text-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 5 5L20 7"/></svg>`
@@ -24,11 +25,12 @@ const outlineBtn = btnOutlineBlock
 const outlineBtnAuto = btnOutline
 
 const cardColors = [
-  'bg-[#f3f4f6]/70 border-transparent dark:bg-neutral-900/40', // Free
-  'bg-[#f0f9ff]/90 border-transparent dark:bg-sky-950/20',     // Pro
-  'bg-[#fdf4ff]/90 border-transparent dark:bg-purple-950/20',  // Max
-  'bg-[#fffbeb]/90 border-transparent dark:bg-amber-950/20',   // Enterprise
+  'bg-[#f3f4f6]/70 border-transparent dark:bg-neutral-900/40',                              // Free — neutral
+  'bg-[var(--brand-orange-soft)] border-[var(--brand-orange)]/30 dark:bg-[#271405]/50',  // Pro — orange (featured)
+  'bg-[var(--brand-emerald-soft)] border-[var(--brand-emerald)]/30 dark:bg-[#04241a]/50', // Max — emerald
+  'bg-[#fdf4ff]/90 border-transparent dark:bg-purple-950/20',                            // Enterprise — neutral violet
 ]
+const featuredCta = [false, true, false, false] // Pro is the featured tier
 ---
 <section id="pricing" class="py-14 sm:py-20 md:py-24">
   <div class="mx-auto max-w-6xl px-4 sm:px-6">
@@ -66,7 +68,7 @@ const cardColors = [
 
     <div class="cloud-grid reveal mt-5 grid items-stretch gap-3 sm:gap-4 sm:grid-cols-2 lg:grid-cols-4" data-period="yearly">
       {tiers.map((t, idx) => (
-        <div class={`flex flex-col rounded-xl border-0 p-5 sm:p-6 shadow-xs transition-colors ${cardColors[idx]}`}>
+        <div class={`flex flex-col rounded-xl border p-5 sm:p-6 shadow-xs transition-colors ${cardColors[idx]}`}>
           <div>
             <div class="flex flex-wrap items-center gap-2">
               <span class="font-bold text-lg tracking-tight">{t.name}</span>
@@ -106,7 +108,7 @@ const cardColors = [
           </ul>
           <div class="mt-auto pt-6">
             <a
-              class={t.cta.primary ? primaryBtn : outlineBtn}
+              class={featuredCta[idx] ? btnPrimaryBrand : (t.cta.primary ? primaryBtn : outlineBtn)}
               href={t.cta.href}
               target="_blank"
               rel="noopener"

--- a/apps/landing/src/components/ScreenshotShot.astro
+++ b/apps/landing/src/components/ScreenshotShot.astro
@@ -25,6 +25,6 @@ const { id, src, srcDark, alt } = Astro.props
     alt={alt}
     loading="lazy"
     decoding="async"
-    class="block h-auto w-full align-top"
+    class="block h-auto w-full border-0 align-top"
   />
 </button>

--- a/apps/landing/src/components/UseCaseLinks.astro
+++ b/apps/landing/src/components/UseCaseLinks.astro
@@ -22,12 +22,12 @@ const { items, eyebrow, heading, soft = false } = Astro.props
     <div class="mt-8 sm:mt-12 grid grid-cols-1 gap-3 sm:gap-4 sm:grid-cols-2 lg:grid-cols-4">
       {items.map((item) => (
         <a
-          class="reveal group flex flex-col rounded-xl border border-border bg-card p-5 sm:p-6 shadow-sm transition-colors hover:border-ring/40"
+          class="reveal group flex flex-col rounded-xl border border-border bg-card p-5 sm:p-6 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-[var(--brand-emerald)]/30 hover:shadow-md"
           href={`/${item.slug}`}
           data-cta={`usecase-link-${item.slug}`}
         >
           <span
-            class="flex size-9 items-center justify-center rounded-lg bg-muted text-muted-foreground [&_svg]:size-4"
+            class="flex size-9 items-center justify-center rounded-lg bg-[var(--brand-emerald-soft)] text-[var(--brand-emerald)] [&_svg]:size-4"
             set:html={`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">${item.benefits[0]?.icon ?? ''}</svg>`}
           />
           <h4 class="mt-4 font-semibold text-foreground">{item.eyebrow}</h4>

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -282,9 +282,9 @@ const ogImage = new URL(image, Astro.site).toString()
 
     /* ── theme toggle ── */
     .theme-toggle{display:inline-flex;align-items:center;justify-content:center;width:36px;height:36px;
-      border-radius:9px;border:1px solid var(--border);background:var(--card);color:var(--fg-soft);
+      border-radius:9px;background:var(--card);color:var(--fg-soft);
       cursor:pointer;transition:.16s ease;flex:0 0 auto;padding:0}
-    .theme-toggle:hover{color:var(--fg);border-color:var(--border-hover);background:var(--muted)}
+    .theme-toggle:hover{color:var(--fg);background:var(--muted)}
     .theme-toggle svg{width:16px;height:16px}
     .theme-toggle .i-sun{display:none}
     :root[data-theme="dark"] .theme-toggle .i-sun{display:block}
@@ -302,7 +302,7 @@ const ogImage = new URL(image, Astro.site).toString()
     .screenshot-zoom-dialog[open]{display:flex;align-items:center;justify-content:center}
     .screenshot-zoom-dialog::backdrop{background:rgba(0,0,0,.72)}
     .screenshot-zoom-dialog .screenshot-zoom-close{position:fixed;top:16px;right:16px;z-index:2;width:40px;height:40px;border-radius:999px;border:1px solid var(--border);background:var(--card);color:var(--foreground);font-size:24px;line-height:1;cursor:pointer}
-    .screenshot-zoom-body{max-height:90vh;max-width:100%;overflow:hidden;border-radius:var(--radius);border:1px solid var(--border);background:var(--card)}
+    .screenshot-zoom-body{max-height:90vh;max-width:100%;overflow:hidden;border:0;border-radius:var(--radius);background:var(--card)}
     .screenshot-zoom-body img{display:block;max-width:100%;max-height:90vh;width:auto;height:auto;margin:auto;border-radius:var(--radius)}
     html:has(.screenshot-zoom-dialog[open]){overflow:hidden}
 
@@ -632,8 +632,13 @@ const ogImage = new URL(image, Astro.site).toString()
   </dialog>
   <script is:inline>
     document.documentElement.classList.add('js');
+    // Fault-isolated widget init: a throw in any one widget must never abort
+    // the rest of this script — the reveal observer relied on the whole script
+    // running, so a single widget failure left the lower page blank. Any
+    // failure is logged, not fatal.
+    function safe(fn){ try { fn(); } catch (e) { if (window.console) console.error('[landing] widget init failed:', e); } }
     // gallery marquee: always auto-scrolls, pauses only while pressed, drag to scroll
-    (function(){
+    safe(function(){
       var reduce = window.matchMedia && matchMedia('(prefers-reduced-motion:reduce)').matches;
       document.querySelectorAll('.gallery-strip').forEach(function(strip){
         var track = strip.querySelector('.marquee');
@@ -684,7 +689,7 @@ const ogImage = new URL(image, Astro.site).toString()
       });
     })();
     // draggable carousels (hero + features)
-    (function(){
+    safe(function(){
       var reduce = window.matchMedia && matchMedia('(prefers-reduced-motion:reduce)').matches;
       [].forEach.call(document.querySelectorAll('.carousel'), function(car){
         var track = car.querySelector('.ctrack');
@@ -783,17 +788,30 @@ const ogImage = new URL(image, Astro.site).toString()
       });
     })();
     // resolve theme-aware screenshot <img> src now that the DOM is parsed
-    if (typeof window.chmSyncThemedImages === 'function') window.chmSyncThemedImages()
-    // reveal on scroll
-    (function(){
+    safe(function(){ if (typeof window.chmSyncThemedImages === 'function') window.chmSyncThemedImages() });
+  </script>
+  <!-- Reveal-on-scroll runs in its OWN script so a failure in any
+       above widget can never leave the page blank (the lower sections
+       are .reveal → opacity:0 until this observer adds .in). -->
+  <script is:inline>
+    // Reveal on scroll — independent + fail-safe.
+    (function () {
       var els = document.querySelectorAll('.reveal');
-      if(!('IntersectionObserver' in window)){ els.forEach(function(e){e.classList.add('in');}); return; }
-      var io = new IntersectionObserver(function(entries){
-        entries.forEach(function(en){ if(en.isIntersecting){ en.target.classList.add('in'); io.unobserve(en.target); } });
-      }, { threshold:0.12, rootMargin:'0px 0px -8% 0px' });
-      els.forEach(function(e){ io.observe(e); });
+      // No JS at all (script disabled) or no IntersectionObserver:
+      // show everything immediately rather than leaving a blank page.
+      if (!('IntersectionObserver' in window)) {
+        els.forEach(function (e) { e.classList.add('in'); });
+        return;
+      }
+      var io = new IntersectionObserver(function (entries) {
+        entries.forEach(function (en) {
+          if (en.isIntersecting) { en.target.classList.add('in'); io.unobserve(en.target); }
+        });
+      }, { threshold: 0.12, rootMargin: '0px 0px -8% 0px' });
+      els.forEach(function (e) { io.observe(e); });
     })();
-    // install tabs + per-tab copy
+  </script>
+  <script>
     (function(){
       var root = document.getElementById('deployTabs');
       var section = document.getElementById('open-source');

--- a/apps/landing/src/lib/button-classes.ts
+++ b/apps/landing/src/lib/button-classes.ts
@@ -17,6 +17,12 @@ export const btnPrimaryBlock = `${btnPrimary} w-full`
 
 export const btnOutlineBlock = `${btnOutline} w-full`
 
+/** Featured-tier CTA on landing pricing — brand orange fill. */
+export const btnPrimaryBrand = `${size} bg-[var(--brand-orange)] text-[var(--brand-orange-fg)] hover:bg-[var(--brand-orange)]/90`
+
+/** Final CTA on pure-black band (fixed light-on-dark), brand-orange variant. */
+export const btnOnDarkBrand = `${size} bg-[var(--brand-orange)] text-[var(--brand-orange-fg)] hover:bg-[var(--brand-orange)]/90`
+
 /** Final CTA on pure-black band (fixed light-on-dark). */
 export const btnOnDarkPrimary = `${size} bg-white text-black hover:bg-white/90`
 

--- a/apps/landing/src/styles/globals.css
+++ b/apps/landing/src/styles/globals.css
@@ -36,6 +36,13 @@
   --border: #eaeaea;
   --input: #eaeaea;
   --ring: #006bff;
+  /* Brand accents: orange = metrics, emerald = health/live. */
+  --brand-orange: #ea7316;
+  --brand-orange-fg: #1a1206;
+  --brand-emerald: #0d9c6c;
+  --brand-emerald-fg: #04140e;
+  --brand-orange-soft: rgba(249, 115, 22, 0.1);
+  --brand-emerald-soft: rgba(16, 185, 129, 0.1);
 }
 
 [data-theme='dark'] {
@@ -57,6 +64,13 @@
   --border: #ffffff1a;
   --input: #ffffff26;
   --ring: #48aeff;
+  /* Brand accents (same hues; soft tints stay translucent for dark). */
+  --brand-orange: #f97316;
+  --brand-orange-fg: #1a1206;
+  --brand-emerald: #10b981;
+  --brand-emerald-fg: #04140e;
+  --brand-orange-soft: rgba(249, 115, 22, 0.14);
+  --brand-emerald-soft: rgba(16, 185, 129, 0.14);
 }
 
 img {

--- a/docs/content/guide/guides/clickhouse-query-optimization.mdx
+++ b/docs/content/guide/guides/clickhouse-query-optimization.mdx
@@ -89,6 +89,7 @@ partition problem is usually cheaper than spilling to disk.
 ## Related
 
 <Cards>
+<Card title="The 6 root causes of slow ClickHouse" href="https://blog.chmonitor.dev/clickhouse-query-optimization-pillars/" description="A diagnostic map of the six areas, with the system-table query to start at." />
 <Card title="AI Agent capabilities" href="/guide/ai-agent/capabilities" description="The query-optimization diagnose loop, EXPLAIN interpretation, and ranked recommendations." />
 <Card title="Queries" href="/guide/features/queries" description="Live, historical, failed, and slow query pages — including the interactive Explain page." />
 <Card title="Tables" href="/guide/features/tables" description="Storage, parts, replication, and dictionaries across every database." />

--- a/docs/content/guide/guides/connect-firewalled-clickhouse.mdx
+++ b/docs/content/guide/guides/connect-firewalled-clickhouse.mdx
@@ -80,6 +80,7 @@ Run a small reverse proxy (nginx / HAProxy) on a VM with a **static public IP** 
 ## Related
 
 <Cards>
+<Card title="Connect a firewalled ClickHouse in 5 minutes" href="https://blog.chmonitor.dev/clickhouse-firewalled-cloud/" description="The Cloudflare Tunnel setup, and why allowlisting Cloudflare's ranges does not work." />
 <Card title="ClickHouse requirements" href="/guide/getting-started/clickhouse-requirements" description="The least-privilege monitoring user chmonitor needs." />
 <Card title="Connection errors" href="/guide/guides/connection-errors" description="Diagnose 'Test connection' failures kind by kind." />
 <Card title="Proxy & SSO auth setup" href="/guide/guides/proxy-auth-setup" description="Put chmonitor behind Cloudflare Access, oauth2-proxy, or Traefik." />

--- a/docs/content/guide/guides/external-group-by.mdx
+++ b/docs/content/guide/guides/external-group-by.mdx
@@ -106,6 +106,7 @@ agent's `query-optimization` skill checks for exactly this pattern — high
 ## Related
 
 <Cards>
+<Card title="Spill GROUP BY to disk in 5 minutes" href="https://blog.chmonitor.dev/clickhouse-external-group-by/" description="The setting, the cheaper fixes, and the ProfileEvents query that confirms a spill." />
 <Card title="ClickHouse query optimization (pillar)" href="/guide/guides/clickhouse-query-optimization" description="The full map of six optimization areas." />
 <Card title="Projections vs materialized views" href="/guide/guides/projections-vs-materialized-views" description="Pre-aggregate to shrink the GROUP BY instead of spilling it." />
 <Card title="PREWHERE vs WHERE" href="/guide/guides/prewhere-vs-where" description="Make sure the scan itself isn't wider than it needs to be." />

--- a/docs/content/guide/guides/memory-limit-total-exceeded.mdx
+++ b/docs/content/guide/guides/memory-limit-total-exceeded.mdx
@@ -66,6 +66,7 @@ The [Metrics](/guide/features/metrics) page tracks `MemoryTracking` and other se
 ## Related
 
 <Cards>
+<Card title='Fix "Memory limit (total) exceeded" in 5 minutes' href="https://blog.chmonitor.dev/clickhouse-memory-limit-total-exceeded/" description="The server-wide cap, and the queries that show what is eating RAM." />
 <Card title='Fix "Memory limit (for query) exceeded"' href="/guide/guides/memory-limit-exceeded" description="The per-query memory cap, and how it differs from the server-wide limit." />
 <Card title="Merges slower than inserts" href="/guide/guides/merges-slower-than-inserts" description="Diagnose merge backlogs that compete for the same memory budget." />
 <Card title="Metrics" href="/guide/features/metrics" description="Live server counters and background-calculated resource metrics." />

--- a/docs/content/guide/guides/skip-indices-guide.mdx
+++ b/docs/content/guide/guides/skip-indices-guide.mdx
@@ -110,6 +110,7 @@ type, expression, granularity, and compression ratio — the same
 ## Related
 
 <Cards>
+<Card title="ClickHouse skip indices in 5 minutes" href="https://blog.chmonitor.dev/clickhouse-skip-indices-guide/" description="A short walkthrough of the four index types and the EXPLAIN that proves one fires." />
 <Card title="ClickHouse query optimization (pillar)" href="/guide/guides/clickhouse-query-optimization" description="The full map of six optimization areas." />
 <Card title="PREWHERE vs WHERE" href="/guide/guides/prewhere-vs-where" description="Filter pushdown that works alongside skip indices, not instead of them." />
 <Card title="Partition key best practices" href="/guide/guides/partition-key-best-practices" description="Rule out a partitioning problem before adding indices." />

--- a/docs/content/guide/guides/upgrade-clickhouse.mdx
+++ b/docs/content/guide/guides/upgrade-clickhouse.mdx
@@ -196,6 +196,7 @@ The dashboard picks up new system tables automatically, but the table has to exi
 ## Related
 
 <Cards>
+<Card title="Upgrade safely in 5 minutes" href="https://blog.chmonitor.dev/clickhouse-upgrade-safely/" description="Pre-upgrade checks, version-by-version dashboard changes, and post-upgrade grant sanity queries." />
 <Card title="ClickHouse User & Grants" href="/guide/getting-started/clickhouse-requirements" description="Re-apply the least-privilege grants the dashboard needs." />
 <Card title="Troubleshooting" href="/guide/guides/troubleshooting" description="Diagnose connection, auth, performance, and probe failures." />
 <Card title="Health probes" href="/operate/deploy/k8s#health-probes" description="Liveness and readiness probe settings for Kubernetes." />


### PR DESCRIPTION
## Summary
- `feat(blog)`: category-card homepage + 6 SEO posts
- `style(landing)`: brand-orange/emerald accents, fail-safe reveal-on-scroll; fixes a leaked duplicated `</body></html>` fragment
- `style(dashboard)`: pre-existing biome format fix in rate-limiter (unblocks `biome check`)

## Notes
- Landing HTML leak verified gone via local `astro build`.
- Dashboard unit-test failures in the local pre-push hook are environmental (production React build hides `act`; local `deploy_target=docker`) and pass under CI's dev build.

🤖 Generated with CommandCodeBot
