### PR TITLE
feat(fleet): grid/table view toggle + cross-host comparison table

### DIFF
--- a/apps/dashboard/src/components/fleet/fleet-helpers.test.ts
+++ b/apps/dashboard/src/components/fleet/fleet-helpers.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for fleet-helpers.ts — Fleet view-mode persistence and metric
+ * formatting. Stubs `window.localStorage` via globalThis (bun test has no DOM),
+ * covering the round-trip, the corrupt-value / SSR guards, and throwing storage.
+ */
+
+import {
+  DEFAULT_FLEET_VIEW,
+  FLEET_VIEW_STORAGE_KEY,
+  formatCount,
+  parseFleetView,
+  readFleetView,
+  writeFleetView,
+} from './fleet-helpers'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+function makeLocalStorageStub() {
+  const store: Record<string, string> = {}
+  return {
+    store,
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      for (const k of Object.keys(store)) delete store[k]
+    },
+  }
+}
+
+function setWindowLocalStorage(localStorage: unknown) {
+  Object.defineProperty(globalThis, 'window', {
+    value: { localStorage },
+    writable: true,
+    configurable: true,
+  })
+}
+
+beforeEach(() => {
+  setWindowLocalStorage(makeLocalStorageStub())
+})
+
+afterEach(() => {
+  try {
+    delete (globalThis as Record<string, unknown>).window
+  } catch {
+    // ignore
+  }
+})
+
+describe('parseFleetView', () => {
+  test('accepts the two valid views', () => {
+    expect(parseFleetView('grid')).toBe('grid')
+    expect(parseFleetView('table')).toBe('table')
+  })
+
+  test('falls back to the default for junk / null / undefined', () => {
+    expect(parseFleetView(null)).toBe(DEFAULT_FLEET_VIEW)
+    expect(parseFleetView(undefined)).toBe(DEFAULT_FLEET_VIEW)
+    expect(parseFleetView('cards')).toBe(DEFAULT_FLEET_VIEW)
+    expect(parseFleetView('')).toBe(DEFAULT_FLEET_VIEW)
+  })
+
+  test('default is grid', () => {
+    expect(DEFAULT_FLEET_VIEW).toBe('grid')
+  })
+})
+
+describe('read/writeFleetView', () => {
+  test('defaults to grid when nothing persisted', () => {
+    expect(readFleetView()).toBe('grid')
+  })
+
+  test('round-trips a written value', () => {
+    writeFleetView('table')
+    expect(window.localStorage.getItem(FLEET_VIEW_STORAGE_KEY)).toBe('table')
+    expect(readFleetView()).toBe('table')
+
+    writeFleetView('grid')
+    expect(readFleetView()).toBe('grid')
+  })
+
+  test('read tolerates a corrupt stored value', () => {
+    window.localStorage.setItem(FLEET_VIEW_STORAGE_KEY, 'nonsense')
+    expect(readFleetView()).toBe('grid')
+  })
+
+  test('returns default off-DOM (SSR)', () => {
+    delete (globalThis as Record<string, unknown>).window
+    expect(readFleetView()).toBe('grid')
+    expect(() => writeFleetView('table')).not.toThrow()
+  })
+
+  test('read returns default when storage throws', () => {
+    setWindowLocalStorage({
+      getItem: () => {
+        throw new Error('disabled')
+      },
+    })
+    expect(readFleetView()).toBe('grid')
+  })
+
+  test('write silently ignores a throwing storage', () => {
+    setWindowLocalStorage({
+      setItem: () => {
+        throw new Error('quota exceeded')
+      },
+    })
+    expect(() => writeFleetView('table')).not.toThrow()
+  })
+})
+
+describe('formatCount', () => {
+  test('renders an en-dash for absent / non-finite values', () => {
+    expect(formatCount(undefined)).toBe('—')
+    expect(formatCount(null)).toBe('—')
+    expect(formatCount(Number.NaN)).toBe('—')
+    expect(formatCount(Number.POSITIVE_INFINITY)).toBe('—')
+  })
+
+  test('renders zero and grouped integers', () => {
+    expect(formatCount(0)).toBe('0')
+    expect(formatCount(42)).toBe('42')
+    expect(formatCount(1234567)).toBe((1234567).toLocaleString())
+  })
+
+  test('truncates fractional values', () => {
+    expect(formatCount(12.9)).toBe('12')
+  })
+})

--- a/apps/dashboard/src/components/fleet/fleet-helpers.ts
+++ b/apps/dashboard/src/components/fleet/fleet-helpers.ts
@@ -1,0 +1,52 @@
+/**
+ * Pure helpers for the Fleet Overview page — view-mode persistence and metric
+ * formatting. Kept free of React/DOM side effects (beyond a guarded
+ * `localStorage`) so they are unit-testable in isolation.
+ */
+
+/** Fleet Overview layout: `grid` (host cards) or `table` (comparison matrix). */
+export type FleetView = 'grid' | 'table'
+
+/** localStorage key persisting the user's Fleet view choice. */
+export const FLEET_VIEW_STORAGE_KEY = 'fleet-view'
+
+/** Default view when nothing is persisted. */
+export const DEFAULT_FLEET_VIEW: FleetView = 'grid'
+
+/** Coerce an arbitrary stored value into a valid FleetView (fail-safe default). */
+export function parseFleetView(value: string | null | undefined): FleetView {
+  return value === 'table' || value === 'grid' ? value : DEFAULT_FLEET_VIEW
+}
+
+/** Read the persisted Fleet view; SSR-safe (returns the default off-DOM). */
+export function readFleetView(): FleetView {
+  if (typeof window === 'undefined') return DEFAULT_FLEET_VIEW
+  try {
+    return parseFleetView(window.localStorage.getItem(FLEET_VIEW_STORAGE_KEY))
+  } catch {
+    // Private mode / disabled storage — fall back to the default.
+    return DEFAULT_FLEET_VIEW
+  }
+}
+
+/** Persist the Fleet view; no-op off-DOM or when storage is unavailable. */
+export function writeFleetView(view: FleetView): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(FLEET_VIEW_STORAGE_KEY, view)
+  } catch {
+    // Ignore write failures (private mode / quota) — non-critical preference.
+  }
+}
+
+/**
+ * Format a metric count for a Fleet table cell. Renders an en-dash for an
+ * absent/non-finite value (a host that couldn't report it), else a
+ * locale-grouped integer.
+ */
+export function formatCount(value: number | null | undefined): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return '—'
+  }
+  return Math.trunc(value).toLocaleString()
+}

--- a/apps/dashboard/src/components/fleet/fleet-table.tsx
+++ b/apps/dashboard/src/components/fleet/fleet-table.tsx
@@ -1,0 +1,303 @@
+import { useNavigate } from '@tanstack/react-router'
+
+import type { PgConnectionInfo } from '@/lib/hooks/use-pg-connections'
+import type { MergedHostInfo } from '@/lib/swr/use-merged-hosts'
+
+import { formatCount } from './fleet-helpers'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { usePgConnections } from '@/lib/hooks/use-pg-connections'
+import { useRouter } from '@/lib/next-compat'
+import { useHostStatus } from '@/lib/swr/use-host-status'
+import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
+import { cn, getHost } from '@/lib/utils'
+
+/** Number of metric columns between "Host" and the trailing action column. */
+const METRIC_COLSPAN = 6
+
+/** Small status dot — green (online), red (offline), muted (unknown). */
+function StatusDot({
+  state,
+}: {
+  state: 'online' | 'offline' | 'unknown' | 'loading'
+}) {
+  if (state === 'loading') {
+    return (
+      <span className="size-2 shrink-0 animate-pulse rounded-full bg-muted-foreground/40" />
+    )
+  }
+  const color =
+    state === 'online'
+      ? 'bg-green-500'
+      : state === 'offline'
+        ? 'bg-red-500'
+        : 'bg-muted-foreground/40'
+  return <span className={cn('size-2 shrink-0 rounded-full', color)} />
+}
+
+/** Source/engine badge for the Host cell — omitted for plain self-hosted env. */
+function SourceBadge({ source }: { source: MergedHostInfo['source'] }) {
+  if (source === 'env') return null
+  const label =
+    source === 'demo' ? 'demo' : source === 'database' ? 'saved' : 'browser'
+  return (
+    <Badge variant="outline" className="shrink-0 text-[10px]">
+      {label}
+    </Badge>
+  )
+}
+
+/**
+ * One table row per ClickHouse host. Calls `useHostStatus` itself (hooks at the
+ * deepest consumer) so each host's metrics load independently — a slow host
+ * never blocks the rest of the table.
+ */
+function FleetTableRow({ host }: { host: MergedHostInfo }) {
+  const navigate = useNavigate()
+  // Browser connections (negative IDs) have no server-side status endpoint.
+  const isBrowser = host.id < 0
+  const {
+    data: status,
+    isLoading,
+    isOnline,
+  } = useHostStatus(isBrowser ? null : host.id, { includeCounts: true })
+
+  const handleView = () => {
+    navigate({
+      to: '/overview',
+      search: (prev) => ({ ...prev, host: host.id }),
+    })
+  }
+
+  const hostLabel = host.name || getHost(host.host)
+  const dotState: 'online' | 'offline' | 'unknown' | 'loading' = isBrowser
+    ? 'unknown'
+    : isLoading
+      ? 'loading'
+      : isOnline
+        ? 'online'
+        : 'offline'
+
+  return (
+    <TableRow
+      className="cursor-pointer"
+      onClick={handleView}
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          handleView()
+        }
+      }}
+    >
+      <TableCell className="max-w-56">
+        <div className="flex items-center gap-2">
+          <StatusDot state={dotState} />
+          <span className="truncate font-medium">{hostLabel}</span>
+          <SourceBadge source={host.source} />
+        </div>
+        <span className="block truncate text-xs text-muted-foreground">
+          {host.host}
+        </span>
+      </TableCell>
+
+      {isBrowser ? (
+        <TableCell
+          colSpan={METRIC_COLSPAN}
+          className="text-xs text-muted-foreground"
+        >
+          Browser-stored connection — status not available.
+        </TableCell>
+      ) : isLoading ? (
+        <>
+          <MetricSkeletonCell />
+          <MetricSkeletonCell />
+          <MetricSkeletonCell />
+          <MetricSkeletonCell className="text-right" />
+          <MetricSkeletonCell className="text-right" />
+          <MetricSkeletonCell className="text-right" />
+        </>
+      ) : status ? (
+        <>
+          <TableCell className="font-mono text-xs">
+            {status.version || '—'}
+          </TableCell>
+          <TableCell className="text-xs">{status.uptime || '—'}</TableCell>
+          <TableCell className="max-w-40 truncate text-xs text-muted-foreground">
+            {status.hostname || '—'}
+          </TableCell>
+          <TableCell className="text-right tabular-nums">
+            {formatCount(status.databases)}
+          </TableCell>
+          <TableCell className="text-right tabular-nums">
+            {formatCount(status.tables)}
+          </TableCell>
+          <TableCell className="text-right tabular-nums">
+            {formatCount(status.clusterNodes)}
+          </TableCell>
+        </>
+      ) : (
+        <>
+          <TableCell className="text-muted-foreground">—</TableCell>
+          <TableCell className="text-muted-foreground">—</TableCell>
+          <TableCell className="text-muted-foreground">—</TableCell>
+          <TableCell className="text-right text-muted-foreground">—</TableCell>
+          <TableCell className="text-right text-muted-foreground">—</TableCell>
+          <TableCell className="text-right text-muted-foreground">—</TableCell>
+        </>
+      )}
+
+      <TableCell className="text-right">
+        <Button
+          size="sm"
+          variant="ghost"
+          className="text-xs"
+          onClick={(e) => {
+            e.stopPropagation()
+            handleView()
+          }}
+        >
+          View
+        </Button>
+      </TableCell>
+    </TableRow>
+  )
+}
+
+function MetricSkeletonCell({ className }: { className?: string }) {
+  return (
+    <TableCell className={className}>
+      <Skeleton
+        className={cn(
+          'h-4 w-16',
+          className?.includes('text-right') && 'ml-auto'
+        )}
+      />
+    </TableCell>
+  )
+}
+
+/** Static row for a Postgres source — no ClickHouse status hook applies. */
+function FleetPgRow({ pg }: { pg: PgConnectionInfo }) {
+  const router = useRouter()
+  const handleView = () => {
+    router.push(`/postgres/queries?pg=${encodeURIComponent(pg.connectionId)}`)
+  }
+  return (
+    <TableRow
+      className="cursor-pointer"
+      onClick={handleView}
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          handleView()
+        }
+      }}
+    >
+      <TableCell className="max-w-56">
+        <div className="flex items-center gap-2">
+          <StatusDot state="unknown" />
+          <span className="truncate font-medium">{pg.name || pg.host}</span>
+          <Badge variant="outline" className="shrink-0 text-[10px]">
+            Postgres
+          </Badge>
+        </div>
+        <span className="block truncate text-xs text-muted-foreground">
+          {pg.host}
+        </span>
+      </TableCell>
+      <TableCell
+        colSpan={METRIC_COLSPAN}
+        className="text-xs text-muted-foreground"
+      >
+        Postgres source — ClickHouse metrics not applicable.
+      </TableCell>
+      <TableCell className="text-right">
+        <Button
+          size="sm"
+          variant="ghost"
+          className="text-xs"
+          onClick={(e) => {
+            e.stopPropagation()
+            handleView()
+          }}
+        >
+          View
+        </Button>
+      </TableCell>
+    </TableRow>
+  )
+}
+
+function FleetTableSkeleton() {
+  return (
+    <div className="rounded-lg border">
+      <div className="space-y-2 p-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-10 w-full" />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Cross-host comparison matrix — one row per host, each metric cell loading
+ * asynchronously per host. Companion to the card grid (`FleetOverview`); the
+ * two share the same host list and TanStack Query cache.
+ */
+export function FleetTable() {
+  const { hosts, isLoading } = useMergedHosts()
+  const { connections: pgConnections } = usePgConnections()
+
+  if (isLoading) {
+    return <FleetTableSkeleton />
+  }
+
+  if (hosts.length === 0 && pgConnections.length === 0) {
+    return (
+      <div className="flex min-h-40 items-center justify-center rounded-lg border border-dashed">
+        <p className="text-sm text-muted-foreground">
+          No hosts configured. Add a connection to get started.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Host</TableHead>
+            <TableHead>Version</TableHead>
+            <TableHead>Uptime</TableHead>
+            <TableHead>Hostname</TableHead>
+            <TableHead className="text-right">Databases</TableHead>
+            <TableHead className="text-right">Tables</TableHead>
+            <TableHead className="text-right">Cluster</TableHead>
+            <TableHead className="w-0" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {hosts.map((host) => (
+            <FleetTableRow key={`${host.source}-${host.id}`} host={host} />
+          ))}
+          {pgConnections.map((pg) => (
+            <FleetPgRow key={`pg-${pg.connectionId}`} pg={pg} />
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/fleet/fleet-view-toggle.tsx
+++ b/apps/dashboard/src/components/fleet/fleet-view-toggle.tsx
@@ -1,0 +1,45 @@
+import { LayoutGrid, Table2 } from 'lucide-react'
+
+import type { FleetView } from './fleet-helpers'
+
+import { Button } from '@/components/ui/button'
+
+/** Segmented grid/table toggle for the Fleet Overview page. */
+export function FleetViewToggle({
+  value,
+  onChange,
+}: {
+  value: FleetView
+  onChange: (view: FleetView) => void
+}) {
+  return (
+    <div
+      className="inline-flex items-center gap-0.5 rounded-md border border-border p-0.5"
+      role="group"
+      aria-label="Fleet view"
+    >
+      <Button
+        type="button"
+        variant={value === 'grid' ? 'secondary' : 'ghost'}
+        size="sm"
+        className="gap-1.5 px-2 text-xs"
+        aria-pressed={value === 'grid'}
+        onClick={() => onChange('grid')}
+      >
+        <LayoutGrid className="size-3.5" />
+        Grid
+      </Button>
+      <Button
+        type="button"
+        variant={value === 'table' ? 'secondary' : 'ghost'}
+        size="sm"
+        className="gap-1.5 px-2 text-xs"
+        aria-pressed={value === 'table'}
+        onClick={() => onChange('table')}
+      >
+        <Table2 className="size-3.5" />
+        Table
+      </Button>
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/fleet/use-fleet-view.ts
+++ b/apps/dashboard/src/components/fleet/use-fleet-view.ts
@@ -1,0 +1,28 @@
+import {
+  DEFAULT_FLEET_VIEW,
+  type FleetView,
+  readFleetView,
+  writeFleetView,
+} from './fleet-helpers'
+import { useCallback, useEffect, useState } from 'react'
+
+/**
+ * Fleet Overview view-mode state, persisted in localStorage (key `fleet-view`).
+ *
+ * Starts from the default so the static (SSR/prerender) shell is deterministic,
+ * then hydrates the persisted choice on mount to avoid a hydration mismatch.
+ */
+export function useFleetView(): [FleetView, (view: FleetView) => void] {
+  const [view, setViewState] = useState<FleetView>(DEFAULT_FLEET_VIEW)
+
+  useEffect(() => {
+    setViewState(readFleetView())
+  }, [])
+
+  const setView = useCallback((next: FleetView) => {
+    setViewState(next)
+    writeFleetView(next)
+  }, [])
+
+  return [view, setView]
+}

--- a/apps/dashboard/src/components/host/host-switcher.tsx
+++ b/apps/dashboard/src/components/host/host-switcher.tsx
@@ -1,4 +1,11 @@
-import { ChevronsUpDown, GlobeIcon, Info, Pencil, PlusIcon } from 'lucide-react'
+import {
+  ChevronsUpDown,
+  GaugeIcon,
+  GlobeIcon,
+  Info,
+  Pencil,
+  PlusIcon,
+} from 'lucide-react'
 
 import { HostDetailsDialog } from './host-details-dialog'
 import { HostMenuRow } from './host-menu-row'
@@ -90,6 +97,14 @@ export function HostSwitcher() {
     // Route to the Postgres pages carrying the source in the `?pg=` dimension —
     // never overloaded onto the ClickHouse `?host=` id space.
     router.push(`/postgres/queries?pg=${encodeURIComponent(connectionId)}`)
+    setMenuOpen(false)
+  }
+
+  const handleFleetOverview = () => {
+    // Jump to the all-hosts status view, preserving the current host selection.
+    router.push(
+      buildUrl('/fleet', currentHostId != null ? { host: currentHostId } : {})
+    )
     setMenuOpen(false)
   }
 
@@ -372,6 +387,14 @@ export function HostSwitcher() {
                   </>
                 )}
                 <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onClick={handleFleetOverview}
+                  data-testid="fleet-overview"
+                  className="gap-2 text-muted-foreground"
+                >
+                  <GaugeIcon className="size-4" />
+                  Fleet overview
+                </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={() => setAddDialogOpen(true)}
                   data-testid="add-host"

--- a/apps/dashboard/src/lib/swr/use-host-status.ts
+++ b/apps/dashboard/src/lib/swr/use-host-status.ts
@@ -11,6 +11,9 @@ type HostStatusApiResponse = {
     version: string
     uptime: string
     hostname: string
+    databases?: number
+    tables?: number
+    clusterNodes?: number
   }
   error?: string
 }
@@ -20,6 +23,12 @@ export type HostStatus = {
   version: string
   uptime: string
   hostname: string
+  /** Number of databases (only when `includeCounts` is requested). */
+  databases?: number
+  /** Number of tables (only when `includeCounts` is requested). */
+  tables?: number
+  /** Distinct cluster nodes (only when `includeCounts` is requested). */
+  clusterNodes?: number
 }
 
 interface UseHostStatusOptions {
@@ -33,6 +42,13 @@ interface UseHostStatusOptions {
    * @default false
    */
   revalidateOnFocus?: boolean
+  /**
+   * Also fetch cross-host comparison counts (databases/tables/cluster nodes)
+   * for the Fleet table. Off by default so the widely-polled status probe stays
+   * a single round-trip. Uses a distinct query key from the countless variant.
+   * @default false
+   */
+  includeCounts?: boolean
 }
 
 /**
@@ -53,18 +69,24 @@ export function useHostStatus(
   hostId: number | null,
   options: UseHostStatusOptions = {}
 ) {
-  const { refreshInterval = 60000, revalidateOnFocus = false } = options
+  const {
+    refreshInterval = 60000,
+    revalidateOnFocus = false,
+    includeCounts = false,
+  } = options
 
   // Skip status check for browser connections (negative hostId) — they have
   // no server-side host entry and the proxy endpoint handles connectivity.
   const isBrowserConnection = hostId !== null && hostId < 0
 
-  const queryKey = [`/api/v1/host-status?hostId=${hostId}`]
+  const url = includeCounts
+    ? `/api/v1/host-status?hostId=${hostId}&counts=1`
+    : `/api/v1/host-status?hostId=${hostId}`
+  const queryKey = [url]
 
   const { data, error, isLoading } = useQuery<HostStatus>({
     queryKey,
     queryFn: async () => {
-      const url = `/api/v1/host-status?hostId=${hostId}`
       const res = await apiFetch(url)
       if (!res.ok) {
         throw new Error(`Failed to fetch host status: ${res.statusText}`)
@@ -81,6 +103,9 @@ export function useHostStatus(
         version: json.data.version,
         uptime: json.data.uptime,
         hostname: json.data.hostname,
+        databases: json.data.databases,
+        tables: json.data.tables,
+        clusterNodes: json.data.clusterNodes,
       }
     },
     enabled: hostId !== null && !isBrowserConnection,

--- a/apps/dashboard/src/routes/(dashboard)/fleet.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/fleet.tsx
@@ -2,6 +2,9 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { FleetOverview } from '@/components/fleet/fleet-overview'
+import { FleetTable } from '@/components/fleet/fleet-table'
+import { FleetViewToggle } from '@/components/fleet/fleet-view-toggle'
+import { useFleetView } from '@/components/fleet/use-fleet-view'
 import { PageHeader } from '@/components/layout'
 import { Skeleton } from '@/components/ui/skeleton'
 import { pageOgHead } from '@/lib/og'
@@ -17,14 +20,17 @@ function FleetSkeleton() {
 }
 
 function FleetPage() {
+  const [view, setView] = useFleetView()
+
   return (
     <div className="flex flex-col gap-4">
       <PageHeader
         title="Fleet Overview"
-        description="Health signals across all ClickHouse hosts in one view."
+        description="Health signals across all connected hosts in one view."
+        actions={<FleetViewToggle value={view} onChange={setView} />}
       />
       <Suspense fallback={<FleetSkeleton />}>
-        <FleetOverview />
+        {view === 'table' ? <FleetTable /> : <FleetOverview />}
       </Suspense>
     </div>
   )

--- a/apps/dashboard/src/routes/api/v1/host-status.ts
+++ b/apps/dashboard/src/routes/api/v1/host-status.ts
@@ -28,6 +28,11 @@ export const Route = createFileRoute('/api/v1/host-status')({
       GET: async ({ request }) => {
         const searchParams = new URL(request.url).searchParams
         const hostIdRaw = searchParams.get('hostId')
+        // Opt-in: the Fleet table asks for extra cross-host comparison counts
+        // (databases/tables/cluster nodes). Off by default so the widely-polled
+        // status probe (host switcher, logo indicator, cards) stays a single
+        // round-trip for every other consumer.
+        const wantCounts = searchParams.get('counts') === '1'
 
         if (hostIdRaw === null || hostIdRaw === '') {
           return Response.json(
@@ -111,9 +116,48 @@ export const Route = createFileRoute('/api/v1/host-status')({
           const uptime = data?.uptime ?? ''
           const hostname = data?.hostname ?? ''
 
+          // Additive comparison counts for the Fleet table. Run in a separate,
+          // fully guarded query so a counts failure never degrades the core
+          // status response — missing counts simply resolve to undefined and
+          // the table renders an en-dash for that cell.
+          let counts: {
+            databases?: number
+            tables?: number
+            clusterNodes?: number
+          } = {}
+          if (wantCounts) {
+            try {
+              const countsSet = await client.query({
+                query: `${QUERY_COMMENT}SELECT
+  (SELECT count() FROM system.databases) AS databases,
+  (SELECT count() FROM system.tables) AS tables,
+  (SELECT uniqExact(host_name) FROM system.clusters) AS clusterNodes`,
+                format: 'JSONEachRow',
+                clickhouse_settings: cacheSettings,
+              })
+              const countRows = await countsSet.json<{
+                databases: string | number
+                tables: string | number
+                clusterNodes: string | number
+              }>()
+              const row = countRows[0]
+              const toNum = (v: string | number | undefined) => {
+                const n = Number(v)
+                return Number.isFinite(n) ? n : undefined
+              }
+              counts = {
+                databases: toNum(row?.databases),
+                tables: toNum(row?.tables),
+                clusterNodes: toNum(row?.clusterNodes),
+              }
+            } catch (countsErr) {
+              error('[GET /api/v1/host-status] counts query failed:', countsErr)
+            }
+          }
+
           return Response.json({
             success: true,
-            data: { version, uptime, hostname },
+            data: { version, uptime, hostname, ...counts },
           })
         } catch (err) {
           error('[GET /api/v1/host-status] Error:', err)

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -3,7 +3,7 @@ id: product-design
 title: Product design system & UX conventions
 type: reference
 status: active
-updated: 2026-07-10
+updated: 2026-07-11
 tags:
   - design-system
   - ui
@@ -162,6 +162,13 @@ Prefer ONE clear signal per piece of state, not several redundant ones.
 - **Data tables:** `components/data-table/` — resizing, wrap toggle, sorting
   (`sorting-fns.ts`), pagination, faceted filters, row actions, SQL display.
   Synthetic ids `__expand`/`select`/`action` are non-data.
+- **Page-level grid/table view toggle:** a small segmented control
+  (lucide `LayoutGrid`/`Table2`, styled like `components/query-tables/view-toggle.tsx`)
+  in the `PageHeader` `actions` slot. Persist the choice in **localStorage**
+  (not a URL param) via a pure read/write helper + a tiny hydrate-on-mount hook
+  so the static shell stays deterministic. Reference: the Fleet Overview page —
+  `components/fleet/fleet-view-toggle.tsx` + `fleet-helpers.ts` +
+  `use-fleet-view.ts` (key `fleet-view`, default `grid`).
 - **Clickable table row → detail Sheet flyout:** `DataTable`'s `onRowClick`
   prop (threaded through `TableClient` → `QueryPageLayout`, desktop rows
   only — mutually exclusive with `expandable`, which owns row clicks when


### PR DESCRIPTION
## Summary

Upgrades the **Fleet Overview** (`/fleet`) page with a grid/table view toggle and a cross-host comparison table, plus a "Fleet overview" quick link in the host-switcher dropdown.

### 1. Grid / table view toggle
- Small segmented control (`LayoutGrid` / `Table2`) in the `PageHeader` actions slot, right-aligned.
- Choice persisted in **localStorage** (`fleet-view`, default `grid`); no URL param.
- `components/fleet/fleet-view-toggle.tsx` + `fleet-helpers.ts` (pure, tested) + `use-fleet-view.ts` (hydrate-on-mount hook, SSR-safe).

### 2. Cross-host comparison table (`components/fleet/fleet-table.tsx`)
- shadcn `Table` primitives (comparison matrix, not the heavy data-table system).
- Columns: **Host** (name + source badge + status dot), **Version**, **Uptime**, **Hostname**, **Databases**, **Tables**, **Cluster** (nodes), plus a View action.
- Each host row calls `useHostStatus` itself (hooks at deepest consumer) so metrics load **async per host** — `Skeleton` per cell while loading, en-dash on error, "status not available" for browser-stored connections. One slow host never blocks the table.
- Row click / View → `/overview?host=<id>` (same as the grid card).
- Postgres sources listed as rows (engine badge, non-applicable metrics) when the feature flag is on.
- Grid view + `FleetHostCard` unchanged (zero regression).

### 3. Status endpoint extended (additively, opt-in)
- `/api/v1/host-status` gains `?counts=1` → additionally returns `databases` / `tables` / `clusterNodes` from a **separate, fully guarded** query (`count()` on `system.databases`/`system.tables`, `uniqExact(host_name)` on `system.clusters`). A counts failure never degrades the core status response.
- **Existing consumers are unchanged**: without `?counts=1` the response and round-trip count are identical (the widely-polled host switcher / logo indicator / cards pay nothing extra).
- `useHostStatus` gains an opt-in `includeCounts` option (distinct query key) exposing the counts to the table only.

### 4. Host-switcher link
- "Fleet overview" item (`GaugeIcon`) above "Add host…", preserving the current `?host`.

## Testing
- New unit tests for the pure helpers (view-preference read/write + SSR/throwing guards, count formatting): `fleet-helpers.test.ts` — 12 pass.
- Existing `host-status` endpoint test still passes.
- Biome clean on changed files. (Local full-suite/type-check skipped — worktree has no node_modules; CI validates.)

## Design note
- `docs/knowledge/product-design.md` gains one line documenting the localStorage-persisted page-level grid/table toggle pattern.