### PR TITLE
feat(postgres): query insights pages + engine-aware menu (phase 3)

### DIFF
--- a/apps/dashboard/src/components/app-sidebar.tsx
+++ b/apps/dashboard/src/components/app-sidebar.tsx
@@ -16,13 +16,16 @@ import {
 import { GUEST_USER } from '@/lib/clerk/guest-user'
 import { DOCS_SITE_URL } from '@/lib/docs-site'
 import { useFeaturePermissions } from '@/lib/feature-permissions/context'
+import { useActiveHostEngine } from '@/lib/hooks/use-active-pg-connection'
 import { getVisibleMenuItems } from '@/lib/menu/visible-items'
 
 export function AppSidebar() {
   const { config } = useFeaturePermissions()
-  // Feature-permission + cloud-only (Billing/Organization) gates resolved in
-  // one place — see lib/menu/visible-items.ts.
-  const menuItems = getVisibleMenuItems(config)
+  // Feature-permission + cloud-only (Billing/Organization) + engine gates
+  // resolved in one place — see lib/menu/visible-items.ts. The active engine
+  // swaps the menu to Postgres pages when a Postgres source is selected (#2450).
+  const engine = useActiveHostEngine()
+  const menuItems = getVisibleMenuItems(config, engine)
 
   return (
     <Sidebar collapsible="icon" variant="inset">

--- a/apps/dashboard/src/components/controls/command-palette.tsx
+++ b/apps/dashboard/src/components/controls/command-palette.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/components/ui/command'
 import { IconButton } from '@/components/ui/icon-button'
 import { useFeaturePermissions } from '@/lib/feature-permissions/context'
+import { useActiveHostEngine } from '@/lib/hooks/use-active-pg-connection'
 import { getVisibleMenuItems } from '@/lib/menu/visible-items'
 import { useRouter, useSearchParams } from '@/lib/next-compat'
 import { buildUrl } from '@/lib/url/url-builder'
@@ -76,7 +77,8 @@ export const CommandPalette = function CommandPalette({
   const [internalOpen, setInternalOpen] = React.useState(false)
   const [inputValue, setInputValue] = useState('')
   const { config } = useFeaturePermissions()
-  const menuItems = getVisibleMenuItems(config)
+  const engine = useActiveHostEngine()
+  const menuItems = getVisibleMenuItems(config, engine)
 
   const open = controlledOpen ?? internalOpen
   const setOpen = onOpenChange ?? setInternalOpen

--- a/apps/dashboard/src/components/host/host-switcher.tsx
+++ b/apps/dashboard/src/components/host/host-switcher.tsx
@@ -26,6 +26,7 @@ import {
   useSidebar,
 } from '@/components/ui/sidebar'
 import { Skeleton } from '@/components/ui/skeleton'
+import { usePgConnections } from '@/lib/hooks/use-pg-connections'
 import { canEditHost } from '@/lib/host-permissions'
 import { usePathname, useRouter, useSearchParams } from '@/lib/next-compat'
 import { useHostId } from '@/lib/swr'
@@ -49,7 +50,9 @@ export function HostSwitcher() {
   const searchParams = useSearchParams()
   const { isMobile, state } = useSidebar()
   const { hosts, isLoading, error, isUnauthorized } = useMergedHosts()
+  const { connections: pgConnections } = usePgConnections()
   const currentHostId = useHostId()
+  const activePgId = searchParams.get('pg')
   const [addDialogOpen, setAddDialogOpen] = useState(false)
   // Controlled so a per-row "details/edit" click can close the menu before the
   // dialog opens — otherwise the dropdown's focus trap fights the dialog's.
@@ -75,8 +78,19 @@ export function HostSwitcher() {
   }, [isLoading])
 
   const handleHostChange = (hostId: number) => {
-    const url = buildUrl(pathname, { host: hostId }, searchParams)
+    // Selecting a ClickHouse host clears any active Postgres source (`?pg=`) so
+    // the nav menu reverts to the ClickHouse menu (#2450 engine-aware swap).
+    const next = new URLSearchParams(searchParams)
+    next.delete('pg')
+    const url = buildUrl(pathname, { host: hostId }, next)
     router.push(url)
+  }
+
+  const handlePgChange = (connectionId: string) => {
+    // Route to the Postgres pages carrying the source in the `?pg=` dimension —
+    // never overloaded onto the ClickHouse `?host=` id space.
+    router.push(`/postgres/queries?pg=${encodeURIComponent(connectionId)}`)
+    setMenuOpen(false)
   }
 
   // Show the skeleton only while we still have nothing to render and the load
@@ -324,6 +338,39 @@ export function HostSwitcher() {
                     </DropdownMenuItem>
                   )
                 })}
+                {pgConnections.length > 0 && (
+                  <>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuGroup>
+                      <DropdownMenuLabel className="text-xs text-muted-foreground">
+                        Postgres Sources
+                      </DropdownMenuLabel>
+                    </DropdownMenuGroup>
+                    {pgConnections.map((pg) => (
+                      <DropdownMenuItem
+                        key={`pg-${pg.connectionId}`}
+                        onClick={() => handlePgChange(pg.connectionId)}
+                        className="gap-2 p-2"
+                        data-testid={`pg-option-${pg.connectionId}`}
+                      >
+                        <GlobeIcon className="size-3 shrink-0 text-muted-foreground" />
+                        <div className="min-w-0 flex-1">
+                          <span className="flex items-center gap-1.5">
+                            <span className="truncate text-sm">
+                              {pg.name || pg.host}
+                            </span>
+                            {pg.connectionId === activePgId && (
+                              <span className="size-1.5 shrink-0 rounded-full bg-emerald-500" />
+                            )}
+                          </span>
+                        </div>
+                        <span className="shrink-0 rounded border border-border px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                          Postgres
+                        </span>
+                      </DropdownMenuItem>
+                    ))}
+                  </>
+                )}
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
                   onClick={() => setAddDialogOpen(true)}

--- a/apps/dashboard/src/components/menu/types.ts
+++ b/apps/dashboard/src/components/menu/types.ts
@@ -1,3 +1,4 @@
+import type { SourceEngine } from '@chm/types'
 import type { Icon } from '@chm/types/icon'
 import type { FeaturePermission } from '@/lib/feature-permissions/types'
 import type { BadgeVariant } from '@/types/badge-variant'
@@ -33,4 +34,14 @@ export interface MenuItem {
    * honors it without each one re-implementing the gate.
    */
   cloudOnly?: boolean
+  /**
+   * Source engines this item applies to (issue #2450 — engine-aware menu swap,
+   * decision 4). ABSENT means the ClickHouse family (`clickhouse` +
+   * `clickhouse-cloud`) — i.e. every existing item is unchanged. Postgres-only
+   * items declare `engines: ['postgres']`. Filtered centrally by
+   * `getVisibleMenuItems` against the ACTIVE host's engine, so switching to a
+   * Postgres source swaps the nav menu to Postgres pages while ClickHouse hosts
+   * keep today's exact menu (zero-diff invariant).
+   */
+  engines?: SourceEngine[]
 }

--- a/apps/dashboard/src/components/postgres/__tests__/pg-extension-empty-state.cy.tsx
+++ b/apps/dashboard/src/components/postgres/__tests__/pg-extension-empty-state.cy.tsx
@@ -1,0 +1,34 @@
+/**
+ * Cypress component test for the Postgres extension-missing empty state
+ * (issue #2450).
+ *
+ * WHY: when the `pg_stat_statements` extension is not installed, the Query
+ * Insights page must render a graceful, actionable empty state — never a raw
+ * Postgres error. This asserts the user-facing contract in a real DOM: the
+ * extension name is shown and the enable instructions (`shared_preload_libraries`
+ * + `CREATE EXTENSION`) are present so an operator knows exactly what to do.
+ */
+
+import { PgExtensionEmptyState } from '../pg-extension-empty-state'
+import React from 'react'
+
+describe('PgExtensionEmptyState', () => {
+  it('names the extension and shows the enable steps', () => {
+    cy.mount(<PgExtensionEmptyState extension="pg_stat_statements" />)
+
+    // Title calls out the specific missing extension.
+    cy.contains('pg_stat_statements').should('be.visible')
+    cy.contains(/is not installed/i).should('be.visible')
+
+    // The enable instructions are present and complete.
+    cy.get('[data-testid="pg-extension-enable-steps"]').within(() => {
+      cy.contains('shared_preload_libraries').should('exist')
+      cy.contains('CREATE EXTENSION pg_stat_statements').should('exist')
+    })
+  })
+
+  it('renders for an arbitrary extension name', () => {
+    cy.mount(<PgExtensionEmptyState extension="pg_buffercache" />)
+    cy.contains('CREATE EXTENSION pg_buffercache').should('exist')
+  })
+})

--- a/apps/dashboard/src/components/postgres/pg-extension-empty-state.tsx
+++ b/apps/dashboard/src/components/postgres/pg-extension-empty-state.tsx
@@ -1,0 +1,57 @@
+/**
+ * Graceful empty state shown when a required Postgres extension (e.g.
+ * `pg_stat_statements`) is not installed on the target database (issue #2450).
+ * The Postgres analog of the ClickHouse `table-missing` state: it explains how
+ * to enable the extension and never surfaces a raw Postgres error.
+ */
+
+import { PuzzleIcon } from 'lucide-react'
+
+import { EmptyState } from '@/components/ui/empty-state'
+
+export interface PgExtensionEmptyStateProps {
+  extension: string
+}
+
+export function PgExtensionEmptyState({
+  extension,
+}: PgExtensionEmptyStateProps) {
+  return (
+    <EmptyState
+      variant="table-missing"
+      icon={
+        <PuzzleIcon
+          className="h-10 w-10 text-muted-foreground/60"
+          strokeWidth={1.5}
+        />
+      }
+      title={`Extension "${extension}" is not installed`}
+      description={
+        <span className="flex flex-col items-center gap-3">
+          <span className="max-w-md text-center">
+            This view reads from the{' '}
+            <code className="font-mono">{extension}</code> extension, which
+            isn't enabled on this database. Enable it, then refresh.
+          </span>
+          <span
+            data-testid="pg-extension-enable-steps"
+            className="w-full max-w-md rounded-lg border bg-muted/40 p-3 text-left font-mono text-xs leading-relaxed text-foreground/90"
+          >
+            <span className="block text-muted-foreground">
+              {
+                '-- 1. add to shared_preload_libraries in postgresql.conf, restart:'
+              }
+            </span>
+            <span className="block">
+              shared_preload_libraries = '{extension}'
+            </span>
+            <span className="mt-2 block text-muted-foreground">
+              {'-- 2. then, in the target database:'}
+            </span>
+            <span className="block">CREATE EXTENSION {extension};</span>
+          </span>
+        </span>
+      }
+    />
+  )
+}

--- a/apps/dashboard/src/components/postgres/pg-format.tsx
+++ b/apps/dashboard/src/components/postgres/pg-format.tsx
@@ -1,0 +1,50 @@
+/**
+ * Value formatting for Postgres table cells, driven by `PgColumn.format`
+ * (issue #2450). Mirrors the ClickHouse column formatters but on the small,
+ * self-contained `PgColumnFormat` set.
+ */
+
+import type { PgColumnFormat } from '@/types/pg-query-config'
+
+import { formatReadableSize } from '@/lib/format-readable'
+import { formatDuration } from '@/lib/utils'
+
+/** Coerce an unknown row value to a finite number, or `null`. */
+function toNumber(value: unknown): number | null {
+  if (value === null || value === undefined || value === '') return null
+  const n = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(n) ? n : null
+}
+
+/** Format a raw cell value to its display string for a given column format. */
+export function formatPgValue(
+  value: unknown,
+  format: PgColumnFormat = 'text'
+): string {
+  if (value === null || value === undefined) return '—'
+
+  switch (format) {
+    case 'number': {
+      const n = toNumber(value)
+      return n === null ? String(value) : n.toLocaleString()
+    }
+    case 'ms': {
+      const n = toNumber(value)
+      return n === null ? String(value) : `${n.toLocaleString()} ms`
+    }
+    case 'duration_ms': {
+      const n = toNumber(value)
+      return n === null ? String(value) : formatDuration(n)
+    }
+    case 'bytes': {
+      const n = toNumber(value)
+      return n === null ? String(value) : formatReadableSize(n)
+    }
+    case 'percent': {
+      const n = toNumber(value)
+      return n === null ? String(value) : `${n}%`
+    }
+    default:
+      return String(value)
+  }
+}

--- a/apps/dashboard/src/components/postgres/pg-page.tsx
+++ b/apps/dashboard/src/components/postgres/pg-page.tsx
@@ -1,0 +1,167 @@
+/**
+ * Page shell for a Postgres `PgQueryConfig` (issue #2450). The Postgres analog
+ * of `QueryPageLayout`: it resolves the active Postgres source (`?pg=`), fetches
+ * the config's rows via `usePgQuery`, and renders the appropriate state —
+ * skeleton, graceful error (keeps prior rows on a background-refresh failure,
+ * matching the ClickHouse stale-indicator pattern), the extension-missing
+ * EmptyState, an empty-data state, or the `PgTable`.
+ *
+ * Never surfaces a raw Postgres error: extension-missing is a first-class
+ * empty state, and genuine failures render a friendly, classified message.
+ */
+
+import { AlertTriangleIcon, DatabaseIcon, RefreshCwIcon } from 'lucide-react'
+
+import type { PgQueryConfig } from '@/types/pg-query-config'
+
+import { PgExtensionEmptyState } from './pg-extension-empty-state'
+import { PgTable } from './pg-table'
+import { TableSkeleton } from '@/components/skeletons'
+import { Button } from '@/components/ui/button'
+import { EmptyState } from '@/components/ui/empty-state'
+import { useActivePgConnection } from '@/lib/hooks/use-active-pg-connection'
+import { usePgQuery } from '@/lib/hooks/use-pg-query'
+
+export interface PgPageProps {
+  config: PgQueryConfig
+  /** Auto-refresh interval in ms (e.g. running queries). */
+  refetchInterval?: number
+  onRowClick?: (row: Record<string, unknown>) => void
+}
+
+export function PgPage({ config, refetchInterval, onRowClick }: PgPageProps) {
+  const pgConn = useActivePgConnection()
+  const { data, error, isLoading, isFetching, refetch } = usePgQuery(
+    config.name,
+    pgConn,
+    { refetchInterval }
+  )
+
+  const rows = data?.data ?? []
+  const hasData = rows.length > 0
+
+  return (
+    <div className="flex min-w-0 w-full max-w-full flex-1 flex-col gap-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h1 className="text-xl font-semibold tracking-tight">
+            {config.title}
+          </h1>
+          {config.description ? (
+            <p className="mt-1 text-sm text-muted-foreground">
+              {config.description}
+            </p>
+          ) : null}
+          {pgConn ? (
+            <p className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+              <DatabaseIcon className="size-3.5" strokeWidth={1.5} />
+              {pgConn.name} · {pgConn.host}
+            </p>
+          ) : null}
+        </div>
+        <div className="flex items-center gap-2">
+          {error && hasData ? (
+            <span
+              className="flex items-center gap-1 text-xs text-amber-600 dark:text-amber-500"
+              title={error instanceof Error ? error.message : String(error)}
+            >
+              <AlertTriangleIcon className="size-3.5" strokeWidth={1.5} />
+              Refresh failed
+            </span>
+          ) : null}
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => refetch()}
+            disabled={!pgConn || isFetching}
+          >
+            <RefreshCwIcon className="mr-1.5 size-3.5" strokeWidth={1.5} />
+            Refresh
+          </Button>
+        </div>
+      </div>
+
+      <PgPageBody
+        config={config}
+        pgConnActive={Boolean(pgConn)}
+        isLoading={isLoading}
+        error={error}
+        hasData={hasData}
+        rows={rows}
+        extensionMissing={Boolean(data?.extensionMissing)}
+        onRowClick={onRowClick}
+        onRetry={() => refetch()}
+      />
+    </div>
+  )
+}
+
+function PgPageBody({
+  config,
+  pgConnActive,
+  isLoading,
+  error,
+  hasData,
+  rows,
+  extensionMissing,
+  onRowClick,
+  onRetry,
+}: {
+  config: PgQueryConfig
+  pgConnActive: boolean
+  isLoading: boolean
+  error: unknown
+  hasData: boolean
+  rows: Record<string, unknown>[]
+  extensionMissing: boolean
+  onRowClick?: (row: Record<string, unknown>) => void
+  onRetry: () => void
+}) {
+  if (!pgConnActive) {
+    return (
+      <EmptyState
+        variant="no-data"
+        icon={
+          <DatabaseIcon
+            className="h-10 w-10 text-muted-foreground/60"
+            strokeWidth={1.5}
+          />
+        }
+        title="No Postgres source selected"
+        description="Choose a Postgres connection from the host switcher to view its query insights."
+      />
+    )
+  }
+
+  if (extensionMissing && config.extensionCheck) {
+    return <PgExtensionEmptyState extension={config.extensionCheck} />
+  }
+
+  if (isLoading && !hasData) {
+    return <TableSkeleton />
+  }
+
+  if (error && !hasData) {
+    return (
+      <EmptyState
+        variant="error"
+        title="Couldn't load Postgres data"
+        description={error instanceof Error ? error.message : String(error)}
+        action={{ label: 'Retry', onClick: onRetry }}
+      />
+    )
+  }
+
+  if (!hasData) {
+    return (
+      <EmptyState
+        variant="no-data"
+        title="No rows"
+        description="This view returned no rows for the current Postgres source."
+        onRefresh={onRetry}
+      />
+    )
+  }
+
+  return <PgTable config={config} rows={rows} onRowClick={onRowClick} />
+}

--- a/apps/dashboard/src/components/postgres/pg-pattern-detail-sheet.tsx
+++ b/apps/dashboard/src/components/postgres/pg-pattern-detail-sheet.tsx
@@ -1,0 +1,87 @@
+/**
+ * Detail flyout for a Postgres query pattern (issue #2450). Mirrors the
+ * ClickHouse slow-query-patterns `PatternDetailSheet`: clicking a row opens a
+ * Sheet scoped to that pattern with the full (normalized) query text and a
+ * per-metric breakdown. The clicked row already carries every aggregate the
+ * table computed, so no extra query is needed here.
+ */
+
+import type { PgQueryConfig } from '@/types/pg-query-config'
+
+import { formatPgValue } from './pg-format'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Separator } from '@/components/ui/separator'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
+
+export interface PgPatternDetailSheetProps {
+  config: PgQueryConfig
+  /** Which row key holds the full query text. Defaults to `query`. */
+  queryKey?: string
+  row: Record<string, unknown> | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function PgPatternDetailSheet({
+  config,
+  queryKey = 'query',
+  row,
+  open,
+  onOpenChange,
+}: PgPatternDetailSheetProps) {
+  const queryText = row ? String(row[queryKey] ?? '') : ''
+  // Every metric column except the query text itself.
+  const metricColumns = config.columns.filter((c) => c.key !== queryKey)
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="flex w-full flex-col gap-0 p-0 sm:max-w-xl md:max-w-2xl"
+      >
+        {open && row ? (
+          <>
+            <SheetHeader className="space-y-3 border-b px-5 py-4">
+              <SheetTitle className="text-base">Query pattern</SheetTitle>
+              <SheetDescription>
+                Aggregate metrics for this normalized statement.
+              </SheetDescription>
+              <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border/60 bg-muted/40 px-3 py-2 font-mono text-xs leading-relaxed">
+                {queryText || '—'}
+              </pre>
+            </SheetHeader>
+
+            <ScrollArea className="min-h-0 flex-1">
+              <div className="space-y-4 px-5 py-4">
+                <div>
+                  <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                    This pattern
+                  </h4>
+                  <Separator className="mb-3" />
+                  <dl className="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-3">
+                    {metricColumns.map((col) => (
+                      <div key={col.key} className="min-w-0">
+                        <dt className="truncate text-xs text-muted-foreground">
+                          {col.label}
+                        </dt>
+                        <dd className="mt-0.5 font-mono text-sm tabular-nums">
+                          {formatPgValue(row[col.key], col.format)}
+                        </dd>
+                      </div>
+                    ))}
+                  </dl>
+                </div>
+              </div>
+            </ScrollArea>
+          </>
+        ) : null}
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/apps/dashboard/src/components/postgres/pg-table.tsx
+++ b/apps/dashboard/src/components/postgres/pg-table.tsx
@@ -1,0 +1,191 @@
+/**
+ * Declarative table for a `PgQueryConfig` (issue #2450). Renders the config's
+ * `PgColumn[]` with per-column formatting and optional inline share bars (the
+ * Postgres analog of the ClickHouse BackgroundBar `pct_*` convention), with
+ * client-side pagination for the capped result sets. Clicking a row invokes
+ * `onRowClick` (used to open the detail flyout).
+ */
+
+import {
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  getPaginationRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+
+import type { PgColumn, PgQueryConfig } from '@/types/pg-query-config'
+
+import { formatPgValue } from './pg-format'
+import { useMemo } from 'react'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { activateOnEnterOrSpace } from '@/lib/a11y'
+import { cn } from '@/lib/utils'
+
+type Row = Record<string, unknown>
+const columnHelper = createColumnHelper<Row>()
+const PAGE_SIZE = 50
+const CODE_MAX = 160
+
+/** A single formatted cell, with an optional share bar behind the value. */
+function PgCell({ column, row }: { column: PgColumn; row: Row }) {
+  const display = formatPgValue(row[column.key], column.format)
+  const pct =
+    column.barPctKey != null ? Number(row[column.barPctKey] ?? 0) : null
+
+  if (column.format === 'code') {
+    const str = String(row[column.key] ?? '')
+    const truncated = str.length > CODE_MAX ? `${str.slice(0, CODE_MAX)}…` : str
+    return (
+      <span
+        className="block max-w-[38rem] truncate font-mono text-xs text-foreground/90"
+        title={str}
+      >
+        {truncated || '—'}
+      </span>
+    )
+  }
+
+  const alignRight = column.align === 'right'
+  return (
+    <div className={cn('relative', alignRight ? 'text-right' : 'text-left')}>
+      {pct != null && Number.isFinite(pct) && pct > 0 ? (
+        <span
+          aria-hidden
+          className="absolute inset-y-0 left-0 rounded-sm bg-primary/10"
+          style={{ width: `${Math.min(pct, 100)}%` }}
+        />
+      ) : null}
+      <span
+        className={cn('relative', column.format ? 'tabular-nums' : undefined)}
+      >
+        {display}
+      </span>
+    </div>
+  )
+}
+
+export interface PgTableProps {
+  config: PgQueryConfig
+  rows: Row[]
+  onRowClick?: (row: Row) => void
+}
+
+export function PgTable({ config, rows, onRowClick }: PgTableProps) {
+  const columns = useMemo(
+    () =>
+      config.columns.map((col) =>
+        columnHelper.accessor((r) => r[col.key], {
+          id: col.key,
+          header: col.label,
+          cell: (info) => <PgCell column={col} row={info.row.original} />,
+        })
+      ),
+    [config.columns]
+  )
+
+  const table = useReactTable({
+    data: rows,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    initialState: { pagination: { pageSize: PAGE_SIZE } },
+  })
+
+  const pageCount = table.getPageCount()
+  const pageIndex = table.getState().pagination.pageIndex
+  const clickable = Boolean(onRowClick && config.rowClickable)
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="overflow-x-auto rounded-lg border bg-card">
+        <Table style={{ width: '100%' }}>
+          <TableHeader className="sticky top-0 z-10 bg-muted/50">
+            {table.getHeaderGroups().map((hg) => (
+              <TableRow key={hg.id}>
+                {hg.headers.map((header) => {
+                  const col = config.columns.find((c) => c.key === header.id)
+                  return (
+                    <TableHead
+                      key={header.id}
+                      className={cn(
+                        'select-none whitespace-nowrap text-xs font-medium',
+                        col?.align === 'right' && 'text-right'
+                      )}
+                      title={col?.help}
+                    >
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext()
+                          )}
+                    </TableHead>
+                  )
+                })}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows.map((row) => (
+              <TableRow
+                key={row.id}
+                className={cn(
+                  'align-top',
+                  clickable && 'cursor-pointer hover:bg-muted/50'
+                )}
+                {...(clickable
+                  ? {
+                      role: 'button',
+                      tabIndex: 0,
+                      onClick: () => onRowClick?.(row.original),
+                      onKeyDown: activateOnEnterOrSpace(() =>
+                        onRowClick?.(row.original)
+                      ),
+                    }
+                  : {})}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell key={cell.id} className="py-2 text-[13px]">
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {pageCount > 1 && (
+        <div className="flex items-center justify-end gap-3 text-xs text-muted-foreground">
+          <span>
+            Page {pageIndex + 1} of {pageCount} · {rows.length} rows
+          </span>
+          <button
+            type="button"
+            className="rounded border px-2 py-1 hover:bg-muted disabled:opacity-40"
+            disabled={!table.getCanPreviousPage()}
+            onClick={() => table.previousPage()}
+          >
+            Previous
+          </button>
+          <button
+            type="button"
+            className="rounded border px-2 py-1 hover:bg-muted disabled:opacity-40"
+            disabled={!table.getCanNextPage()}
+            onClick={() => table.nextPage()}
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/dashboard/src/lib/connection-query/execute-pg-query.ts
+++ b/apps/dashboard/src/lib/connection-query/execute-pg-query.ts
@@ -1,0 +1,91 @@
+/**
+ * Server-side Postgres query executor for the Postgres pages (issue #2450).
+ *
+ * REUSES the Phase 2 read-only query path (`@chm/postgres-client.queryPostgres`)
+ * — per-request connect, session pinned read-only, single-SELECT gate, extended
+ * protocol — rather than opening a second Postgres access path. Every call
+ * re-runs the TCP SSRF guard (`validatePostgresHost`), matching the ClickHouse
+ * connection path's posture, because the host comes from user-supplied
+ * connection credentials.
+ */
+
+import type { ConnectionCredentials } from '@/lib/connection-store/types'
+
+import {
+  type PostgresConnectionConfig,
+  queryPostgres,
+} from '@chm/postgres-client'
+import { validatePostgresHost } from '@/lib/browser-connections/host-url'
+
+/** Default Postgres TCP port when a connection omits one. */
+const DEFAULT_PG_PORT = 5432
+/** Default database when a connection omits one. */
+const DEFAULT_PG_DATABASE = 'postgres'
+
+/**
+ * Map decrypted connection credentials (v2 envelope, `kind: 'postgres'`) to the
+ * `@chm/postgres-client` connection config. For Postgres the stored `host` is a
+ * BARE hostname/IP (no scheme) and the endpoint is `host:port`.
+ */
+export function credentialsToPgConfig(
+  credentials: ConnectionCredentials
+): PostgresConnectionConfig {
+  return {
+    host: credentials.host,
+    port: credentials.port ?? DEFAULT_PG_PORT,
+    user: credentials.user,
+    password: credentials.password,
+    database: credentials.database ?? DEFAULT_PG_DATABASE,
+    sslmode: credentials.sslmode,
+  }
+}
+
+/** Guard the target, then fail loud with the SSRF/validation reason. */
+async function assertHostAllowed(
+  config: PostgresConnectionConfig
+): Promise<void> {
+  const reason = await validatePostgresHost(config.host, config.port)
+  if (reason) {
+    throw new Error(reason)
+  }
+}
+
+/**
+ * Whether a Postgres extension is installed on the target database. Used as the
+ * Postgres analog of the ClickHouse `tableCheck` — drives the graceful
+ * "extension not installed" empty state instead of surfacing a raw error.
+ */
+export async function isPgExtensionInstalled(
+  config: PostgresConnectionConfig,
+  extname: string
+): Promise<boolean> {
+  const { rows } = await queryPostgres<{ ok: number }>(
+    config,
+    'SELECT 1 AS ok FROM pg_extension WHERE extname = $1',
+    [extname]
+  )
+  return rows.length > 0
+}
+
+export interface PgQueryResult {
+  data: Record<string, unknown>[]
+  metadata: { duration: number; rows: number }
+}
+
+/**
+ * Run a single read-only Postgres statement and return its rows plus timing
+ * metadata. Re-guards the host before connecting.
+ */
+export async function executePgQuery(
+  config: PostgresConnectionConfig,
+  sql: string,
+  params?: ReadonlyArray<unknown>
+): Promise<PgQueryResult> {
+  await assertHostAllowed(config)
+  const start = Date.now()
+  const { rows } = await queryPostgres(config, sql, params)
+  return {
+    data: rows,
+    metadata: { duration: Date.now() - start, rows: rows.length },
+  }
+}

--- a/apps/dashboard/src/lib/hooks/use-active-pg-connection.ts
+++ b/apps/dashboard/src/lib/hooks/use-active-pg-connection.ts
@@ -1,0 +1,39 @@
+/**
+ * Resolves the ACTIVE Postgres source from the `?pg=<connectionId>` search
+ * param (issue #2450). This is the Postgres analog of `?host=<n>` — a SEPARATE
+ * routing dimension so a Postgres source is never overloaded onto a ClickHouse
+ * `hostId`. When a valid `?pg=` is present, the active engine is `'postgres'`
+ * and the nav menu swaps to Postgres pages (decision 4).
+ *
+ * Fail-closed: without the feature flag / a resolvable connection, the engine
+ * is `'clickhouse'`, so the ClickHouse menu is byte-for-byte unchanged.
+ */
+
+import type { SourceEngine } from '@chm/types'
+
+import {
+  type PgConnectionInfo,
+  usePgConnections,
+} from '@/lib/hooks/use-pg-connections'
+import { useSearchParams } from '@/lib/next-compat'
+
+/** The `?pg=` query-param name carrying the active Postgres connection id. */
+export const PG_HOST_PARAM = 'pg'
+
+/** The active Postgres connection, or `null` when no Postgres source is active. */
+export function useActivePgConnection(): PgConnectionInfo | null {
+  const searchParams = useSearchParams()
+  const pgId = searchParams.get(PG_HOST_PARAM)
+  const { getByConnectionId } = usePgConnections()
+  if (!pgId) return null
+  return getByConnectionId(pgId) ?? null
+}
+
+/**
+ * The active host's source engine, threaded into `getVisibleMenuItems` to swap
+ * the nav menu. `'postgres'` only when a valid `?pg=` is active; otherwise
+ * `'clickhouse'` (ClickHouse hosts keep today's exact menu).
+ */
+export function useActiveHostEngine(): SourceEngine {
+  return useActivePgConnection() ? 'postgres' : 'clickhouse'
+}

--- a/apps/dashboard/src/lib/hooks/use-pg-connections.ts
+++ b/apps/dashboard/src/lib/hooks/use-pg-connections.ts
@@ -1,0 +1,101 @@
+/**
+ * Client-side registry of the visitor's Postgres connections (issue #2450).
+ *
+ * Postgres sources are deliberately EXCLUDED from `useMergedHosts` / the
+ * ClickHouse host id-space (they would be mis-queried as ClickHouse hostIds).
+ * The engine-aware host switcher and the Postgres pages instead select a
+ * Postgres source by its `connectionId` via this hook, which unifies the two
+ * storage origins:
+ *   - `database` — per-user connections stored encrypted on the server (D1).
+ *     Credentials never reach the client; the query route resolves them by
+ *     `connectionId`.
+ *   - `browser`  — connections stored (encrypted) in this browser. Credentials
+ *     ARE available client-side and are POSTed inline to the query route.
+ *
+ * Fail-closed: returns an empty list unless `CHM_FEATURE_POSTGRES_SOURCE` is on.
+ */
+
+import { useMemo } from 'react'
+import { featureFlags } from '@/lib/feature-flags'
+import { useBrowserConnections } from '@/lib/hooks/use-browser-connections'
+import { useUserConnections } from '@/lib/hooks/use-user-connections'
+
+export interface PgConnectionInfo {
+  /** UUID — server connection id (database) or browser connection id. */
+  connectionId: string
+  source: 'database' | 'browser'
+  name: string
+  /** Bare hostname/IP (no scheme). */
+  host: string
+  user: string
+  database?: string
+  port?: number
+  sslmode?: string
+  /**
+   * Browser-only: the password is available client-side for the inline POST.
+   * Absent for `database` connections (server resolves those by id).
+   */
+  password?: string
+}
+
+export interface UsePgConnectionsResult {
+  connections: PgConnectionInfo[]
+  isLoading: boolean
+  getByConnectionId: (id: string) => PgConnectionInfo | undefined
+}
+
+export function usePgConnections(): UsePgConnectionsResult {
+  const enabled = featureFlags.postgresSource()
+
+  const {
+    connections: dbConnections,
+    isLoading: dbLoading,
+    featureEnabled: dbFeatureEnabled,
+    isSignedIn,
+  } = useUserConnections(enabled)
+  const { connections: browserConnections, mounted } = useBrowserConnections()
+
+  const connections = useMemo<PgConnectionInfo[]>(() => {
+    if (!enabled) return []
+
+    const fromDatabase: PgConnectionInfo[] =
+      dbFeatureEnabled && isSignedIn
+        ? dbConnections
+            .filter((c) => c.engine === 'postgres')
+            .map((c) => ({
+              connectionId: c.id,
+              source: 'database' as const,
+              name: c.name,
+              host: c.host,
+              user: c.user,
+            }))
+        : []
+
+    const fromBrowser: PgConnectionInfo[] = browserConnections
+      .filter((c) => c.engine === 'postgres')
+      .map((c) => ({
+        connectionId: c.id,
+        source: 'browser' as const,
+        name: c.name,
+        host: c.host,
+        user: c.user,
+        database: c.database,
+        port: c.port,
+        sslmode: c.sslmode,
+        password: c.password,
+      }))
+
+    return [...fromDatabase, ...fromBrowser]
+  }, [enabled, dbConnections, dbFeatureEnabled, isSignedIn, browserConnections])
+
+  const getByConnectionId = useMemo(() => {
+    const byId = new Map(connections.map((c) => [c.connectionId, c]))
+    return (id: string) => byId.get(id)
+  }, [connections])
+
+  return {
+    connections,
+    isLoading: enabled && (dbLoading || !mounted),
+    getByConnectionId,
+  }
+}

--- a/apps/dashboard/src/lib/hooks/use-pg-query.ts
+++ b/apps/dashboard/src/lib/hooks/use-pg-query.ts
@@ -1,0 +1,86 @@
+/**
+ * TanStack Query hook that fetches a `PgQueryConfig`'s rows for the active
+ * Postgres source via `POST /api/v1/pg/query/:name` (issue #2450).
+ *
+ * Sends `{ connectionId }` for server-stored (database) connections or inline
+ * `{ connection }` credentials for browser connections — the server runs the
+ * read-only statement through the Phase 2 Postgres client. Surfaces the
+ * graceful `extensionMissing` signal so the page can render an EmptyState
+ * instead of an error.
+ */
+
+import { useQuery } from '@tanstack/react-query'
+
+import type { PgConnectionInfo } from '@/lib/hooks/use-pg-connections'
+
+import { apiFetch } from '@/lib/swr/api-fetch'
+
+export interface PgQueryResult {
+  data: Record<string, unknown>[]
+  extensionMissing: boolean
+  extension?: string
+  metadata?: { duration?: number; rows?: number }
+}
+
+interface PgQueryApiResponse {
+  success: boolean
+  data?: Record<string, unknown>[]
+  metadata?: { duration?: number; rows?: number }
+  extensionMissing?: boolean
+  extension?: string
+  error?: { type: string; message: string }
+}
+
+function buildBody(pgConn: PgConnectionInfo): Record<string, unknown> {
+  if (pgConn.source === 'database') {
+    return { connectionId: pgConn.connectionId }
+  }
+  return {
+    connection: {
+      host: pgConn.host,
+      user: pgConn.user,
+      password: pgConn.password ?? '',
+      port: pgConn.port,
+      database: pgConn.database,
+      sslmode: pgConn.sslmode,
+    },
+  }
+}
+
+async function fetchPgQuery(
+  configName: string,
+  pgConn: PgConnectionInfo
+): Promise<PgQueryResult> {
+  const res = await apiFetch(`/api/v1/pg/query/${configName}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(buildBody(pgConn)),
+  })
+  const json = (await res.json()) as PgQueryApiResponse
+  if (!res.ok || !json.success) {
+    throw new Error(
+      json.error?.message ?? `Postgres query failed (${res.status})`
+    )
+  }
+  return {
+    data: json.data ?? [],
+    extensionMissing: Boolean(json.extensionMissing),
+    extension: json.extension,
+    metadata: json.metadata,
+  }
+}
+
+export function usePgQuery(
+  configName: string,
+  pgConn: PgConnectionInfo | null,
+  options?: { refetchInterval?: number }
+) {
+  return useQuery<PgQueryResult>({
+    queryKey: ['pg-query', configName, pgConn?.connectionId],
+    queryFn: () => fetchPgQuery(configName, pgConn as PgConnectionInfo),
+    enabled: Boolean(pgConn),
+    refetchInterval: options?.refetchInterval,
+    // Keep prior rows visible during background refresh (graceful pattern).
+    placeholderData: (prev) => prev,
+  })
+}

--- a/apps/dashboard/src/lib/menu/__tests__/visible-items.test.ts
+++ b/apps/dashboard/src/lib/menu/__tests__/visible-items.test.ts
@@ -3,7 +3,10 @@ import { menuItemsConfig } from '@/menu'
 import type { MenuItem } from '@/components/menu/types'
 
 import { describe, expect, test } from 'bun:test'
-import { filterCloudOnly } from '@/lib/menu/visible-items'
+import {
+  filterCloudOnly,
+  filterMenuItemsByEngine,
+} from '@/lib/menu/visible-items'
 
 const leaf = (overrides: Partial<MenuItem> = {}): MenuItem => ({
   title: overrides.title ?? 'Item',
@@ -102,5 +105,83 @@ describe('menu config cloud-only contract', () => {
     const titles = filterCloudOnly(menuItemsConfig, false).map((i) => i.title)
     expect(titles).not.toContain('Billing')
     expect(titles).not.toContain('Organization')
+  })
+})
+
+// Engine-aware menu swap (issue #2450, decision 4). The HARD invariant: for the
+// ClickHouse family the menu is byte-for-byte today's menu; for Postgres only
+// the Postgres-tagged items show.
+describe('filterMenuItemsByEngine', () => {
+  test('absent `engines` = ClickHouse family only', () => {
+    const items = [
+      leaf({ title: 'Overview', href: '/overview' }),
+      leaf({ title: 'PG', href: '/postgres/queries', engines: ['postgres'] }),
+    ]
+    expect(
+      filterMenuItemsByEngine(items, 'clickhouse').map((i) => i.title)
+    ).toEqual(['Overview'])
+    expect(
+      filterMenuItemsByEngine(items, 'clickhouse-cloud').map((i) => i.title)
+    ).toEqual(['Overview'])
+    expect(
+      filterMenuItemsByEngine(items, 'postgres').map((i) => i.title)
+    ).toEqual(['PG'])
+  })
+
+  test('drops a parent group left empty for the engine', () => {
+    const items: MenuItem[] = [
+      {
+        title: 'Queries',
+        href: '',
+        items: [leaf({ title: 'Running', href: '/running-queries' })],
+      },
+      {
+        title: 'Postgres',
+        href: '',
+        engines: ['postgres'],
+        items: [
+          leaf({
+            title: 'PG Queries',
+            href: '/postgres/queries',
+            engines: ['postgres'],
+          }),
+        ],
+      },
+    ]
+    // ClickHouse: CH group kept, Postgres group dropped entirely.
+    expect(
+      filterMenuItemsByEngine(items, 'clickhouse').map((i) => i.title)
+    ).toEqual(['Queries'])
+    // Postgres: only the Postgres group.
+    expect(
+      filterMenuItemsByEngine(items, 'postgres').map((i) => i.title)
+    ).toEqual(['Postgres'])
+  })
+
+  test('ZERO-DIFF: filtering the real config for ClickHouse is a no-op', () => {
+    // Every current menu item lacks `engines`, so the ClickHouse view must equal
+    // the config with the (new) Postgres-only items removed — i.e. the exact
+    // pre-#2450 menu. Guards against accidentally tagging an existing item.
+    const chTitles = filterMenuItemsByEngine(menuItemsConfig, 'clickhouse').map(
+      (i) => i.title
+    )
+    const expected = menuItemsConfig
+      .filter((i) => !i.engines?.includes('postgres'))
+      .map((i) => i.title)
+    expect(chTitles).toEqual(expected)
+    // And none of the Postgres pages leak into the ClickHouse menu.
+    expect(chTitles).not.toContain('Query Insights')
+    expect(chTitles).not.toContain('Running Queries')
+  })
+
+  test('Postgres view surfaces the Postgres pages', () => {
+    const pgTitles = filterMenuItemsByEngine(menuItemsConfig, 'postgres').map(
+      (i) => i.title
+    )
+    expect(pgTitles).toContain('Query Insights')
+    expect(pgTitles).toContain('Running Queries')
+    // ClickHouse-only top-level items must not appear.
+    expect(pgTitles).not.toContain('Overview')
+    expect(pgTitles).not.toContain('Health')
   })
 })

--- a/apps/dashboard/src/lib/menu/visible-items.ts
+++ b/apps/dashboard/src/lib/menu/visible-items.ts
@@ -12,6 +12,7 @@
 
 import { menuItemsConfig } from '@/menu'
 
+import type { SourceEngine } from '@chm/types'
 import type { MenuItem } from '@/components/menu/types'
 import type { PublicFeaturePermissionConfig } from '@/lib/feature-permissions/types'
 
@@ -42,15 +43,57 @@ export function filterCloudOnly(
 }
 
 /**
+ * Whether a menu item applies to the given source engine (issue #2450).
+ *
+ * ABSENT `engines` means the ClickHouse family (`clickhouse` +
+ * `clickhouse-cloud`), so every existing item shows for ClickHouse hosts and is
+ * hidden for Postgres. Postgres-only items (`engines: ['postgres']`) do the
+ * reverse. This is the whole zero-diff invariant: for a ClickHouse engine the
+ * result is exactly today's menu, and for Postgres only the Postgres items.
+ */
+function itemMatchesEngine(item: MenuItem, engine: SourceEngine): boolean {
+  if (!item.engines || item.engines.length === 0) {
+    return engine === 'clickhouse' || engine === 'clickhouse-cloud'
+  }
+  return item.engines.includes(engine)
+}
+
+/**
+ * Drop items that don't apply to the active host's engine (and any parent left
+ * empty by their removal). Recursive, mirroring {@link filterCloudOnly}.
+ */
+export function filterMenuItemsByEngine(
+  items: readonly MenuItem[],
+  engine: SourceEngine
+): MenuItem[] {
+  return items.flatMap((item) => {
+    if (!itemMatchesEngine(item, engine)) return []
+
+    if (!item.items) return [{ ...item }]
+
+    const childItems = filterMenuItemsByEngine(item.items, engine)
+    if (childItems.length === 0) return []
+
+    return [{ ...item, items: childItems }]
+  })
+}
+
+/**
  * The single source of truth for what a CLIENT nav surface may render:
- * `menuItemsConfig` with feature-permission and cloud-only gates applied.
- * `isCloudModeClient()` is resolved at build time, so this is cheap and stable
- * across renders.
+ * `menuItemsConfig` with feature-permission, cloud-only, and engine gates
+ * applied. `isCloudModeClient()` is resolved at build time, so this is cheap and
+ * stable across renders.
+ *
+ * `engine` is the ACTIVE host's source engine (defaults to `'clickhouse'`), so
+ * a caller that doesn't thread it — and every ClickHouse host — sees exactly
+ * today's menu.
  */
 export function getVisibleMenuItems(
-  config: PublicFeaturePermissionConfig
+  config: PublicFeaturePermissionConfig,
+  engine: SourceEngine = 'clickhouse'
 ): MenuItem[] {
   const cloudMode = isCloudModeClient()
   const byPermission = filterMenuItemsByPermissions(menuItemsConfig, config)
-  return filterCloudOnly(byPermission, cloudMode)
+  const byCloud = filterCloudOnly(byPermission, cloudMode)
+  return filterMenuItemsByEngine(byCloud, engine)
 }

--- a/apps/dashboard/src/lib/pg-query-config/index.ts
+++ b/apps/dashboard/src/lib/pg-query-config/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Central registry for Postgres query configs (issue #2450). The Postgres
+ * analog of `lib/query-config/index.ts`, kept separate so the ClickHouse
+ * registry stays engine-pure. Keyed by `PgQueryConfig.name`; the
+ * `/api/v1/pg/query/:name` route and the Postgres pages resolve configs here.
+ */
+
+import type { PgQueryConfig } from '@/types/pg-query-config'
+
+import { pgRunningQueriesConfig } from './running-queries'
+import { pgSlowPatternsConfig } from './slow-patterns'
+
+export { pgRunningQueriesConfig, pgSlowPatternsConfig }
+
+const PG_QUERY_CONFIGS: readonly PgQueryConfig[] = [
+  pgSlowPatternsConfig,
+  pgRunningQueriesConfig,
+]
+
+const PG_QUERY_CONFIG_BY_NAME = new Map<string, PgQueryConfig>(
+  PG_QUERY_CONFIGS.map((c) => [c.name, c])
+)
+
+/** Look up a Postgres query config by its registry `name`. */
+export function getPgQueryConfigByName(
+  name: string
+): PgQueryConfig | undefined {
+  return PG_QUERY_CONFIG_BY_NAME.get(name)
+}

--- a/apps/dashboard/src/lib/pg-query-config/running-queries.ts
+++ b/apps/dashboard/src/lib/pg-query-config/running-queries.ts
@@ -1,0 +1,58 @@
+import type { PgQueryConfig } from '@/types/pg-query-config'
+
+/**
+ * Currently-running queries from `pg_stat_activity` — the Postgres analog of
+ * ClickHouse's Running Queries view. One row per active backend, with state,
+ * wait event, and how long the current statement has been running.
+ *
+ * No extension required (`pg_stat_activity` is always present). We exclude our
+ * own monitoring backend (`pid <> pg_backend_pid()`) and rows with no
+ * statement text so the view shows real client activity.
+ */
+export const pgRunningQueriesConfig: PgQueryConfig = {
+  name: 'pg-running-queries',
+  title: 'Running Queries',
+  description:
+    'Live client backends from pg_stat_activity — state, wait events, and current-statement duration.',
+  docs: 'https://www.postgresql.org/docs/current/monitoring-stats.html#MONITORING-PG-STAT-ACTIVITY-VIEW',
+  rowClickable: true,
+  sql: `
+    SELECT
+      pid,
+      usename AS username,
+      datname AS database,
+      state,
+      wait_event_type,
+      wait_event,
+      round(
+        EXTRACT(EPOCH FROM (now() - query_start)) * 1000
+      )::bigint AS duration_ms,
+      query
+    FROM pg_stat_activity
+    WHERE state IS NOT NULL
+      AND query <> ''
+      AND pid <> pg_backend_pid()
+    ORDER BY query_start ASC NULLS LAST
+    LIMIT 200
+  `.trim(),
+  columns: [
+    { key: 'pid', label: 'PID', format: 'number', align: 'right' },
+    { key: 'state', label: 'State', format: 'text' },
+    {
+      key: 'duration_ms',
+      label: 'Duration',
+      format: 'duration_ms',
+      align: 'right',
+      help: 'How long the current statement has been running',
+    },
+    { key: 'username', label: 'User', format: 'text' },
+    { key: 'database', label: 'Database', format: 'text' },
+    {
+      key: 'wait_event_type',
+      label: 'Wait type',
+      format: 'text',
+    },
+    { key: 'wait_event', label: 'Wait event', format: 'text' },
+    { key: 'query', label: 'Query', format: 'code' },
+  ],
+}

--- a/apps/dashboard/src/lib/pg-query-config/slow-patterns.ts
+++ b/apps/dashboard/src/lib/pg-query-config/slow-patterns.ts
@@ -1,0 +1,105 @@
+import type { PgQueryConfig } from '@/types/pg-query-config'
+
+/**
+ * Slow query patterns from `pg_stat_statements` — the Postgres analog of the
+ * ClickHouse Slow Query Patterns view. Each row is a normalized statement with
+ * aggregate execution metrics, mirroring ClickHouse Cloud's per-pattern Query
+ * Insights (calls, total/mean exec time, spread, rows, cache hit, WAL bytes).
+ *
+ * Requires the `pg_stat_statements` extension (`extensionCheck`) — when it is
+ * not installed the page shows a graceful "enable the extension" empty state
+ * rather than surfacing a raw Postgres error.
+ *
+ * Column names follow `pg_stat_statements` on PostgreSQL 13+ (the `*_exec_time`
+ * rename). `pct_total_time` / `pct_calls` are window-function share columns for
+ * the inline BackgroundBar-style bars, matching the ClickHouse `pct_*`
+ * convention.
+ */
+export const pgSlowPatternsConfig: PgQueryConfig = {
+  name: 'pg-slow-patterns',
+  title: 'Slow Query Patterns',
+  description:
+    'Normalized statements aggregated by pg_stat_statements — calls, execution time, spread, cache hit ratio, and WAL per pattern.',
+  docs: 'https://www.postgresql.org/docs/current/pgstatstatements.html',
+  extensionCheck: 'pg_stat_statements',
+  rowClickable: true,
+  sql: `
+    SELECT
+      queryid::text AS queryid,
+      query,
+      calls,
+      round(total_exec_time::numeric, 2) AS total_exec_time,
+      round(mean_exec_time::numeric, 2) AS mean_exec_time,
+      round(stddev_exec_time::numeric, 2) AS stddev_exec_time,
+      round(min_exec_time::numeric, 2) AS min_exec_time,
+      round(max_exec_time::numeric, 2) AS max_exec_time,
+      rows,
+      shared_blks_hit,
+      shared_blks_read,
+      round(
+        100.0 * shared_blks_hit
+          / NULLIF(shared_blks_hit + shared_blks_read, 0),
+        1
+      ) AS cache_hit_ratio,
+      wal_bytes,
+      round(
+        (100.0 * total_exec_time
+          / NULLIF(SUM(total_exec_time) OVER (), 0))::numeric,
+        1
+      ) AS pct_total_time,
+      round(
+        (100.0 * calls / NULLIF(SUM(calls) OVER (), 0))::numeric,
+        1
+      ) AS pct_calls
+    FROM pg_stat_statements
+    ORDER BY total_exec_time DESC
+    LIMIT 100
+  `.trim(),
+  columns: [
+    { key: 'query', label: 'Query', format: 'code' },
+    {
+      key: 'calls',
+      label: 'Calls',
+      format: 'number',
+      align: 'right',
+      barPctKey: 'pct_calls',
+    },
+    {
+      key: 'total_exec_time',
+      label: 'Total time',
+      format: 'ms',
+      align: 'right',
+      barPctKey: 'pct_total_time',
+      help: 'Total execution time across all calls (ms)',
+    },
+    {
+      key: 'mean_exec_time',
+      label: 'Mean',
+      format: 'ms',
+      align: 'right',
+      help: 'Mean execution time per call (ms)',
+    },
+    {
+      key: 'stddev_exec_time',
+      label: 'Std dev',
+      format: 'ms',
+      align: 'right',
+      help: 'Standard deviation of execution time — spread proxy for percentiles',
+    },
+    {
+      key: 'max_exec_time',
+      label: 'Max',
+      format: 'ms',
+      align: 'right',
+    },
+    { key: 'rows', label: 'Rows', format: 'number', align: 'right' },
+    {
+      key: 'cache_hit_ratio',
+      label: 'Cache hit',
+      format: 'percent',
+      align: 'right',
+      help: 'shared_blks_hit / (hit + read)',
+    },
+    { key: 'wal_bytes', label: 'WAL', format: 'bytes', align: 'right' },
+  ],
+}

--- a/apps/dashboard/src/menu.ts
+++ b/apps/dashboard/src/menu.ts
@@ -63,6 +63,34 @@ export const menuItemsConfig: MenuItem[] = [
     section: 'main',
     permission: { feature: 'overview' },
   },
+  // Postgres-only nav (issue #2450, decision 4). These items appear ONLY when
+  // the active host is a Postgres source (`engines: ['postgres']`); for
+  // ClickHouse hosts they are filtered out, so the ClickHouse menu is byte-for
+  // -byte unchanged. Fail-closed: Postgres sources only exist behind
+  // CHM_FEATURE_POSTGRES_SOURCE, so with the flag off the active engine is
+  // always ClickHouse and these never render.
+  {
+    title: 'Query Insights',
+    href: '/postgres/queries',
+    description:
+      'Slow query patterns from pg_stat_statements — calls, execution time, cache hit ratio, and WAL per pattern',
+    icon: ActivityIcon,
+    section: 'main',
+    isNew: true,
+    engines: ['postgres'],
+    docs: 'https://www.postgresql.org/docs/current/pgstatstatements.html',
+  },
+  {
+    title: 'Running Queries',
+    href: '/postgres/activity',
+    description:
+      'Live client backends from pg_stat_activity — state, wait events, and current-statement duration',
+    icon: MixIcon,
+    section: 'main',
+    isNew: true,
+    engines: ['postgres'],
+    docs: 'https://www.postgresql.org/docs/current/monitoring-stats.html',
+  },
   {
     // Parent groups the chat UI, its settings (provider, model, system
     // prompt, skills, external MCP server registrations), and this

--- a/apps/dashboard/src/routes/(dashboard)/postgres/activity.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/postgres/activity.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { PgPage } from '@/components/postgres/pg-page'
+import { pgRunningQueriesConfig } from '@/lib/pg-query-config'
+
+/**
+ * Postgres Running Queries — live client backends from `pg_stat_activity`
+ * (issue #2450). Polls on a short interval, mirroring the ClickHouse Running
+ * Queries view.
+ */
+function PostgresActivityPage() {
+  return <PgPage config={pgRunningQueriesConfig} refetchInterval={5_000} />
+}
+
+export const Route = createFileRoute('/(dashboard)/postgres/activity')({
+  component: PostgresActivityPage,
+})

--- a/apps/dashboard/src/routes/(dashboard)/postgres/queries.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/postgres/queries.tsx
@@ -1,0 +1,42 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { useState } from 'react'
+import { PgPage } from '@/components/postgres/pg-page'
+import { PgPatternDetailSheet } from '@/components/postgres/pg-pattern-detail-sheet'
+import { pgSlowPatternsConfig } from '@/lib/pg-query-config'
+
+/**
+ * Postgres Query Insights — slow query patterns from `pg_stat_statements`
+ * (issue #2450). Holds the selected-pattern state and renders the detail
+ * flyout alongside the table, mirroring the ClickHouse Slow Query Patterns page.
+ */
+function PostgresQueriesPage() {
+  const [selectedRow, setSelectedRow] = useState<Record<
+    string,
+    unknown
+  > | null>(null)
+  const [sheetOpen, setSheetOpen] = useState(false)
+
+  return (
+    <>
+      <PgPage
+        config={pgSlowPatternsConfig}
+        refetchInterval={30_000}
+        onRowClick={(row) => {
+          setSelectedRow(row)
+          setSheetOpen(true)
+        }}
+      />
+      <PgPatternDetailSheet
+        config={pgSlowPatternsConfig}
+        row={selectedRow}
+        open={sheetOpen}
+        onOpenChange={setSheetOpen}
+      />
+    </>
+  )
+}
+
+export const Route = createFileRoute('/(dashboard)/postgres/queries')({
+  component: PostgresQueriesPage,
+})

--- a/apps/dashboard/src/routes/api/v1/pg/query/$name.ts
+++ b/apps/dashboard/src/routes/api/v1/pg/query/$name.ts
@@ -1,0 +1,185 @@
+/**
+ * Read-only Postgres query endpoint for the Postgres Insights pages (#2450).
+ * POST /api/v1/pg/query/$name
+ *
+ * Resolves a `PgQueryConfig` by name and runs its single read-only statement
+ * against a Postgres source, from EITHER:
+ *   - `{ connectionId }`  → a server-stored (D1) per-user connection, or
+ *   - `{ connection }`    → inline browser-stored credentials (localStorage),
+ * mirroring the ClickHouse browser-proxy / user-connection split but on ONE
+ * route (Postgres has a single execution path).
+ *
+ * Fail-closed behind `CHM_FEATURE_POSTGRES_SOURCE`. A missing required
+ * extension (e.g. `pg_stat_statements`) returns an empty result flagged
+ * `extensionMissing` so the page renders a graceful empty state — never a raw
+ * Postgres error. All other failures are classified, logged, and returned as a
+ * sanitized message.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { error as logError } from '@chm/logger'
+import {
+  formatPostgresError,
+  type PostgresConnectionConfig,
+} from '@chm/postgres-client'
+import { classifyConnectionError } from '@/lib/connection-errors'
+import {
+  credentialsToPgConfig,
+  executePgQuery,
+  isPgExtensionInstalled,
+} from '@/lib/connection-query/execute-pg-query'
+import { resolveConnectionUserId } from '@/lib/connection-store/auth'
+import { resolveConnectionStore } from '@/lib/connection-store/resolve-store'
+import { getUserConnectionsServerConfig } from '@/lib/connection-store/server-feature'
+import { featureFlags } from '@/lib/feature-flags'
+import { getPgQueryConfigByName } from '@/lib/pg-query-config'
+
+const ROUTE = '/api/v1/pg/query/$name'
+
+interface InlinePgConnection {
+  host: string
+  user: string
+  password: string
+  port?: number
+  database?: string
+  sslmode?: string
+}
+
+interface PgQueryBody {
+  connectionId?: string
+  connection?: InlinePgConnection
+}
+
+function jsonError(
+  type: string,
+  message: string,
+  status: number,
+  details?: Record<string, string>
+): Response {
+  return Response.json(
+    {
+      success: false,
+      error: { type, message, ...(details ? { details } : {}) },
+    },
+    { status }
+  )
+}
+
+async function resolvePgConfig(
+  body: PgQueryBody
+): Promise<PostgresConnectionConfig | { error: Response }> {
+  // Inline browser credentials take precedence when supplied.
+  if (body.connection?.host && body.connection.user) {
+    return credentialsToPgConfig({
+      kind: 'postgres',
+      host: body.connection.host,
+      user: body.connection.user,
+      password:
+        typeof body.connection.password === 'string'
+          ? body.connection.password
+          : '',
+      port: body.connection.port,
+      database: body.connection.database,
+      sslmode: body.connection.sslmode,
+    })
+  }
+
+  if (body.connectionId) {
+    if (!getUserConnectionsServerConfig().dbStorageEnabled) {
+      return {
+        error: jsonError(
+          'permission_error',
+          'Server-stored connections are not enabled.',
+          501
+        ),
+      }
+    }
+    const userId = await resolveConnectionUserId()
+    const store = await resolveConnectionStore()
+    const credentials = await store.getCredentials(userId, body.connectionId)
+    if (!credentials) {
+      return {
+        error: jsonError('permission_error', 'Connection not found', 404),
+      }
+    }
+    return credentialsToPgConfig(credentials)
+  }
+
+  return {
+    error: jsonError(
+      'validation_error',
+      'Missing connection: provide connectionId or connection credentials',
+      400
+    ),
+  }
+}
+
+async function handlePost(request: Request, name: string): Promise<Response> {
+  if (!featureFlags.postgresSource()) {
+    return jsonError(
+      'permission_error',
+      'Postgres source engine is not enabled.',
+      501
+    )
+  }
+
+  const queryConfig = getPgQueryConfigByName(name)
+  if (!queryConfig) {
+    return jsonError(
+      'table_not_found',
+      `Postgres query not found: ${name}`,
+      404
+    )
+  }
+
+  let body: PgQueryBody
+  try {
+    body = (await request.json()) as PgQueryBody
+  } catch {
+    return jsonError('validation_error', 'Request body must be valid JSON', 400)
+  }
+
+  const resolved = await resolvePgConfig(body)
+  if ('error' in resolved) return resolved.error
+  const config = resolved
+
+  try {
+    // Extension gate (Postgres analog of `tableCheck`): a missing extension is
+    // an expected, graceful empty state — not an error.
+    if (
+      queryConfig.extensionCheck &&
+      !(await isPgExtensionInstalled(config, queryConfig.extensionCheck))
+    ) {
+      return Response.json({
+        success: true,
+        data: [],
+        metadata: { duration: 0, rows: 0 },
+        extensionMissing: true,
+        extension: queryConfig.extensionCheck,
+      })
+    }
+
+    const result = await executePgQuery(config, queryConfig.sql)
+    return Response.json({
+      success: true,
+      data: result.data,
+      metadata: result.metadata,
+    })
+  } catch (err) {
+    const raw = formatPostgresError(err)
+    logError(`[${ROUTE}] Postgres query failed for "${name}": ${raw}`)
+    const classified = classifyConnectionError(raw)
+    return jsonError('query_error', classified.title, 502, {
+      kind: classified.kind,
+    })
+  }
+}
+
+export const Route = createFileRoute('/api/v1/pg/query/$name')({
+  server: {
+    handlers: {
+      POST: async ({ request, params }) => handlePost(request, params.name),
+    },
+  },
+})

--- a/apps/dashboard/src/types/pg-query-config.ts
+++ b/apps/dashboard/src/types/pg-query-config.ts
@@ -1,0 +1,79 @@
+/**
+ * `PgQueryConfig` — the Postgres analog of `QueryConfig`, kept deliberately
+ * minimal and SEPARATE (issue #2450 / RFC #2264).
+ *
+ * `QueryConfig` bakes in ClickHouse specifics — `sql: string | VersionedSql[]`
+ * versioned by ClickHouse version string, plus a direct `ClickHouseSettings`
+ * import. Generalizing it to be engine-parametric would touch every existing
+ * ClickHouse page for a benefit only Postgres needs, so instead we add this
+ * small parallel type: a single read-only SQL string (run through the
+ * `@chm/postgres-client` read-only query path), declarative column formatting,
+ * and an optional `extensionCheck` — the Postgres analog of `tableCheck` for
+ * optional ClickHouse system tables.
+ */
+
+/** How a column's raw value is formatted for display. */
+export type PgColumnFormat =
+  /** Locale-grouped integer (e.g. `12,345`). */
+  | 'number'
+  /** Milliseconds → `1.2s` / `340ms` via `formatDuration`. */
+  | 'duration_ms'
+  /** A value already in milliseconds, shown as `1,234 ms`. */
+  | 'ms'
+  /** Byte count → `1.2 MB` via `formatReadableSize`. */
+  | 'bytes'
+  /** A 0–100 number rendered as `98.4%`. */
+  | 'percent'
+  /** Monospaced code/SQL (truncated with expand). */
+  | 'code'
+  /** Plain text (default). */
+  | 'text'
+
+/** A single displayed column in a `PgQueryConfig`. */
+export interface PgColumn {
+  /** Row key this column reads (must exist in the SQL projection). */
+  key: string
+  /** Human header label. */
+  label: string
+  /** Value formatter; defaults to `text`. */
+  format?: PgColumnFormat
+  /**
+   * When set, an inline share bar is drawn behind the cell using this row key,
+   * which must project a 0–100 percentage (mirrors the ClickHouse
+   * BackgroundBar `pct_*` convention).
+   */
+  barPctKey?: string
+  /** Right-align numeric columns. Defaults from `format` when omitted. */
+  align?: 'left' | 'right'
+  /** Optional short header tooltip. */
+  help?: string
+}
+
+/** A declarative Postgres data view. */
+export interface PgQueryConfig {
+  /** Stable registry key (also the `/api/v1/pg/query/:name` segment). */
+  name: string
+  /** Page/table title. */
+  title: string
+  /** One-line description shown under the title. */
+  description?: string
+  /** Optional external documentation link. */
+  docs?: string
+  /**
+   * A SINGLE read-only SQL statement. Sent through
+   * `@chm/postgres-client.queryPostgres`, which pins the session read-only,
+   * gates to a single SELECT/WITH/…, and always uses the extended protocol.
+   */
+  sql: string
+  /** Columns to render, in order. */
+  columns: PgColumn[]
+  /**
+   * A Postgres extension that MUST be installed for this view to return data
+   * (e.g. `pg_stat_statements`). When missing, the server returns an empty
+   * result flagged `extensionMissing` and the page renders a graceful
+   * "enable the extension" EmptyState instead of any raw Postgres error.
+   */
+  extensionCheck?: string
+  /** When true, clicking a row opens the detail flyout. */
+  rowClickable?: boolean
+}


### PR DESCRIPTION
Closes #2450. Part of the Postgres epic (#2264); builds on Phase 1 (#2570) + Phase 2 (#2571). Merged latest `main` (incl. the #2572 pg-dedupe Docker fix).

## Scope A — PgQueryConfig + two data views

- **Minimal parallel `PgQueryConfig`** (`types/pg-query-config.ts`) — a single read-only SQL string, declarative columns, optional `extensionCheck`. `QueryConfig` (CH-versioned SQL + `ClickHouseSettings`) is **not** generalized.
- **Query executor reuses Phase 2** — `lib/connection-query/execute-pg-query.ts` calls `@chm/postgres-client.queryPostgres` (session pinned read-only, SELECT-only gate, extended protocol) and **re-runs the TCP SSRF guard** `validatePostgresHost` on every request. No second Postgres access path.
- **One API route** `POST /api/v1/pg/query/$name` resolves either a server-stored (`connectionId` → D1) or inline browser Postgres source, gated by `CHM_FEATURE_POSTGRES_SOURCE`.
- **Overview page** `/postgres/queries` — slow patterns from `pg_stat_statements` (query, calls, total/mean/stddev exec time, max, rows, cache-hit ratio, WAL) with BackgroundBar-style share bars. **Running queries** `/postgres/activity` from `pg_stat_activity` (pid, state, duration, wait event, query), polling.
- **Detail flyout** — clicking a pattern opens a Sheet with the full query text + per-metric breakdown (mirrors the CH `PatternDetailSheet`).
- **Graceful empty state** when `pg_stat_statements` is missing — detected via `SELECT 1 FROM pg_extension WHERE extname=$1`; renders `PgExtensionEmptyState` with `CREATE EXTENSION` + `shared_preload_libraries` instructions. **No raw Postgres error is ever surfaced** (missing extension is a first-class empty state; genuine failures are classified/sanitized). Cypress component test co-located.

## Scope B — engine-aware menu swap (decision 4)

- `MenuItem` gains optional `engines?: SourceEngine[]`. **Absent = ClickHouse family** (unchanged); Postgres pages declare `engines: ['postgres']`.
- `getVisibleMenuItems(config, engine)` filters by the active engine, threaded via a new `?pg=<connectionId>` routing dimension → `useActiveHostEngine()` into the sidebar **and** ⌘K palette.
- **Zero-diff invariant** (hard gate): a ClickHouse host / flag-off sees today's exact menu; Postgres shows only its pages. Unit-tested in `visible-items.test.ts`.
- Host switcher lists Postgres sources under a "Postgres Sources" group with an engine badge; selecting one routes to `/postgres/queries?pg=id`, selecting a ClickHouse host clears `?pg=`. PG hosts stay out of `useMergedHosts` (never mis-queried as CH hostIds), per the Phase 2 handoff.

## Verification (live, against local PG 17.10 + `pg_stat_statements`)

Data path exercised end-to-end through the dev-server route (`CHM_ALLOW_PRIVATE_HOSTS=true`, `127.0.0.1:54329`):

| Check | Result |
|---|---|
| `pg-slow-patterns` on `pocdb` | `success: true`, **27 rows**, all columns incl. `cache_hit_ratio=40.2`, `pct_total_time=59.6` |
| `pg-running-queries` w/ live `SELECT pg_sleep(8)` | **1 row** — pid 453, `state=active`, `duration_ms=1046` |
| `pg-slow-patterns` on `noext` (no extension) | `success: true`, **`extensionMissing: true`, `extension: pg_stat_statements`** → empty state |
| Write gate (`CREATE TABLE …`) | rejected: "Only read-only statements are allowed" |
| `?pg=` preserved through host-redirect middleware | `/postgres/queries?pg=abc123&host=0` ✓ |

Gates: `pnpm run build` ✓, biome ✓, `type-check` ✓, `type-check:test` ✓, full `test:unit` ✓ (**6453 pass, 0 fail**, incl. 4 new menu-engine tests). No `package.json` changed → no lockfile churn.

**Caveat:** browser screenshots of the UI (menu swap / flyout render) could not be captured — the Chrome extension isn't connected in this environment. The menu-swap invariant is covered by unit tests and the data path is proven live via the running dev server; the pages serve 200 and compile without error.

https://claude.ai/code/session_01Vr3H4qxbgDVXgFM2trPeCD
