### PR TITLE
feat(sidebar): move Billing/Organization/About to footer, exempt /about from first-run gate

### DIFF
--- a/apps/dashboard/src/components/app-sidebar.tsx
+++ b/apps/dashboard/src/components/app-sidebar.tsx
@@ -2,6 +2,7 @@ import { BookOpenIcon } from 'lucide-react'
 
 import { HostSwitcher } from '@/components/host/host-switcher'
 import { SampleClusterBanner } from '@/components/host/sample-cluster-banner'
+import { HostPrefixedLink } from '@/components/menu/link-with-context'
 import { NavUser } from '@/components/nav-user'
 import { NavMain } from '@/components/navigation/nav-main'
 import {
@@ -17,7 +18,9 @@ import { GUEST_USER } from '@/lib/clerk/guest-user'
 import { DOCS_SITE_URL } from '@/lib/docs-site'
 import { useFeaturePermissions } from '@/lib/feature-permissions/context'
 import { useActiveHostEngine } from '@/lib/hooks/use-active-pg-connection'
+import { isMenuItemActive } from '@/lib/menu/breadcrumb'
 import { getVisibleMenuItems } from '@/lib/menu/visible-items'
+import { usePathname } from '@/lib/next-compat'
 
 export function AppSidebar() {
   const { config } = useFeaturePermissions()
@@ -26,6 +29,11 @@ export function AppSidebar() {
   // swaps the menu to Postgres pages when a Postgres source is selected (#2450).
   const engine = useActiveHostEngine()
   const menuItems = getVisibleMenuItems(config, engine)
+  // Footer nav rows (Billing / Organization / About). Same visibility pipeline
+  // as the body, so cloud-only + permission + engine gating still applies; they
+  // render as compact rows in the footer instead of a labelled body group.
+  const footerItems = menuItems.filter((item) => item.section === 'footer')
+  const pathname = usePathname()
 
   return (
     <Sidebar collapsible="icon" variant="inset">
@@ -39,6 +47,30 @@ export function AppSidebar() {
       </SidebarContent>
 
       <SidebarFooter>
+        {/* App-level links (Billing / Organization / About) as compact footer
+            rows, above the Docs link and user button. */}
+        {footerItems.length > 0 && (
+          <SidebarMenu>
+            {footerItems.map((item) => (
+              <SidebarMenuItem key={item.href}>
+                <SidebarMenuButton
+                  size="sm"
+                  isActive={isMenuItemActive(item.href, pathname)}
+                  tooltip={item.title}
+                  render={
+                    <HostPrefixedLink
+                      href={item.href}
+                      className="flex w-full items-center"
+                    />
+                  }
+                >
+                  {item.icon && <item.icon className="size-4 shrink-0" />}
+                  <span>{item.title}</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            ))}
+          </SidebarMenu>
+        )}
         {/* Small Docs link sitting just above the user button. Docs live on
             the external site (docs.chmonitor.dev), so this leaves the app. */}
         <SidebarMenu>

--- a/apps/dashboard/src/components/host/first-run-decision.test.ts
+++ b/apps/dashboard/src/components/host/first-run-decision.test.ts
@@ -1,6 +1,9 @@
 import type { FirstRunInput } from './first-run-decision'
 
-import { resolveFirstRunAction } from './first-run-decision'
+import {
+  isFirstRunExemptPath,
+  resolveFirstRunAction,
+} from './first-run-decision'
 import { describe, expect, it } from 'bun:test'
 
 /**
@@ -120,7 +123,7 @@ describe('resolveFirstRunAction — self-hosted (OSS) unchanged', () => {
 })
 
 describe('resolveFirstRunAction — exemptions & auth', () => {
-  it('exempt paths (/setup, /billing, /organization) always render', () => {
+  it('exempt paths (/setup, /billing, /organization, /about) always render', () => {
     const action = resolveFirstRunAction(
       input({
         onExemptPath: true,
@@ -143,5 +146,23 @@ describe('resolveFirstRunAction — exemptions & auth', () => {
       })
     )
     expect(action).toEqual({ type: 'render' })
+  })
+})
+
+// The pathname → exemption mapping FirstRunGate feeds into `onExemptPath`. These
+// pages must render with zero hosts configured instead of redirecting to /setup.
+describe('isFirstRunExemptPath', () => {
+  it.each([
+    '/setup',
+    '/billing',
+    '/organization',
+    '/about',
+  ])('exempts %s from the first-run /setup redirect', (path) => {
+    expect(isFirstRunExemptPath(path)).toBe(true)
+  })
+
+  it('does not exempt a normal monitoring page', () => {
+    expect(isFirstRunExemptPath('/overview')).toBe(false)
+    expect(isFirstRunExemptPath('/merges')).toBe(false)
   })
 })

--- a/apps/dashboard/src/components/host/first-run-decision.ts
+++ b/apps/dashboard/src/components/host/first-run-decision.ts
@@ -25,6 +25,26 @@
  * visible" rather than the raw id, which stays correct for every source.
  */
 
+/**
+ * Paths that stay reachable with zero hosts configured and are never re-pointed:
+ *  - `/setup` renders the onboarding surface (exempting it avoids a redirect loop);
+ *  - `/billing` + `/organization` let a paying user manage plan/org before they
+ *    connect a host;
+ *  - `/about` is a static version-info page with no host dependency.
+ * These render as footer rows (Billing/Organization/About) — see AppSidebar.
+ */
+export const FIRST_RUN_EXEMPT_PATHS = [
+  '/setup',
+  '/billing',
+  '/organization',
+  '/about',
+] as const
+
+/** Whether `pathname` is exempt from the first-run `/setup` redirect. */
+export function isFirstRunExemptPath(pathname: string): boolean {
+  return (FIRST_RUN_EXEMPT_PATHS as readonly string[]).includes(pathname)
+}
+
 /** What FirstRunGate should do this render. */
 export type FirstRunAction =
   /** Render the routed page. */
@@ -44,7 +64,7 @@ export interface FirstRunInput {
   isLoading: boolean
   /** The env-host fetch returned 401/403 (an auth failure, not a real empty). */
   isUnauthorized: boolean
-  /** Current path is exempt (/setup, /billing, /organization). */
+  /** Current path is exempt (/setup, /billing, /organization, /about). */
   onExemptPath: boolean
   /** Number of VISIBLE merged hosts. */
   hostCount: number
@@ -82,8 +102,8 @@ export function resolveFirstRunAction(input: FirstRunInput): FirstRunAction {
   // render and individual data calls surface their own states. (Unchanged.)
   if (isUnauthorized) return { type: 'render' }
 
-  // Account/billing/setup pages stay reachable with zero hosts and must not be
-  // re-pointed. (Unchanged.)
+  // Account/billing/about/setup pages stay reachable with zero hosts and must
+  // not be re-pointed. (Unchanged.)
   if (onExemptPath) return { type: 'render' }
 
   // Cloud + signed-in: the env host is a hidden read-only demo. If the active

--- a/apps/dashboard/src/components/host/first-run-gate.tsx
+++ b/apps/dashboard/src/components/host/first-run-gate.tsx
@@ -1,4 +1,7 @@
-import { resolveFirstRunAction } from './first-run-decision'
+import {
+  isFirstRunExemptPath,
+  resolveFirstRunAction,
+} from './first-run-decision'
 import { useEffect } from 'react'
 import { PageSkeleton } from '@/components/skeletons'
 import { usePathname, useRouter, useSearchParams } from '@/lib/next-compat'
@@ -45,14 +48,11 @@ export function FirstRunGate({ children }: { children: React.ReactNode }) {
   const searchParams = useSearchParams()
   const hostId = useHostId()
 
-  // Account/billing pages stay reachable with zero hosts — a paying user with no
-  // host connected yet must still be able to view/manage their plan and org
-  // (otherwise they're trapped on /setup). /setup is itself exempt (no redirect
-  // loop, it renders the onboarding surface).
-  const onExemptPath =
-    pathname === '/setup' ||
-    pathname === '/billing' ||
-    pathname === '/organization'
+  // Account/billing/about pages stay reachable with zero hosts (a paying user
+  // with no host yet must manage plan/org; About is a static info page). /setup
+  // is itself exempt — no redirect loop, it renders the onboarding surface. See
+  // FIRST_RUN_EXEMPT_PATHS in first-run-decision.ts.
+  const onExemptPath = isFirstRunExemptPath(pathname)
 
   const action = resolveFirstRunAction({
     isLoading,

--- a/apps/dashboard/src/components/menu/types.ts
+++ b/apps/dashboard/src/components/menu/types.ts
@@ -3,7 +3,7 @@ import type { Icon } from '@chm/types/icon'
 import type { FeaturePermission } from '@/lib/feature-permissions/types'
 import type { BadgeVariant } from '@/types/badge-variant'
 
-export type MenuSection = 'main' | 'others'
+export type MenuSection = 'main' | 'others' | 'footer'
 
 export interface MenuItem {
   title: string
@@ -16,7 +16,11 @@ export interface MenuItem {
   countVariant?: BadgeVariant
   items?: MenuItem[]
   icon?: Icon
-  /** Section grouping for sidebar display */
+  /**
+   * Section grouping for sidebar display. `main` / `others` render as labelled
+   * groups in the sidebar body (NavMain); `footer` items render as compact rows
+   * in the sidebar footer (AppSidebar), above the Docs link and user button.
+   */
   section?: MenuSection
   /** Show "New" badge - hidden after user visits the page */
   isNew?: boolean

--- a/apps/dashboard/src/components/navigation/nav-main/index.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/index.tsx
@@ -1,5 +1,4 @@
-import type { MenuSection } from '@/components/menu/types'
-import type { NavMainProps } from './types'
+import type { NavMainProps, NavRenderSection } from './types'
 
 import { MenuGroup } from './menu-group'
 import { usePathname } from '@/lib/next-compat'
@@ -22,7 +21,7 @@ import { usePathname } from '@/lib/next-compat'
  */
 export function NavMain({ items }: NavMainProps) {
   const pathname = usePathname()
-  const sections: MenuSection[] = ['main', 'others']
+  const sections: NavRenderSection[] = ['main', 'others']
 
   return (
     <>

--- a/apps/dashboard/src/components/navigation/nav-main/menu-group.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/menu-group.tsx
@@ -1,5 +1,4 @@
-import type { MenuSection } from '@/components/menu/types'
-import type { MenuGroupProps } from './types'
+import type { MenuGroupProps, NavRenderSection } from './types'
 
 import { MenuItem } from './menu-item'
 import {
@@ -11,7 +10,7 @@ import {
 /**
  * Section label mapping
  */
-const SECTION_LABELS: Record<MenuSection, string> = {
+const SECTION_LABELS: Record<NavRenderSection, string> = {
   main: 'Main',
   others: 'Others',
 }

--- a/apps/dashboard/src/components/navigation/nav-main/types.ts
+++ b/apps/dashboard/src/components/navigation/nav-main/types.ts
@@ -4,6 +4,14 @@ import type {
 } from '@/components/menu/types'
 
 /**
+ * Sections NavMain renders as labelled groups in the sidebar body. `footer`
+ * items are rendered separately in the sidebar footer (see AppSidebar), so they
+ * are excluded here — that keeps {@link SectionLabelMap} exhaustive without a
+ * (never-shown) "Footer" label.
+ */
+export type NavRenderSection = Exclude<MenuSection, 'footer'>
+
+/**
  * Props for rendering a single menu item
  */
 export interface MenuItemProps {
@@ -18,7 +26,7 @@ export interface MenuItemProps {
  */
 export interface MenuGroupProps {
   /** Section identifier */
-  section: MenuSection
+  section: NavRenderSection
   /** Items in this section */
   items: MenuItemType[]
   /** Current pathname for active state detection */
@@ -46,4 +54,4 @@ export interface MenuItemActiveState {
 /**
  * Section label mapping
  */
-export type SectionLabelMap = Record<MenuSection, string>
+export type SectionLabelMap = Record<NavRenderSection, string>

--- a/apps/dashboard/src/lib/menu/__tests__/visible-items.test.ts
+++ b/apps/dashboard/src/lib/menu/__tests__/visible-items.test.ts
@@ -108,6 +108,50 @@ describe('menu config cloud-only contract', () => {
   })
 })
 
+// Footer nav rows (Billing / Organization / About) render in the sidebar footer
+// (AppSidebar) instead of a labelled body group, but flow through the SAME
+// visibility pipeline. These guard the section wiring so the footer stays in
+// sync with menu.ts.
+describe('menu config footer section', () => {
+  const footerTitles = (items: MenuItem[]) =>
+    items.filter((i) => i.section === 'footer').map((i) => i.title)
+
+  test('Billing, Organization, About are top-level footer items', () => {
+    const byHref = (href: string) =>
+      menuItemsConfig.find((item) => item.href === href)
+    expect(byHref('/billing')?.section).toBe('footer')
+    expect(byHref('/organization')?.section).toBe('footer')
+    expect(byHref('/about')?.section).toBe('footer')
+  })
+
+  test('About is reachable in OSS (not cloudOnly, keeps its permission)', () => {
+    const about = menuItemsConfig.find((item) => item.href === '/about')
+    expect(about?.cloudOnly).toBeUndefined()
+    expect(about?.permission).toEqual({ feature: 'about' })
+  })
+
+  test('About is no longer nested under the Operations group', () => {
+    const operations = menuItemsConfig.find(
+      (item) => item.title === 'Operations'
+    )
+    expect(operations?.items?.some((i) => i.href === '/about')).toBe(false)
+  })
+
+  test('OSS footer keeps About, drops cloud-only Billing/Organization', () => {
+    expect(footerTitles(filterCloudOnly(menuItemsConfig, false))).toEqual([
+      'About',
+    ])
+  })
+
+  test('cloud footer surfaces Billing, Organization, About in order', () => {
+    expect(footerTitles(filterCloudOnly(menuItemsConfig, true))).toEqual([
+      'Billing',
+      'Organization',
+      'About',
+    ])
+  })
+})
+
 // Engine-aware menu swap (issue #2450, decision 4). The HARD invariant: for the
 // ClickHouse family the menu is byte-for-byte today's menu; for Postgres only
 // the Postgres-tagged items show.

--- a/apps/dashboard/src/menu.ts
+++ b/apps/dashboard/src/menu.ts
@@ -824,7 +824,7 @@ export const menuItemsConfig: MenuItem[] = [
     title: 'Billing',
     href: '/billing',
     icon: CircleDollarSignIcon,
-    section: 'others',
+    section: 'footer',
     permission: { feature: 'billing' },
     cloudOnly: true,
   },
@@ -834,9 +834,21 @@ export const menuItemsConfig: MenuItem[] = [
     title: 'Organization',
     href: '/organization',
     icon: UsersIcon,
-    section: 'others',
+    section: 'footer',
     permission: { feature: 'billing' },
     cloudOnly: true,
+  },
+  {
+    // Dashboard + server version info. Rendered as a compact footer row (see
+    // AppSidebar), not inside a labelled body group. Reachable in both editions
+    // — no `cloudOnly` — and with zero hosts configured (exempt from the
+    // first-run /setup redirect, see first-run-gate.tsx).
+    title: 'About',
+    href: '/about',
+    description: 'Dashboard and server version information',
+    icon: InfoCircledIcon,
+    section: 'footer',
+    permission: { feature: 'about' },
   },
   {
     title: 'System',
@@ -1029,13 +1041,6 @@ export const menuItemsConfig: MenuItem[] = [
         countLabel: 'views',
         icon: BarChartIcon,
         tableCheck: EVENTS_TABLE,
-      },
-      {
-        title: 'About',
-        href: '/about',
-        description: 'Dashboard and server version information',
-        icon: InfoCircledIcon,
-        permission: { feature: 'about' },
       },
     ],
   },


### PR DESCRIPTION
## What

Moves **Billing**, **Organization**, and **About** out of the sidebar "Others" menu body into the **sidebar footer** as compact rows (above the Docs link and user button), and stops force-redirecting `/about` → `/setup` when zero hosts are configured.

## Changes

- **Footer nav rows** (`app-sidebar.tsx`): render `section:'footer'` items in `SidebarFooter`, reusing the existing `getVisibleMenuItems(config, engine)` pipeline so permission + `cloudOnly` + engine gating still apply. Compact `SidebarMenuButton` rows with `HostPrefixedLink` and active-state.
- **menu.ts**: Billing + Organization `section: 'others'` → `'footer'`; About moved from the **Operations** group to a top-level `section:'footer'` item (keeps its `permission: { feature: 'about' }`, no `cloudOnly` so it stays reachable in OSS).
- **New `'footer'` MenuSection** (`components/menu/types.ts`). `NavMain` still renders only `['main','others']`, so **no "Footer" group label** appears. A new `NavRenderSection = Exclude<MenuSection,'footer'>` keeps `SECTION_LABELS` exhaustive without a footer entry.
- **First-run gate** (`first-run-gate.tsx` / `first-run-decision.ts`): add `/about` to the exempt paths via a new testable `isFirstRunExemptPath` helper (`FIRST_RUN_EXEMPT_PATHS`). About/Billing/Organization now render as normal pages with zero hosts.

## Zero-regression / engine-aware

Footer items have no `engines`, so they gate exactly as before (ClickHouse family; the empty-guard hides the footer block on Postgres hosts — same as their pre-change behavior). Command palette (⌘K) and breadcrumbs still list/resolve Billing/Organization/About since they remain in `menuItemsConfig`. The NavUser dropdown entries are intentionally left as-is (separate surface).

## Tests

- `visible-items.test.ts`: footer-section contract (Billing/Org/About are top-level `footer`; About not `cloudOnly`, keeps permission, no longer under Operations; OSS drops cloud-only, cloud surfaces all three in order).
- `first-run-decision.test.ts`: `isFirstRunExemptPath` covers `/setup /billing /organization /about` and rejects normal pages.

Both suites pass locally (`bun test`); Biome lint + format clean.

Co-Authored-By: duyetbot <bot@duyet.net>