### PR TITLE
feat(agent): postgres cross-source tools (phase 4)

### DIFF
--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -101,6 +101,19 @@ CHM_FEATURE_AGENT_ACCESS=public
 # both cloud and self-hosted; a pure env gate (no Clerk requirement) so OSS has
 # equal Postgres support. Everything Postgres stays inert until this is on.
 # CHM_FEATURE_POSTGRES_SOURCE=false
+# Postgres sources the AI agent can query (read-only) when the flag above is on.
+# Comma-separated, index-aligned lists (the id space is a flat pgHostId index,
+# like CLICKHOUSE_* → hostId). A single POSTGRES_USER/POSTGRES_PASSWORD applies
+# to all hosts. Host entries accept host or host:port; POSTGRES_PORT is the
+# fallback (default 5432). These are operator-supplied hosts, trusted like
+# CLICKHOUSE_HOST. See docs/content/guide/ai-agent/configuration.mdx.
+# POSTGRES_HOST=db.internal:5432
+# POSTGRES_PORT=5432
+# POSTGRES_USER=readonly
+# POSTGRES_PASSWORD=
+# POSTGRES_DATABASE=postgres
+# POSTGRES_SSLMODE=require
+# POSTGRES_NAME=Primary
 
 # Allow connecting to private / LAN / loopback / Tailscale (100.64.0.0/10 CGNAT)
 # ClickHouse hosts through the connection form. SELF-HOST ONLY — it is forced OFF

--- a/apps/dashboard/src/lib/ai/agent/prompts/clickhouse-instructions.ts
+++ b/apps/dashboard/src/lib/ai/agent/prompts/clickhouse-instructions.ts
@@ -150,6 +150,18 @@ everything else.
 When enabled: **kill_query**, **optimize_table**, **kill_mutation**. Always confirm
 with the user before calling. If they are not available, do not pretend to run them —
 explain the change and how the user can apply it.
+
+### Cross-source (Postgres — env-gated, off by default)
+Present only when a Postgres source engine is configured. These read a Postgres
+database (never ClickHouse) and take a \`pgHostId\` (the Postgres source index),
+NOT a ClickHouse \`hostId\`.
+- **run_postgres_select_query**: Run a read-only SQL query against a Postgres source. SELECT / WITH / SHOW / EXPLAIN / TABLE / VALUES only (writes and multi-statement strings are rejected; the session is pinned read-only). Required \`sql\`, \`pgHostId\`; optional \`limit\`.
+- **get_postgres_metrics**: Postgres health — version, uptime, connection counts by state, buffer-cache hit ratio, transaction commit/rollback + deadlocks, database size, and replication status. Required \`pgHostId\`. The Postgres analog of **get_metrics**.
+- **list_postgres_slow_query_patterns**: Top normalized slow-query patterns from \`pg_stat_statements\` (calls, total/mean exec time, rows, cache-hit, WAL bytes). Required \`pgHostId\`; optional \`limit\`. Returns an informative message when the extension is not installed. The Postgres analog of **list_slow_query_patterns**.
+
+To answer a cross-source question, call a ClickHouse tool (e.g. **query**) and a
+Postgres tool in the same turn, then correlate the two results yourself in your
+answer — there is no join tool.
 `
 
 const SEC_SKILLS = `

--- a/apps/dashboard/src/lib/ai/agent/tools/__tests__/postgres-tools-gate.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/__tests__/postgres-tools-gate.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for the Postgres cross-source tool gate in createAllTools().
+ *
+ * The three Postgres tools (run_postgres_select_query, get_postgres_metrics,
+ * list_postgres_slow_query_patterns) must be ABSENT — not merely failing —
+ * unless CHM_FEATURE_POSTGRES_SOURCE === 'true'. A regression would advertise
+ * Postgres tools to the model on a deployment that never enabled the source
+ * engine. Mirrors create-all-tools-gate.test.ts (control-tool gate).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+mock.module('server-only', () => ({}))
+mock.module('@chm/clickhouse-client', () => ({
+  getClient: async () => ({
+    command: async () => ({}),
+    insert: async () => ({}),
+    query: async () => ({ json: async () => [] }),
+  }),
+  fetchData: async () => ({ data: [], error: null }),
+}))
+
+const { createAllTools } = await import('../index')
+
+const POSTGRES_TOOLS = [
+  'run_postgres_select_query',
+  'get_postgres_metrics',
+  'list_postgres_slow_query_patterns',
+] as const
+
+describe('createAllTools — Postgres source gate', () => {
+  const original = process.env.CHM_FEATURE_POSTGRES_SOURCE
+
+  beforeEach(() => {
+    delete process.env.CHM_FEATURE_POSTGRES_SOURCE
+  })
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.CHM_FEATURE_POSTGRES_SOURCE
+    } else {
+      process.env.CHM_FEATURE_POSTGRES_SOURCE = original
+    }
+  })
+
+  test('excludes Postgres tools when the flag is unset', () => {
+    const tools = createAllTools(0)
+    for (const name of POSTGRES_TOOLS) expect(tools).not.toHaveProperty(name)
+  })
+
+  test('includes Postgres tools when CHM_FEATURE_POSTGRES_SOURCE=true', () => {
+    process.env.CHM_FEATURE_POSTGRES_SOURCE = 'true'
+    const tools = createAllTools(0)
+    for (const name of POSTGRES_TOOLS) expect(tools).toHaveProperty(name)
+  })
+
+  test('a non-"true" flag value does not enable Postgres tools', () => {
+    process.env.CHM_FEATURE_POSTGRES_SOURCE = '1'
+    const tools = createAllTools(0)
+    for (const name of POSTGRES_TOOLS) expect(tools).not.toHaveProperty(name)
+  })
+
+  test('Postgres tools are independent of the control-tool gate', () => {
+    process.env.CHM_FEATURE_POSTGRES_SOURCE = 'true'
+    // includeControlTools=false, control env unset — control tools stay off,
+    // Postgres tools still on.
+    const tools = createAllTools(0, false)
+    for (const name of POSTGRES_TOOLS) expect(tools).toHaveProperty(name)
+    expect(tools).not.toHaveProperty('kill_query')
+  })
+})

--- a/apps/dashboard/src/lib/ai/agent/tools/__tests__/postgres-tools.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/__tests__/postgres-tools.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Unit tests for the agent's Postgres cross-source tools.
+ *
+ * The read-only SELECT-only gate itself (assertReadOnlyStatement) is exercised
+ * against the REAL Phase-2 client in
+ * apps/dashboard/src/lib/connection-query/postgres-readonly.test.ts and
+ * packages/postgres-client; here we mock the shared `runPostgresReadOnly`
+ * helper so these tests stay hermetic and focus on the tools' own behavior:
+ * result shaping/truncation, the metrics summary math, and the graceful
+ * "extension not installed" branch.
+ */
+
+import { z } from 'zod'
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// These tools import result helpers from `./helpers`, which pulls
+// `@chm/clickhouse-client` (which imports `server-only`) at module load. Mock
+// only `server-only` — NOT `@chm/sql-builder` — so this file does not leak an
+// incomplete sql-builder mock into other suites (e.g. tool-docs-sync) that need
+// the real module. `../postgres-helpers` is mocked so no real Postgres runs.
+mock.module('server-only', () => ({}))
+
+const mockRun = mock(
+  async (
+    _pgHostId: number,
+    _sql: string,
+    _params?: ReadonlyArray<unknown>
+  ): Promise<{ rows: any[]; fields: any[] }> => ({ rows: [], fields: [] })
+) as any
+
+mock.module('../postgres-helpers', () => ({
+  pgHostIdSchema: z.coerce.number().int().nonnegative(),
+  runPostgresReadOnly: mockRun,
+}))
+
+const { createPostgresQueryTools } = await import('../postgres-query-tools')
+const { createPostgresHealthTools } = await import('../postgres-health-tools')
+
+beforeEach(() => {
+  mockRun.mockReset()
+  mockRun.mockImplementation(async () => ({ rows: [], fields: [] }))
+})
+
+describe('run_postgres_select_query', () => {
+  test('returns rows untruncated for a small result', async () => {
+    mockRun.mockImplementation(async () => ({
+      rows: [{ id: 1 }, { id: 2 }],
+      fields: [],
+    }))
+    const tools = createPostgresQueryTools() as any
+    const result = await tools.run_postgres_select_query.execute({
+      sql: 'SELECT id FROM t',
+      pgHostId: 0,
+    })
+    expect(result.data).toEqual([{ id: 1 }, { id: 2 }])
+    expect(result.truncated).toBe(false)
+    expect(result.note).toBeUndefined()
+  })
+
+  test('truncates to the requested limit and adds a note', async () => {
+    mockRun.mockImplementation(async () => ({
+      rows: [{ id: 1 }, { id: 2 }, { id: 3 }],
+      fields: [],
+    }))
+    const tools = createPostgresQueryTools() as any
+    const result = await tools.run_postgres_select_query.execute({
+      sql: 'SELECT id FROM t',
+      pgHostId: 0,
+      limit: 2,
+    })
+    expect(result.data).toHaveLength(2)
+    expect(result.truncated).toBe(true)
+    expect(result.note).toContain('truncated')
+  })
+
+  test('propagates a gate/driver error thrown by the query path', async () => {
+    mockRun.mockImplementation(async () => {
+      throw new Error(
+        'Only read-only statements are allowed (SELECT, WITH, SHOW, EXPLAIN, TABLE, VALUES)'
+      )
+    })
+    const tools = createPostgresQueryTools() as any
+    await expect(
+      tools.run_postgres_select_query.execute({
+        sql: 'INSERT INTO t VALUES (1)',
+        pgHostId: 0,
+      })
+    ).rejects.toThrow(/read-only/)
+  })
+})
+
+describe('list_postgres_slow_query_patterns', () => {
+  test('returns an informative message when pg_stat_statements is missing', async () => {
+    mockRun.mockImplementation(async (_id: number, sql: string) => {
+      if (sql.includes('pg_extension'))
+        return { rows: [{ present: 0 }], fields: [] }
+      return { rows: [], fields: [] }
+    })
+    const tools = createPostgresQueryTools() as any
+    const result = await tools.list_postgres_slow_query_patterns.execute({
+      pgHostId: 0,
+    })
+    expect(result.available).toBe(false)
+    expect(result.message).toContain('pg_stat_statements')
+    // Must NOT have queried the (nonexistent) view.
+    const queriedView = mockRun.mock.calls.some((c: any[]) =>
+      String(c[1]).includes('FROM pg_stat_statements')
+    )
+    expect(queriedView).toBe(false)
+  })
+
+  test('returns patterns when the extension is present', async () => {
+    const patterns = [{ queryid: '1', query: 'SELECT 1', calls: 10 }]
+    mockRun.mockImplementation(async (_id: number, sql: string) => {
+      if (sql.includes('pg_extension'))
+        return { rows: [{ present: 1 }], fields: [] }
+      if (sql.includes('FROM pg_stat_statements'))
+        return { rows: patterns, fields: [] }
+      return { rows: [], fields: [] }
+    })
+    const tools = createPostgresQueryTools() as any
+    const result = await tools.list_postgres_slow_query_patterns.execute({
+      pgHostId: 0,
+      limit: 5,
+    })
+    expect(result.available).toBe(true)
+    expect(result.patterns).toEqual(patterns)
+  })
+})
+
+describe('get_postgres_metrics', () => {
+  test('assembles version, connections, cache ratio, transactions, and replication', async () => {
+    mockRun.mockImplementation(async (_id: number, sql: string) => {
+      if (sql.includes('pg_postmaster_start_time')) {
+        return {
+          rows: [
+            {
+              version: 'PostgreSQL 17.0',
+              uptime_seconds: '3600',
+              blks_hit: '900',
+              blks_read: '100',
+              xact_commit: '50',
+              xact_rollback: '2',
+              deadlocks: '0',
+              db_size_bytes: '1048576',
+              db_size: '1024 kB',
+              is_replica: false,
+              replica_lag_seconds: null,
+            },
+          ],
+          fields: [],
+        }
+      }
+      if (sql.includes('pg_stat_activity')) {
+        return {
+          rows: [
+            { state: 'active', count: 3 },
+            { state: 'idle', count: 5 },
+          ],
+          fields: [],
+        }
+      }
+      if (sql.includes('pg_stat_replication')) {
+        return { rows: [], fields: [] }
+      }
+      return { rows: [], fields: [] }
+    })
+
+    const tools = createPostgresHealthTools() as any
+    const result = await tools.get_postgres_metrics.execute({ pgHostId: 0 })
+
+    expect(result.version).toBe('PostgreSQL 17.0')
+    expect(result.uptime_seconds).toBe(3600)
+    expect(result.connections.total).toBe(8)
+    expect(result.connections.by_state).toEqual({ active: 3, idle: 5 })
+    // 900 hits / (900 + 100) = 90.00%
+    expect(result.cache.hit_pct).toBe(90)
+    expect(result.transactions.xact_commit).toBe(50)
+    expect(result.transactions.deadlocks).toBe(0)
+    expect(result.database.size_bytes).toBe(1048576)
+    expect(result.replication.is_replica).toBe(false)
+    expect(result.replication.standbys).toEqual([])
+  })
+
+  test('reports replica lag when the source is in recovery', async () => {
+    mockRun.mockImplementation(async (_id: number, sql: string) => {
+      if (sql.includes('pg_postmaster_start_time')) {
+        return {
+          rows: [
+            {
+              version: 'PostgreSQL 17.0',
+              uptime_seconds: '10',
+              blks_hit: '0',
+              blks_read: '0',
+              xact_commit: '0',
+              xact_rollback: '0',
+              deadlocks: '0',
+              db_size_bytes: '0',
+              db_size: '0 bytes',
+              is_replica: true,
+              replica_lag_seconds: 1.5,
+            },
+          ],
+          fields: [],
+        }
+      }
+      return { rows: [], fields: [] }
+    })
+
+    const tools = createPostgresHealthTools() as any
+    const result = await tools.get_postgres_metrics.execute({ pgHostId: 0 })
+    expect(result.replication.is_replica).toBe(true)
+    expect(result.replication.replica_lag_seconds).toBe(1.5)
+    // No blocks read/hit → cache hit ratio is null, not a divide-by-zero.
+    expect(result.cache.hit_pct).toBeNull()
+  })
+})

--- a/apps/dashboard/src/lib/ai/agent/tools/index.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/index.ts
@@ -16,6 +16,8 @@ import { createInsightTools } from './insight-tools'
 import { createMergeTools } from './merge-tools'
 import { createMvDesignerTools } from './mv-designer-tools'
 import { createPlanTools } from './plan-tools'
+import { createPostgresHealthTools } from './postgres-health-tools'
+import { createPostgresQueryTools } from './postgres-query-tools'
 import { createQueryTools } from './query-tools'
 import { createReferenceQueryTools } from './reference-query-tools'
 import { createReplicationTools } from './replication-tools'
@@ -46,9 +48,15 @@ import { createVisualizationTools } from './visualization-tools'
  *  - Advisor: recommend_materialized_view
  *  - Dashboards: suggest_dashboard
  *  - Control (destructive, env-gated): kill_query, optimize_table, kill_mutation
+ *  - Postgres (cross-source, env-gated): run_postgres_select_query,
+ *    get_postgres_metrics, list_postgres_slow_query_patterns
  */
 export function createAllTools(hostId: number, includeControlTools = false) {
   const enableControlTools = process.env.AGENT_ENABLE_CONTROL_TOOLS === 'true'
+  // Postgres cross-source tools stay ABSENT (not merely failing) unless the
+  // source engine is enabled — a pure env gate, no Clerk, so OSS has equal
+  // support. Server reads the canonical CHM_* name (VITE_* is the client mirror).
+  const enablePostgresTools = process.env.CHM_FEATURE_POSTGRES_SOURCE === 'true'
 
   return {
     // Schema & exploration
@@ -98,6 +106,15 @@ export function createAllTools(hostId: number, includeControlTools = false) {
     // Control actions (destructive) — off unless explicitly enabled
     ...(enableControlTools && includeControlTools
       ? createControlTools(hostId)
+      : {}),
+
+    // Postgres cross-source tools — off unless CHM_FEATURE_POSTGRES_SOURCE=true.
+    // They take an explicit `pgHostId` per call, so no hostId is threaded here.
+    ...(enablePostgresTools
+      ? {
+          ...createPostgresQueryTools(),
+          ...createPostgresHealthTools(),
+        }
       : {}),
   }
 }

--- a/apps/dashboard/src/lib/ai/agent/tools/postgres-health-tools.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/postgres-health-tools.ts
@@ -1,0 +1,140 @@
+/**
+ * Postgres health tool for the agent (cross-source, env-gated).
+ *
+ * `get_postgres_metrics` is the Postgres analog of ClickHouse `get_metrics`:
+ * version/uptime, connection counts by state, buffer-cache hit ratio,
+ * transaction commit/rollback + deadlocks, database size, and replication
+ * status (lag on a replica, connected standbys on a primary).
+ *
+ * All reads go through the shared Phase-2 read-only path. The scalar summary is
+ * one round-trip (subselects), connections and standbys are one each — three
+ * queries total, all plain SELECTs.
+ */
+
+import { z } from 'zod'
+
+import { pgHostIdSchema, runPostgresReadOnly } from './postgres-helpers'
+import { dynamicTool } from 'ai'
+
+/** One-shot scalar summary: version, uptime, cache, xacts, size, recovery. */
+const SUMMARY_SQL = `SELECT
+  version() AS version,
+  extract(epoch FROM (now() - pg_postmaster_start_time()))::bigint AS uptime_seconds,
+  (SELECT sum(blks_hit) FROM pg_stat_database)::bigint AS blks_hit,
+  (SELECT sum(blks_read) FROM pg_stat_database)::bigint AS blks_read,
+  (SELECT sum(xact_commit) FROM pg_stat_database)::bigint AS xact_commit,
+  (SELECT sum(xact_rollback) FROM pg_stat_database)::bigint AS xact_rollback,
+  (SELECT sum(deadlocks) FROM pg_stat_database)::bigint AS deadlocks,
+  pg_database_size(current_database())::bigint AS db_size_bytes,
+  pg_size_pretty(pg_database_size(current_database())) AS db_size,
+  pg_is_in_recovery() AS is_replica,
+  CASE
+    WHEN pg_is_in_recovery()
+    THEN extract(epoch FROM (now() - pg_last_xact_replay_timestamp()))::float
+    ELSE NULL
+  END AS replica_lag_seconds`
+
+/** Connection counts grouped by backend state. */
+const CONNECTIONS_SQL = `SELECT coalesce(state, 'unknown') AS state, count(*)::int AS count
+FROM pg_stat_activity
+GROUP BY state
+ORDER BY count DESC`
+
+/** Connected standbys (primary side); empty on a replica or standalone. */
+const STANDBYS_SQL = `SELECT
+  application_name,
+  client_addr::text AS client_addr,
+  state,
+  sync_state,
+  extract(epoch FROM write_lag)::float AS write_lag_seconds,
+  extract(epoch FROM flush_lag)::float AS flush_lag_seconds,
+  extract(epoch FROM replay_lag)::float AS replay_lag_seconds
+FROM pg_stat_replication`
+
+type SummaryRow = {
+  version: string
+  uptime_seconds: number | string | null
+  blks_hit: number | string | null
+  blks_read: number | string | null
+  xact_commit: number | string | null
+  xact_rollback: number | string | null
+  deadlocks: number | string | null
+  db_size_bytes: number | string | null
+  db_size: string | null
+  is_replica: boolean
+  replica_lag_seconds: number | null
+}
+
+/** Coerce a possibly-bigint-as-string numeric column to a JS number. */
+function toNum(v: number | string | null | undefined): number {
+  if (v === null || v === undefined) return 0
+  return typeof v === 'number' ? v : Number(v)
+}
+
+export function createPostgresHealthTools() {
+  return {
+    get_postgres_metrics: dynamicTool({
+      description:
+        'Get health metrics for a Postgres source: version and uptime, connection counts by state (pg_stat_activity), buffer-cache hit ratio (pg_stat_database), transaction commit/rollback and deadlock counts, current database size, and replication status (lag on a replica, connected standbys on a primary). The Postgres analog of ClickHouse `get_metrics`. Requires `pgHostId`.',
+      inputSchema: z.object({
+        pgHostId: pgHostIdSchema,
+      }),
+      execute: async (input: unknown) => {
+        const { pgHostId } = input as { pgHostId: number }
+
+        const [summaryRes, connectionsRes, standbysRes] = await Promise.all([
+          runPostgresReadOnly<SummaryRow>(pgHostId, SUMMARY_SQL),
+          runPostgresReadOnly<{ state: string; count: number }>(
+            pgHostId,
+            CONNECTIONS_SQL
+          ),
+          runPostgresReadOnly<Record<string, unknown>>(pgHostId, STANDBYS_SQL),
+        ])
+
+        const s = summaryRes.rows[0]
+        const blksHit = toNum(s?.blks_hit)
+        const blksRead = toNum(s?.blks_read)
+        const cacheDenom = blksHit + blksRead
+        const cacheHitPct =
+          cacheDenom > 0
+            ? Math.round((blksHit * 10000) / cacheDenom) / 100
+            : null
+
+        const connectionsByState: Record<string, number> = {}
+        let totalConnections = 0
+        for (const row of connectionsRes.rows) {
+          connectionsByState[row.state] = row.count
+          totalConnections += row.count
+        }
+
+        return {
+          version: s?.version,
+          uptime_seconds: toNum(s?.uptime_seconds),
+          connections: {
+            total: totalConnections,
+            by_state: connectionsByState,
+          },
+          cache: {
+            blks_hit: blksHit,
+            blks_read: blksRead,
+            hit_pct: cacheHitPct,
+          },
+          transactions: {
+            xact_commit: toNum(s?.xact_commit),
+            xact_rollback: toNum(s?.xact_rollback),
+            deadlocks: toNum(s?.deadlocks),
+          },
+          database: {
+            size_bytes: toNum(s?.db_size_bytes),
+            size: s?.db_size,
+          },
+          replication: {
+            is_replica: Boolean(s?.is_replica),
+            replica_lag_seconds: s?.replica_lag_seconds ?? null,
+            standbys: standbysRes.rows,
+          },
+        }
+      },
+    }),
+  }
+}

--- a/apps/dashboard/src/lib/ai/agent/tools/postgres-helpers.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/postgres-helpers.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared helpers for the agent's Postgres tools.
+ *
+ * These tools resolve a `pgHostId` against the env-based `POSTGRES_*` lists
+ * (see `@chm/postgres-client`'s `getPostgresConfigs`) and execute through the
+ * ONE read-only Postgres query path Phase 2 built (`queryPostgres`): a
+ * per-request connect that pins `default_transaction_read_only=on`, gates the
+ * SQL to a single SELECT/WITH/SHOW/EXPLAIN/TABLE/VALUES statement, and always
+ * uses the extended protocol (rejecting multi-statement strings at the wire).
+ *
+ * SSRF note: env-configured Postgres hosts are OPERATOR-supplied config, the
+ * exact trust level as `CLICKHOUSE_HOST`. The ClickHouse agent path
+ * (`getClickHouseConfigs` → `fetchData`) does NOT SSRF-guard its env hosts —
+ * `validatePostgresHost` guards only browser/user-supplied connections in the
+ * connection routes. We MATCH that precedent here and do not re-guard env
+ * hosts; the guard would otherwise block loopback/LAN operators point at
+ * on purpose.
+ */
+
+import { z } from 'zod'
+
+import {
+  formatPostgresError,
+  getAndValidatePostgresConfig,
+  queryPostgres,
+} from '@chm/postgres-client'
+
+/**
+ * Required per-call `pgHostId` — a flat positional index into the `POSTGRES_*`
+ * env lists. Unlike the ClickHouse `hostId` (which defaults to 0), the Postgres
+ * tools have no ambient default host, so this is required. Null / empty-string
+ * are normalized to `undefined` so they fail validation loudly instead of
+ * silently coercing to source 0.
+ */
+export const pgHostIdSchema = z
+  .preprocess((val) => {
+    if (val === null || val === undefined) return undefined
+    if (typeof val === 'string' && val.trim() === '') return undefined
+    return val
+  }, z.coerce.number().int().nonnegative())
+  .describe('Postgres source id (index into the POSTGRES_* env lists)')
+
+/**
+ * Resolve `pgHostId` → env config and run ONE read-only statement through the
+ * shared Phase-2 query path. Returns the rows and field metadata `pg` reports.
+ *
+ * Throws for an unconfigured / out-of-range `pgHostId` or a rejected (non
+ * read-only / multi-) statement; connection/driver errors are normalized with
+ * their SQLSTATE via {@link formatPostgresError} so the model gets an
+ * actionable message.
+ */
+export async function runPostgresReadOnly<
+  T extends Record<string, unknown> = Record<string, unknown>,
+>(
+  pgHostId: number,
+  sql: string,
+  params?: ReadonlyArray<unknown>
+): Promise<{ rows: T[]; fields: { name: string; dataTypeID: number }[] }> {
+  const config = getAndValidatePostgresConfig(pgHostId)
+  try {
+    return await queryPostgres<T>(config, sql, params)
+  } catch (err) {
+    throw new Error(formatPostgresError(err))
+  }
+}

--- a/apps/dashboard/src/lib/ai/agent/tools/postgres-query-tools.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/postgres-query-tools.ts
@@ -1,0 +1,117 @@
+/**
+ * Postgres query tools for the agent (cross-source, env-gated).
+ *
+ * `run_postgres_select_query` is the Postgres analog of the ClickHouse `query`
+ * tool: a read-only-enforced SELECT primitive. `list_postgres_slow_query_patterns`
+ * mirrors ClickHouse's `list_slow_query_patterns`, but over `pg_stat_statements`.
+ *
+ * Both resolve a per-call `pgHostId` and run through the shared Phase-2
+ * read-only path (`runPostgresReadOnly` → `queryPostgres`). Cross-source
+ * correlation is prompting-only: the model calls a ClickHouse tool and one of
+ * these in the same turn and correlates the results itself — no join primitive.
+ */
+
+import { z } from 'zod'
+
+import { capResultRows, truncationNote } from './helpers'
+import { pgHostIdSchema, runPostgresReadOnly } from './postgres-helpers'
+import { dynamicTool } from 'ai'
+
+/** Top-N `pg_stat_statements` patterns ranked by total execution time. */
+const SLOW_PATTERNS_SQL = `SELECT
+  queryid::text AS queryid,
+  query,
+  calls,
+  round(total_exec_time::numeric, 2) AS total_exec_ms,
+  round(mean_exec_time::numeric, 2) AS mean_exec_ms,
+  rows,
+  round(
+    shared_blks_hit * 100.0 / nullif(shared_blks_hit + shared_blks_read, 0),
+    2
+  ) AS cache_hit_pct,
+  wal_bytes
+FROM pg_stat_statements
+ORDER BY total_exec_time DESC
+LIMIT $1`
+
+export function createPostgresQueryTools() {
+  return {
+    run_postgres_select_query: dynamicTool({
+      description:
+        'Execute a read-only SQL query against a Postgres source. Only a single SELECT / WITH / SHOW / EXPLAIN / TABLE / VALUES statement is allowed (writes, DDL, and multi-statement strings are rejected, and the session is pinned read-only server-side). Use this to inspect a Postgres database and, in the same conversation, correlate its data with ClickHouse results from the `query` tool. Requires `pgHostId` (the Postgres source index).',
+      inputSchema: z.object({
+        sql: z.string().describe('The read-only SQL query to execute'),
+        pgHostId: pgHostIdSchema,
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(1000)
+          .optional()
+          .describe(
+            'Optional cap on rows returned to the model (default 1000).'
+          ),
+      }),
+      execute: async (input: unknown) => {
+        const { sql, pgHostId, limit } = input as {
+          sql: string
+          pgHostId: number
+          limit?: number
+        }
+        const { rows } = await runPostgresReadOnly(pgHostId, sql)
+        const { data, truncated } = capResultRows(rows, limit)
+        return {
+          data,
+          truncated,
+          ...(truncated && { note: truncationNote(limit) }),
+        }
+      },
+    }),
+
+    list_postgres_slow_query_patterns: dynamicTool({
+      description:
+        'List the slowest NORMALIZED query patterns on a Postgres source — `pg_stat_statements` aggregated per normalized statement, ranked by total execution time, with calls, total/mean exec time (ms), rows, shared-buffer cache-hit ratio, and WAL bytes. The Postgres analog of ClickHouse `list_slow_query_patterns`; use it as the first step of a "why is this Postgres database slow?" investigation. Requires `pgHostId`. Returns an informative message (not an error) when the `pg_stat_statements` extension is not installed.',
+      inputSchema: z.object({
+        pgHostId: pgHostIdSchema,
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(100)
+          .optional()
+          .default(10)
+          .describe('Number of top patterns to return (default 10).'),
+      }),
+      execute: async (input: unknown) => {
+        const { pgHostId, limit = 10 } = input as {
+          pgHostId: number
+          limit?: number
+        }
+
+        // Graceful degradation: pg_stat_statements is an optional extension.
+        // Probe pg_extension first so a missing extension yields an
+        // informative result instead of an "undefined table" throw.
+        const { rows: extRows } = await runPostgresReadOnly<{
+          present: number
+        }>(
+          pgHostId,
+          "SELECT count(*)::int AS present FROM pg_extension WHERE extname = 'pg_stat_statements'"
+        )
+        if (!extRows[0]?.present) {
+          return {
+            available: false,
+            message:
+              'The pg_stat_statements extension is not installed on this Postgres source, so normalized slow-query patterns are unavailable. Ask an administrator to add it (shared_preload_libraries + CREATE EXTENSION pg_stat_statements), or use run_postgres_select_query against pg_stat_activity for currently-running queries instead.',
+          }
+        }
+
+        const { rows } = await runPostgresReadOnly(
+          pgHostId,
+          SLOW_PATTERNS_SQL,
+          [limit]
+        )
+        return { available: true, patterns: rows }
+      },
+    }),
+  }
+}

--- a/apps/dashboard/src/lib/ai/agent/tools/tool-docs-sync.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/tool-docs-sync.test.ts
@@ -28,15 +28,24 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 const originalControlToolsEnv = process.env.AGENT_ENABLE_CONTROL_TOOLS
-// createAllTools reads this env var at call time (not import time), so it
-// must be set before calling it below — see tools/index.ts.
+const originalPostgresEnv = process.env.CHM_FEATURE_POSTGRES_SOURCE
+// createAllTools reads these env vars at call time (not import time), so they
+// must be set before calling it below — see tools/index.ts. Enabling both the
+// control-tool and Postgres gates makes every gated tool present, so the docs
+// / prompt sync assertions below cover them too.
 process.env.AGENT_ENABLE_CONTROL_TOOLS = 'true'
+process.env.CHM_FEATURE_POSTGRES_SOURCE = 'true'
 
 afterAll(() => {
   if (originalControlToolsEnv === undefined) {
     delete process.env.AGENT_ENABLE_CONTROL_TOOLS
   } else {
     process.env.AGENT_ENABLE_CONTROL_TOOLS = originalControlToolsEnv
+  }
+  if (originalPostgresEnv === undefined) {
+    delete process.env.CHM_FEATURE_POSTGRES_SOURCE
+  } else {
+    process.env.CHM_FEATURE_POSTGRES_SOURCE = originalPostgresEnv
   }
 })
 
@@ -86,11 +95,11 @@ const MCP_SERVER_TOOL_NAMES = [
 ] as const
 
 describe('AI agent tool docs stay in sync with the code', () => {
-  test('createAllTools(0, true) exposes 27 default + 3 gated control tools', () => {
-    // Loud guard: if this drops to 27, AGENT_ENABLE_CONTROL_TOOLS was not
-    // honored above and the control-tool assertions below would silently
-    // never run.
-    expect(toolNames.length).toBe(30)
+  test('createAllTools(0, true) exposes 27 default + 3 control + 3 Postgres tools', () => {
+    // Loud guard: if this drops below 33, AGENT_ENABLE_CONTROL_TOOLS or
+    // CHM_FEATURE_POSTGRES_SOURCE was not honored above and the gated-tool
+    // assertions below would silently never run.
+    expect(toolNames.length).toBe(33)
   })
 
   test('every agent tool is documented in ai-agent/capabilities.mdx', () => {

--- a/docs/content/guide/ai-agent.mdx
+++ b/docs/content/guide/ai-agent.mdx
@@ -33,8 +33,11 @@ The agent connects through the **same ClickHouse host and user** as the rest of 
 | Schema & data-type advice | ORDER BY/keys, codecs, skip indexes, column type right-sizing |
 | Tuning & upgrades | Hardware-based settings, version-upgrade guidance |
 | Charts & visualization | Run SQL and render an interactive chart inline |
+| Cross-source Postgres (opt-in) | Read-only SELECT, health metrics, and slow-query patterns against a Postgres source, correlated with ClickHouse in one conversation |
 
 A small set of tools delivers this: dedicated primitives for the common reads, and the `query` tool plus an expert **skill** recipe for everything else. See [Capabilities](/guide/ai-agent/capabilities) for the full list.
+
+**Cross-source Postgres** — with `CHM_FEATURE_POSTGRES_SOURCE=true` and one or more Postgres sources configured via the `POSTGRES_*` env lists (`POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DATABASE`, `POSTGRES_SSLMODE`, `POSTGRES_NAME`), the agent also gains read-only Postgres tools — `run_postgres_select_query`, `get_postgres_metrics`, and `list_postgres_slow_query_patterns` — that take a `pgHostId` (an index into those lists). It can then query ClickHouse and Postgres in the same conversation and correlate the results. Off by default; see [Configuration](/guide/ai-agent/configuration#cross-source-postgres-tools).
 
 **Skills** — when a question needs domain depth, the agent loads a bundled expert guide (a skill) with copy-pasteable SQL recipes before answering. Eighteen skills cover data analysis, anomaly detection, query tuning, schema & data-type design, hardware tuning, version upgrades, concept explanations, incident response, plan-and-verify, and the core domains (replication, cluster, storage, migration, security, best practices, troubleshooting, system tables). Available skills: `GET /api/v1/agent/skills`.
 

--- a/docs/content/guide/ai-agent/capabilities.mdx
+++ b/docs/content/guide/ai-agent/capabilities.mdx
@@ -4,7 +4,7 @@ description: Full reference for the agent's 26+ tools, 18 expert skills, plan-an
 icon: Sparkles
 ---
 
-The agent exposes a small set of **powerful primitives** (26 tools, plus 3 env-gated control tools). Anything without a dedicated tool is done by writing SQL with the `query` tool, guided by a **skill** recipe. You never call tools directly — the agent picks and chains them automatically.
+The agent exposes a small set of **powerful primitives** (27 tools, plus 3 env-gated control tools and 3 env-gated cross-source Postgres tools). Anything without a dedicated tool is done by writing SQL with the `query` tool, guided by a **skill** recipe. You never call tools directly — the agent picks and chains them automatically.
 
 ## Tools
 
@@ -22,11 +22,16 @@ The agent exposes a small set of **powerful primitives** (26 tools, plus 3 env-g
 | Advisor | Ranked skip-index/projection/partition/PREWHERE recommendations for a slow query (recommend-only) | `get_optimization_recommendations` |
 | Dashboards | Suggest a dashboard layout from registry charts for a natural-language request (recommend-only) | `suggest_dashboard` |
 | Control actions (env-gated) | Kill query/mutation, optimize table | `kill_query`, `kill_mutation`, `optimize_table` |
+| Cross-source Postgres (env-gated) | Read-only SELECT, health metrics, and slow-query patterns against a Postgres source, for correlating with ClickHouse in one conversation | `run_postgres_select_query`, `get_postgres_metrics`, `list_postgres_slow_query_patterns` |
 
 Everything else (expensive-query rankings, query patterns, anomalies, table-design advice, settings, logs, replication queue, ZooKeeper, users…) is done with `query` plus the relevant skill recipe — so the agent keeps full reach with a much smaller, more reliable tool surface.
 
 <Callout type="warn" title="Control tools are off by default">
 Control tools (`kill_query`, `kill_mutation`, `optimize_table`) are disabled unless `AGENT_ENABLE_CONTROL_TOOLS=true`. The agent always confirms before using them.
+</Callout>
+
+<Callout type="info" title="Cross-source Postgres tools are off by default">
+The Postgres tools (`run_postgres_select_query`, `get_postgres_metrics`, `list_postgres_slow_query_patterns`) appear only when `CHM_FEATURE_POSTGRES_SOURCE=true` and at least one Postgres source is configured via the `POSTGRES_*` env lists (see [Configuration](/guide/ai-agent/configuration)). They read Postgres over the read-only `pg` path and take a `pgHostId` (an index into the `POSTGRES_*` lists), so the agent can correlate ClickHouse and Postgres in one conversation. They read env-configured Postgres hosts; per-user (D1) Postgres connections are not yet visible to the agent — the same limitation as the ClickHouse agent tools.
 </Callout>
 
 ### Tool reference
@@ -63,6 +68,9 @@ Control tools (`kill_query`, `kill_mutation`, `optimize_table`) are disabled unl
 | `kill_query` | Kill a running query by `query_id`. | **DESTRUCTIVE.** Env-gated: requires `AGENT_ENABLE_CONTROL_TOOLS=true`. Agent always confirms first. |
 | `kill_mutation` | Cancel a running mutation on a table. | **DESTRUCTIVE.** Env-gated: requires `AGENT_ENABLE_CONTROL_TOOLS=true`. Agent always confirms first. |
 | `optimize_table` | Trigger an OPTIMIZE on a table to force merges. | **DESTRUCTIVE.** Env-gated: requires `AGENT_ENABLE_CONTROL_TOOLS=true`. Agent always confirms first. |
+| `run_postgres_select_query` | Execute a read-only SQL query against a Postgres source (`pgHostId`). | Env-gated: requires `CHM_FEATURE_POSTGRES_SOURCE=true`. SELECT / WITH / SHOW / EXPLAIN / TABLE / VALUES only — writes and multi-statement strings are rejected and the session is pinned read-only. Results capped (default 1000 rows) with a `truncated` flag + note. |
+| `get_postgres_metrics` | Postgres health for a source (`pgHostId`): version, uptime, connection counts by state, buffer-cache hit ratio, transaction commit/rollback + deadlocks, database size, and replication status. | Env-gated: requires `CHM_FEATURE_POSTGRES_SOURCE=true`. Reads `pg_stat_activity`, `pg_stat_database`, `pg_stat_replication`. The Postgres analog of `get_metrics`. |
+| `list_postgres_slow_query_patterns` | Top normalized slow-query patterns from `pg_stat_statements` (`pgHostId`): calls, total/mean exec time, rows, shared-buffer cache-hit ratio, WAL bytes. | Env-gated: requires `CHM_FEATURE_POSTGRES_SOURCE=true`. Returns an informative message (not an error) when the `pg_stat_statements` extension is not installed. The Postgres analog of `list_slow_query_patterns`. |
 
 ## Skills
 

--- a/docs/content/guide/ai-agent/configuration.mdx
+++ b/docs/content/guide/ai-agent/configuration.mdx
@@ -87,6 +87,46 @@ curl -H "Authorization: Bearer $AGENT_API_TOKEN" \
      https://your-host/api/v1/agent
 ```
 
+## Cross-source Postgres tools
+
+Set `CHM_FEATURE_POSTGRES_SOURCE=true` to expose the agent's read-only Postgres
+tools (`run_postgres_select_query`, `get_postgres_metrics`,
+`list_postgres_slow_query_patterns`). They resolve a per-call `pgHostId` against
+the `POSTGRES_*` env lists below — a flat positional index, exactly like a
+ClickHouse `hostId` indexes the `CLICKHOUSE_*` lists. All lists are
+comma-separated and index-aligned with `POSTGRES_HOST`; a single `POSTGRES_USER`
+/ `POSTGRES_PASSWORD` broadcasts to every host.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `CHM_FEATURE_POSTGRES_SOURCE` | `false` | Master gate. When `true`, the three Postgres tools are added to the agent. Pure env gate (no Clerk) so self-hosted has equal support. |
+| `POSTGRES_HOST` | — | Comma-separated Postgres hosts (`host` or `host:port`). Defines the `pgHostId` id space. |
+| `POSTGRES_PORT` | `5432` | Ports (used when a host has no inline `:port`). |
+| `POSTGRES_USER` | `postgres` | Users; a single value applies to all hosts. |
+| `POSTGRES_PASSWORD` | — | Passwords; a single value applies to all hosts. |
+| `POSTGRES_DATABASE` | `postgres` | Database names. |
+| `POSTGRES_SSLMODE` | — | libpq `sslmode` (`disable` \| `require` \| `verify-full`). |
+| `POSTGRES_NAME` | — | Display names for the sources. |
+
+<Callout type="info" title="Env hosts only, for now">
+The agent's Postgres tools read **env-configured** hosts (`POSTGRES_*`), like the
+ClickHouse tools read `CLICKHOUSE_*`. Per-user (D1) Postgres connections managed
+in the UI are not yet visible to the agent — the same limitation the ClickHouse
+agent tools already have. Env Postgres hosts are operator-supplied and trusted
+(no SSRF re-guard), matching the `CLICKHOUSE_HOST` precedent.
+</Callout>
+
+Point the Postgres user at a **read-only** role. The tools pin the session
+read-only and gate the SQL, but a least-privilege user is defense in depth.
+
+```bash
+CHM_FEATURE_POSTGRES_SOURCE=true
+POSTGRES_HOST=db.internal:5432
+POSTGRES_USER=readonly
+POSTGRES_PASSWORD=secret
+POSTGRES_DATABASE=appdb
+```
+
 ### Least-privilege ClickHouse user
 
 The agent's `query` tool (and the [MCP server](/reference/mcp-server)) run

--- a/packages/postgres-client/src/index.ts
+++ b/packages/postgres-client/src/index.ts
@@ -25,6 +25,11 @@ export {
   sslOptionsForMode,
 } from './client'
 export {
+  getAndValidatePostgresConfig,
+  getPostgresConfigs,
+  type PostgresSourceConfig,
+} from './postgres-config'
+export {
   DEFAULT_SOURCE_ENGINE,
   isSourceEngine,
   parseSourceEngine,

--- a/packages/postgres-client/src/postgres-config.test.ts
+++ b/packages/postgres-client/src/postgres-config.test.ts
@@ -1,0 +1,110 @@
+import {
+  getAndValidatePostgresConfig,
+  getPostgresConfigs,
+} from './postgres-config'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+const PG_ENV_KEYS = [
+  'POSTGRES_HOST',
+  'POSTGRES_PORT',
+  'POSTGRES_USER',
+  'POSTGRES_PASSWORD',
+  'POSTGRES_DATABASE',
+  'POSTGRES_SSLMODE',
+  'POSTGRES_NAME',
+] as const
+
+const saved: Record<string, string | undefined> = {}
+
+beforeEach(() => {
+  for (const k of PG_ENV_KEYS) {
+    saved[k] = process.env[k]
+    delete process.env[k]
+  }
+})
+
+afterEach(() => {
+  for (const k of PG_ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k]
+    else process.env[k] = saved[k]
+  }
+})
+
+describe('getPostgresConfigs — env-based pgHostId resolver', () => {
+  test('returns an empty list when POSTGRES_HOST is unset', () => {
+    expect(getPostgresConfigs()).toEqual([])
+  })
+
+  test('parses a single host with defaults', () => {
+    process.env.POSTGRES_HOST = 'db.example.com'
+    process.env.POSTGRES_USER = 'postgres'
+    process.env.POSTGRES_PASSWORD = 'secret'
+    process.env.POSTGRES_DATABASE = 'appdb'
+
+    const configs = getPostgresConfigs()
+    expect(configs).toHaveLength(1)
+    expect(configs[0]).toEqual({
+      id: 0,
+      host: 'db.example.com',
+      port: 5432,
+      user: 'postgres',
+      password: 'secret',
+      database: 'appdb',
+    })
+  })
+
+  test('honors an inline host:port and falls back to postgres/5432 defaults', () => {
+    process.env.POSTGRES_HOST = 'db.example.com:5433'
+    const [config] = getPostgresConfigs()
+    expect(config.host).toBe('db.example.com')
+    expect(config.port).toBe(5433)
+    expect(config.user).toBe('postgres')
+    expect(config.password).toBe('')
+    expect(config.database).toBe('postgres')
+  })
+
+  test('POSTGRES_PORT list wins when no inline port is present', () => {
+    process.env.POSTGRES_HOST = 'a.example.com,b.example.com'
+    process.env.POSTGRES_PORT = '5432,6543'
+    const configs = getPostgresConfigs()
+    expect(configs.map((c) => c.port)).toEqual([5432, 6543])
+  })
+
+  test('broadcasts a single user/password across multiple hosts', () => {
+    process.env.POSTGRES_HOST = 'a.example.com,b.example.com'
+    process.env.POSTGRES_USER = 'shared'
+    process.env.POSTGRES_PASSWORD = 'pw'
+    const configs = getPostgresConfigs()
+    expect(configs.map((c) => c.user)).toEqual(['shared', 'shared'])
+    expect(configs.map((c) => c.password)).toEqual(['pw', 'pw'])
+  })
+
+  test('carries sslmode and customName when provided', () => {
+    process.env.POSTGRES_HOST = 'db.example.com'
+    process.env.POSTGRES_SSLMODE = 'verify-full'
+    process.env.POSTGRES_NAME = 'Prod'
+    const [config] = getPostgresConfigs()
+    expect(config.sslmode).toBe('verify-full')
+    expect(config.customName).toBe('Prod')
+  })
+})
+
+describe('getAndValidatePostgresConfig', () => {
+  test('throws a clear error when no sources are configured', () => {
+    expect(() => getAndValidatePostgresConfig(0)).toThrow(
+      /No Postgres sources configured/
+    )
+  })
+
+  test('throws with the available range when pgHostId is out of range', () => {
+    process.env.POSTGRES_HOST = 'a.example.com,b.example.com'
+    expect(() => getAndValidatePostgresConfig(5)).toThrow(
+      /Invalid pgHostId: 5\. Available Postgres sources: 0-1/
+    )
+  })
+
+  test('resolves a valid pgHostId', () => {
+    process.env.POSTGRES_HOST = 'a.example.com,b.example.com'
+    expect(getAndValidatePostgresConfig(1).host).toBe('b.example.com')
+  })
+})

--- a/packages/postgres-client/src/postgres-config.ts
+++ b/packages/postgres-client/src/postgres-config.ts
@@ -1,0 +1,130 @@
+/**
+ * Postgres source configuration — the env-based `pgHostId` resolver.
+ *
+ * The sibling of `@chm/clickhouse-client`'s `clickhouse-config.ts`. A
+ * `pgHostId` is a flat positional index into the comma-separated `POSTGRES_*`
+ * env lists (see the `PgHostId` note in `./index`), exactly the way a
+ * ClickHouse `hostId` indexes the `CLICKHOUSE_*` lists. This is the id space the
+ * agent's Postgres tools resolve against: operator-supplied, no per-user store,
+ * no Clerk — so self-hosted (OSS) has equal Postgres support.
+ *
+ * Everything here is inert unless `CHM_FEATURE_POSTGRES_SOURCE=true` gates the
+ * tools on; an unset `POSTGRES_HOST` simply yields an empty config list.
+ */
+
+import type { PostgresConnectionConfig } from './client'
+
+/** A resolved Postgres source: connection params + its id and display name. */
+export interface PostgresSourceConfig extends PostgresConnectionConfig {
+  /** `pgHostId` — flat positional index into the `POSTGRES_*` env lists. */
+  id: number
+  /** Operator-supplied display name (`POSTGRES_NAME`), if any. */
+  customName?: string
+}
+
+/** Default Postgres TCP port when neither an inline `host:port` nor list gives one. */
+const DEFAULT_PG_PORT = 5432
+
+function splitByComma(value: string | undefined): string[] {
+  if (!value) return []
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+/**
+ * Split a host entry into `host` + optional inline port.
+ *
+ * Accepts `db.example.com`, `db.example.com:5433`, or a bare IPv4. IPv6 with a
+ * port would be ambiguous with a bare `::1`, so an inline port is only parsed
+ * when there's exactly one `:` and the tail is all digits; otherwise the whole
+ * value is treated as the host and the port comes from `POSTGRES_PORT`.
+ */
+function parseHostEntry(entry: string): { host: string; inlinePort?: number } {
+  const idx = entry.lastIndexOf(':')
+  if (idx > 0 && idx === entry.indexOf(':')) {
+    const tail = entry.slice(idx + 1)
+    if (/^\d+$/.test(tail)) {
+      return { host: entry.slice(0, idx), inlinePort: Number(tail) }
+    }
+  }
+  return { host: entry }
+}
+
+/**
+ * Parse the `POSTGRES_*` env lists into indexed source configs.
+ *
+ * Env vars (all comma-separated, index-aligned with `POSTGRES_HOST`):
+ *  - `POSTGRES_HOST`     — hosts (`host` or `host:port`); the id space.
+ *  - `POSTGRES_PORT`     — ports; falls back to inline port then 5432.
+ *  - `POSTGRES_USER`     — users; a single value broadcasts to all hosts.
+ *  - `POSTGRES_PASSWORD` — passwords; a single value broadcasts to all hosts.
+ *  - `POSTGRES_DATABASE` — databases; falls back to the first, then `postgres`.
+ *  - `POSTGRES_SSLMODE`  — libpq sslmodes; falls back to the first.
+ *  - `POSTGRES_NAME`     — display names.
+ *
+ * Not memoized (unlike the ClickHouse resolver) because agent tool calls are
+ * infrequent and tests mutate `process.env` between calls; re-parsing keeps it
+ * honest and stays cheap.
+ */
+export function getPostgresConfigs(): PostgresSourceConfig[] {
+  const hostEntries = splitByComma(process.env.POSTGRES_HOST)
+  if (hostEntries.length === 0) return []
+
+  const ports = splitByComma(process.env.POSTGRES_PORT)
+  const users = splitByComma(process.env.POSTGRES_USER)
+  const passwords = splitByComma(process.env.POSTGRES_PASSWORD)
+  const databases = splitByComma(process.env.POSTGRES_DATABASE)
+  const sslmodes = splitByComma(process.env.POSTGRES_SSLMODE)
+  const names = splitByComma(process.env.POSTGRES_NAME)
+
+  const broadcastUser = users.length === 1
+  const broadcastPassword = passwords.length === 1
+
+  return hostEntries.map((entry, index) => {
+    const { host, inlinePort } = parseHostEntry(entry)
+    const listPort = ports[index] ?? ports[0]
+    const port = inlinePort ?? (listPort ? Number(listPort) : DEFAULT_PG_PORT)
+
+    const user = broadcastUser ? users[0] : (users[index] ?? 'postgres')
+    const password = broadcastPassword ? passwords[0] : (passwords[index] ?? '')
+    const database = databases[index] ?? databases[0] ?? 'postgres'
+    const sslmode = sslmodes[index] ?? sslmodes[0]
+    const customName = names[index]
+
+    return {
+      id: index,
+      host,
+      port: Number.isFinite(port) ? port : DEFAULT_PG_PORT,
+      user,
+      password,
+      database,
+      ...(sslmode ? { sslmode } : {}),
+      ...(customName ? { customName } : {}),
+    }
+  })
+}
+
+/**
+ * Resolve a single Postgres source by `pgHostId`, throwing a clear error when
+ * none are configured or the id is out of range. Centralises the "lookup +
+ * validate" step for the agent's Postgres tools.
+ */
+export function getAndValidatePostgresConfig(
+  pgHostId: number
+): PostgresSourceConfig {
+  const configs = getPostgresConfigs()
+  if (configs.length === 0) {
+    throw new Error(
+      'No Postgres sources configured. Set POSTGRES_HOST (and POSTGRES_USER / POSTGRES_PASSWORD / POSTGRES_DATABASE) to enable Postgres tools.'
+    )
+  }
+  const config = configs[pgHostId]
+  if (!config) {
+    throw new Error(
+      `Invalid pgHostId: ${pgHostId}. Available Postgres sources: 0-${configs.length - 1}`
+    )
+  }
+  return config
+}


### PR DESCRIPTION
Closes #2451. Part of #2264 (phase 4).

## What

Adds three **env-gated** cross-source Postgres tools to the AI agent, cloning ClickHouse Cloud's own set so the model can query Postgres and ClickHouse in one conversation and correlate the results itself (prompting-only — **no join primitive**, per the issue).

| Tool | Module | Does |
|---|---|---|
| `run_postgres_select_query` | `postgres-query-tools.ts` | Read-only SELECT primitive (`pgHostId` + `sql` + optional `limit`). Reuses **Phase 2's** `queryPostgres` path — session pinned `default_transaction_read_only=on`, SELECT/WITH/SHOW/EXPLAIN/TABLE/VALUES-only gate, extended protocol (no second pg access path). Truncated result shape matches the CH `query` tool. |
| `get_postgres_metrics` | `postgres-health-tools.ts` | Version/uptime, connection counts by state (`pg_stat_activity`), buffer-cache hit ratio (`pg_stat_database`), xact commit/rollback + deadlocks, db size, replication status (`pg_stat_replication` / `pg_is_in_recovery`). The PG analog of `get_metrics`. |
| `list_postgres_slow_query_patterns` | `postgres-query-tools.ts` | Top-N `pg_stat_statements` by total exec time (calls, total/mean ms, rows, cache-hit, WAL bytes). Mirrors CH `list_slow_query_patterns`. Returns an **informative message, not a throw**, when the extension is absent. |

Gated in `createAllTools` on `CHM_FEATURE_POSTGRES_SOURCE` (same style as `control-tools`' env gate): tools are **absent, not just failing**, when off. Tools take an explicit per-call `pgHostId`, so `createAllTools`' signature is unchanged.

## pgHostId resolution (design note)

`pgHostId` resolves via a new **env-based** `getPostgresConfigs()` (`packages/postgres-client/src/postgres-config.ts`) reading `POSTGRES_HOST/PORT/USER/PASSWORD/DATABASE/SSLMODE/NAME` comma-lists — the sibling of `getClickHouseConfigs()`, and exactly the "flat positional index" the package's own `PgHostId` doc already describes.

This is deliberate: the agent's ClickHouse tools already resolve `hostId` via **env** (`getClickHouseConfigs` → `fetchData`), **not** the per-user D1 store, and there's no `userId` threaded into `createAllTools`. Making the Postgres tools env-based keeps them consistent, keeps `createAllTools`' signature intact, and — since `CHM_FEATURE_POSTGRES_SOURCE` is a pure env gate (no Clerk) — gives self-hosted (OSS) **equal** Postgres support.

**Limitation (stated for reviewers):** the agent tools read **env-configured** Postgres hosts; per-user (D1) Postgres connections managed in the UI are **not yet visible to the agent** — the same limitation the ClickHouse agent tools already have. Unifying env PG hosts with the UI switcher is a follow-up on the epic, not this PR. SSRF: env hosts are operator-supplied and **trusted, no re-guard**, matching the `CLICKHOUSE_HOST` precedent (the CH agent env path doesn't SSRF-guard env hosts either; `validatePostgresHost` guards only browser/user-supplied connections).

## Docs (same PR — tool-docs-sync test enforces it)

- `docs/content/guide/ai-agent/capabilities.mdx` — category row, callout, tool-reference rows.
- `docs/content/guide/ai-agent/configuration.mdx` — `CHM_FEATURE_POSTGRES_SOURCE` + the `POSTGRES_*` env table.
- `docs/content/guide/ai-agent.mdx` — overview mention + env var list.
- `apps/dashboard/.env.example` — commented `POSTGRES_*` block.
- System prompt (`clickhouse-instructions.ts`) — lists the 3 tools conditionally.

## Verification

- `pnpm run build` (apps/dashboard, Vite + `tsc --noEmit`) ✅ — full prerender.
- `pnpm run type-check:test` (apps/dashboard, `tsc -p tsconfig.test.json`) ✅ clean.
- `pnpm run lint` (Biome, 2379 files) ✅.
- Dashboard unit suite (`bun test src/ --isolate`) ✅ **6460 pass / 0 fail**.
- `bun test packages/postgres-client` ✅ 9 pass (new `postgres-config.test.ts`).
- New tests: `__tests__/postgres-tools.test.ts` (result shaping/truncation, metrics math, graceful missing-extension), `__tests__/postgres-tools-gate.test.ts` (flag on/off ⇒ present/absent), `postgres-config.test.ts` (env parse, broadcast, inline port, out-of-range). `tool-docs-sync.test.ts` now enables the gate → asserts **33 tools** all documented + named in the prompt. (The SELECT-only gate itself is covered against the real client in the existing `postgres-readonly.test.ts`.)
- No `package.json`/lockfile changes → `--frozen-lockfile` safe.

### Live proof — real output against local PG 17.10 (`localhost:54329`, `pocdb`, `pg_stat_statements` loaded)

Each tool's real `execute()` called end-to-end through the env resolver + `queryPostgres`:

```
run_postgres_select_query → { data: [{ db: "pocdb", usr: "postgres", tables: "3" }], truncated: false }
write gate (CREATE TABLE)  → Error: Only read-only statements are allowed (SELECT, WITH, SHOW, EXPLAIN, TABLE, VALUES)
get_postgres_metrics       → version "PostgreSQL 17.10 …", uptime_seconds 5778,
                             connections { total: 8, by_state: { unknown: 5, active: 3 } },
                             cache { blks_hit: 139714, blks_read: 1463, hit_pct: 98.96 },
                             transactions { xact_commit: 1559, xact_rollback: 1, deadlocks: 0 },
                             database { size_bytes: 7960243, size: "7774 kB" },
                             replication { is_replica: false, replica_lag_seconds: null, standbys: [] }
list_postgres_slow_query_patterns (limit 5) → { available: true, patterns: [5 real pg_stat_statements rows] }
out-of-range pgHostId 9    → Error: Invalid pgHostId: 9. Available Postgres sources: 0-0
```

## Out of scope

Destructive PG actions, a cross-source join primitive, the Postgres UI pages (#2450), Hyperdrive.
