### PR TITLE
feat(setup): two-engine chooser + engine-aware add-host dialog

### DIFF
--- a/apps/dashboard/src/components/connections/add-host-dialog.tsx
+++ b/apps/dashboard/src/components/connections/add-host-dialog.tsx
@@ -1,9 +1,11 @@
 import type { HostStorageMode } from '@/lib/types/host-storage'
+import type { ConnectionPreset } from './connection-presets'
 
 import { ConnectionForm, type ConnectionFormData } from './connection-form'
 import { ConnectionHelpPanel } from './connection-help-panel'
+import { addHostDialogChrome, engineForPreset } from './connection-presets'
 import { isSampleClusterHost, SAMPLE_CLUSTER_PRESET } from './sample-preset'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   Dialog,
   DialogContent,
@@ -35,6 +37,12 @@ interface AddHostDialogProps {
    */
   initialPreset?: 'sample'
   /**
+   * Connection-type tab to open on (e.g. the setup page's "Connect Postgres"
+   * CTA). Threaded into the form's preset selector; users can still switch
+   * tabs. Defaults to `'self-hosted'`.
+   */
+  initialEngine?: ConnectionPreset
+  /**
    * Show the in-form "Use sample" quick-fill chip. Defaults on for the
    * regular "Add host" entry points; the sample-cluster convert banner opens
    * this dialog specifically to connect a REAL cluster, so it turns this off
@@ -47,6 +55,7 @@ export function AddHostDialog({
   open,
   onOpenChange,
   initialPreset,
+  initialEngine = 'self-hosted',
   showSamplePreset = true,
 }: AddHostDialogProps) {
   const router = useRouter()
@@ -62,28 +71,47 @@ export function AddHostDialog({
     connections: dbConnections,
   } = useUserConnections()
   const [storageMode, setStorageMode] = useState<HostStorageMode>('browser')
+  // Active connection-type preset — drives the engine-aware title, description
+  // and help panel. Seeded from `initialEngine` and updated as the user
+  // switches tabs inside the form (via `onEngineChange`).
+  const [engine, setEngine] = useState<ConnectionPreset>(initialEngine)
+
+  // The dialog instance is reused (only `open` toggles), so re-sync the engine
+  // to whatever the opener requested each time it opens.
+  useEffect(() => {
+    if (open) setEngine(initialEngine)
+  }, [open, initialEngine])
 
   const dbStorageConfigured = config.userConnections?.dbStorageEnabled === true
   const dbStorageEnabled = dbStorageConfigured && isSignedIn
   const allowPostgres = isFeatureEnabled('postgresSource')
 
   const handleSave = async (data: ConnectionFormData) => {
-    // Postgres sources aren't selectable as a ClickHouse hostId yet (#2449 keeps
-    // them out of the CH switcher; the pages land in #2450), so we store the
-    // connection but do NOT navigate `?host=` into a ClickHouse page.
+    // Postgres sources live in their own `?pg=<connectionId>` id space (never
+    // the ClickHouse `?host=` ids), so on save we route to the Postgres pages
+    // by connection id instead of pushing a `?host=`.
     const isPostgres = data.engine === 'postgres'
 
     if (storageMode === 'database' && dbStorageEnabled) {
       const result = await createConnection(data)
-      const hostId = result.data.hostId
       await refetchDb()
-      if (!isPostgres && hostId !== undefined) {
-        const url = buildUrl(pathname, { host: hostId }, searchParams)
+      if (isPostgres) {
+        router.push(
+          `/postgres/queries?pg=${encodeURIComponent(result.data.id)}`
+        )
+      } else if (result.data.hostId !== undefined) {
+        const url = buildUrl(
+          pathname,
+          { host: result.data.hostId },
+          searchParams
+        )
         router.push(url)
       }
     } else {
       const created = addConnection(data)
-      if (!isPostgres) {
+      if (isPostgres) {
+        router.push(`/postgres/queries?pg=${encodeURIComponent(created.id)}`)
+      } else {
         const url = buildUrl(pathname, { host: created.hostId }, searchParams)
         router.push(url)
       }
@@ -108,17 +136,14 @@ export function AddHostDialog({
   const initialValues =
     initialPreset === 'sample' ? SAMPLE_CLUSTER_PRESET : undefined
 
+  const chrome = addHostDialogChrome(engine)
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-3xl">
         <DialogHeader>
-          <DialogTitle>Add ClickHouse host</DialogTitle>
-          <DialogDescription>
-            Point chmonitor at a ClickHouse cluster to start monitoring. It
-            needs a user with <code>SELECT</code> on <code>system.*</code> — see
-            the guidance on the right for grants, firewall setup, and how your
-            credentials are stored.
-          </DialogDescription>
+          <DialogTitle>{chrome.title}</DialogTitle>
+          <DialogDescription>{chrome.description}</DialogDescription>
         </DialogHeader>
 
         {/* Two columns on md+ (form left, guidance right); stacks with the form
@@ -154,10 +179,12 @@ export function AddHostDialog({
               dbStorageRequiresSignIn={dbStorageConfigured && !isSignedIn}
               showSamplePreset={showSamplePreset}
               allowPostgres={allowPostgres}
+              initialPreset={initialEngine}
+              onEngineChange={setEngine}
             />
           </div>
 
-          <ConnectionHelpPanel />
+          <ConnectionHelpPanel engine={engineForPreset(engine)} />
         </div>
       </DialogContent>
     </Dialog>

--- a/apps/dashboard/src/components/connections/connection-form.tsx
+++ b/apps/dashboard/src/components/connections/connection-form.tsx
@@ -21,7 +21,7 @@ import {
   SELF_HOSTED_HOST_PLACEHOLDER,
 } from './connection-presets'
 import { SAMPLE_CLUSTER_PRESET } from './sample-preset'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -92,6 +92,18 @@ interface ConnectionFormProps {
    * only UI, so there is zero visual change when the flag is off.
    */
   allowPostgres?: boolean
+  /**
+   * Connection-type tab to start on (e.g. the setup page's "Connect Postgres"
+   * CTA opens the dialog straight on the Postgres tab). Users can still switch
+   * tabs afterwards. Defaults to `'self-hosted'`.
+   */
+  initialPreset?: ConnectionPreset
+  /**
+   * Notified whenever the active connection-type preset changes (and once on
+   * mount) so the parent dialog can react — engine-aware title, description and
+   * help panel.
+   */
+  onEngineChange?: (preset: ConnectionPreset) => void
 }
 
 function isValidUrl(value: string): boolean {
@@ -126,21 +138,36 @@ export function ConnectionForm({
   dbStorageRequiresSignIn = false,
   showSamplePreset = false,
   allowPostgres = false,
+  initialPreset = 'self-hosted',
+  onEngineChange,
 }: ConnectionFormProps) {
   const [form, setForm] = useState<ConnectionFormData>({
     name: initialValues?.name ?? '',
     host: initialValues?.host ?? '',
-    user: initialValues?.user ?? '',
+    // Seed the Postgres field defaults up front when the dialog opens straight
+    // on the Postgres tab (setup page "Connect Postgres" CTA), mirroring what
+    // `handlePresetChange('postgres')` would apply on a manual tab switch.
+    user:
+      initialValues?.user ?? (initialPreset === 'postgres' ? 'postgres' : ''),
     password: initialValues?.password ?? '',
-    port: initialValues?.port,
+    port:
+      initialValues?.port ??
+      (initialPreset === 'postgres' ? POSTGRES_DEFAULT_PORT : undefined),
     database: initialValues?.database ?? '',
     sslmode: initialValues?.sslmode ?? 'require',
   })
   const [showPassword, setShowPassword] = useState(false)
   const [testStatus, setTestStatus] = useState<TestStatus>({ state: 'idle' })
-  const [preset, setPreset] = useState<ConnectionPreset>('self-hosted')
+  const [preset, setPreset] = useState<ConnectionPreset>(initialPreset)
 
   const isPostgres = preset === 'postgres'
+
+  // Keep the parent (AddHostDialog) in sync with the initial engine on mount so
+  // its title / description / help panel match the tab the dialog opened on.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only sync
+  useEffect(() => {
+    onEngineChange?.(initialPreset)
+  }, [])
 
   const handleChange =
     (field: keyof ConnectionFormData) =>
@@ -155,6 +182,7 @@ export function ConnectionForm({
   const handlePresetChange = (next: ConnectionPreset) => {
     setPreset(next)
     setTestStatus({ state: 'idle' })
+    onEngineChange?.(next)
     // Only fill a still-empty username — never clobber an existing value
     // (e.g. while editing an existing connection via ConnectionManagerDialog).
     if (next === 'clickhouse-cloud') {

--- a/apps/dashboard/src/components/connections/connection-help-panel.tsx
+++ b/apps/dashboard/src/components/connections/connection-help-panel.tsx
@@ -5,23 +5,78 @@ import {
   Lock,
   MonitorSmartphone,
   Network,
+  Server,
   ShieldCheck,
 } from 'lucide-react'
+
+import type { SourceEngine } from '@chm/types'
+import type { ComponentType } from 'react'
 
 import { ChmonitorLogo } from '@/components/icons/chmonitor-logo'
 import { docsSiteUrl } from '@/lib/docs-site'
 import { cn } from '@/lib/utils'
 
+/** Whether the panel should render its Postgres variant. */
+function isPostgresEngine(engine: SourceEngine): boolean {
+  return engine === 'postgres'
+}
+
 /**
- * Guidance sidebar for the "Add ClickHouse host" dialog. Explains what chmonitor
- * needs to connect (a read-only `SELECT` user, a firewall allowlist), how
- * credentials are protected, and links to the same docs the form references —
- * so the operator has the requirements in view while filling in the form.
+ * Per-engine styling + copy for the help panel. Kept as full class strings (no
+ * dynamic interpolation) so Tailwind's scanner keeps them, and driven by design
+ * tokens / Tailwind palette utilities — never hardcoded hex. `transition-colors`
+ * on the tinted elements animates the swap when the user switches the tab.
+ */
+const ENGINE_UI: Record<
+  'clickhouse' | 'postgres',
+  {
+    label: string
+    Icon: ComponentType<{ className?: string; strokeWidth?: number }>
+    /** flow-dot fill + emphasized-node ring accent */
+    dotFill: string
+    ring: string
+    flowNote: string
+  }
+> = {
+  clickhouse: {
+    label: 'ClickHouse',
+    Icon: Database,
+    dotFill: 'fill-orange-500',
+    ring: 'border-orange-500/40 ring-orange-500/10',
+    flowNote:
+      'chmonitor reads your cluster over the ClickHouse HTTP interface.',
+  },
+  postgres: {
+    label: 'Postgres',
+    Icon: Server,
+    dotFill: 'fill-sky-500',
+    ring: 'border-sky-500/40 ring-sky-500/10',
+    flowNote:
+      'chmonitor reads your database over a read-only Postgres connection.',
+  },
+}
+
+/**
+ * Guidance sidebar for the Add-host dialog. Explains what chmonitor needs to
+ * connect, how credentials are protected, and links to the same docs the form
+ * references — so the operator has the requirements in view while filling in
+ * the form. Engine-aware: the flow diagram, requirements list and accent tint
+ * switch between ClickHouse and Postgres.
  *
  * Purely presentational (no state / no behaviour); the flow diagram and lists
  * are built from design-token divs + `lucide-react` icons.
  */
-export function ConnectionHelpPanel({ className }: { className?: string }) {
+export function ConnectionHelpPanel({
+  className,
+  engine = 'clickhouse',
+}: {
+  className?: string
+  /** Active source engine — defaults to ClickHouse (fail-closed). */
+  engine?: SourceEngine
+}) {
+  const postgres = isPostgresEngine(engine)
+  const ui = postgres ? ENGINE_UI.postgres : ENGINE_UI.clickhouse
+
   return (
     <aside
       className={cn(
@@ -30,45 +85,105 @@ export function ConnectionHelpPanel({ className }: { className?: string }) {
         className
       )}
     >
-      <ConnectionFlowDiagram />
+      <ConnectionFlowDiagram ui={ui} />
 
       <Section
         icon={<KeyRound className="size-4 text-orange-500" strokeWidth={1.5} />}
         title="What chmonitor needs"
       >
         <ul className="space-y-2 text-xs text-muted-foreground">
-          <RequirementItem
-            icon={
-              <ShieldCheck
-                className="size-3.5 text-muted-foreground"
-                strokeWidth={1.5}
-              />
-            }
-          >
-            A ClickHouse user with{' '}
-            <code className="text-foreground">SELECT</code> on{' '}
-            <code className="text-foreground">system.*</code> — read-only is
-            enough.
-          </RequirementItem>
-          <RequirementItem
-            icon={
-              <Network
-                className="size-3.5 text-muted-foreground"
-                strokeWidth={1.5}
-              />
-            }
-          >
-            The HTTP interface reachable from chmonitor (allowlist the Cloud
-            connection in your firewall).
-          </RequirementItem>
+          {postgres ? (
+            <>
+              <RequirementItem
+                icon={
+                  <ShieldCheck
+                    className="size-3.5 text-muted-foreground"
+                    strokeWidth={1.5}
+                  />
+                }
+              >
+                A read-only Postgres user — monitoring only runs{' '}
+                <code className="text-foreground">SELECT</code> against{' '}
+                <code className="text-foreground">pg_stat_*</code> views.
+              </RequirementItem>
+              <RequirementItem
+                icon={
+                  <Network
+                    className="size-3.5 text-muted-foreground"
+                    strokeWidth={1.5}
+                  />
+                }
+              >
+                The Postgres port (default{' '}
+                <code className="text-foreground">5432</code>) reachable from
+                chmonitor — allowlist it in your firewall.
+              </RequirementItem>
+              <RequirementItem
+                icon={
+                  <Lock
+                    className="size-3.5 text-muted-foreground"
+                    strokeWidth={1.5}
+                  />
+                }
+              >
+                An <code className="text-foreground">sslmode</code> that matches
+                your server (<code className="text-foreground">require</code> is
+                the safe default).
+              </RequirementItem>
+              <RequirementItem
+                icon={
+                  <Database
+                    className="size-3.5 text-muted-foreground"
+                    strokeWidth={1.5}
+                  />
+                }
+              >
+                <code className="text-foreground">pg_stat_statements</code>{' '}
+                enabled (optional) unlocks the query-insight views.
+              </RequirementItem>
+            </>
+          ) : (
+            <>
+              <RequirementItem
+                icon={
+                  <ShieldCheck
+                    className="size-3.5 text-muted-foreground"
+                    strokeWidth={1.5}
+                  />
+                }
+              >
+                A ClickHouse user with{' '}
+                <code className="text-foreground">SELECT</code> on{' '}
+                <code className="text-foreground">system.*</code> — read-only is
+                enough.
+              </RequirementItem>
+              <RequirementItem
+                icon={
+                  <Network
+                    className="size-3.5 text-muted-foreground"
+                    strokeWidth={1.5}
+                  />
+                }
+              >
+                The HTTP interface reachable from chmonitor (allowlist the Cloud
+                connection in your firewall).
+              </RequirementItem>
+            </>
+          )}
         </ul>
         <a
-          href={docsSiteUrl('getting-started/clickhouse-requirements')}
+          href={docsSiteUrl(
+            postgres
+              ? 'getting-started'
+              : 'getting-started/clickhouse-requirements'
+          )}
           target="_blank"
           rel="noopener noreferrer"
           className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-foreground underline-offset-2 hover:underline"
         >
-          Required permissions &amp; firewall setup
+          {postgres
+            ? 'Postgres monitoring setup'
+            : 'Required permissions & firewall setup'}
           <ArrowUpRight className="size-3" />
         </a>
       </Section>
@@ -133,11 +248,16 @@ function RequirementItem({
 }
 
 /**
- * A compact "your browser → chmonitor → ClickHouse" flow, so operators can see
- * at a glance where the connection sits. Built from token-driven divs; the
- * connectors are an inline SVG that flips gracefully in dark mode.
+ * A compact "your browser → chmonitor → source" flow, so operators can see at a
+ * glance where the connection sits. Built from token-driven divs; the
+ * connectors are an inline SVG that flips gracefully in dark mode. The third
+ * node + flow-dot accent follow the active engine.
  */
-function ConnectionFlowDiagram() {
+function ConnectionFlowDiagram({
+  ui,
+}: {
+  ui: (typeof ENGINE_UI)[keyof typeof ENGINE_UI]
+}) {
   return (
     <div className="rounded-lg border bg-card/60 p-3">
       <div className="flex items-center justify-between gap-1">
@@ -150,17 +270,18 @@ function ConnectionFlowDiagram() {
             />
           }
         />
-        <FlowConnector />
+        <FlowConnector dotFill={ui.dotFill} />
         <FlowNode
           label="chmonitor"
           icon={<ChmonitorLogo width={20} height={20} />}
           emphasized
+          ring={ui.ring}
         />
-        <FlowConnector />
+        <FlowConnector dotFill={ui.dotFill} />
         <FlowNode
-          label="ClickHouse"
+          label={ui.label}
           icon={
-            <Database
+            <ui.Icon
               className="size-5 text-muted-foreground"
               strokeWidth={1.5}
             />
@@ -168,7 +289,7 @@ function ConnectionFlowDiagram() {
         />
       </div>
       <p className="mt-2.5 text-center text-[11px] text-muted-foreground">
-        chmonitor reads your cluster over the ClickHouse HTTP interface.
+        {ui.flowNote}
       </p>
     </div>
   )
@@ -178,18 +299,20 @@ function FlowNode({
   label,
   icon,
   emphasized = false,
+  ring,
 }: {
   label: string
   icon: React.ReactNode
   emphasized?: boolean
+  /** Accent classes for the emphasized (chmonitor) node — engine-tinted. */
+  ring?: string
 }) {
   return (
     <div className="flex min-w-0 flex-1 flex-col items-center gap-1.5 text-center">
       <div
         className={cn(
-          'flex size-10 items-center justify-center rounded-lg border bg-background',
-          emphasized &&
-            'border-orange-500/40 shadow-sm ring-1 ring-orange-500/10'
+          'flex size-10 items-center justify-center rounded-lg border bg-background transition-colors',
+          emphasized && cn('shadow-sm ring-1', ring)
         )}
       >
         {icon}
@@ -204,9 +327,10 @@ function FlowNode({
 /**
  * A dashed connector with a subtle flow dot. The dot uses the CSS
  * `flow-dot` keyframe via `motion-safe:` so it is disabled under
- * `prefers-reduced-motion` (SMIL would ignore that preference).
+ * `prefers-reduced-motion` (SMIL would ignore that preference). Its fill is
+ * engine-tinted and animates on engine switch via `transition-colors`.
  */
-function FlowConnector() {
+function FlowConnector({ dotFill }: { dotFill: string }) {
   return (
     <svg
       viewBox="0 0 40 8"
@@ -228,7 +352,10 @@ function FlowConnector() {
         cx="6"
         cy="4"
         r="1.75"
-        className="fill-orange-500 motion-safe:animate-flow-dot"
+        className={cn(
+          dotFill,
+          'transition-colors motion-safe:animate-flow-dot'
+        )}
       />
     </svg>
   )

--- a/apps/dashboard/src/components/connections/connection-presets.test.ts
+++ b/apps/dashboard/src/components/connections/connection-presets.test.ts
@@ -1,6 +1,8 @@
 import {
+  addHostDialogChrome,
   applyCloudHostDefaults,
   CLOUD_DEFAULT_PORT,
+  engineForPreset,
 } from './connection-presets'
 import { describe, expect, test } from 'bun:test'
 
@@ -46,5 +48,36 @@ describe('applyCloudHostDefaults — ClickHouse Cloud preset host normalization'
 
   test('leaves an unparseable value untouched rather than throwing', () => {
     expect(applyCloudHostDefaults('https://')).toBe('https://')
+  })
+})
+
+describe('engineForPreset — preset → persisted SourceEngine', () => {
+  test('self-hosted maps to clickhouse', () => {
+    expect(engineForPreset('self-hosted')).toBe('clickhouse')
+  })
+
+  test('clickhouse-cloud maps to clickhouse-cloud', () => {
+    expect(engineForPreset('clickhouse-cloud')).toBe('clickhouse-cloud')
+  })
+
+  test('postgres maps to postgres', () => {
+    expect(engineForPreset('postgres')).toBe('postgres')
+  })
+})
+
+describe('addHostDialogChrome — engine-aware dialog title/description', () => {
+  test('Postgres preset gets Postgres-specific chrome', () => {
+    const chrome = addHostDialogChrome('postgres')
+    expect(chrome.title).toBe('Add Postgres source')
+    expect(chrome.description).toContain('Postgres')
+    expect(chrome.description).not.toContain('ClickHouse')
+  })
+
+  test('ClickHouse presets get the ClickHouse chrome', () => {
+    for (const preset of ['self-hosted', 'clickhouse-cloud'] as const) {
+      const chrome = addHostDialogChrome(preset)
+      expect(chrome.title).toBe('Add ClickHouse host')
+      expect(chrome.description).toContain('ClickHouse')
+    }
   })
 })

--- a/apps/dashboard/src/components/connections/connection-presets.ts
+++ b/apps/dashboard/src/components/connections/connection-presets.ts
@@ -32,6 +32,30 @@ export function engineForPreset(preset: ConnectionPreset): SourceEngine {
   }
 }
 
+/**
+ * Title + description for the Add-host dialog header, keyed on the active
+ * connection preset. Postgres is a distinct source engine (host/port/database),
+ * so its chrome reads "Add Postgres source" rather than "Add ClickHouse host".
+ * Pure so it can be unit-tested without a React harness.
+ */
+export function addHostDialogChrome(preset: ConnectionPreset): {
+  title: string
+  description: string
+} {
+  if (preset === 'postgres') {
+    return {
+      title: 'Add Postgres source',
+      description:
+        'Connect a Postgres database for read-only monitoring. It needs a reachable host on the Postgres port and a user that can read pg_stat_* — see the guidance on the right for requirements and how your credentials are stored.',
+    }
+  }
+  return {
+    title: 'Add ClickHouse host',
+    description:
+      'Point chmonitor at a ClickHouse cluster to start monitoring. It needs a user with SELECT on system.* — see the guidance on the right for grants, firewall setup, and how your credentials are stored.',
+  }
+}
+
 /** Default Postgres TCP port. */
 export const POSTGRES_DEFAULT_PORT = 5432
 

--- a/apps/dashboard/src/components/host/first-run-empty-state.tsx
+++ b/apps/dashboard/src/components/host/first-run-empty-state.tsx
@@ -1,21 +1,23 @@
 import {
-  ArrowRight,
   DatabaseZap,
   FlaskConical,
   KeyRound,
   PlugZap,
+  Server,
   ShieldCheck,
   Terminal,
 } from 'lucide-react'
 import { toast } from 'sonner'
 
 import type { ReactNode } from 'react'
+import type { ConnectionPreset } from '@/components/connections/connection-presets'
 
 import { useState } from 'react'
 import { PlanCard, PopularBadge } from '@/components/billing/plan-card'
 import { ClerkSignInButton as ClerkSignInButtonImpl } from '@/components/clerk/clerk-sign-in-button'
 import { AddHostDialog } from '@/components/connections'
 import { ChmonitorLogo } from '@/components/icons/chmonitor-logo'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { trackEvent } from '@/lib/analytics/analytics'
 import { BILLING_PLAN_LIST } from '@/lib/billing/plans'
@@ -25,7 +27,17 @@ import {
 } from '@/lib/billing/use-billing'
 import { isClerkEnabled } from '@/lib/clerk/clerk-client'
 import { docsSiteUrl } from '@/lib/docs-site'
+import { isFeatureEnabled } from '@/lib/feature-flags'
 import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
+import { cn } from '@/lib/utils'
+
+/** Options for opening the Add-host dialog from a first-run CTA. */
+type OpenAddHostOptions = {
+  /** Prefill the read-only sample ClickHouse preset. */
+  preset?: 'sample'
+  /** Connection-type tab to open on (e.g. `'postgres'`). */
+  engine?: ConnectionPreset
+}
 
 // Clerk's SignInButton needs a mounted <ClerkProvider>. Gate it behind the
 // build-time constant so non-Clerk (self-hosted) builds render null instead.
@@ -52,13 +64,15 @@ export function FirstRunEmptyState() {
   const { cloudMode, isSignedIn } = useMergedHosts()
   const [addOpen, setAddOpen] = useState(false)
   const [addPreset, setAddPreset] = useState<'sample' | undefined>(undefined)
+  const [addEngine, setAddEngine] = useState<ConnectionPreset>('self-hosted')
 
-  // Every open sets the preset explicitly (including `undefined`) — this
+  // Every open sets preset + engine explicitly (including the defaults) — this
   // dialog instance is reused/toggled, not remounted per CTA, so leaving the
-  // previous preset in place would leak "sample" into a later plain
-  // "Add host" click.
-  const openAddHost = (preset?: 'sample') => {
-    setAddPreset(preset)
+  // previous values in place would leak (e.g. "sample" or "postgres") into a
+  // later plain "Connect ClickHouse" click.
+  const openAddHost = (opts?: OpenAddHostOptions) => {
+    setAddPreset(opts?.preset)
+    setAddEngine(opts?.engine ?? 'self-hosted')
     setAddOpen(true)
   }
 
@@ -80,6 +94,7 @@ export function FirstRunEmptyState() {
         open={addOpen}
         onOpenChange={setAddOpen}
         initialPreset={addPreset}
+        initialEngine={addEngine}
       />
     </>
   )
@@ -151,6 +166,57 @@ function DocsFooter({ links }: { links: { slug: string; label: string }[] }) {
   )
 }
 
+/**
+ * Two-engine chooser: "Connect ClickHouse" (primary) plus, when the Postgres
+ * source flag is on, "Connect Postgres" (Beta). Each button opens the Add-host
+ * dialog straight on the matching connection-type tab. Falls back to a single
+ * full-width ClickHouse button when Postgres is disabled — zero visual change
+ * for the ClickHouse-only build.
+ */
+function EngineChooser({
+  onAddHost,
+  allowPostgres,
+  clickhouseLabel,
+  className,
+}: {
+  onAddHost: (opts?: OpenAddHostOptions) => void
+  allowPostgres: boolean
+  clickhouseLabel: string
+  className?: string
+}) {
+  return (
+    <div
+      className={cn('grid gap-2', allowPostgres && 'sm:grid-cols-2', className)}
+    >
+      <Button
+        size="lg"
+        onClick={() => onAddHost({ engine: 'self-hosted' })}
+        data-testid="welcome-add-host"
+      >
+        <PlugZap className="size-4" />
+        {clickhouseLabel}
+      </Button>
+      {allowPostgres && (
+        <Button
+          size="lg"
+          variant="outline"
+          onClick={() => onAddHost({ engine: 'postgres' })}
+          data-testid="welcome-add-postgres"
+        >
+          <Server className="size-4" />
+          Connect Postgres
+          <Badge
+            variant="secondary"
+            className="ml-1 px-1.5 py-0 text-[10px] font-medium"
+          >
+            Beta
+          </Badge>
+        </Button>
+      )}
+    </div>
+  )
+}
+
 /* ------------------------------------------------------------------ */
 /* Cloud — signed in                                                   */
 /* ------------------------------------------------------------------ */
@@ -158,8 +224,9 @@ function DocsFooter({ links }: { links: { slug: string; label: string }[] }) {
 function ConnectYourHost({
   onAddHost,
 }: {
-  onAddHost: (preset?: 'sample') => void
+  onAddHost: (opts?: OpenAddHostOptions) => void
 }) {
+  const allowPostgres = isFeatureEnabled('postgresSource')
   const { data: sub } = useBillingSubscription()
   const currentPlanId = sub?.planId ?? 'free'
   const isPaid = currentPlanId === 'pro' || currentPlanId === 'max'
@@ -187,8 +254,14 @@ function ConnectYourHost({
   return (
     <div className="space-y-7">
       <WelcomeHeader
-        title="Connect your ClickHouse"
-        subtitle="Your workspace is ready. Add a ClickHouse host to start monitoring queries, merges, replication and cluster health."
+        title={
+          allowPostgres ? 'Connect your database' : 'Connect your ClickHouse'
+        }
+        subtitle={
+          allowPostgres
+            ? 'Your workspace is ready. Connect a ClickHouse or Postgres source to start monitoring queries, performance and health.'
+            : 'Your workspace is ready. Add a ClickHouse host to start monitoring queries, merges, replication and cluster health.'
+        }
       />
 
       <div className="rounded-xl border bg-card p-5 shadow-sm">
@@ -197,11 +270,27 @@ function ConnectYourHost({
             icon={<DatabaseZap className="size-4" />}
             title="1. Have your connection details"
           >
-            The HTTP(S) endpoint (e.g.{' '}
-            <code className="rounded bg-muted px-1 text-[11px]">
-              https://host:8443
-            </code>
-            ), username and password.
+            {allowPostgres ? (
+              <>
+                The endpoint or host (e.g.{' '}
+                <code className="rounded bg-muted px-1 text-[11px]">
+                  https://host:8443
+                </code>{' '}
+                for ClickHouse,{' '}
+                <code className="rounded bg-muted px-1 text-[11px]">
+                  host:5432
+                </code>{' '}
+                for Postgres), username and password.
+              </>
+            ) : (
+              <>
+                The HTTP(S) endpoint (e.g.{' '}
+                <code className="rounded bg-muted px-1 text-[11px]">
+                  https://host:8443
+                </code>
+                ), username and password.
+              </>
+            )}
           </SetupStep>
           <SetupStep
             icon={<ShieldCheck className="size-4" />}
@@ -221,22 +310,18 @@ function ConnectYourHost({
           </SetupStep>
         </ul>
 
-        <Button
-          className="mt-5 w-full"
-          size="lg"
-          onClick={() => onAddHost()}
-          data-testid="welcome-add-host"
-        >
-          <PlugZap className="size-4" />
-          Add ClickHouse host
-          <ArrowRight className="ml-auto size-4" />
-        </Button>
+        <EngineChooser
+          className="mt-5"
+          onAddHost={onAddHost}
+          allowPostgres={allowPostgres}
+          clickhouseLabel="Connect ClickHouse"
+        />
 
         <Button
           className="mt-2 w-full"
           size="lg"
           variant="outline"
-          onClick={() => onAddHost('sample')}
+          onClick={() => onAddHost({ preset: 'sample' })}
           data-testid="welcome-try-sample"
         >
           <FlaskConical className="size-4" />
@@ -405,13 +490,22 @@ function SignInToConnect() {
 function SelfHostedSetup({
   onAddHost,
 }: {
-  onAddHost: (preset?: 'sample') => void
+  onAddHost: (opts?: OpenAddHostOptions) => void
 }) {
+  const allowPostgres = isFeatureEnabled('postgresSource')
   return (
     <div className="space-y-7">
       <WelcomeHeader
-        title="Connect a ClickHouse host to get started"
-        subtitle="No ClickHouse hosts are configured yet. Set them once via environment variables, or add one from your browser."
+        title={
+          allowPostgres
+            ? 'Connect a database to get started'
+            : 'Connect a ClickHouse host to get started'
+        }
+        subtitle={
+          allowPostgres
+            ? 'No sources are configured yet. Set ClickHouse hosts once via environment variables, or connect a ClickHouse or Postgres source from your browser.'
+            : 'No ClickHouse hosts are configured yet. Set them once via environment variables, or add one from your browser.'
+        }
       />
 
       <div className="rounded-xl border bg-card p-5 shadow-sm">
@@ -434,20 +528,16 @@ CLICKHOUSE_PASSWORD=••••••••`}</code>
           <span className="h-px flex-1 bg-border" />
         </div>
 
-        <Button
-          className="w-full"
-          variant="outline"
-          onClick={() => onAddHost()}
-          data-testid="welcome-add-host"
-        >
-          <PlugZap className="size-4" />
-          Add a host from this browser
-        </Button>
+        <EngineChooser
+          onAddHost={onAddHost}
+          allowPostgres={allowPostgres}
+          clickhouseLabel="Connect ClickHouse"
+        />
 
         <Button
           className="mt-2 w-full"
           variant="outline"
-          onClick={() => onAddHost('sample')}
+          onClick={() => onAddHost({ preset: 'sample' })}
           data-testid="welcome-try-sample"
         >
           <FlaskConical className="size-4" />

--- a/docs/knowledge/cloud-saas-mode.md
+++ b/docs/knowledge/cloud-saas-mode.md
@@ -3,7 +3,7 @@ id: cloud-saas-mode
 title: Cloud (SaaS) mode — one codebase, two products
 type: spec
 status: active
-updated: 2026-07-10
+updated: 2026-07-11
 tags:
   - saas
   - cloud
@@ -126,10 +126,26 @@ automatic demo, so they don't see this CTA.
   validation and host-limit path as any manual entry, no bypass. Also fires
   `sample_cluster_connected` / `sample_to_real_converted` (see
   `lib/analytics/events.ts`) by comparing the saved host against
-  `isSampleClusterHost`.
-- `components/host/first-run-empty-state.tsx` — secondary "Try with sample
-  ClickHouse" CTA in `ConnectYourHost` (cloud signed-in) and `SelfHostedSetup`;
-  not in `SignInToConnect` (redundant with the automatic demo).
+  `isSampleClusterHost`. Additionally takes `initialEngine?: ConnectionPreset`
+  (which tab to open on) and is **engine-aware**: it tracks the form's current
+  preset via `ConnectionForm`'s `onEngineChange`, swaps the dialog
+  title/description through `addHostDialogChrome(preset)` (connection-presets.ts,
+  "Add Postgres source" vs "Add ClickHouse host"), passes
+  `engineForPreset(preset)` to `ConnectionHelpPanel engine=…`, and on a
+  successful Postgres save routes to `/postgres/queries?pg=<connectionId>`
+  (the `?pg=` id space) instead of `?host=`.
+- `components/connections/connection-help-panel.tsx` — right-side guidance aside;
+  `engine?: SourceEngine` prop renders a ClickHouse or Postgres variant (flow
+  diagram third node + accent tint, requirements list). Fail-closed to
+  ClickHouse.
+- `components/host/first-run-empty-state.tsx` — `EngineChooser` renders a
+  two-engine chooser: "Connect ClickHouse" (`welcome-add-host`) plus, when
+  `isFeatureEnabled('postgresSource')`, "Connect Postgres" (Beta,
+  `welcome-add-postgres`) in `ConnectYourHost` (cloud signed-in) and
+  `SelfHostedSetup`; each opens `AddHostDialog` on the matching tab. Falls back
+  to a single full-width ClickHouse button when the flag is off (zero visual
+  change for OSS ClickHouse-only). Secondary "Try with sample ClickHouse" CTA
+  stays below; not in `SignInToConnect` (redundant with the automatic demo).
 - `components/host/sample-cluster-banner.tsx` (+ `sample-cluster-banner-
   dismissed.ts`) — persistent, dismissible "Connect your own cluster" convert
   nudge rendered in `app-sidebar.tsx`'s `SidebarHeader` below `HostSwitcher`.


### PR DESCRIPTION
## What

Refactors the first-run / setup experience so users pick between **Connect ClickHouse** and **Connect Postgres**, and upgrades the Add-host dialog to be engine-aware.

### Setup page (`first-run-empty-state.tsx`)
- New `EngineChooser`: two side-by-side engine buttons in both `ConnectYourHost` (cloud signed-in) and `SelfHostedSetup`.
  - **Connect ClickHouse** (primary, keeps `data-testid="welcome-add-host"`).
  - **Connect Postgres** (`data-testid="welcome-add-postgres"`, small **Beta** badge) — only when `isFeatureEnabled('postgresSource')`.
  - Falls back to a single full-width ClickHouse button when the flag is off → **zero visual change for the OSS ClickHouse-only build**.
- Copy is engine-neutral ("Connect your database") when the Postgres flag is on; "Try with sample ClickHouse" stays as the tertiary action.

### Add-host dialog (`add-host-dialog.tsx` + `connection-form.tsx`)
- `openAddHost` / `AddHostDialogProps` accept an `initialEngine` (`ConnectionPreset`); the dialog opens straight on that tab (tabs stay switchable).
- `ConnectionForm` gains `initialPreset` + `onEngineChange` (fires on mount and on tab switch) and seeds Postgres field defaults when starting on the Postgres tab.
- Dialog **title/description** react to the engine via `addHostDialogChrome()` ("Add Postgres source" vs "Add ClickHouse host").
- On a successful **Postgres** save it now navigates to `/postgres/queries?pg=<connectionId>` (the `?pg=` id space) instead of doing nothing.

### Engine-aware right-side panel (`connection-help-panel.tsx`)
- New `engine` prop (fail-closed to ClickHouse). Postgres variant: flow-diagram third node becomes **Postgres** (distinct icon), engine-tinted accent (sky vs orange, via Tailwind palette utilities — no hardcoded hex), animated flow retained with `transition-colors` on switch, and Postgres requirements (port 5432 reachability, read-only user, `sslmode`, optional `pg_stat_statements`). "Credentials are safe" section unchanged.

## Tests
- Unit tests for `engineForPreset` and the new `addHostDialogChrome` title/description mapping (`connection-presets.test.ts`, 12 pass locally).

## Notes
- Follows `docs/knowledge/product-design.md`; no `components/ui/*` edits. Client-side navigation only (static site).
- `docs/knowledge/cloud-saas-mode.md` updated to match.