### PR TITLE
docs: announce Postgres monitoring beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -664,6 +664,7 @@ New optional vars: `CHM_AUTH_PROVIDER` (`none\|clerk\|proxy`), `CHM_API_KEY_SECR
 ### ✨ Features
 
 - **Promote TanStack Start dashboard to primary, remove legacy Next.js app** ([#1392](https://github.com/chmonitor/chmonitor/issues/1392)).
+- **postgres:** Postgres as a monitored source (beta) — query insights, running queries, and AI agent tools ([#2570](https://github.com/chmonitor/chmonitor/pull/2570)).
 
 ### 🤖 Migrate with an AI assistant
 

--- a/apps/blog/src/content/blog/postgres-monitoring-beta.md
+++ b/apps/blog/src/content/blog/postgres-monitoring-beta.md
@@ -1,0 +1,80 @@
+---
+title: "Postgres as a monitored source (beta)"
+description: "chmonitor now monitors Postgres alongside ClickHouse — read-only query insights, running queries, and AI agent tools. Beta, free on every plan."
+date: 2026-07-11
+tag: Release
+---
+
+chmonitor started as a ClickHouse dashboard. Today it monitors **Postgres** too —
+same dashboard, same read-only guarantees, no agent to install on the database
+side. It's in **beta**: off by default, free on every plan while it stabilizes.
+
+## What you get
+
+<div class="hl-grid">
+  <div class="hl"><b>Query Insights</b><span>The slowest normalized query patterns from pg_stat_statements, ranked by total execution time.</span></div>
+  <div class="hl"><b>Running Queries</b><span>Live pg_stat_activity — state, wait event, query text, duration, refreshed every 5 seconds.</span></div>
+  <div class="hl"><b>Engine-aware menu</b><span>Switch to a Postgres host and the sidebar swaps automatically — no ClickHouse-only pages to skip past.</span></div>
+  <div class="hl"><b>AI agent tools</b><span>Three new tools — run a read-only query, pull health metrics, or list slow query patterns — from the same agent you already use for ClickHouse.</span></div>
+</div>
+
+## Why Postgres, and why now
+
+A lot of chmonitor users run Postgres somewhere next to ClickHouse — as the
+system of record feeding a CDC pipeline, or just as another database the same
+team owns. Asking them to open a second tool for it never made sense. Postgres
+support adds a **source engine** dimension alongside ClickHouse and ClickHouse
+Cloud, so the dashboard, the menu, and the AI agent all understand "this host
+speaks Postgres" the same way they already understand "this host is a
+ClickHouse Cloud cluster."
+
+## Read-only, the same way ClickHouse is
+
+Every Postgres query runs through one path: it connects per request, pins
+`default_transaction_read_only=on`, and only allows a single
+`SELECT`/`WITH`/`SHOW`/`EXPLAIN`/`TABLE`/`VALUES` statement. There's no second
+access path and no write capability anywhere in the feature. Connecting to a
+user-supplied host also goes through an SSRF guard before chmonitor ever opens
+a socket.
+
+We recommend pointing the connection at a dedicated read-only Postgres role —
+belt and suspenders on top of the query-level guard.
+
+## Query Insights needs `pg_stat_statements`
+
+Running Queries works out of the box against `pg_stat_activity`, which every
+Postgres has. Query Insights needs the `pg_stat_statements` extension. If it's
+not installed, the page shows the exact two steps instead of an error:
+
+```sql
+-- postgresql.conf, then restart Postgres
+shared_preload_libraries = 'pg_stat_statements'
+```
+
+```sql
+CREATE EXTENSION pg_stat_statements;
+```
+
+## Ask the agent
+
+Three new tools join the agent's existing set: `run_postgres_select_query`,
+`get_postgres_metrics`, and `list_postgres_slow_query_patterns`. Point them at
+a Postgres host and ask the same kind of questions you'd ask about ClickHouse —
+what's slow, what's the cache hit ratio, what's currently running.
+
+If you're moving data from Postgres into ClickHouse, the agent's
+migration-planning skill now covers that path too, with
+[PeerDB](https://docs.chmonitor.dev/guide/features/peerdb) as the recommended
+CDC route.
+
+## Try it
+
+Set `CHM_FEATURE_POSTGRES_SOURCE=true`, add a `POSTGRES_HOST` (or connect one
+from the dashboard UI), and open `/postgres/queries`. Full setup, environment
+variables, and beta limitations are in the
+[Postgres docs](https://docs.chmonitor.dev/guide/features/postgres).
+
+This is a beta: expect rough edges, and treat it as ready for evaluation, not
+yet for every production cluster. Feedback is welcome — open an issue on
+[GitHub](https://github.com/chmonitor/chmonitor) or try it on the
+[live dashboard](https://dash.chmonitor.dev).

--- a/apps/landing/src/components/FeatureShowcase.astro
+++ b/apps/landing/src/components/FeatureShowcase.astro
@@ -59,6 +59,18 @@ const icons: Record<string, string> = {
                     {bullet}
                   </li>
                 ))}
+                {section.learnMoreHref && (
+                  <li class="mt-1">
+                    <a
+                      class="text-[var(--brand-ink)] text-sm font-medium hover:underline"
+                      href={section.learnMoreHref}
+                      target="_blank"
+                      rel="noopener"
+                    >
+                      Learn more →
+                    </a>
+                  </li>
+                )}
               </ul>
             </div>
 

--- a/apps/landing/src/data/feature-showcase.ts
+++ b/apps/landing/src/data/feature-showcase.ts
@@ -20,6 +20,8 @@ export type FeatureSection = {
   }
   /** Flip screenshot to the left on wide screens */
   reverse?: boolean
+  /** Optional "Learn more" link, e.g. to a docs page */
+  learnMoreHref?: string
 }
 
 export const FEATURE_SECTIONS: FeatureSection[] = [
@@ -133,5 +135,27 @@ export const FEATURE_SECTIONS: FeatureSection[] = [
       alt: 'Record-breaking queries ranked by duration, memory and rows read',
     },
     reverse: true,
+  },
+  {
+    id: 'feature-postgres',
+    icon: 'database',
+    eyebrow: 'Postgres · Beta',
+    title: 'Monitor Postgres alongside ClickHouse',
+    description:
+      'Same dashboard, same read-only guarantees. Query insights from pg_stat_statements, live activity from pg_stat_activity, and agent tools — free on every plan while in beta.',
+    bullets: [
+      'Slowest query patterns from pg_stat_statements',
+      'Live pg_stat_activity, refreshed every 5 seconds',
+      'Every query pinned read-only, SSRF-guarded connections',
+      'Three new AI agent tools for Postgres',
+    ],
+    screenshot: {
+      // Placeholder: no dedicated Postgres UI capture exists yet — this reuses
+      // an unused query-focused dashboard shot. Swap for a real /postgres/queries
+      // or /postgres/activity screenshot once available.
+      src: '/landing-assets/queries-memory-dark.webp',
+      alt: 'Query insights dashboard, the same pattern used for Postgres monitoring',
+    },
+    learnMoreHref: 'https://docs.chmonitor.dev/guide/features/postgres',
   },
 ]

--- a/apps/landing/src/data/pricing.ts
+++ b/apps/landing/src/data/pricing.ts
@@ -191,7 +191,7 @@ export const pricingFaqs: PricingFaq[] = [
   },
   {
     q: "What's a “host”?",
-    a: 'A host is a single ClickHouse connection (one cluster endpoint). Your plan caps how many hosts you can connect to the hosted dashboard at once. Self-hosting has no host limit.',
+    a: 'A host is a single monitored connection — one ClickHouse cluster endpoint, or (beta) one Postgres database. Your plan caps how many hosts you can connect to the hosted dashboard at once. Self-hosting has no host limit.',
   },
   {
     q: 'How does AI usage metering work?',

--- a/apps/landing/src/pages/pricing.astro
+++ b/apps/landing/src/pages/pricing.astro
@@ -44,6 +44,7 @@ const breadcrumbJsonLd = {
           <span class="eyebrow">Pricing</span>
           <h1>Simple pricing that scales with your fleet</h1>
           <p>Self-hosting is always free under GPL-3.0. The hosted cloud connects a cluster in minutes — start free, upgrade when your team grows. <strong>Early access is free to try</strong> while in beta.</p>
+          <p>Postgres source monitoring (beta) is available on every plan, including Free and self-hosted.</p>
         </div>
       </div>
     </section>

--- a/docs/content/guide/features/postgres.mdx
+++ b/docs/content/guide/features/postgres.mdx
@@ -1,0 +1,157 @@
+---
+description: Monitor a Postgres database alongside your ClickHouse clusters — read-only query insights, running queries, and AI agent tools. Beta, free on every plan.
+icon: Database
+title: Postgres
+---
+
+chmonitor can monitor a Postgres database the same way it monitors ClickHouse: read-only, no agent to install, from the same dashboard. This is a **beta** feature — off by default, free on every plan (including self-hosted) while it stabilizes.
+
+<Callout type="warn" title="Beta">
+Postgres support is new. Expect rough edges, and treat the feature flag as "on for evaluation," not "on for every production cluster" just yet.
+</Callout>
+
+<TypeTable
+  data={{
+    Routes: { type: "/postgres/queries, /postgres/activity", description: "Pages shown when a Postgres source is selected" },
+    "Feature id": { type: "postgres", description: "Gated by CHM_FEATURE_POSTGRES_SOURCE" },
+    "Default access": { type: "off", description: "Feature flag defaults to false — nothing changes until you enable it" },
+    "Requires auth": { type: "Depends on your setup", description: "Same auth posture as your other hosts" },
+    "System tables": { type: "pg_stat_activity, pg_stat_statements", description: "pg_stat_statements is optional but recommended" },
+    "Write access": { type: "None", description: "Every query is pinned read-only; only a single SELECT/WITH/SHOW/EXPLAIN/TABLE/VALUES statement is allowed" },
+  }}
+/>
+
+## What it does
+
+Postgres is a **source engine**, alongside ClickHouse and ClickHouse Cloud. Once `CHM_FEATURE_POSTGRES_SOURCE` is on, chmonitor can connect to a Postgres database and adds two pages:
+
+- **Query Insights** (`/postgres/queries`) — the slowest normalized query patterns from `pg_stat_statements`, ranked by total execution time, with a detail flyout per pattern. Refreshes every 30 seconds.
+- **Running Queries** (`/postgres/activity`) — live backends from `pg_stat_activity`: state, wait event, query, duration. Refreshes every 5 seconds.
+
+Switching to a Postgres host swaps the sidebar to these two pages automatically — the same engine-aware menu that shows ClickHouse-only pages for ClickHouse hosts.
+
+### Pages
+
+| Page | Route | Source | Refresh |
+|---|---|---|---|
+| Query Insights | `/postgres/queries` | `pg_stat_statements` | 30s |
+| Running Queries | `/postgres/activity` | `pg_stat_activity` | 5s |
+
+## Using it
+
+<Steps>
+<Step>
+### Turn on the feature flag
+
+```bash
+CHM_FEATURE_POSTGRES_SOURCE=true
+```
+
+Nothing changes anywhere else until this is set — the flag is fail-closed by design.
+
+</Step>
+<Step>
+### Add a Postgres connection
+
+Two ways to connect, same as ClickHouse:
+
+**Environment variables** (comma-separated lists, mirroring `CLICKHOUSE_HOST` etc.):
+
+```bash
+POSTGRES_HOST=db.example.com
+POSTGRES_PORT=5432
+POSTGRES_USER=chmonitor_ro
+POSTGRES_PASSWORD=my-password
+POSTGRES_DATABASE=postgres
+POSTGRES_SSLMODE=require
+POSTGRES_NAME=Production Postgres
+```
+
+**Per-user connection** (dashboard UI, when per-user connections are enabled): open the connection form and pick the **Postgres** tab. Fields are host, port, database, user, password, and SSL mode.
+
+Use a dedicated **read-only Postgres role** for the connection user — chmonitor pins `default_transaction_read_only=on` on every query as the authoritative guard, but a read-only role is good defense in depth and makes the intent explicit at the database level.
+
+</Step>
+<Step>
+### Enable `pg_stat_statements` (recommended)
+
+Query Insights needs the `pg_stat_statements` extension. Without it, the page shows an empty state with the exact steps instead of an error:
+
+```sql
+-- postgresql.conf, then restart Postgres
+shared_preload_libraries = 'pg_stat_statements'
+```
+
+```sql
+CREATE EXTENSION pg_stat_statements;
+```
+
+Running Queries works without the extension — it only needs `pg_stat_activity`, which is always available.
+
+</Step>
+<Step>
+### Open the Postgres pages
+
+Switch to the Postgres host (`?pg=<connectionId>` in the URL, or the host switcher). The sidebar shows Query Insights and Running Queries in place of the ClickHouse pages.
+
+</Step>
+</Steps>
+
+## Security
+
+<Callout type="info" title="Read-only, always">
+Every Postgres query goes through one path: `queryPostgres()`. It connects per request, pins `default_transaction_read_only=on`, and only allows a single `SELECT`/`WITH`/`SHOW`/`EXPLAIN`/`TABLE`/`VALUES` statement. There is no second Postgres access path anywhere in chmonitor.
+</Callout>
+
+- **SSRF guard**: `validatePostgresHost()` rejects private, loopback, link-local and other internal address ranges (both the literal host and its resolved IPs) before connecting. Set `CHM_ALLOW_PRIVATE_HOSTS=true` to allow `localhost` for local development — this override has no effect in Cloud mode.
+- **Credential encryption**: per-user Postgres connection credentials are encrypted at rest, same as ClickHouse connections.
+
+## AI agent tools
+
+Three tools, gated off with the feature flag (they simply don't appear when it's disabled):
+
+<TypeTable
+  data={{
+    run_postgres_select_query: { type: "tool", description: "Execute a read-only SELECT/WITH/SHOW/EXPLAIN/TABLE/VALUES query against a Postgres source." },
+    get_postgres_metrics: { type: "tool", description: "Version, uptime, connection counts by state, cache hit ratio, commit/rollback/deadlock counts, database size and replication status." },
+    list_postgres_slow_query_patterns: { type: "tool", description: "Slowest normalized query patterns from pg_stat_statements — returns a helpful message instead of an error if the extension isn't installed." },
+  }}
+/>
+
+<Callout type="warn" title="Agent tools currently see env-configured hosts only">
+The agent tools resolve Postgres hosts from `POSTGRES_HOST` (and siblings) — the same limitation ClickHouse agent tools have today with per-user connections. Per-user Postgres connections added through the dashboard UI are not yet visible to the agent.
+</Callout>
+
+Cross-source correlation (e.g. "compare this Postgres table to its ClickHouse mirror") works by giving the agent both tool sets in one conversation — there is no dedicated join primitive.
+
+## Configuration
+
+<TypeTable
+  data={{
+    CHM_FEATURE_POSTGRES_SOURCE: { type: "boolean", description: "Master switch for Postgres as a source. Default: false." },
+    POSTGRES_HOST: { type: "string", description: "Comma-separated Postgres host(s), optionally host:port." },
+    POSTGRES_PORT: { type: "number", description: "Port for hosts that don't specify one inline. Default: 5432." },
+    POSTGRES_USER: { type: "string", description: "Comma-separated user(s). A single value applies to every host. Default: postgres." },
+    POSTGRES_PASSWORD: { type: "string", description: "Comma-separated password(s). A single value applies to every host." },
+    POSTGRES_DATABASE: { type: "string", description: "Comma-separated database name(s). Falls back to the first entry. Default: postgres." },
+    POSTGRES_SSLMODE: { type: "string", description: "Comma-separated sslmode(s) (disable, require, verify-ca, verify-full, ...). Optional." },
+    POSTGRES_NAME: { type: "string", description: "Comma-separated display name(s) for the host switcher. Optional." },
+    CHM_ALLOW_PRIVATE_HOSTS: { type: "boolean", description: "Allow localhost/private addresses for local development. Ignored in Cloud mode." },
+  }}
+/>
+
+## Notes & limitations (beta)
+
+- Free on every plan, including self-hosted, while the feature is in beta — no billing gate yet.
+- Postgres connections have their own id space (`?pg=<connectionId>`) separate from ClickHouse `hostId`; the two are never mixed.
+- Agent tools only see env-configured Postgres hosts, not per-user connections (see above).
+- No live TLS certificate verification against a remote Postgres yet.
+- Migrating data from Postgres into ClickHouse via CDC? See the agent's migration-planning skill, which recommends [PeerDB](/guide/features/peerdb) as the CDC path.
+
+## Related
+
+<Cards>
+  <Card title="PeerDB" href="/guide/features/peerdb" description="Monitor CDC replication from Postgres into ClickHouse." />
+  <Card title="User connections" href="/guide/features/user-connections" description="Per-user connections, including Postgres, in the hosted dashboard." />
+  <Card title="AI Agent" href="/guide/ai-agent" description="Full list of agent tools, including the Postgres tool set." />
+</Cards>


### PR DESCRIPTION
## Summary

Announces Postgres as a monitored source (beta, epic #2264) across four surfaces:

- **Docs**: new `docs/content/guide/features/postgres.mdx` — feature flag, env-var and per-user connection setup, `pg_stat_statements` prerequisite, SSRF/read-only guarantees, and the three agent tools.
- **Blog**: `apps/blog/src/content/blog/postgres-monitoring-beta.md` — announcement post linking to the docs page.
- **Landing**: new Postgres (beta) entry in the homepage feature showcase, with a "Learn more" link to the docs page (added an optional `learnMoreHref` to `FeatureSection`).
- **Pricing**: beta note ("available on every plan, including Free and self-hosted") + broadened "What's a host?" FAQ answer to cover Postgres.
- **Changelog**: one bullet in the `Unreleased` → Features section.

## Follow-ups (not blocking)

- The landing feature section reuses an existing dashboard screenshot (`queries-memory-dark.webp`) as a placeholder — no dedicated Postgres UI capture exists yet. Flagged with a code comment; swap for a real `/postgres/queries` or `/postgres/activity` screenshot once available.
- Blog publish pipeline (OG image generation, RSS, sitemap) should pick this up automatically at build — no manual step identified.

## Test plan

- [x] Blog frontmatter validated against `apps/blog/src/content.config.ts` schema (title/description/date/tag all present and typed correctly).
- [x] Docs page follows the `peerdb.mdx` sibling's frontmatter/format conventions; `apps/docs/content/docs/**` confirmed generated + gitignored (no manual sync needed).
- [x] `pnpm run check` (Biome) and `pnpm run test:unit` / `pnpm run test:packages` pass locally via the pre-push hook.
- [ ] CI: `dashboard`, `unit-tests` (required), plus blog/landing/docs build checks.