### PR TITLE
feat(agent): page-context chip + dockable panel for the floating widget

### DIFF
--- a/apps/dashboard/src/components/assistant-ui/-thread/composer.tsx
+++ b/apps/dashboard/src/components/assistant-ui/-thread/composer.tsx
@@ -16,6 +16,7 @@ import {
   formatContextBlock,
 } from '@/components/agents/welcome/add-context-dialog'
 import { ComposerToolbar } from '@/components/agents/welcome/composer-toolbar'
+import { PageContextChip } from '@/components/assistant-ui/-thread/page-context-chip'
 import { useAgentAuthGate } from '@/components/assistant-ui/agent-auth-gate'
 import { track } from '@/lib/telemetry'
 
@@ -32,6 +33,7 @@ export function WelcomeComposer() {
 
   return (
     <div className="flex flex-col gap-2">
+      <PageContextChip className="self-start" />
       <PromptInputTextareaWithMentions
         isLoading={isRunning}
         onResolvedSubmit={(text) => {
@@ -66,7 +68,8 @@ export function ThreadComposer() {
   const { ensureAuthed } = useAgentAuthGate()
 
   return (
-    <div className="w-full">
+    <div className="flex w-full flex-col gap-1.5">
+      <PageContextChip className="self-start" />
       <PromptInputTextareaWithMentions
         isLoading={isRunning}
         onResolvedSubmit={(text) => {

--- a/apps/dashboard/src/components/assistant-ui/-thread/page-context-chip.tsx
+++ b/apps/dashboard/src/components/assistant-ui/-thread/page-context-chip.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+/**
+ * Compact "current page" chip shown above the floating agent's composer. It
+ * makes the widget's page awareness VISIBLE — the agent already receives the
+ * page as `pageContext` (see `agent-runtime-provider.tsx`), and this chip tells
+ * the user so, e.g. `⌞ Fleet Overview`. Clicking × drops page context for the
+ * current page (re-arms on navigation).
+ *
+ * Renders nothing when there's no page-context control (the full `/agents`
+ * page, which never mounts the provider), no resolvable page, or the user has
+ * dismissed it — so it's strictly a floating-widget affordance.
+ */
+
+import { TextQuoteIcon, XIcon } from 'lucide-react'
+
+import { usePageContextControl } from '@/components/assistant-ui/page-context-control'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+
+export function PageContextChip({ className }: { className?: string }) {
+  const control = usePageContextControl()
+  if (!control || !control.enabled) return null
+
+  const label = control.pageContext?.label ?? control.pageContext?.route
+  if (!label) return null
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <div
+              className={cn(
+                'bg-muted/60 text-muted-foreground inline-flex max-w-full items-center gap-1.5 rounded-md py-1 pr-1 pl-2 text-xs',
+                className
+              )}
+            />
+          }
+        >
+          <TextQuoteIcon className="size-3 shrink-0" />
+          <span className="truncate font-medium">{label}</span>
+          <button
+            type="button"
+            aria-label="Drop page context for this message"
+            onClick={control.disable}
+            className="hover:bg-muted hover:text-foreground ml-0.5 inline-flex size-4 shrink-0 items-center justify-center rounded-sm transition-colors"
+          >
+            <XIcon className="size-3" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          The agent can see the page you're on
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}

--- a/apps/dashboard/src/components/assistant-ui/agent-runtime-provider.tsx
+++ b/apps/dashboard/src/components/assistant-ui/agent-runtime-provider.tsx
@@ -23,6 +23,7 @@ import {
 import { useChatRuntime } from '@assistant-ui/react-ai-sdk'
 import { DefaultChatTransport } from 'ai'
 import { type ReactNode, useMemo, useRef } from 'react'
+import { usePageContextControl } from '@/components/assistant-ui/page-context-control'
 import { buildPageContext } from '@/lib/ai/agent/page-context'
 import { trackEvent } from '@/lib/analytics/analytics'
 import { resolveThreadListAdapter } from '@/lib/conversation-store/adapter/resolve-thread-list-adapter'
@@ -57,6 +58,11 @@ function useAgentChatRuntime() {
   const sessionId = useMemo(() => crypto.randomUUID(), [])
   const { customServers, disabledServers } = useMcpConfig()
   const pathname = usePathname()
+  // Present only for the floating widget (null on the full /agents page). When
+  // present, the composer chip can switch page context off for the current
+  // page. The ref object is stable across renders, so it's a safe memo dep that
+  // never rebuilds the transport when the flag flips.
+  const pageEnabledRef = usePageContextControl()?.enabledRef
 
   // Only pass enabled custom servers to the agent route. Derive from the stable
   // `customServers` + `disabledServers` arrays (not `isServerEnabled`, which is a
@@ -92,8 +98,15 @@ function useAgentChatRuntime() {
         }) => {
           const isNewThread = messages.length <= 1
           const pageChanged = lastSentPathnameRef.current !== pathname
+          // The floating chip can drop page context for the current page; the
+          // ref is read live so a toggle never rebuilds the transport. Absent a
+          // provider (the /agents page) it defaults to enabled — behaviour is
+          // identical to before.
+          const pageContextEnabled = pageEnabledRef?.current ?? true
           const shouldSendPageContext =
-            Boolean(pathname) && (isNewThread || pageChanged)
+            pageContextEnabled &&
+            Boolean(pathname) &&
+            (isNewThread || pageChanged)
 
           if (shouldSendPageContext) {
             lastSentPathnameRef.current = pathname
@@ -116,7 +129,15 @@ function useAgentChatRuntime() {
     // mcpServers is a derived array — include it directly so the transport
     // re-creates when the user toggles or adds custom servers.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [hostId, model, disabledTools, sessionId, mcpServers, pathname]
+    [
+      hostId,
+      model,
+      disabledTools,
+      sessionId,
+      mcpServers,
+      pathname,
+      pageEnabledRef,
+    ]
   )
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/dashboard/src/components/assistant-ui/assistant-modal.tsx
+++ b/apps/dashboard/src/components/assistant-ui/assistant-modal.tsx
@@ -4,44 +4,120 @@
  * Floating chat bubble — assistant-ui `AssistantModal`. Mounted app-wide so the
  * ClickHouse agent is reachable from any dashboard page (see
  * `global-assistant-modal.tsx`).
+ *
+ * Two layouts, remembered per browser (`useAgentWidgetMode`):
+ *  - `floating` — the small bottom-right popover (Radix Popover positioning).
+ *  - `docked`   — a full-height right sidebar. Because Radix Popper wraps the
+ *    popover content in a transformed positioner (which would trap a `fixed`
+ *    child), the docked layout is rendered as its own fixed panel OUTSIDE the
+ *    Popper. That means we control the Root's `open` state ourselves so the
+ *    docked panel can mount/unmount with it (and the Thread stops polling when
+ *    closed, same as the popover). Open/close is driven by the bubble trigger
+ *    and the header close button — the floating widget's runtime is only ever
+ *    run from inside the (already-open) widget, so there's no external
+ *    open-on-run-start path to preserve.
  */
 
-import { BotIcon, XIcon } from 'lucide-react'
+import { BotIcon, Minimize2Icon, PanelRightIcon, XIcon } from 'lucide-react'
 
 import { Thread } from './thread'
 import { AssistantModalPrimitive } from '@assistant-ui/react'
-import { forwardRef } from 'react'
+import { forwardRef, useState } from 'react'
+import { TooltipIconButton } from '@/components/assistant-ui/tooltip-icon-button'
 import { Button } from '@/components/ui/button'
+import { useAgentWidgetMode } from '@/lib/hooks/use-agent-widget-mode'
 import { cn } from '@/lib/utils'
 
 export function AssistantModal() {
+  const { isDocked, toggleMode } = useAgentWidgetMode()
+  const [open, setOpen] = useState(false)
+
+  const header = (
+    <WidgetHeader
+      isDocked={isDocked}
+      onToggleMode={toggleMode}
+      onClose={() => setOpen(false)}
+    />
+  )
+
   return (
-    <AssistantModalPrimitive.Root>
+    <AssistantModalPrimitive.Root open={open} onOpenChange={setOpen}>
       <AssistantModalPrimitive.Anchor className="fixed right-4 bottom-4 z-40 size-11">
         <AssistantModalPrimitive.Trigger asChild>
           <AssistantModalButton />
         </AssistantModalPrimitive.Trigger>
       </AssistantModalPrimitive.Anchor>
 
-      <AssistantModalPrimitive.Content
-        sideOffset={16}
-        className={cn(
-          'bg-popover text-popover-foreground z-50 flex h-[34rem] max-h-[80vh] w-[26rem] max-w-[calc(100vw-2rem)] flex-col overflow-hidden rounded-2xl border shadow-2xl outline-none',
-          'data-[state=open]:animate-in data-[state=closed]:animate-out',
-          'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-          'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
-          '[&>.aui-root]:rounded-none [&>.aui-root]:border-0'
-        )}
-      >
-        <div className="flex items-center gap-2 border-b px-3 py-2">
-          <BotIcon className="text-primary size-4" />
-          <span className="text-sm font-medium">ClickHouse Agent</span>
-        </div>
-        <div className="min-h-0 flex-1">
-          <Thread />
-        </div>
-      </AssistantModalPrimitive.Content>
+      {isDocked ? (
+        open && (
+          <div
+            role="dialog"
+            aria-label="ClickHouse Agent"
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') setOpen(false)
+            }}
+            className={cn(
+              'bg-popover text-popover-foreground fixed inset-y-0 right-0 z-50 flex h-dvh w-[min(28rem,100vw)] flex-col overflow-hidden border-l shadow-2xl outline-none',
+              'animate-in slide-in-from-right-4 duration-200',
+              '[&>.aui-root]:rounded-none [&>.aui-root]:border-0'
+            )}
+          >
+            {header}
+            <div className="min-h-0 flex-1">
+              <Thread />
+            </div>
+          </div>
+        )
+      ) : (
+        <AssistantModalPrimitive.Content
+          sideOffset={16}
+          className={cn(
+            'bg-popover text-popover-foreground z-50 flex h-[34rem] max-h-[80vh] w-[26rem] max-w-[calc(100vw-2rem)] flex-col overflow-hidden rounded-2xl border shadow-2xl outline-none',
+            'data-[state=open]:animate-in data-[state=closed]:animate-out',
+            'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+            'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+            '[&>.aui-root]:rounded-none [&>.aui-root]:border-0'
+          )}
+        >
+          {header}
+          <div className="min-h-0 flex-1">
+            <Thread />
+          </div>
+        </AssistantModalPrimitive.Content>
+      )}
     </AssistantModalPrimitive.Root>
+  )
+}
+
+function WidgetHeader({
+  isDocked,
+  onToggleMode,
+  onClose,
+}: {
+  isDocked: boolean
+  onToggleMode: () => void
+  onClose: () => void
+}) {
+  return (
+    <div className="flex items-center gap-2 border-b px-3 py-2">
+      <BotIcon className="text-primary size-4" />
+      <span className="text-sm font-medium">ClickHouse Agent</span>
+      <div className="ml-auto flex items-center">
+        <TooltipIconButton
+          tooltip={isDocked ? 'Collapse to corner' : 'Dock to side'}
+          onClick={onToggleMode}
+        >
+          {isDocked ? (
+            <Minimize2Icon className="size-4" />
+          ) : (
+            <PanelRightIcon className="size-4" />
+          )}
+        </TooltipIconButton>
+        <TooltipIconButton tooltip="Close" onClick={onClose}>
+          <XIcon className="size-4" />
+        </TooltipIconButton>
+      </div>
+    </div>
   )
 }
 

--- a/apps/dashboard/src/components/assistant-ui/global-assistant-modal-impl.tsx
+++ b/apps/dashboard/src/components/assistant-ui/global-assistant-modal-impl.tsx
@@ -8,11 +8,14 @@
 
 import { AgentRuntimeProvider } from '@/components/assistant-ui/agent-runtime-provider'
 import { AssistantModal } from '@/components/assistant-ui/assistant-modal'
+import { PageContextControlProvider } from '@/components/assistant-ui/page-context-control'
 
 export function GlobalAssistantModalImpl() {
   return (
-    <AgentRuntimeProvider>
-      <AssistantModal />
-    </AgentRuntimeProvider>
+    <PageContextControlProvider>
+      <AgentRuntimeProvider>
+        <AssistantModal />
+      </AgentRuntimeProvider>
+    </PageContextControlProvider>
   )
 }

--- a/apps/dashboard/src/components/assistant-ui/page-context-control.tsx
+++ b/apps/dashboard/src/components/assistant-ui/page-context-control.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+/**
+ * Shared control for the floating agent's "current page" awareness.
+ *
+ * The floating widget grounds an ambiguous question ("why is this slow?") in the
+ * page the user is on by attaching `pageContext` to the chat request (see
+ * `agent-runtime-provider.tsx` + the server route's `sanitizePageContext`). This
+ * provider surfaces that same context to the composer so the user can SEE it as
+ * a dismissible chip, and lets them switch it off for the current page.
+ *
+ * Two consumers sit in different parts of the tree, so the state lives here:
+ *  - the composer chip (`-thread/page-context-chip.tsx`) reads `pageContext` /
+ *    `enabled` and calls `disable()`;
+ *  - the chat transport reads `enabledRef.current` at send time (a ref so a
+ *    toggle never rebuilds the transport — same trick as `lastSentPathnameRef`).
+ *
+ * Mounted ONLY around the floating modal (`global-assistant-modal-impl.tsx`).
+ * The full `/agents` page has no provider, so `usePageContextControl()` returns
+ * `null` there and both consumers behave exactly as before (chip hidden,
+ * transport keeps its default send behaviour).
+ */
+
+import {
+  createContext,
+  type MutableRefObject,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { buildPageContext, type PageContext } from '@/lib/ai/agent/page-context'
+import { usePathname } from '@/lib/next-compat'
+
+export interface PageContextControl {
+  /** Current page context, or `null` when the route can't be resolved. */
+  pageContext: PageContext | null
+  /** Whether page context will ride along with the next message. */
+  enabled: boolean
+  /** Drop page context (user dismissed the chip). Re-arms on navigation. */
+  disable: () => void
+  /**
+   * Live view of `enabled` for the transport to read at send time without
+   * being a memo dependency (so toggling never rebuilds the transport).
+   */
+  enabledRef: MutableRefObject<boolean>
+}
+
+const PageContextControlContext = createContext<PageContextControl | null>(null)
+
+export function PageContextControlProvider({
+  children,
+}: {
+  children: ReactNode
+}) {
+  const pathname = usePathname()
+  const pageContext = useMemo(
+    () => (pathname ? buildPageContext(pathname) : null),
+    [pathname]
+  )
+
+  // Track the path the chip was dismissed for (rather than a boolean), so
+  // context automatically re-arms when the user navigates elsewhere — a new
+  // page is fresh context worth showing again.
+  const [dismissedPath, setDismissedPath] = useState<string | null>(null)
+  const enabled = pathname !== dismissedPath
+
+  const enabledRef = useRef(enabled)
+  useEffect(() => {
+    enabledRef.current = enabled
+  }, [enabled])
+
+  const value = useMemo<PageContextControl>(
+    () => ({
+      pageContext,
+      enabled,
+      disable: () => setDismissedPath(pathname),
+      enabledRef,
+    }),
+    [pageContext, enabled, pathname]
+  )
+
+  return (
+    <PageContextControlContext.Provider value={value}>
+      {children}
+    </PageContextControlContext.Provider>
+  )
+}
+
+/**
+ * Access the floating widget's page-context control. Returns `null` when no
+ * provider is mounted (e.g. the full `/agents` page) — callers must treat that
+ * as "no page-context UI, default transport behaviour".
+ */
+export function usePageContextControl(): PageContextControl | null {
+  return useContext(PageContextControlContext)
+}

--- a/apps/dashboard/src/lib/ai/agent/page-context.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/page-context.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Unit tests for the client-side page-context helpers (`getPageLabel` /
+ * `buildPageContext`) that resolve the "current page" hint the floating agent
+ * widget attaches to each request and surfaces as the composer chip.
+ *
+ * Title resolution goes through the menu-driven breadcrumb lookup, with a
+ * segment-title fallback for routes that aren't registered in the menu — so
+ * these assertions stay stable even as the menu evolves.
+ */
+
+import { buildPageContext, getPageLabel } from './page-context'
+import { describe, expect, test } from 'bun:test'
+
+describe('getPageLabel', () => {
+  test('resolves a registered route to its menu title', () => {
+    expect(getPageLabel('/overview')).toBe('Overview')
+    expect(getPageLabel('/merges')).toBe('Merges')
+  })
+
+  test('ignores the query string when resolving', () => {
+    expect(getPageLabel('/merges?host=1')).toBe('Merges')
+  })
+
+  test('falls back to a title-cased segment for unregistered routes', () => {
+    expect(getPageLabel('/some-unregistered-xyz')).toBe('Some Unregistered Xyz')
+  })
+
+  test('returns undefined for the root path (no segment to title)', () => {
+    expect(getPageLabel('/')).toBeUndefined()
+  })
+})
+
+describe('buildPageContext', () => {
+  test('carries the raw route plus the resolved label', () => {
+    expect(buildPageContext('/merges')).toEqual({
+      route: '/merges',
+      label: 'Merges',
+    })
+  })
+
+  test('omits the label when none resolves', () => {
+    expect(buildPageContext('/')).toEqual({ route: '/' })
+  })
+})

--- a/apps/dashboard/src/lib/hooks/use-agent-widget-mode.ts
+++ b/apps/dashboard/src/lib/hooks/use-agent-widget-mode.ts
@@ -1,0 +1,88 @@
+'use client'
+
+/**
+ * useAgentWidgetMode Hook
+ *
+ * Remembers whether the floating agent widget is shown as the small bottom-right
+ * popover (`floating`) or docked as a full-height right sidebar (`docked`).
+ * Persisted to localStorage so the preferred layout survives reloads and is
+ * shared across tabs of the same browser.
+ */
+
+import { useEffect, useState } from 'react'
+
+export type AgentWidgetMode = 'floating' | 'docked'
+
+const WIDGET_MODE_STORAGE_KEY = 'clickhouse-monitor-agent-widget-mode'
+const WIDGET_MODE_CHANGE_EVENT = 'clickhouse-monitor-agent-widget-mode-changed'
+
+const DEFAULT_MODE: AgentWidgetMode = 'floating'
+
+function isWidgetMode(value: string | null): value is AgentWidgetMode {
+  return value === 'floating' || value === 'docked'
+}
+
+function getSavedMode(): AgentWidgetMode {
+  if (typeof window === 'undefined') return DEFAULT_MODE
+  try {
+    const saved = localStorage.getItem(WIDGET_MODE_STORAGE_KEY)
+    if (isWidgetMode(saved)) return saved
+  } catch {
+    // localStorage may be disabled
+  }
+  return DEFAULT_MODE
+}
+
+function saveMode(mode: AgentWidgetMode): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(WIDGET_MODE_STORAGE_KEY, mode)
+  } catch {
+    // localStorage may be disabled
+  }
+}
+
+function emitModeChange(mode: AgentWidgetMode): void {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(
+    new CustomEvent<AgentWidgetMode>(WIDGET_MODE_CHANGE_EVENT, { detail: mode })
+  )
+}
+
+export interface UseAgentWidgetModeResult {
+  mode: AgentWidgetMode
+  isDocked: boolean
+  setMode: (mode: AgentWidgetMode) => void
+  toggleMode: () => void
+}
+
+/**
+ * Manages the floating-vs-docked layout of the agent widget. Writing the mode
+ * persists it and broadcasts a custom event so any other consumer in the tab
+ * stays in sync without a reload.
+ */
+export function useAgentWidgetMode(): UseAgentWidgetModeResult {
+  const [mode, setModeState] = useState<AgentWidgetMode>(() => getSavedMode())
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<AgentWidgetMode>).detail
+      setModeState(isWidgetMode(detail) ? detail : getSavedMode())
+    }
+    window.addEventListener(WIDGET_MODE_CHANGE_EVENT, handler)
+    return () => window.removeEventListener(WIDGET_MODE_CHANGE_EVENT, handler)
+  }, [])
+
+  const setMode = (next: AgentWidgetMode): void => {
+    saveMode(next)
+    setModeState(next)
+    emitModeChange(next)
+  }
+
+  const toggleMode = (): void => {
+    setMode(mode === 'docked' ? 'floating' : 'docked')
+  }
+
+  return { mode, isDocked: mode === 'docked', setMode, toggleMode }
+}

--- a/docs/content/guide/ai-agent.mdx
+++ b/docs/content/guide/ai-agent.mdx
@@ -240,6 +240,18 @@ not baked into the (byte-stable, cached) system prompt. Purely additive:
 omitting it (MCP and API-token callers have no "page") behaves exactly as
 before.
 
+In the **floating chat widget** this awareness is made visible: a small chip
+above the composer (e.g. `⌞ Fleet Overview`) shows which page the agent can
+see, so "why is this slow?" is understood as _this_ page. Click the chip's ×
+to drop page context for the current page (it re-arms when you navigate
+elsewhere). The chip is a floating-widget affordance only — the full
+`/agents` page has no "current page" and shows no chip.
+
+**Floating vs docked layout.** The floating widget can be expanded from the
+small bottom-right popover into a full-height right-hand sidebar (and collapsed
+back) via the header toggle. The preference is remembered per browser
+(localStorage `clickhouse-monitor-agent-widget-mode`).
+
 ## MCP Server
 
 The dashboard exposes an MCP (Model Context Protocol) endpoint at `/api/mcp`. The same implementation runs in the standalone Cloudflare MCP Worker (`apps/mcp`). All tools are read-only by design — write and DDL statements are rejected.

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -3,7 +3,7 @@ id: product-design
 title: Product design system & UX conventions
 type: reference
 status: active
-updated: 2026-07-10
+updated: 2026-07-11
 tags:
   - design-system
   - ui
@@ -191,6 +191,21 @@ Prefer ONE clear signal per piece of state, not several redundant ones.
   `lib/context/time-range-context.tsx`) drives every chart widget's baseline
   `lastHours`/`interval` via explicit props, which outrank both the chart's
   own default and the global header time-range picker.
+- **Floating agent widget (page-aware + dockable):** the app-wide chat bubble
+  (`components/assistant-ui/assistant-modal.tsx`, on top of assistant-ui's
+  Radix-Popover `AssistantModalPrimitive`) has two remembered layouts —
+  `floating` (bottom-right popover) and `docked` (full-height right sidebar,
+  `fixed inset-y-0 right-0 w-[min(28rem,100vw)] border-l`). Because Radix
+  Popper wraps content in a transformed positioner (which traps a `fixed`
+  child), the docked layout is rendered as its own fixed panel outside the
+  Popper, with the Root's `open` controlled so it mounts/unmounts (Thread stops
+  polling when closed). Mode persists via `useAgentWidgetMode`
+  (`lib/hooks/use-agent-widget-mode.ts`, localStorage +
+  CustomEvent, same shape as `useAgentModel`). A dismissible **page-context
+  chip** above the composer (`-thread/page-context-chip.tsx`) surfaces the page
+  the agent can see; its shared state (`page-context-control.tsx`, floating-only
+  provider) also gates whether `pageContext` rides along with the request — see
+  `docs/content/guide/ai-agent.mdx`.
 
 ## UX conventions
 


### PR DESCRIPTION
## What

Makes the floating ClickHouse Agent widget **page-aware and visibly so**, and lets it expand into a docked right-side panel.

Builds on the existing (already-merged, #2457) `pageContext` request field — this PR adds the **visible + interactive** surface for it plus the dock layout. The full `/agents` page is deliberately unaffected.

### 1. Dismissible page-context chip
- A compact chip above the composer (quote icon + page title, e.g. `⌞ Fleet Overview`) shows which page the agent can see. Tooltip: "The agent can see the page you're on".
- Click the chip's **×** to drop page context for the current page; it re-arms automatically when you navigate elsewhere.
- Shared state lives in a **floating-only** `PageContextControlProvider`; the chat transport reads a stable `enabledRef` at send time, so toggling never rebuilds the transport. No provider on `/agents` ⇒ chip hidden, transport behaviour identical to before.

### 2. Dockable right-panel mode
- Header toggle switches between `floating` (bottom-right popover) and `docked` (full-height right sidebar, `fixed inset-y-0 right-0 w-[min(28rem,100vw)] border-l`).
- Preference persisted per browser via `useAgentWidgetMode` (localStorage + CustomEvent).
- Radix Popper wraps popover content in a transformed positioner that would trap a `fixed` child, so the docked layout renders as its own fixed panel **outside** the Popper; the Root's `open` is controlled so the panel mounts/unmounts (Thread stops polling when closed). Esc closes it, matching the popover.

## Files
- `components/assistant-ui/page-context-control.tsx` (new) — floating-only shared control
- `components/assistant-ui/-thread/page-context-chip.tsx` (new) — the chip
- `components/assistant-ui/-thread/composer.tsx` — render chip above the input
- `components/assistant-ui/agent-runtime-provider.tsx` — gate `pageContext` on the chip's enabled-ref
- `components/assistant-ui/global-assistant-modal-impl.tsx` — wrap floating widget in the provider
- `components/assistant-ui/assistant-modal.tsx` — floating/docked layouts + header toggle
- `lib/hooks/use-agent-widget-mode.ts` (new) — persisted layout mode
- `lib/ai/agent/page-context.test.ts` (new) — pure page-label resolution tests
- docs: `guide/ai-agent.mdx`, `knowledge/product-design.md`

## Testing
- `bun test` page-context (client + existing server helpers): 17 pass
- `biome check` clean on all changed files
- `tsc` clean for all changed files (remaining route-tree errors are the pre-existing bare-`tsc` codegen artifact, resolved by the vite build)

## Notes
- Minor behaviour change: the floating widget no longer auto-opens on `thread.runStart`. Nothing external starts a run on the floating runtime while it's closed (runs only originate inside the already-open widget), so there was no real trigger to preserve, and dropping it keeps `open` cleanly controllable for the dock.

Co-Authored-By: duyetbot <bot@duyet.net>