### PR TITLE
fix(connections): make add-host dialog scrollable on small screens

### DIFF
--- a/apps/dashboard/src/components/connections/add-host-dialog.tsx
+++ b/apps/dashboard/src/components/connections/add-host-dialog.tsx
@@ -140,7 +140,7 @@ export function AddHostDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-3xl">
+      <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-3xl">
         <DialogHeader>
           <DialogTitle>{chrome.title}</DialogTitle>
           <DialogDescription>{chrome.description}</DialogDescription>

--- a/apps/dashboard/src/components/health/health-audit-prompt-dialog.tsx
+++ b/apps/dashboard/src/components/health/health-audit-prompt-dialog.tsx
@@ -104,7 +104,7 @@ export function HealthAuditPromptDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-3xl">
+      <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto max-w-3xl">
         <DialogHeader>
           <DialogTitle>Audit prompt: {title}</DialogTitle>
           <DialogDescription>

--- a/apps/dashboard/src/components/health/health-settings-dialog.tsx
+++ b/apps/dashboard/src/components/health/health-settings-dialog.tsx
@@ -217,7 +217,7 @@ export function HealthSettingsDialog() {
         <Settings className="mr-2 size-4" />
         Settings
       </DialogTrigger>
-      <DialogContent className="max-w-2xl">
+      <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto max-w-2xl">
         <DialogHeader>
           <DialogTitle>Health Settings</DialogTitle>
           <DialogDescription>


### PR DESCRIPTION
## What

`DialogContent` is fixed-position and vertically centered (`top-1/2 -translate-y-1/2`) with no `max-height`. On short viewports — laptops under ~1200px tall, and effectively all phones — the Add-host dialog's title and Save/Cancel footer clip off-screen with no way to scroll to them.

Fixed by capping height at the usage site (never touching `components/ui/dialog.tsx`, per repo convention):

```
max-h-[calc(100dvh-2rem)] overflow-y-auto
```

## Why `dvh` not `vh`

`100vh` on mobile is the *maximum* viewport height, ignoring the browser's URL bar / toolbar chrome. A dialog sized off `vh` still overflows the *visible* area on phones even though it "fits" on paper. `dvh` (dynamic viewport height) tracks the actual visible viewport as chrome shows/hides, so the cap is accurate on mobile too.

## Two-column layout (unchanged, verified correct)

The form/help-panel grid (`grid gap-6 md:grid-cols-[minmax(0,1fr)_17rem]`) already has no base `grid-cols`, so it single-columns below `md`, and the form div already comes before `ConnectionHelpPanel` in the DOM — so on mobile the form shows above the help panel, as intended. No change needed there. `ConnectionHelpPanel` also has no internal fixed height/overflow that would fight the new parent scroll.

## Sibling dialog sweep

Grepped every `DialogContent` usage for the same bug (no height cap, content that can exceed a screen) and applied the identical fix to:

- **`components/health/health-settings-dialog.tsx`** — 8-tab settings dialog; the "Alerts" tab has ~5 stacked sections with no internal scroll and the container had no height cap at all.
- **`components/health/health-audit-prompt-dialog.tsx`** — header + toggle row + 360px scroll area + footer, again with no cap on the outer `DialogContent`.

Deliberately left alone (already handle this correctly or are short enough not to need it):
- `bulk-explain-dialog.tsx`, `skills-library-dialog.tsx`, `mcp-connect-agent-dialog.tsx`, `chart-error-dialog-content.tsx`, `chart-error.tsx` → `top-memory-queries.tsx`, `card-toolbar.tsx`, `agent-thread-page.tsx` — already have `max-h-[...]` + `overflow`/flex-scroll handling.
- `health-detail-dialog.tsx` — inner content is already bounded by `ScrollArea` `max-h-[60vh]`.
- `security/confirm-dialog.tsx`, `ui/suggestion-card.tsx` — short, fixed-shape content; no evidence they exceed a screen.

## Verification

- `pnpm exec biome check` on the 3 changed files — clean.
- `bun test src/ --isolate` (apps/dashboard) — 6479 pass, 0 fail (required a local `pnpm install` inside `apps/dashboard` to relink the `@chm/*` workspace packages in this worktree; unrelated to the actual change).
- Pre-commit (Biome + `tsc --noEmit`) and pre-push (Biome, dashboard unit tests, package unit tests) hooks both passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)