### PR TITLE
fix(ui): symmetric breadcrumb separator + unified sidebar footer rows

### DIFF
--- a/apps/dashboard/src/components/app-sidebar.tsx
+++ b/apps/dashboard/src/components/app-sidebar.tsx
@@ -46,16 +46,18 @@ export function AppSidebar() {
         <NavMain items={menuItems} />
       </SidebarContent>
 
-      <SidebarFooter>
+      <SidebarFooter className="pt-0">
         {/* App-level links (Billing / Organization / About) and the external
             Docs link share ONE menu so every footer row has the same rhythm —
             separate SidebarMenu blocks would pick up the footer's gap-2 and
-            drift apart. The user button below stays its own block. */}
+            drift apart. Rows use the default SidebarMenuButton size (same as
+            the body menu in nav-main/menu-item.tsx) so the footer reads as a
+            continuation of the menu list, not a separate compact widget. The
+            user button below stays its own block. */}
         <SidebarMenu>
           {footerItems.map((item) => (
             <SidebarMenuItem key={item.href}>
               <SidebarMenuButton
-                size="sm"
                 isActive={isMenuItemActive(item.href, pathname)}
                 tooltip={item.title}
                 render={
@@ -72,7 +74,6 @@ export function AppSidebar() {
           ))}
           <SidebarMenuItem>
             <SidebarMenuButton
-              size="sm"
               tooltip="Docs"
               render={
                 <a

--- a/apps/dashboard/src/components/layout/dashboard-shell.tsx
+++ b/apps/dashboard/src/components/layout/dashboard-shell.tsx
@@ -47,7 +47,7 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
           <header className="relative z-10 flex min-h-16 shrink-0 flex-wrap items-center gap-x-2 gap-y-2 transition-[width,height] ease-linear sm:h-16 sm:flex-nowrap sm:group-has-data-[collapsible=icon]/sidebar-wrapper:h-12 sm:group-has-data-[collapsible=icon]/sidebar-wrapper:min-h-12">
             <div className="flex min-w-0 flex-1 items-center gap-2 px-4 pt-3 sm:pt-0">
               <SidebarTrigger className="-ml-1" />
-              <Separator orientation="vertical" className="mr-2 h-4" />
+              <Separator orientation="vertical" className="h-4" />
               <Suspense fallback={<Skeleton className="h-4 w-32" />}>
                 <Breadcrumb className="min-w-0" />
               </Suspense>


### PR DESCRIPTION
## Summary

Two small spacing fixes reported by the user:

**1. Header breadcrumb separator was asymmetric.** The parent flex container (`gap-2`) already spaces its children, but the separator also carried `mr-2`, so it got 8px on the left (from the parent gap) and 16px on the right (gap + `mr-2`). Dropped `mr-2`, keeping `h-4`, so the parent gap governs both sides evenly.

- Before: `<Separator orientation="vertical" className="mr-2 h-4" />`
- After: `<Separator orientation="vertical" className="h-4" />`

Checked the rest of the header row (`HeaderActions`) for anything compensating for the old margin — nothing does; it's a separate flex child with its own `sm:ml-auto` unrelated to this separator.

**2. Sidebar footer rows (Billing/Organization/About/Docs) read as a separate widget from the body menu.** They already share one `SidebarMenu` (from #2581), but:
- They used `size="sm"` (`h-7 text-xs`) while the body menu (`nav-main/menu-item.tsx`) uses the default `SidebarMenuButton` size (`h-8 text-sm`). Dropped `size="sm"` so footer rows match the body rows' size/typography exactly.
- `SidebarFooter` (from `components/ui/sidebar.tsx`, not edited) carries `flex flex-col gap-2 p-2`; combined with the last body group's own `p-2`, the content/footer boundary had doubled padding. Added `className="pt-0"` on the `SidebarFooter` usage in `app-sidebar.tsx` to remove it.

Verified both the desktop (always-visible) sidebar and the mobile sheet variant (same `Sidebar` component tree renders inside a `SheetContent` on mobile — confirmed via `components/ui/sidebar.tsx`), via a live dev-server DOM check: footer buttons now compute to `h-8 text-sm` (was `h-7 text-xs`), and `SidebarFooter` className now includes `pt-0`.

## Files changed
- `apps/dashboard/src/components/layout/dashboard-shell.tsx` — drop `mr-2` on the breadcrumb separator
- `apps/dashboard/src/components/app-sidebar.tsx` — drop `size="sm"` on the 4 footer `SidebarMenuButton`s, add `pt-0` to `SidebarFooter`

## Test plan
- [x] `pnpm exec biome check` on both changed files — clean
- [x] Live DOM check against dev server confirming rendered classes match the diff (separator has no `mr-2`; footer buttons compute `h-8 text-sm`; `SidebarFooter` has `pt-0`)
- [x] Full `pnpm run test` (via pre-push hook) — 962 pass, 0 fail
- [x] Full `biome check .` (via pre-push hook) — clean (pre-existing unrelated warning in an untouched test file)