### PR TITLE
fix(postgres): resolve pg from app root in the node/Docker build

### DIFF
--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -584,6 +584,11 @@ export default defineConfig({
     // path — dedupe forces these bare specifiers to resolve from the app root.
     dedupe: [
       '@clickhouse/client-web',
+      // `pg` is a dep of @chm/postgres-client (bundled from source). In the
+      // Docker node build the packages/* dirs are copied WITHOUT node_modules,
+      // so `pg` only exists in the app's own node_modules — dedupe forces this
+      // bare specifier to resolve from the app root, exactly like the deps below.
+      'pg',
       'lru-cache',
       'zod',
       'react',


### PR DESCRIPTION
Follow-up to #2571. The OSS node-server Docker build (`build:node:ci`) fails with:

```
[vite]: Rolldown failed to resolve import "pg" from packages/postgres-client/src/client.ts
```

**Cause:** the Docker `builder` stage copies `packages/` WITHOUT node_modules and only the app's `node_modules`. So when rolldown bundles `@chm/postgres-client` (from source) and hits `import 'pg'`, `pg` is unresolvable from the package dir — it only exists in the app's node_modules. Worker + local builds passed because `pnpm install` had symlinked `packages/postgres-client/node_modules/pg` into the app store, which the Docker builder doesn't copy.

**Fix:** add `pg` to vite `resolve.dedupe` so the bare specifier resolves from the app root — the exact pattern already used for `@clickhouse/client-web` / `zod` / `lru-cache` (the other @chm-package deps).

**Verified:** `docker build --target builder` — `build:node:ci` completes, `pg` bundled, zero resolve errors, reaches image export. This keeps the OSS-parity invariant intact (self-hosted Node image must build with pg bundled).

https://claude.ai/code/session_01Vr3H4qxbgDVXgFM2trPeCD