### PR TITLE
ci(postgres): live postgres:17 integration job + client/executePgQuery tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,3 +211,72 @@ jobs:
 
       - name: Run package integration tests
         run: pnpm run test:packages:ci
+
+  # Live Postgres integration tests for the postgres-source path (@chm/postgres-client
+  # + the dashboard's executePgQuery/SSRF guard). Started via `docker run` (not
+  # `services:`) because `pg_stat_statements` needs `shared_preload_libraries` at
+  # server start, which `services:` containers can't override. Not a required
+  # check — self-skips everywhere else via `describe.skipIf(!POSTGRES_HOST)`.
+  test-postgres-integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      POSTGRES_HOST: localhost
+      POSTGRES_PORT: '5432'
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DATABASE: chm_test
+      POSTGRES_SSLMODE: disable
+      CHM_ALLOW_PRIVATE_HOSTS: 'true'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.14'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Install dashboard dependencies
+        working-directory: apps/dashboard
+        run: pnpm install --frozen-lockfile
+
+      - name: Start Postgres (with pg_stat_statements preloaded)
+        run: |
+          docker run -d --name pg -p 5432:5432 \
+            -e POSTGRES_PASSWORD=postgres \
+            -e POSTGRES_USER=postgres \
+            -e POSTGRES_DB=chm_test \
+            postgres:17 -c shared_preload_libraries=pg_stat_statements
+
+          for i in $(seq 1 30); do
+            if docker exec pg pg_isready -U postgres >/dev/null 2>&1; then
+              echo "Postgres is ready"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "Postgres never became ready"
+              docker logs pg
+              exit 1
+            fi
+            sleep 1
+          done
+
+          docker exec pg psql -U postgres -d chm_test \
+            -c 'CREATE EXTENSION IF NOT EXISTS pg_stat_statements;'
+
+      - name: Run Postgres integration tests
+        run: pnpm run test:pg-integration

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -27,6 +27,7 @@
     "test:query-config": "bun test src/lib/query-config --isolate",
     "test:coverage": "bun test src/ --isolate --coverage --coverage-reporter=lcov --coverage-reporter=text",
     "test:coverage:ci": "bun test src/ --isolate --coverage --coverage-reporter=lcov",
+    "test:pg-integration": "bun test src/lib/connection-query/execute-pg-query.integration.test.ts --isolate",
     "test:component": "cypress open --component",
     "test:component:headless": "cypress run --component",
     "test:e2e": "cypress open --e2e",

--- a/apps/dashboard/src/lib/connection-query/execute-pg-query.integration.test.ts
+++ b/apps/dashboard/src/lib/connection-query/execute-pg-query.integration.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Live Postgres integration tests for `executePgQuery` / `isPgExtensionInstalled`
+ * — the dashboard's Postgres query executor (Phase 2/3, #2450), including its
+ * SSRF guard (`validatePostgresHost`).
+ *
+ * These hit a REAL Postgres server (see the `test-postgres-integration` CI
+ * job in `.github/workflows/test.yml`). They self-skip whenever
+ * `POSTGRES_HOST` is unset — i.e. in the `unit-tests` job and for local
+ * `bun test` runs without a live database — so they never affect the
+ * required check. Run locally with:
+ *
+ *   docker run -d --name chm-pg -p 5432:5432 \
+ *     -e POSTGRES_PASSWORD=postgres -e POSTGRES_USER=postgres -e POSTGRES_DB=chm_test \
+ *     postgres:17 -c shared_preload_libraries=pg_stat_statements
+ *   docker exec chm-pg psql -U postgres -d chm_test \
+ *     -c 'CREATE EXTENSION IF NOT EXISTS pg_stat_statements;'
+ *   POSTGRES_HOST=localhost POSTGRES_PORT=5432 POSTGRES_USER=postgres \
+ *     POSTGRES_PASSWORD=postgres POSTGRES_DATABASE=chm_test \
+ *     CHM_ALLOW_PRIVATE_HOSTS=true \
+ *     bun test apps/dashboard/src/lib/connection-query/execute-pg-query.integration.test.ts
+ */
+
+import type { PostgresConnectionConfig } from '@chm/postgres-client'
+
+import { executePgQuery, isPgExtensionInstalled } from './execute-pg-query'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+const HAS_LIVE_POSTGRES = !!process.env.POSTGRES_HOST
+
+const config: PostgresConnectionConfig = {
+  host: process.env.POSTGRES_HOST ?? 'localhost',
+  port: Number(process.env.POSTGRES_PORT ?? 5432),
+  user: process.env.POSTGRES_USER ?? 'postgres',
+  password: process.env.POSTGRES_PASSWORD ?? 'postgres',
+  database: process.env.POSTGRES_DATABASE ?? 'chm_test',
+  sslmode: process.env.POSTGRES_SSLMODE ?? 'disable',
+}
+
+describe.skipIf(!HAS_LIVE_POSTGRES)(
+  'live Postgres — executePgQuery / isPgExtensionInstalled',
+  () => {
+    // These need CHM_ALLOW_PRIVATE_HOSTS=true (the CI job sets it) since the
+    // target is localhost/127.0.0.1 — a private/loopback address the SSRF
+    // guard blocks by default.
+    describe('with private hosts allowed', () => {
+      const savedAllowPrivate = process.env.CHM_ALLOW_PRIVATE_HOSTS
+
+      beforeEach(() => {
+        process.env.CHM_ALLOW_PRIVATE_HOSTS = 'true'
+      })
+
+      afterEach(() => {
+        if (savedAllowPrivate === undefined) {
+          delete process.env.CHM_ALLOW_PRIVATE_HOSTS
+        } else {
+          process.env.CHM_ALLOW_PRIVATE_HOSTS = savedAllowPrivate
+        }
+      })
+
+      test('executePgQuery returns rows + duration/row-count metadata', async () => {
+        const result = await executePgQuery(config, 'SELECT $1::int AS n', [7])
+        expect(result.data).toEqual([{ n: 7 }])
+        expect(result.metadata.rows).toBe(1)
+        expect(result.metadata.duration).toBeGreaterThanOrEqual(0)
+      })
+
+      test('isPgExtensionInstalled is false for a bogus extension name', async () => {
+        const installed = await isPgExtensionInstalled(
+          config,
+          'this_extension_does_not_exist_chm'
+        )
+        expect(installed).toBe(false)
+      })
+
+      test('isPgExtensionInstalled is true for pg_stat_statements (enabled by the CI job)', async () => {
+        const installed = await isPgExtensionInstalled(
+          config,
+          'pg_stat_statements'
+        )
+        expect(installed).toBe(true)
+      })
+    })
+
+    describe('SSRF guard — private hosts NOT allowed (default)', () => {
+      const savedAllowPrivate = process.env.CHM_ALLOW_PRIVATE_HOSTS
+      const savedDeploymentMode = process.env.CHM_DEPLOYMENT_MODE
+
+      beforeEach(() => {
+        delete process.env.CHM_ALLOW_PRIVATE_HOSTS
+        delete process.env.CHM_DEPLOYMENT_MODE
+      })
+
+      afterEach(() => {
+        if (savedAllowPrivate === undefined) {
+          delete process.env.CHM_ALLOW_PRIVATE_HOSTS
+        } else {
+          process.env.CHM_ALLOW_PRIVATE_HOSTS = savedAllowPrivate
+        }
+        if (savedDeploymentMode === undefined) {
+          delete process.env.CHM_DEPLOYMENT_MODE
+        } else {
+          process.env.CHM_DEPLOYMENT_MODE = savedDeploymentMode
+        }
+      })
+
+      test('rejects a loopback target before ever connecting', async () => {
+        await expect(
+          executePgQuery({ ...config, host: '127.0.0.1' }, 'SELECT 1')
+        ).rejects.toThrow(/internal addresses are not allowed/i)
+      })
+    })
+  }
+)

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test:coverage": "(cd apps/dashboard && pnpm run test:coverage) && pnpm run test:packages",
     "test:packages": "bun test packages --isolate --coverage --coverage-reporter=lcov --coverage-reporter=text",
     "test:packages:ci": "bun test packages --isolate --coverage --coverage-reporter=lcov",
+    "test:pg-integration": "bun test packages/postgres-client/src --isolate && cd apps/dashboard && pnpm run test:pg-integration",
     "test:component": "cd apps/dashboard && pnpm run test:component",
     "test:component:headless": "cd apps/dashboard && pnpm run test:component:headless",
     "test:e2e": "cd apps/dashboard && pnpm run test:e2e",

--- a/packages/postgres-client/src/client.integration.test.ts
+++ b/packages/postgres-client/src/client.integration.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Live Postgres integration tests for `@chm/postgres-client`.
+ *
+ * These hit a REAL Postgres server (see the `test-postgres-integration` CI
+ * job in `.github/workflows/test.yml`, which runs `postgres:17` via `docker
+ * run` so `pg_stat_statements` can be preloaded). They self-skip whenever
+ * `POSTGRES_HOST` is unset — i.e. in the `unit-tests` job and for local
+ * `bun test` runs without a live database — so they never affect the
+ * required check. Run locally with:
+ *
+ *   docker run -d --name chm-pg -p 5432:5432 \
+ *     -e POSTGRES_PASSWORD=postgres -e POSTGRES_USER=postgres -e POSTGRES_DB=chm_test \
+ *     postgres:17
+ *   POSTGRES_HOST=localhost POSTGRES_PORT=5432 POSTGRES_USER=postgres \
+ *     POSTGRES_PASSWORD=postgres POSTGRES_DATABASE=chm_test \
+ *     bun test packages/postgres-client/src/client.integration.test.ts
+ */
+
+import {
+  formatPostgresError,
+  getPostgresVersion,
+  type PostgresConnectionConfig,
+  queryPostgres,
+} from './client'
+import { describe, expect, test } from 'bun:test'
+import { Client } from 'pg'
+
+const HAS_LIVE_POSTGRES = !!process.env.POSTGRES_HOST
+
+const config: PostgresConnectionConfig = {
+  host: process.env.POSTGRES_HOST ?? 'localhost',
+  port: Number(process.env.POSTGRES_PORT ?? 5432),
+  user: process.env.POSTGRES_USER ?? 'postgres',
+  password: process.env.POSTGRES_PASSWORD ?? 'postgres',
+  database: process.env.POSTGRES_DATABASE ?? 'chm_test',
+  sslmode: process.env.POSTGRES_SSLMODE ?? 'disable',
+}
+
+/** A raw `pg` client for tests that need to bypass the read-only query path. */
+function newRawClient(): Client {
+  return new Client({
+    host: config.host,
+    port: config.port,
+    user: config.user,
+    password: config.password,
+    database: config.database,
+    ssl: false,
+  })
+}
+
+describe.skipIf(!HAS_LIVE_POSTGRES)('live Postgres — queryPostgres', () => {
+  test('getPostgresVersion returns a real server version string', async () => {
+    const version = await getPostgresVersion(config)
+    expect(version).toContain('PostgreSQL')
+  })
+
+  test('queryPostgres returns rows + field metadata for a SELECT', async () => {
+    const { rows, fields } = await queryPostgres<{ n: number; label: string }>(
+      config,
+      'SELECT $1::int AS n, $2::text AS label',
+      [42, 'hello']
+    )
+    expect(rows).toEqual([{ n: 42, label: 'hello' }])
+    expect(fields.map((f) => f.name)).toEqual(['n', 'label'])
+    expect(fields.every((f) => typeof f.dataTypeID === 'number')).toBe(true)
+  })
+
+  test('assertReadOnlyStatement blocks a write before it ever reaches Postgres', async () => {
+    await expect(
+      queryPostgres(config, 'CREATE TEMP TABLE should_not_exist (id int)')
+    ).rejects.toThrow(/read-only statements are allowed/i)
+  })
+
+  test('the session read-only pin rejects a write server-side (SQLSTATE 25006)', async () => {
+    // Exercises the AUTHORITATIVE guard directly: even if a write slipped past
+    // `assertReadOnlyStatement`, `SET default_transaction_read_only = on`
+    // (which `queryPostgres` issues on every connection) makes Postgres itself
+    // reject it with `25006 read_only_sql_transaction`.
+    //
+    // NOTE: this must be a PERMANENT table — Postgres allows writes to a
+    // session-local TEMP table even under `default_transaction_read_only`
+    // (temp tables aren't WAL-logged), so a temp table would not exercise the
+    // guard. Use a fresh setup/teardown connection (without the pin) to
+    // create/drop it, matching the "raw client, not queryPostgres" note above.
+    const tableName = `pg_integration_write_probe_${Date.now()}`
+    const setupClient = newRawClient()
+    await setupClient.connect()
+    try {
+      await setupClient.query(`CREATE TABLE ${tableName} (id int)`)
+    } finally {
+      await setupClient.end()
+    }
+
+    const client = newRawClient()
+    await client.connect()
+    try {
+      await client.query('SET default_transaction_read_only = on')
+      await expect(
+        client.query(`INSERT INTO ${tableName} VALUES (1)`)
+      ).rejects.toMatchObject({ code: '25006' })
+    } finally {
+      await client.end()
+    }
+
+    const teardownClient = newRawClient()
+    await teardownClient.connect()
+    try {
+      await teardownClient.query(`DROP TABLE IF EXISTS ${tableName}`)
+    } finally {
+      await teardownClient.end()
+    }
+  })
+
+  test('wrong password classifies as SQLSTATE 28P01', async () => {
+    const badConfig: PostgresConnectionConfig = {
+      ...config,
+      password: 'definitely-not-the-password',
+    }
+    let caught: unknown
+    try {
+      await queryPostgres(badConfig, 'SELECT 1')
+    } catch (err) {
+      caught = err
+    }
+    expect(caught).toBeDefined()
+    expect(formatPostgresError(caught)).toContain('[28P01]')
+  })
+
+  test('unknown database classifies as SQLSTATE 3D000', async () => {
+    const badConfig: PostgresConnectionConfig = {
+      ...config,
+      database: 'this_database_does_not_exist_chm',
+    }
+    let caught: unknown
+    try {
+      await queryPostgres(badConfig, 'SELECT 1')
+    } catch (err) {
+      caught = err
+    }
+    expect(caught).toBeDefined()
+    expect(formatPostgresError(caught)).toContain('[3D000]')
+  })
+
+  test('connection-refused port classifies as ECONNREFUSED (or 08006)', async () => {
+    const badConfig: PostgresConnectionConfig = {
+      ...config,
+      // Port 1 is reserved and nothing listens there in CI.
+      port: 1,
+    }
+    let caught: unknown
+    try {
+      await queryPostgres(badConfig, 'SELECT 1')
+    } catch (err) {
+      caught = err
+    }
+    expect(caught).toBeDefined()
+    const formatted = formatPostgresError(caught)
+    expect(formatted).toMatch(/\[(ECONNREFUSED|08006)\]/)
+  })
+
+  test('statement_timeout fires on a long-running query (SQLSTATE 57014)', async () => {
+    let caught: unknown
+    try {
+      await queryPostgres(config, 'SELECT pg_sleep(30)')
+    } catch (err) {
+      caught = err
+    }
+    expect(caught).toBeDefined()
+    expect(formatPostgresError(caught)).toContain('[57014]')
+  }, 20_000)
+})


### PR DESCRIPTION
## Summary
- Adds real-Postgres integration tests for the postgres-source path:
  - `packages/postgres-client/src/client.integration.test.ts` — `getPostgresVersion`/`queryPostgres` happy path, the `assertReadOnlyStatement` gate, the server-side `default_transaction_read_only` pin (SQLSTATE `25006`), SQLSTATE classification (`28P01` wrong password, `3D000` unknown database, `ECONNREFUSED`/`08006` connection refused), and `statement_timeout` firing (`57014`).
  - `apps/dashboard/src/lib/connection-query/execute-pg-query.integration.test.ts` — `executePgQuery` live round trip, `isPgExtensionInstalled` true/false, and the SSRF guard rejecting a loopback target before connecting.
- Both files self-skip via `describe.skipIf(!process.env.POSTGRES_HOST)`, so they're inert in the required `unit-tests` job and for local `bun test` without a live database.
- New `test-postgres-integration` CI job (non-required) starts `postgres:17` via `docker run` (not `services:`, since `pg_stat_statements` needs `shared_preload_libraries` at server start) and runs the new `test:pg-integration` scripts (root + dashboard).

## Test plan
- [x] Verified locally against a live `postgres:17` container (same `docker run` command as the CI job): both test files pass (8 + 4 tests).
- [x] Verified both files self-skip cleanly when `POSTGRES_HOST` is unset (matches `unit-tests` job behavior).
- [x] Ran the full `bun test packages --isolate` and `bun test src/ --isolate` (dashboard) suites without `POSTGRES_HOST` — no regressions (962 + 6464 passing, only the new files skip).
- [x] `biome check`/`biome format` clean on all touched files.