### PR TITLE
fix(sidebar): uniform footer spacing, dedupe View plans, footer on postgres

### DIFF
--- a/apps/dashboard/src/components/app-sidebar.tsx
+++ b/apps/dashboard/src/components/app-sidebar.tsx
@@ -47,33 +47,29 @@ export function AppSidebar() {
       </SidebarContent>
 
       <SidebarFooter>
-        {/* App-level links (Billing / Organization / About) as compact footer
-            rows, above the Docs link and user button. */}
-        {footerItems.length > 0 && (
-          <SidebarMenu>
-            {footerItems.map((item) => (
-              <SidebarMenuItem key={item.href}>
-                <SidebarMenuButton
-                  size="sm"
-                  isActive={isMenuItemActive(item.href, pathname)}
-                  tooltip={item.title}
-                  render={
-                    <HostPrefixedLink
-                      href={item.href}
-                      className="flex w-full items-center"
-                    />
-                  }
-                >
-                  {item.icon && <item.icon className="size-4 shrink-0" />}
-                  <span>{item.title}</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            ))}
-          </SidebarMenu>
-        )}
-        {/* Small Docs link sitting just above the user button. Docs live on
-            the external site (docs.chmonitor.dev), so this leaves the app. */}
+        {/* App-level links (Billing / Organization / About) and the external
+            Docs link share ONE menu so every footer row has the same rhythm —
+            separate SidebarMenu blocks would pick up the footer's gap-2 and
+            drift apart. The user button below stays its own block. */}
         <SidebarMenu>
+          {footerItems.map((item) => (
+            <SidebarMenuItem key={item.href}>
+              <SidebarMenuButton
+                size="sm"
+                isActive={isMenuItemActive(item.href, pathname)}
+                tooltip={item.title}
+                render={
+                  <HostPrefixedLink
+                    href={item.href}
+                    className="flex w-full items-center"
+                  />
+                }
+              >
+                {item.icon && <item.icon className="size-4 shrink-0" />}
+                <span>{item.title}</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          ))}
           <SidebarMenuItem>
             <SidebarMenuButton
               size="sm"

--- a/apps/dashboard/src/components/nav-user/clerk-nav.tsx
+++ b/apps/dashboard/src/components/nav-user/clerk-nav.tsx
@@ -101,24 +101,9 @@ export function ClerkNavWrapper() {
   return (
     <>
       <SidebarMenu>
-        {/* Not signed in - surface plans + a Sign In / Sign Up entry point.
-            The plans link sits above the account slot so Sign In stays the
-            bottom anchor (matching the signed-in user button position). */}
-        {!isSignedIn && (
-          <SidebarMenuItem>
-            <SidebarMenuButton
-              size="sm"
-              tooltip="View plans"
-              data-testid="nav-user-plans"
-              render={
-                <a href="/billing">
-                  <CreditCard />
-                  <span>View plans</span>
-                </a>
-              }
-            />
-          </SidebarMenuItem>
-        )}
+        {/* Signed-out plans discovery is covered by the Billing footer row
+            (same /billing target) rendered by AppSidebar — no separate
+            "View plans" entry here, it duplicated that link. */}
         <SidebarMenuItem>
           {/* Not signed in - show Sign In button */}
           {!isSignedIn && (

--- a/apps/dashboard/src/lib/menu/__tests__/visible-items.test.ts
+++ b/apps/dashboard/src/lib/menu/__tests__/visible-items.test.ts
@@ -203,14 +203,15 @@ describe('filterMenuItemsByEngine', () => {
   })
 
   test('ZERO-DIFF: filtering the real config for ClickHouse is a no-op', () => {
-    // Every current menu item lacks `engines`, so the ClickHouse view must equal
-    // the config with the (new) Postgres-only items removed — i.e. the exact
-    // pre-#2450 menu. Guards against accidentally tagging an existing item.
+    // The ClickHouse view must equal the config with the Postgres-ONLY items
+    // removed — i.e. the exact pre-#2450 menu. Items tagged with every engine
+    // (the footer rows) still count as ClickHouse items. Guards against
+    // accidentally hiding an existing item from the ClickHouse menu.
     const chTitles = filterMenuItemsByEngine(menuItemsConfig, 'clickhouse').map(
       (i) => i.title
     )
     const expected = menuItemsConfig
-      .filter((i) => !i.engines?.includes('postgres'))
+      .filter((i) => !i.engines || i.engines.includes('clickhouse'))
       .map((i) => i.title)
     expect(chTitles).toEqual(expected)
     // And none of the Postgres pages leak into the ClickHouse menu.
@@ -224,6 +225,9 @@ describe('filterMenuItemsByEngine', () => {
     )
     expect(pgTitles).toContain('Query Insights')
     expect(pgTitles).toContain('Running Queries')
+    // Account-level footer rows are engine-independent and stay visible.
+    expect(pgTitles).toContain('About')
+    expect(pgTitles).toContain('Billing')
     // ClickHouse-only top-level items must not appear.
     expect(pgTitles).not.toContain('Overview')
     expect(pgTitles).not.toContain('Health')

--- a/apps/dashboard/src/menu.ts
+++ b/apps/dashboard/src/menu.ts
@@ -827,6 +827,9 @@ export const menuItemsConfig: MenuItem[] = [
     section: 'footer',
     permission: { feature: 'billing' },
     cloudOnly: true,
+    // Account-level page — engine-independent, so keep it visible while a
+    // Postgres source is selected (absent `engines` means ClickHouse family).
+    engines: ['clickhouse', 'clickhouse-cloud', 'postgres'],
   },
   {
     // Cloud (SaaS) team management — members, roles, invitations. Cloud-only
@@ -837,6 +840,7 @@ export const menuItemsConfig: MenuItem[] = [
     section: 'footer',
     permission: { feature: 'billing' },
     cloudOnly: true,
+    engines: ['clickhouse', 'clickhouse-cloud', 'postgres'],
   },
   {
     // Dashboard + server version info. Rendered as a compact footer row (see
@@ -849,6 +853,7 @@ export const menuItemsConfig: MenuItem[] = [
     icon: InfoCircledIcon,
     section: 'footer',
     permission: { feature: 'about' },
+    engines: ['clickhouse', 'clickhouse-cloud', 'postgres'],
   },
   {
     title: 'System',


### PR DESCRIPTION
Follow-up to #2577 from live UI review.

- **Uniform spacing**: Docs now renders in the same `SidebarMenu` as Billing/Organization/About — previously three stacked blocks picked up the footer's `gap-2`, making Docs and View plans sit visibly apart from the rest.
- **Dedupe**: removed the signed-out **View plans** row in `clerk-nav.tsx`; it linked to the same `/billing` page as the always-visible Billing footer row.
- **Postgres mode**: footer rows (account-level pages) are now tagged with all engines so they no longer disappear when a Postgres source is selected. Updated the ZERO-DIFF guard test derivation accordingly (+2 assertions for the postgres view).

Tests: `bun test src/lib/menu src/components/host/first-run-decision.test.ts` — 47 pass. Biome clean.