### PR TITLE
fix(ui): restore dropdown item handlers broken by Base UI migration

### DIFF
--- a/apps/dashboard/src/components/dashboard/add-widget-menu.tsx
+++ b/apps/dashboard/src/components/dashboard/add-widget-menu.tsx
@@ -63,13 +63,13 @@ export function AddWidgetMenu({ onAdd }: AddWidgetMenuProps) {
           Add Widget
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuItem onSelect={() => setDialog('table')}>
+          <DropdownMenuItem onClick={() => setDialog('table')}>
             Table…
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setDialog('stat')}>
+          <DropdownMenuItem onClick={() => setDialog('stat')}>
             Stat…
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setDialog('text')}>
+          <DropdownMenuItem onClick={() => setDialog('text')}>
             Text…
           </DropdownMenuItem>
         </DropdownMenuContent>

--- a/apps/dashboard/src/components/data-table/buttons/column-visibility.tsx
+++ b/apps/dashboard/src/components/data-table/buttons/column-visibility.tsx
@@ -16,12 +16,6 @@ interface ColumnVisibilityButtonProps<TData extends RowData = RowData> {
 export const ColumnVisibilityButton = function ColumnVisibilityButton<
   TData extends RowData = RowData,
 >({ table }: ColumnVisibilityButtonProps<TData>) {
-  const handleSelect = (event: { preventDefault: () => void }) => {
-    event.preventDefault()
-    // Prevent default selection behavior to avoid
-    // unintended interactions with checkbox state
-  }
-
   return (
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger
@@ -47,7 +41,6 @@ export const ColumnVisibilityButton = function ColumnVisibilityButton<
                 key={column.id}
                 checked={column.getIsVisible()}
                 onCheckedChange={(value) => column.toggleVisibility(!!value)}
-                onSelect={handleSelect}
                 role="checkbox"
                 aria-label={column.id}
               >

--- a/apps/dashboard/src/components/data-table/components/data-table-header-parts.tsx
+++ b/apps/dashboard/src/components/data-table/components/data-table-header-parts.tsx
@@ -105,25 +105,13 @@ export function DisplayOptionsDropdown<TData extends RowData>({
             onValueChange={(v) => onDensityChange(v as TableDensity)}
             className="px-1"
           >
-            <DropdownMenuRadioItem
-              value="comfortable"
-              className="text-xs"
-              onSelect={(e) => e.preventDefault()}
-            >
+            <DropdownMenuRadioItem value="comfortable" className="text-xs">
               Comfortable
             </DropdownMenuRadioItem>
-            <DropdownMenuRadioItem
-              value="compact"
-              className="text-xs"
-              onSelect={(e) => e.preventDefault()}
-            >
+            <DropdownMenuRadioItem value="compact" className="text-xs">
               Compact
             </DropdownMenuRadioItem>
-            <DropdownMenuRadioItem
-              value="dense"
-              className="text-xs"
-              onSelect={(e) => e.preventDefault()}
-            >
+            <DropdownMenuRadioItem value="dense" className="text-xs">
               Dense
             </DropdownMenuRadioItem>
           </DropdownMenuRadioGroup>
@@ -143,7 +131,6 @@ export function DisplayOptionsDropdown<TData extends RowData>({
                 key={column.id}
                 checked={column.getIsVisible()}
                 onCheckedChange={(value) => column.toggleVisibility(!!value)}
-                onSelect={(e) => e.preventDefault()}
                 className="text-xs"
               >
                 {getColumnLabel(column.id)}

--- a/apps/dashboard/src/components/nav-user.tsx
+++ b/apps/dashboard/src/components/nav-user.tsx
@@ -177,7 +177,7 @@ export function NavUser({
                   {canUseSettings && (
                     <DropdownMenuItem
                       className="flex items-center gap-2"
-                      onSelect={() => {
+                      onClick={() => {
                         setSettingsOpen(true)
                       }}
                       data-testid="nav-user-settings"

--- a/apps/dashboard/src/components/nav-user/clerk-nav.tsx
+++ b/apps/dashboard/src/components/nav-user/clerk-nav.tsx
@@ -235,7 +235,7 @@ export function ClerkNavWrapper() {
                 <DropdownMenuGroup>
                   <DropdownMenuItem
                     className="flex items-center gap-2"
-                    onSelect={() => openUserProfile()}
+                    onClick={() => openUserProfile()}
                     data-testid="nav-user-account"
                   >
                     <UserIcon className="size-4" />
@@ -298,7 +298,7 @@ export function ClerkNavWrapper() {
                   {canUseSettings && (
                     <DropdownMenuItem
                       className="flex items-center gap-2"
-                      onSelect={() => {
+                      onClick={() => {
                         setSettingsOpen(true)
                       }}
                       data-testid="nav-user-settings"
@@ -314,7 +314,7 @@ export function ClerkNavWrapper() {
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
                   className="flex items-center gap-2 text-destructive focus:text-destructive"
-                  onSelect={async () => {
+                  onClick={async () => {
                     clearUserConnectionsCache(queryClient)
                     try {
                       await signOut({ redirectUrl: '/' })

--- a/apps/dashboard/src/components/query-tables/column-visibility-menu.tsx
+++ b/apps/dashboard/src/components/query-tables/column-visibility-menu.tsx
@@ -18,8 +18,9 @@ interface ColumnVisibilityMenuProps<TKey extends string> {
 
 /**
  * Column-visibility dropdown shared by the query tables — a checkbox per
- * optional column, checked when the column is visible. `onSelect` is
- * prevented so the menu stays open while toggling several columns.
+ * optional column, checked when the column is visible. Base UI's
+ * `MenuCheckboxItem` already defaults `closeOnClick` to `false`, so the menu
+ * stays open while toggling several columns without extra wiring.
  */
 export function ColumnVisibilityMenu<TKey extends string>({
   columns,
@@ -49,7 +50,6 @@ export function ColumnVisibilityMenu<TKey extends string>({
             key={col.key}
             checked={!hiddenColumns.has(col.key)}
             onCheckedChange={() => onToggle(col.key)}
-            onSelect={(e) => e.preventDefault()}
           >
             {col.label}
           </DropdownMenuCheckboxItem>

--- a/apps/dashboard/src/lib/__tests__/no-onselect-on-menu-items.test.ts
+++ b/apps/dashboard/src/lib/__tests__/no-onselect-on-menu-items.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Regression guard for the "Sign Out does nothing" incident.
+ *
+ * PR #2361 migrated `components/ui/dropdown-menu.tsx` from Radix UI to Base
+ * UI (`@base-ui/react/menu`). Radix's `DropdownMenu.Item` fires `onSelect`;
+ * Base UI's `Menu.Item` (and the Checkbox/Radio/SubTrigger variants) has no
+ * `onSelect` prop and the wrapper passes props straight through with no
+ * mapping — React silently drops the unknown prop, so `onSelect={...}`
+ * became a dead click across the app (Sign Out, Settings, Add Widget menu,
+ * …). The fix is `onClick` (Base UI's real click handler); a checkbox/radio
+ * item that used `onSelect={(e) => e.preventDefault()}` just to keep the
+ * menu open should instead rely on Base UI's default `closeOnClick={false}`
+ * for those variants, or use `closeOnClick={false}` explicitly on a plain
+ * item.
+ *
+ * This test scans the app source for `<DropdownMenu*Item`/`SubTrigger` tags
+ * that still carry `onSelect=` so this class of bug can't silently return.
+ */
+import { describe, expect, test } from 'bun:test'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// `src/` — three levels above this `__tests__` folder (lib/__tests__ -> lib -> src).
+const SRC_ROOT = fileURLToPath(new URL('../..', import.meta.url))
+
+function walk(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    const stat = statSync(full)
+    if (stat.isDirectory()) {
+      if (entry === '__tests__' || entry === 'ui') continue
+      out.push(...walk(full))
+    } else if (
+      (entry.endsWith('.tsx') || entry.endsWith('.ts')) &&
+      !entry.includes('.test.') &&
+      !entry.includes('.spec.')
+    ) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+// Matches an opening `<DropdownMenuItem`, `<DropdownMenuCheckboxItem`,
+// `<DropdownMenuRadioItem`, or `<DropdownMenuSubTrigger` tag that contains an
+// `onSelect=` prop before its closing `>`. `[^>]` also matches newlines (only
+// `.` excludes them in JS regex), so this spans multi-line JSX props.
+const MENU_ITEM_ONSELECT =
+  /<DropdownMenu(?:Item|CheckboxItem|RadioItem|SubTrigger)\b[^>]*\bonSelect=/
+
+describe('no onSelect on Base UI dropdown menu items', () => {
+  const files = walk(SRC_ROOT)
+
+  test('discovers a meaningful number of source files', () => {
+    expect(files.length).toBeGreaterThan(100)
+  })
+
+  test('no DropdownMenu*Item/SubTrigger uses onSelect (Base UI has no such prop; use onClick)', () => {
+    const offenders = files.filter((f) =>
+      MENU_ITEM_ONSELECT.test(readFileSync(f, 'utf8'))
+    )
+    if (offenders.length > 0) {
+      const rel = offenders.map((f) => f.slice(SRC_ROOT.length))
+      throw new Error(
+        'Found <DropdownMenuItem>/<DropdownMenuCheckboxItem>/' +
+          '<DropdownMenuRadioItem>/<DropdownMenuSubTrigger> with an onSelect ' +
+          'prop. Base UI menu items (components/ui/dropdown-menu.tsx, backed ' +
+          'by @base-ui/react/menu) have no onSelect prop — React silently ' +
+          'drops it and the handler never runs (see the "Sign Out does ' +
+          'nothing" incident). Use onClick instead; if onSelect was only ' +
+          'used to keep the menu open, note that Base UI already defaults ' +
+          'closeOnClick to false for CheckboxItem/RadioItem, or set ' +
+          `closeOnClick={false} explicitly on a plain Item:\n  ${rel.join('\n  ')}`
+      )
+    }
+    expect(offenders).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Root cause

PR #2361 migrated `components/ui/dropdown-menu.tsx` from Radix UI to **Base UI** (`Menu as MenuPrimitive from '@base-ui/react/menu'`). Radix's `DropdownMenu.Item` fires `onSelect`; **Base UI's `Menu.Item` (and the Checkbox/Radio/SubTrigger variants) has no `onSelect` prop**, and the wrapper (`DropdownMenuItem`, `DropdownMenuCheckboxItem`, `DropdownMenuRadioItem`) passes props straight through with no mapping — React silently drops the unknown prop. Every `<DropdownMenuItem onSelect={...}>` in the app was therefore a dead click: the menu closes, the handler never runs. That's why **Sign Out** (`nav-user/clerk-nav.tsx`) did nothing — same bug also hit Settings, Account Settings, and the "Add Widget" menu.

Confirmed via Base UI's type defs (`@base-ui/react` `menu/item/MenuItem.d.ts`): `MenuItem` supports `onClick` and `closeOnClick` (default `true`), not `onSelect`. `MenuCheckboxItem`/`MenuRadioItem` support `onCheckedChange`/`onValueChange` (already correctly wired) and default `closeOnClick` to **`false`** — i.e. Base UI already keeps the menu open on toggle by default, so the old Radix idiom of `onSelect={(e) => e.preventDefault()}` to prevent the menu closing was dead weight even before this fix.

## Fix — classification of every `onSelect=` site outside `components/ui/`

| File | Component | Action |
|---|---|---|
| `nav-user/clerk-nav.tsx` (Account Settings, Settings, **Sign Out**) | `DropdownMenuItem` | `onSelect` → `onClick` |
| `nav-user.tsx` (Settings, guest variant) | `DropdownMenuItem` | `onSelect` → `onClick` |
| `dashboard/add-widget-menu.tsx` (Table/Stat/Text ×3) | `DropdownMenuItem` | `onSelect` → `onClick` (same dead-click bug, found during the sweep — Add Widget never opened its dialogs) |
| `data-table/buttons/column-visibility.tsx` | `DropdownMenuCheckboxItem` | Removed `onSelect={(e)=>e.preventDefault()}` + its `handleSelect` helper — `closeOnClick` already defaults to `false` for checkbox items |
| `data-table/components/data-table-header-parts.tsx` (3× Radio + 1× Checkbox) | `DropdownMenuRadioItem` / `DropdownMenuCheckboxItem` | Same — removed dead `onSelect` preventDefault |
| `query-tables/column-visibility-menu.tsx` | `DropdownMenuCheckboxItem` | Same — removed dead `onSelect` preventDefault, updated stale doc comment |

Everything else that still uses `onSelect=` was traced to its underlying primitive and left unchanged because it's a different component that genuinely supports `onSelect`:
- **`CommandItem`** (cmdk) — `command-palette/*.tsx`, `controls/command-palette.tsx`, `controls/interval-select.tsx`, `filters/add-filter-popover.tsx`, `filters/filter-editor.tsx`, `insights/settings/model-combobox.tsx`, `sql-console/database-combobox.tsx`, `explain/query-picker.tsx` — cmdk's own `onSelect` prop, unrelated to Base UI.
- **Custom components with their own `onSelect` prop name** (plain `<button onClick={onSelect}>` internally, or a callback prop) — `agents/welcome/agent-model-picker.tsx` / `agents/settings/provider-models-tab.tsx` (`ModelOptionRow`), `agents/mentions/*`, `assistant-ui/thread.tsx` (`FollowUpChips`), `charts/primitives/area.tsx` (`DeploymentMarkerLabel`), `charts/query/query-count-heatmap.tsx` (`ModePill`), `cluster-topology/*`, `explorer/tree/*-node.tsx`, `expensive-queries-view.tsx` / `slow-queries-view.tsx` / `user-processes-view.tsx` (`FilterGroup`), `query-favorites/query-favorites-panel.tsx` (`FavoriteItem`), `sql-console/sql-console.tsx` (`QueryHistoryPanel`/`QueryFavoritesPanel`), `routes/(dashboard)/explain.tsx` (`QueryPicker`).

No other Radix-era prop mismatches (e.g. `onCheckedChange`) were found — that prop is natively supported by Base UI's `MenuCheckboxItem` and was already correctly wired.

## Regression guard

Added `apps/dashboard/src/lib/__tests__/no-onselect-on-menu-items.test.ts`, mirroring the existing source-scanning convention test style (`routes/api/__tests__/hostid-validation-contract.test.ts`). It walks `apps/dashboard/src` (excluding `components/ui` and test files) and fails if any `<DropdownMenuItem>` / `<DropdownMenuCheckboxItem>` / `<DropdownMenuRadioItem>` / `<DropdownMenuSubTrigger>` still carries an `onSelect=` prop, with an error message pointing at this incident. Verified it fails when the bug is reintroduced and passes on the fixed tree.

## Verify

- Ran the dev server locally and drove the guest nav-user dropdown end-to-end: clicked "Settings" and confirmed the Settings dialog now opens (it silently did nothing before the fix, same as Sign Out).
- `bun test src/lib/__tests__/` — 214 pass.
- `pnpm exec biome check` on all changed files — clean.
- Pre-push hooks (full biome check, dashboard unit tests, package unit tests) all passed locally.
- Did not run `pnpm run build` per instructions.

Fixes the "could not sign out" report.

Co-Authored-By: duyetbot <bot@duyet.net>