### PR TITLE
fix(layout): hide header controls scrollbar on narrow viewports

### DIFF
--- a/apps/dashboard/src/components/layout/dashboard-shell.tsx
+++ b/apps/dashboard/src/components/layout/dashboard-shell.tsx
@@ -52,7 +52,9 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
                 <Breadcrumb className="min-w-0" />
               </Suspense>
             </div>
-            <div className="w-full min-w-0 overflow-x-auto px-4 pb-3 sm:ml-auto sm:w-auto sm:overflow-visible sm:pb-0">
+            {/* scrollbar-hide: stays swipe-scrollable on narrow viewports
+                without a visible scrollbar under the header controls. */}
+            <div className="scrollbar-hide w-full min-w-0 overflow-x-auto px-4 pb-3 sm:ml-auto sm:w-auto sm:overflow-visible sm:pb-0">
               <HeaderActions />
             </div>
           </header>


### PR DESCRIPTION
The header actions strip (time range, refresh, search, theme) is
overflow-x-auto below sm, which paints a visible scrollbar on mobile
and short desktop windows. Apply the existing scrollbar-hide utility
so it stays swipe-scrollable without the bar. Covers both dashboard
and PeerDB layouts (shared DashboardShell).

Co-Authored-By: duyetbot <bot@duyet.net>
