### PR TITLE
feat(settings): units, colors, and layout preferences

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -118,6 +118,19 @@ Use the `components/data-table/` system (resizing, wrap toggle, sorting via
 Synthetic column ids `__expand`, `select`, `action` are non-data — skip them in
 filter/search/sort/card wiring.
 
+## User appearance settings
+
+The Settings dialog (`components/settings/settings-form.tsx`) exposes units
+(`byteUnit`, `numberFormat`), chart palette (`chartPalette`), table density
+(`tableDensity`) and default time range on `UserSettings`. Every DEFAULT
+reproduces the prior look byte-for-byte. Applied by `AppearanceSettingsProvider`
+(`lib/context/appearance-settings.tsx`): units → module snapshot in
+`lib/format-settings.ts` (read by the `format-readable` helpers); palette/density
+→ `data-chart-palette` / `data-density` on `<html>` with `--chart-*` and
+`data-slot` padding overrides in `styles.css` (never edit `ui/table.tsx`). For
+2–3 choices use `components/settings/segmented-control.tsx`. Full detail:
+`docs/knowledge/product-design.md`.
+
 ## Adding a page
 
 1. `src/routes/(dashboard)/my-page.tsx` (`'use client'`, uses `useHostId()`).

--- a/apps/dashboard/src/components/settings/segmented-control.tsx
+++ b/apps/dashboard/src/components/settings/segmented-control.tsx
@@ -1,0 +1,63 @@
+import type { LucideIcon } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+export interface SegmentedOption<T extends string> {
+  value: T
+  label: string
+  icon?: LucideIcon
+}
+
+interface SegmentedControlProps<T extends string> {
+  value: T
+  onChange: (value: T) => void
+  options: readonly SegmentedOption<T>[]
+  ariaLabel: string
+}
+
+/**
+ * A compact segmented button group for 2–3 mutually exclusive choices, styled
+ * to match the theme picker's card look. Used across the Settings dialog for
+ * unit / palette / density toggles.
+ */
+export function SegmentedControl<T extends string>({
+  value,
+  onChange,
+  options,
+  ariaLabel,
+}: SegmentedControlProps<T>) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      className="grid gap-2"
+      style={{
+        gridTemplateColumns: `repeat(${options.length}, minmax(0, 1fr))`,
+      }}
+    >
+      {options.map((option) => {
+        const Icon = option.icon
+        const isSelected = value === option.value
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={isSelected}
+            onClick={() => onChange(option.value)}
+            className={cn(
+              'relative flex flex-col items-center justify-center gap-1.5 rounded-lg border-2 p-2.5 transition-[opacity,border-color,background-color,box-shadow] hover:opacity-80',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50',
+              isSelected
+                ? 'border-primary bg-primary/5 ring-2 ring-primary/20'
+                : 'border-muted bg-muted/20'
+            )}
+          >
+            {Icon && <Icon className="size-4" aria-hidden="true" />}
+            <span className="text-xs font-medium">{option.label}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/settings/settings-form.tsx
+++ b/apps/dashboard/src/components/settings/settings-form.tsx
@@ -1,7 +1,26 @@
-import { Globe, Monitor, Moon, RotateCcw, Sun } from 'lucide-react'
+import {
+  Binary,
+  Globe,
+  Hash,
+  Monitor,
+  Moon,
+  Palette,
+  RotateCcw,
+  Rows3,
+  Sun,
+} from 'lucide-react'
 
-import type { UserSettings } from '@/lib/types/user-settings'
+import type {
+  ByteUnit,
+  ChartPalette,
+  DefaultTimeRange,
+  NumberFormat,
+  TableDensity,
+  UserSettings,
+} from '@/lib/types/user-settings'
+import type { SegmentedOption } from './segmented-control'
 
+import { SegmentedControl } from './segmented-control'
 import { useTheme } from 'next-themes'
 import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
@@ -15,7 +34,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { Separator } from '@/components/ui/separator'
 import { TIMEZONE_GROUPS } from '@/lib/constants/timezones'
+import { TIME_RANGE_PRESETS } from '@/lib/context/time-range-context'
+import {
+  formatReadableQuantity,
+  formatReadableSize,
+} from '@/lib/format-readable'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { cn } from '@/lib/utils'
 
@@ -35,6 +60,65 @@ const themeOptions = [
     description: 'Sync with system',
   },
 ] as const
+
+const byteUnitOptions: readonly SegmentedOption<ByteUnit>[] = [
+  { value: 'binary', label: 'Binary' },
+  { value: 'decimal', label: 'Decimal' },
+]
+
+const numberFormatOptions: readonly SegmentedOption<NumberFormat>[] = [
+  { value: 'abbreviated', label: 'Abbreviated' },
+  { value: 'full', label: 'Full' },
+]
+
+const chartPaletteOptions: readonly SegmentedOption<ChartPalette>[] = [
+  { value: 'default', label: 'Default' },
+  { value: 'colorblind-safe', label: 'Colorblind' },
+  { value: 'monochrome', label: 'Mono' },
+]
+
+const densityOptions: readonly SegmentedOption<TableDensity>[] = [
+  { value: 'comfortable', label: 'Comfortable' },
+  { value: 'compact', label: 'Compact' },
+]
+
+/** Sample byte value (1.5 GiB) used for the live units preview. */
+const BYTE_PREVIEW_SAMPLE = 1.5 * 1024 ** 3
+/** Sample quantity (1,200,000) used for the live numbers preview. */
+const NUMBER_PREVIEW_SAMPLE = 1_200_000
+
+function SectionHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+      {children}
+    </h3>
+  )
+}
+
+function Field({
+  label,
+  icon: Icon,
+  description,
+  children,
+}: {
+  label: string
+  icon?: React.ComponentType<{ className?: string }>
+  description?: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="space-y-2">
+      <Label className="flex items-center gap-1.5 text-sm font-medium">
+        {Icon && <Icon className="size-3.5" aria-hidden="true" />}
+        {label}
+      </Label>
+      {children}
+      {description && (
+        <p className="text-xs text-muted-foreground">{description}</p>
+      )}
+    </div>
+  )
+}
 
 export function SettingsForm({
   settings,
@@ -83,115 +167,224 @@ export function SettingsForm({
   const isUsingDefault =
     defaultTimezone && settings.timezone === defaultTimezone
 
+  // Live previews reflect the selected unit explicitly (independent of the
+  // global format snapshot), so the example updates as the user toggles.
+  const bytePreview = `${formatReadableSize(
+    BYTE_PREVIEW_SAMPLE,
+    1,
+    'binary'
+  )} ↔ ${formatReadableSize(BYTE_PREVIEW_SAMPLE, 1, 'decimal')}`
+  const numberPreview = `${formatReadableQuantity(
+    NUMBER_PREVIEW_SAMPLE,
+    'short'
+  )} ↔ ${formatReadableQuantity(NUMBER_PREVIEW_SAMPLE, 'long')}`
+
   return (
-    <div className="space-y-6 py-4">
-      {/* Timezone Section */}
-      <div className="space-y-3">
-        <div className="flex items-center justify-between">
-          <Label htmlFor="timezone" className="text-sm font-medium">
-            Timezone
-          </Label>
+    <div className="max-h-[70vh] space-y-6 overflow-y-auto py-4 pr-1">
+      {/* General */}
+      <section className="space-y-3">
+        <SectionHeader>General</SectionHeader>
+        <Field
+          label="Timezone"
+          description="All datetimes will be displayed in your selected timezone"
+        >
           {!isLoadingDefault && defaultTimezone && (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="h-7 px-2 text-xs"
-              onClick={handleResetTimezone}
-              disabled={!!isUsingDefault}
-            >
-              <RotateCcw className="size-3 mr-1" />
-              Reset to default
-            </Button>
-          )}
-        </div>
-        <Select
-          value={settings.timezone}
-          onValueChange={(value) => onUpdate({ timezone: value ?? undefined })}
-        >
-          <SelectTrigger id="timezone" className="h-9">
-            <SelectValue placeholder="Select timezone" />
-          </SelectTrigger>
-          <SelectContent>
-            {TIMEZONE_GROUPS.map((group) => (
-              <SelectGroup key={group.label}>
-                <SelectLabel className="text-xs">{group.label}</SelectLabel>
-                {group.timezones.map((tz) => (
-                  <SelectItem
-                    key={tz.value}
-                    value={tz.value}
-                    className="text-xs"
-                  >
-                    <div className="flex items-center justify-between gap-2">
-                      <span>{tz.label}</span>
-                      {defaultTimezone === tz.value && (
-                        <span className="text-[10px] text-muted-foreground">
-                          (default)
-                        </span>
-                      )}
-                    </div>
-                  </SelectItem>
-                ))}
-              </SelectGroup>
-            ))}
-          </SelectContent>
-        </Select>
-        <p className="text-xs text-muted-foreground">
-          All datetimes will be displayed in your selected timezone
-        </p>
-      </div>
-
-      {/* Theme Section */}
-      <div className="space-y-3">
-        <Label className="text-sm font-medium">Theme</Label>
-        <div className="grid grid-cols-3 gap-2">
-          {themeOptions.map((option) => {
-            const Icon = option.icon
-            const isSelected = settings.theme === option.value
-            return (
-              <button
-                key={option.value}
+            <div className="flex justify-end">
+              <Button
                 type="button"
-                onClick={() => handleThemeChange(option.value)}
-                className={cn(
-                  'relative flex flex-col items-center justify-center rounded-lg border-2 p-3 transition-[opacity,border-color,background-color,box-shadow] hover:opacity-80',
-                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50',
-                  isSelected
-                    ? 'border-primary bg-primary/5 ring-2 ring-primary/20'
-                    : 'border-muted bg-muted/20'
-                )}
-                aria-pressed={isSelected}
-                aria-label={`Select ${option.description}`}
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-xs"
+                onClick={handleResetTimezone}
+                disabled={!!isUsingDefault}
               >
-                <Icon className="mb-2 size-5" aria-hidden="true" />
-                <span className="text-xs font-medium">{option.label}</span>
-              </button>
-            )
-          })}
-        </div>
-      </div>
+                <RotateCcw className="mr-1 size-3" />
+                Reset to default
+              </Button>
+            </div>
+          )}
+          <Select
+            value={settings.timezone}
+            onValueChange={(value) =>
+              onUpdate({ timezone: value ?? undefined })
+            }
+          >
+            <SelectTrigger id="timezone" className="h-9">
+              <SelectValue placeholder="Select timezone" />
+            </SelectTrigger>
+            <SelectContent>
+              {TIMEZONE_GROUPS.map((group) => (
+                <SelectGroup key={group.label}>
+                  <SelectLabel className="text-xs">{group.label}</SelectLabel>
+                  {group.timezones.map((tz) => (
+                    <SelectItem
+                      key={tz.value}
+                      value={tz.value}
+                      className="text-xs"
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <span>{tz.label}</span>
+                        {defaultTimezone === tz.value && (
+                          <span className="text-[10px] text-muted-foreground">
+                            (default)
+                          </span>
+                        )}
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              ))}
+            </SelectContent>
+          </Select>
+        </Field>
+      </section>
 
-      {/* MCP Server Section */}
-      <div className="space-y-3">
-        <Label className="text-sm font-medium flex items-center gap-1.5">
-          <Globe className="size-3.5" />
-          MCP Server
-        </Label>
-        <p className="text-xs text-muted-foreground">
-          Connect AI assistants to your ClickHouse cluster via the Model Context
-          Protocol.
-        </p>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="w-full justify-start text-xs"
-          onClick={() => window.open('/mcp', '_blank')}
+      <Separator />
+
+      {/* Appearance */}
+      <section className="space-y-4">
+        <SectionHeader>Appearance</SectionHeader>
+
+        <Field label="Theme">
+          <div className="grid grid-cols-3 gap-2">
+            {themeOptions.map((option) => {
+              const Icon = option.icon
+              const isSelected = settings.theme === option.value
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => handleThemeChange(option.value)}
+                  className={cn(
+                    'relative flex flex-col items-center justify-center rounded-lg border-2 p-3 transition-[opacity,border-color,background-color,box-shadow] hover:opacity-80',
+                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50',
+                    isSelected
+                      ? 'border-primary bg-primary/5 ring-2 ring-primary/20'
+                      : 'border-muted bg-muted/20'
+                  )}
+                  aria-pressed={isSelected}
+                  aria-label={`Select ${option.description}`}
+                >
+                  <Icon className="mb-2 size-5" aria-hidden="true" />
+                  <span className="text-xs font-medium">{option.label}</span>
+                </button>
+              )
+            })}
+          </div>
+        </Field>
+
+        <Field
+          label="Chart palette"
+          icon={Palette}
+          description="Color scheme for chart series. Colorblind uses the Okabe-Ito palette; Mono is a single-hue ramp."
         >
-          <Globe className="size-3 mr-2" />
-          View MCP Server Details
-        </Button>
-      </div>
+          <SegmentedControl
+            ariaLabel="Chart palette"
+            value={settings.chartPalette}
+            onChange={(value) => onUpdate({ chartPalette: value })}
+            options={chartPaletteOptions}
+          />
+        </Field>
+      </section>
+
+      <Separator />
+
+      {/* Units */}
+      <section className="space-y-4">
+        <SectionHeader>Units</SectionHeader>
+
+        <Field
+          label="Byte sizes"
+          icon={Binary}
+          description={`Binary uses 1024-based KiB/MiB; Decimal uses 1000-based KB/MB. e.g. ${bytePreview}`}
+        >
+          <SegmentedControl
+            ariaLabel="Byte sizes"
+            value={settings.byteUnit}
+            onChange={(value) => onUpdate({ byteUnit: value })}
+            options={byteUnitOptions}
+          />
+        </Field>
+
+        <Field
+          label="Large numbers"
+          icon={Hash}
+          description={`Abbreviated shows compact suffixes; Full shows grouped digits. e.g. ${numberPreview}`}
+        >
+          <SegmentedControl
+            ariaLabel="Large numbers"
+            value={settings.numberFormat}
+            onChange={(value) => onUpdate({ numberFormat: value })}
+            options={numberFormatOptions}
+          />
+        </Field>
+      </section>
+
+      <Separator />
+
+      {/* Layout */}
+      <section className="space-y-4">
+        <SectionHeader>Layout</SectionHeader>
+
+        <Field
+          label="Table density"
+          icon={Rows3}
+          description="Row height for data tables. Compact fits more rows on screen."
+        >
+          <SegmentedControl
+            ariaLabel="Table density"
+            value={settings.tableDensity}
+            onChange={(value) => onUpdate({ tableDensity: value })}
+            options={densityOptions}
+          />
+        </Field>
+
+        <Field
+          label="Default time range"
+          description="Initial time range for time-series pages. Explicit clicks and shared ?range= links still take priority."
+        >
+          <Select
+            value={settings.defaultTimeRange}
+            onValueChange={(value) =>
+              value && onUpdate({ defaultTimeRange: value as DefaultTimeRange })
+            }
+          >
+            <SelectTrigger id="default-time-range" className="h-9">
+              <SelectValue placeholder="Select default range" />
+            </SelectTrigger>
+            <SelectContent>
+              {TIME_RANGE_PRESETS.map((preset) => (
+                <SelectItem key={preset.value} value={preset.value}>
+                  {preset.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Field>
+      </section>
+
+      <Separator />
+
+      {/* Integrations */}
+      <section className="space-y-3">
+        <SectionHeader>Integrations</SectionHeader>
+        <Field
+          label="MCP Server"
+          icon={Globe}
+          description="Connect AI assistants to your ClickHouse cluster via the Model Context Protocol."
+        >
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="w-full justify-start text-xs"
+            onClick={() => window.open('/mcp', '_blank')}
+          >
+            <Globe className="mr-2 size-3" />
+            View MCP Server Details
+          </Button>
+        </Field>
+      </section>
 
       <div className="flex justify-end pt-4">
         <Button onClick={onClose}>Done</Button>

--- a/apps/dashboard/src/lib/context/appearance-settings.tsx
+++ b/apps/dashboard/src/lib/context/appearance-settings.tsx
@@ -1,0 +1,52 @@
+import { useEffect } from 'react'
+import { setFormatSettings } from '@/lib/format-settings'
+import { useUserSettings } from '@/lib/hooks/use-user-settings'
+
+/**
+ * Applies the appearance-related user settings that live outside React's render
+ * tree:
+ *
+ * - **Units** (byte unit + number format) are pushed into the module-level
+ *   `format-settings` snapshot that the `format-readable` helpers read.
+ * - **Chart palette** and **table density** are applied as `data-*` attributes
+ *   on `<html>`, which CSS in `styles.css` keys off. The default value
+ *   (`default` palette / `comfortable` density) removes the attribute entirely,
+ *   so an untouched install renders exactly as before.
+ *
+ * Rendered once near the app root; renders nothing.
+ */
+export function AppearanceSettingsProvider({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const { settings } = useUserSettings()
+  const { byteUnit, numberFormat, chartPalette, tableDensity } = settings
+
+  // Keep the format-readable snapshot in sync with the user's unit choices.
+  useEffect(() => {
+    setFormatSettings({ byteUnit, numberFormat })
+  }, [byteUnit, numberFormat])
+
+  // Chart palette → data-chart-palette on <html> (absent = default palette).
+  useEffect(() => {
+    const root = document.documentElement
+    if (chartPalette && chartPalette !== 'default') {
+      root.setAttribute('data-chart-palette', chartPalette)
+    } else {
+      root.removeAttribute('data-chart-palette')
+    }
+  }, [chartPalette])
+
+  // Table density → data-density on <html> (absent = comfortable).
+  useEffect(() => {
+    const root = document.documentElement
+    if (tableDensity && tableDensity !== 'comfortable') {
+      root.setAttribute('data-density', tableDensity)
+    } else {
+      root.removeAttribute('data-density')
+    }
+  }, [tableDensity])
+
+  return children
+}

--- a/apps/dashboard/src/lib/context/time-range-context.tsx
+++ b/apps/dashboard/src/lib/context/time-range-context.tsx
@@ -1,6 +1,10 @@
 import type { ClickHouseInterval } from '@chm/types/clickhouse-interval'
 
 import { createContext, use, useCallback, useMemo, useState } from 'react'
+import {
+  DEFAULT_USER_SETTINGS,
+  USER_SETTINGS_STORAGE_KEY,
+} from '@/lib/types/user-settings'
 
 export interface TimeRangeOption {
   /** Display label shown in the picker (e.g., "24h") */
@@ -43,16 +47,40 @@ const STORAGE_KEY = 'chm-global-time-range'
 /** URL search param used to share the active time range */
 const SEARCH_PARAM = 'range'
 
-/** Resolve a stored value string against the presets; unknown -> default. */
-function resolveTimeRange(value: string | null): TimeRangeOption {
-  if (!value) return DEFAULT_TIME_RANGE
-  return TIME_RANGE_PRESETS.find((p) => p.value === value) ?? DEFAULT_TIME_RANGE
+/** Resolve a stored value string against the presets; unknown -> fallback. */
+function resolveTimeRange(
+  value: string | null,
+  fallback: TimeRangeOption = DEFAULT_TIME_RANGE
+): TimeRangeOption {
+  if (!value) return fallback
+  return TIME_RANGE_PRESETS.find((p) => p.value === value) ?? fallback
 }
 
 /**
- * Read the initial time range, preferring the URL `?range=` param, falling
- * back to localStorage, then the default. Wrapped in try/catch for SSR and
- * private-browsing safety.
+ * Read the user's configured default time range from the user-settings
+ * localStorage blob, resolved to a preset. Used only as the initial value when
+ * no explicit range (URL param or previously-persisted click) is present, so it
+ * never overrides an explicit user choice. Falls back to the hard default
+ * (24h) when unset or unparseable.
+ */
+function readSettingsDefault(): TimeRangeOption {
+  try {
+    const raw = localStorage.getItem(USER_SETTINGS_STORAGE_KEY)
+    if (!raw) return DEFAULT_TIME_RANGE
+    const parsed = JSON.parse(raw) as { defaultTimeRange?: string }
+    return resolveTimeRange(
+      parsed.defaultTimeRange ?? DEFAULT_USER_SETTINGS.defaultTimeRange
+    )
+  } catch {
+    return DEFAULT_TIME_RANGE
+  }
+}
+
+/**
+ * Read the initial time range, preferring the URL `?range=` param, then the
+ * previously-persisted range (an explicit user click), then the user's
+ * configured default-time-range setting, then the hard default. Wrapped in
+ * try/catch for SSR and private-browsing safety.
  */
 function readInitialTimeRange(): TimeRangeOption {
   if (typeof window === 'undefined') return DEFAULT_TIME_RANGE
@@ -61,7 +89,11 @@ function readInitialTimeRange(): TimeRangeOption {
       SEARCH_PARAM
     )
     if (fromUrl) return resolveTimeRange(fromUrl)
-    return resolveTimeRange(localStorage.getItem(STORAGE_KEY))
+
+    const persisted = localStorage.getItem(STORAGE_KEY)
+    if (persisted) return resolveTimeRange(persisted)
+
+    return readSettingsDefault()
   } catch {
     return DEFAULT_TIME_RANGE
   }

--- a/apps/dashboard/src/lib/format-readable.test.ts
+++ b/apps/dashboard/src/lib/format-readable.test.ts
@@ -5,7 +5,15 @@ import {
   formatReadableSecondDuration,
   formatReadableSize,
 } from './format-readable'
-import { describe, expect, test } from 'bun:test'
+import { getFormatSettings, setFormatSettings } from './format-settings'
+import { afterEach, describe, expect, test } from 'bun:test'
+
+// The unit/number-format helpers read a module-level snapshot as their default.
+// Restore it to the historical defaults after every test so cross-test order
+// never leaks a mutated global.
+afterEach(() => {
+  setFormatSettings({ byteUnit: 'binary', numberFormat: 'abbreviated' })
+})
 
 describe('formatReadableSize', () => {
   test('zero / falsy bytes render as "0 Bytes"', () => {
@@ -31,6 +39,29 @@ describe('formatReadableSize', () => {
   test('caps at the largest unit', () => {
     expect(formatReadableSize(1024 ** 9)).toContain('YiB')
   })
+
+  test('default (no unit arg) is byte-identical to the historical binary output', () => {
+    // Invariant: a user who never opens Settings sees zero change.
+    expect(getFormatSettings().byteUnit).toBe('binary')
+    expect(formatReadableSize(1536)).toBe('1.5 KiB')
+    expect(formatReadableSize(1024 * 1024)).toBe('1 MiB')
+  })
+
+  test('explicit decimal unit uses 1000-based SI labels', () => {
+    expect(formatReadableSize(1500, 1, 'decimal')).toBe('1.5 KB')
+    expect(formatReadableSize(1_500_000, 1, 'decimal')).toBe('1.5 MB')
+    expect(formatReadableSize(1_500_000_000, 1, 'decimal')).toBe('1.5 GB')
+  })
+
+  test('explicit binary unit forces 1024-based regardless of snapshot', () => {
+    setFormatSettings({ byteUnit: 'decimal' })
+    expect(formatReadableSize(1024, 1, 'binary')).toBe('1 KiB')
+  })
+
+  test('snapshot byteUnit=decimal changes the default output', () => {
+    setFormatSettings({ byteUnit: 'decimal' })
+    expect(formatReadableSize(1500)).toBe('1.5 KB')
+  })
 })
 
 describe('formatReadableQuantity', () => {
@@ -40,6 +71,21 @@ describe('formatReadableQuantity', () => {
 
   test('long preset uses grouped standard notation', () => {
     expect(formatReadableQuantity(123456789, 'long')).toBe('123,456,789')
+  })
+
+  test('default (no preset) is byte-identical to the historical short output', () => {
+    expect(getFormatSettings().numberFormat).toBe('abbreviated')
+    expect(formatReadableQuantity(123456789)).toBe('123M')
+  })
+
+  test('snapshot numberFormat=full changes the no-preset default to grouped', () => {
+    setFormatSettings({ numberFormat: 'full' })
+    expect(formatReadableQuantity(123456789)).toBe('123,456,789')
+  })
+
+  test('explicit preset always wins over the snapshot', () => {
+    setFormatSettings({ numberFormat: 'full' })
+    expect(formatReadableQuantity(123456789, 'short')).toBe('123M')
   })
 })
 

--- a/apps/dashboard/src/lib/format-readable.ts
+++ b/apps/dashboard/src/lib/format-readable.ts
@@ -1,20 +1,34 @@
+import type { ByteUnit } from '@/lib/types/user-settings'
+
+import { getFormatSettings } from '@/lib/format-settings'
+
+const BINARY_SIZES = [
+  'Bytes',
+  'KiB',
+  'MiB',
+  'GiB',
+  'TiB',
+  'PiB',
+  'EiB',
+  'ZiB',
+  'YiB',
+]
+const DECIMAL_SIZES = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+
 // https://stackoverflow.com/a/18650828
-export function formatReadableSize(bytes: number, decimals = 1) {
+export function formatReadableSize(
+  bytes: number,
+  decimals = 1,
+  unit?: ByteUnit
+) {
   if (!+bytes) return '0 Bytes'
 
-  const k = 1024
+  // Default (binary, 1024-based) reproduces the historical output exactly;
+  // decimal (1000-based, SI units) is the opt-in alternative.
+  const resolvedUnit = unit ?? getFormatSettings().byteUnit
+  const k = resolvedUnit === 'decimal' ? 1000 : 1024
+  const sizes = resolvedUnit === 'decimal' ? DECIMAL_SIZES : BINARY_SIZES
   const dm = decimals < 0 ? 0 : decimals
-  const sizes = [
-    'Bytes',
-    'KiB',
-    'MiB',
-    'GiB',
-    'TiB',
-    'PiB',
-    'EiB',
-    'ZiB',
-    'YiB',
-  ]
 
   const sign = bytes < 0 ? '-' : ''
   const abs = Math.abs(bytes)
@@ -34,15 +48,17 @@ export function formatReadableSize(bytes: number, decimals = 1) {
  * formatReadableQuantity(123456789, 'long') => 123,456,789
  *
  * @param quantity
- * @param preset 'short' or 'long', defaults to 'short'
+ * @param preset 'short' or 'long'. When omitted, resolves from the user's
+ *   number-format setting (abbreviated → 'short', full → 'long'). Default
+ *   settings resolve to 'short', reproducing the historical behaviour.
  * @returns
  */
-export function formatReadableQuantity(
-  quantity: number,
-  preset: string = 'short'
-) {
+export function formatReadableQuantity(quantity: number, preset?: string) {
+  const resolvedPreset =
+    preset ?? (getFormatSettings().numberFormat === 'full' ? 'long' : 'short')
+
   const options =
-    preset === 'short'
+    resolvedPreset === 'short'
       ? {
           notation: 'compact' as 'compact',
           compactDisplay: 'short' as 'short',

--- a/apps/dashboard/src/lib/format-settings.ts
+++ b/apps/dashboard/src/lib/format-settings.ts
@@ -1,0 +1,35 @@
+import type { ByteUnit, NumberFormat } from '@/lib/types/user-settings'
+
+/**
+ * Module-level snapshot of the format-affecting user settings.
+ *
+ * The `format-readable` helpers are plain synchronous functions called from
+ * hundreds of table cells and chart formatters that cannot each take a React
+ * hook. Instead, the user-settings provider syncs the chosen units here once on
+ * load and on every change (see `AppearanceSettingsProvider`), and the helpers
+ * read this snapshot as their default when no explicit override is passed.
+ *
+ * Defaults intentionally reproduce the historical behaviour byte-for-byte
+ * (binary sizes, abbreviated numbers), so a build that never syncs — SSR / the
+ * Worker runtime, or a user who never opens Settings — renders exactly as before.
+ */
+export interface FormatSettings {
+  byteUnit: ByteUnit
+  numberFormat: NumberFormat
+}
+
+const snapshot: FormatSettings = {
+  byteUnit: 'binary',
+  numberFormat: 'abbreviated',
+}
+
+/** Read the current format settings snapshot. */
+export function getFormatSettings(): FormatSettings {
+  return snapshot
+}
+
+/** Update the format settings snapshot (called by the settings provider). */
+export function setFormatSettings(next: Partial<FormatSettings>): void {
+  if (next.byteUnit) snapshot.byteUnit = next.byteUnit
+  if (next.numberFormat) snapshot.numberFormat = next.numberFormat
+}

--- a/apps/dashboard/src/lib/hooks/use-user-settings.ts
+++ b/apps/dashboard/src/lib/hooks/use-user-settings.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import {
   DEFAULT_USER_SETTINGS,
+  mergeUserSettings,
   USER_SETTINGS_STORAGE_KEY,
   type UserSettings,
 } from '@/lib/types/user-settings'
@@ -48,7 +49,7 @@ function loadSettings(): UserSettings {
   try {
     const stored = localStorage.getItem(USER_SETTINGS_STORAGE_KEY)
     if (stored) {
-      return { ...DEFAULT_USER_SETTINGS, ...JSON.parse(stored) }
+      return mergeUserSettings(JSON.parse(stored))
     }
   } catch (error) {
     console.error('Failed to load user settings:', error)

--- a/apps/dashboard/src/lib/types/user-settings.test.ts
+++ b/apps/dashboard/src/lib/types/user-settings.test.ts
@@ -1,0 +1,49 @@
+import {
+  DEFAULT_USER_SETTINGS,
+  mergeUserSettings,
+  type UserSettings,
+} from './user-settings'
+import { describe, expect, test } from 'bun:test'
+
+describe('mergeUserSettings', () => {
+  test('a legacy stored blob (only timezone + theme) fills new keys from defaults', () => {
+    // Represents settings persisted before Units/Colors/Layout existed.
+    const legacy = { timezone: 'America/New_York', theme: 'dark' }
+    const merged = mergeUserSettings(legacy)
+
+    expect(merged.timezone).toBe('America/New_York')
+    expect(merged.theme).toBe('dark')
+    // New keys must resolve to their defaults, not undefined.
+    expect(merged.byteUnit).toBe('binary')
+    expect(merged.numberFormat).toBe('abbreviated')
+    expect(merged.chartPalette).toBe('default')
+    expect(merged.tableDensity).toBe('comfortable')
+    expect(merged.defaultTimeRange).toBe('24h')
+  })
+
+  test('stored values override the defaults', () => {
+    const stored: UserSettings = {
+      ...DEFAULT_USER_SETTINGS,
+      byteUnit: 'decimal',
+      numberFormat: 'full',
+      chartPalette: 'colorblind-safe',
+      tableDensity: 'compact',
+      defaultTimeRange: '7d',
+    }
+    const merged = mergeUserSettings(stored)
+    expect(merged).toEqual(stored)
+  })
+
+  test('null / non-object input returns a fresh copy of the defaults', () => {
+    expect(mergeUserSettings(null)).toEqual(DEFAULT_USER_SETTINGS)
+    expect(mergeUserSettings('junk')).toEqual(DEFAULT_USER_SETTINGS)
+    // Must be a copy, not the shared reference.
+    expect(mergeUserSettings(null)).not.toBe(DEFAULT_USER_SETTINGS)
+  })
+
+  test('default byteUnit/numberFormat reproduce historical behaviour', () => {
+    // Guards the fail-closed invariant at the type level.
+    expect(DEFAULT_USER_SETTINGS.byteUnit).toBe('binary')
+    expect(DEFAULT_USER_SETTINGS.numberFormat).toBe('abbreviated')
+  })
+})

--- a/apps/dashboard/src/lib/types/user-settings.ts
+++ b/apps/dashboard/src/lib/types/user-settings.ts
@@ -1,11 +1,45 @@
+export type ByteUnit = 'binary' | 'decimal'
+export type NumberFormat = 'abbreviated' | 'full'
+export type ChartPalette = 'default' | 'colorblind-safe' | 'monochrome'
+export type TableDensity = 'comfortable' | 'compact'
+export type DefaultTimeRange = '1h' | '6h' | '24h' | '7d' | '30d'
+
 export interface UserSettings {
   timezone: string // IANA timezone identifier (e.g., 'America/New_York')
   theme: 'light' | 'dark' | 'system'
+  /** Byte size units: binary (1024, KiB) or decimal (1000, KB). */
+  byteUnit: ByteUnit
+  /** Large-number display: abbreviated (1.2M) or full (1,200,000). */
+  numberFormat: NumberFormat
+  /** Chart series color palette. */
+  chartPalette: ChartPalette
+  /** Data-table row density. */
+  tableDensity: TableDensity
+  /** Initial global time range for time-series pages. */
+  defaultTimeRange: DefaultTimeRange
 }
 
 export const DEFAULT_USER_SETTINGS: UserSettings = {
   timezone: Intl?.DateTimeFormat()?.resolvedOptions()?.timeZone || 'UTC',
   theme: 'system',
+  byteUnit: 'binary',
+  numberFormat: 'abbreviated',
+  chartPalette: 'default',
+  tableDensity: 'comfortable',
+  defaultTimeRange: '24h',
 }
 
 export const USER_SETTINGS_STORAGE_KEY = 'clickhouse-monitor-user-settings'
+
+/**
+ * Merge a persisted settings object (which may predate newer keys) over the
+ * defaults, so a stored blob missing `byteUnit` / `chartPalette` / etc. still
+ * resolves to a complete `UserSettings` with the correct defaults. Tolerates a
+ * non-object / null input by returning the defaults unchanged.
+ */
+export function mergeUserSettings(stored: unknown): UserSettings {
+  if (!stored || typeof stored !== 'object') {
+    return { ...DEFAULT_USER_SETTINGS }
+  }
+  return { ...DEFAULT_USER_SETTINGS, ...(stored as Partial<UserSettings>) }
+}

--- a/apps/dashboard/src/routes/__root.tsx
+++ b/apps/dashboard/src/routes/__root.tsx
@@ -13,6 +13,7 @@ import { WebMcpRegistration } from '@/components/webmcp'
 import { SignupAnalyticsTracker } from '@/lib/analytics/signup-tracker'
 import { isClerkClientEnabled } from '@/lib/clerk/clerk-client'
 import { AppProvider } from '@/lib/context/app-context'
+import { AppearanceSettingsProvider } from '@/lib/context/appearance-settings'
 import { BrowserConnectionsProvider } from '@/lib/context/browser-connections-context'
 import { TimeRangeProvider } from '@/lib/context/time-range-context'
 import { TimezoneProvider } from '@/lib/context/timezone-context'
@@ -163,25 +164,27 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
         <WebMcpRegistration />
         <ClerkAuthProvider>
           <TimezoneProvider>
-            <ThemeProvider>
-              <TimeRangeProvider>
-                <QueryProvider>
-                  {isClerkClientEnabled() ? (
-                    <>
-                      <UserConnectionsCacheGuard />
-                      <SignupAnalyticsTracker />
-                    </>
-                  ) : null}
-                  <BrowserConnectionsProvider>
-                    <AppProvider>
-                      <FeaturePermissionsProvider>
-                        {children}
-                      </FeaturePermissionsProvider>
-                    </AppProvider>
-                  </BrowserConnectionsProvider>
-                </QueryProvider>
-              </TimeRangeProvider>
-            </ThemeProvider>
+            <AppearanceSettingsProvider>
+              <ThemeProvider>
+                <TimeRangeProvider>
+                  <QueryProvider>
+                    {isClerkClientEnabled() ? (
+                      <>
+                        <UserConnectionsCacheGuard />
+                        <SignupAnalyticsTracker />
+                      </>
+                    ) : null}
+                    <BrowserConnectionsProvider>
+                      <AppProvider>
+                        <FeaturePermissionsProvider>
+                          {children}
+                        </FeaturePermissionsProvider>
+                      </AppProvider>
+                    </BrowserConnectionsProvider>
+                  </QueryProvider>
+                </TimeRangeProvider>
+              </ThemeProvider>
+            </AppearanceSettingsProvider>
           </TimezoneProvider>
         </ClerkAuthProvider>
         <Scripts />

--- a/apps/dashboard/src/styles.css
+++ b/apps/dashboard/src/styles.css
@@ -514,6 +514,53 @@
   --sidebar-ring: oklch(0.556 0 0);
 }
 
+/* ---------------------------------------------------------------
+ * Chart palettes (user setting: Settings › Appearance › Chart palette)
+ *
+ * Applied via `data-chart-palette` on <html> by AppearanceSettingsProvider.
+ * The attribute is ABSENT for the default palette, so an untouched install
+ * keeps the exact `--chart-1..13` tokens defined above. These overrides come
+ * after both `:root` and `.dark` so they win by source order in either theme
+ * (chart tokens are theme-independent). Series colors flow through
+ * `seriesColorVar()` → `var(--chart-N)`, so overriding the tokens is enough.
+ *
+ * - colorblind-safe: the Okabe-Ito qualitative palette (8 hues, distinguishable
+ *   under the common forms of color-vision deficiency), cycled for 9..13.
+ * - monochrome: a single-hue (brand orange) lightness ramp for low-chroma,
+ *   print-friendly charts.
+ * --------------------------------------------------------------- */
+:root[data-chart-palette='colorblind-safe'] {
+  --chart-1: #e69f00; /* orange */
+  --chart-2: #56b4e9; /* sky blue */
+  --chart-3: #009e73; /* bluish green */
+  --chart-4: #f0e442; /* yellow */
+  --chart-5: #0072b2; /* blue */
+  --chart-6: #d55e00; /* vermillion */
+  --chart-7: #cc79a7; /* reddish purple */
+  --chart-8: #999999; /* grey */
+  --chart-9: #e69f00;
+  --chart-10: #56b4e9;
+  --chart-11: #009e73;
+  --chart-12: #0072b2;
+  --chart-13: #cc79a7;
+}
+
+:root[data-chart-palette='monochrome'] {
+  --chart-1: oklch(0.84 0.15 70);
+  --chart-2: oklch(0.75 0.16 66);
+  --chart-3: oklch(0.66 0.16 62);
+  --chart-4: oklch(0.57 0.15 56);
+  --chart-5: oklch(0.48 0.13 50);
+  --chart-6: oklch(0.9 0.08 72);
+  --chart-7: oklch(0.4 0.11 48);
+  --chart-8: oklch(0.7 0.05 70);
+  --chart-9: oklch(0.84 0.15 70);
+  --chart-10: oklch(0.66 0.16 62);
+  --chart-11: oklch(0.48 0.13 50);
+  --chart-12: oklch(0.9 0.08 72);
+  --chart-13: oklch(0.57 0.15 56);
+}
+
 @theme inline {
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
@@ -583,6 +630,25 @@
   .animate-rq-indeterminate {
     animation: rq-indeterminate 1.3s ease-in-out infinite;
   }
+}
+
+/* ---------------------------------------------------------------
+ * Table density (user setting: Settings › Layout › Density)
+ *
+ * Applied via `data-density` on <html> by AppearanceSettingsProvider. The
+ * attribute is ABSENT for the default `comfortable` density, so untouched
+ * installs keep the shadcn table's `p-2` cell / `h-10` header padding. The
+ * `compact` override tightens vertical rhythm by keying off the table's
+ * `data-slot` markers, so it applies to every data table without touching
+ * `components/ui/table.tsx`.
+ * --------------------------------------------------------------- */
+:root[data-density='compact'] [data-slot='table-head'] {
+  height: 2rem; /* h-8 (was h-10) */
+}
+
+:root[data-density='compact'] [data-slot='table-cell'] {
+  padding-top: 0.25rem; /* py-1 (was p-2 → 0.5rem vertical) */
+  padding-bottom: 0.25rem;
 }
 
 /* ---------------------------------------------------------------

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -3,7 +3,7 @@ id: product-design
 title: Product design system & UX conventions
 type: reference
 status: active
-updated: 2026-07-11
+updated: 2026-07-12
 tags:
   - design-system
   - ui
@@ -71,6 +71,42 @@ Fonts: Geist Variable (sans) + Geist Mono.
 
 **OKLCH gotcha:** prefer `oklch(from var(--x) l c h)` for derived colors over
 `hsl(var(--x))` — see `cluster-topology.md` for the dynamic-color lightness bug.
+
+## User appearance settings (Settings dialog)
+
+`UserSettings` (`lib/types/user-settings.ts`, localStorage
+`clickhouse-monitor-user-settings`, merged over `DEFAULT_USER_SETTINGS` via
+`mergeUserSettings` so legacy blobs pick up new keys) carries the
+timezone/theme plus **units** (`byteUnit`, `numberFormat`), **colors**
+(`chartPalette`), and **layout** (`tableDensity`, `defaultTimeRange`). The
+Settings dialog (`components/settings/settings-form.tsx`) groups these into
+labeled `<section>`s (General / Appearance / Units / Layout / Integrations) with
+`Separator`s; 2–3 choice toggles use the shared
+`components/settings/segmented-control.tsx` (card look mirroring the theme
+picker), 5-option ones use `Select`.
+
+**Invariant: every default reproduces the prior behaviour byte-for-byte** —
+`byteUnit: 'binary'`, `numberFormat: 'abbreviated'`, `chartPalette: 'default'`
+(attribute absent), `tableDensity: 'comfortable'` (attribute absent),
+`defaultTimeRange: '24h'`.
+
+How each applies (all wired by `AppearanceSettingsProvider`,
+`lib/context/appearance-settings.tsx`, mounted at `__root`):
+- **Units** are pushed into a module-level snapshot
+  (`lib/format-settings.ts`, `get/setFormatSettings`); the plain
+  `formatReadableSize` / `formatReadableQuantity` helpers read it as their
+  default when no explicit override arg is passed. Because the snapshot isn't
+  reactive, already-rendered tables update on their next data refresh, not
+  instantly (acceptable v1).
+- **Chart palette** → `data-chart-palette` on `<html>`; `styles.css` overrides
+  `--chart-1..13` under `:root[data-chart-palette='…']` (after `:root`/`.dark`
+  so it wins). `colorblind-safe` = Okabe-Ito, `monochrome` = single-hue ramp.
+- **Table density** → `data-density` on `<html>`; `styles.css` tightens the
+  `data-slot='table-cell'/'table-head'` padding under `[data-density='compact']`
+  (no `components/ui/table.tsx` edit).
+- **Default time range** is read as the *initial* value only in
+  `lib/context/time-range-context.tsx` (`readInitialTimeRange`), after the URL
+  `?range=` param and any persisted click — never overriding an explicit choice.
 
 ## shadcn/ui rule
 


### PR DESCRIPTION
## Summary
Expands the Settings dialog beyond Timezone + Theme with **Units, Colors, and Layout** preferences, organized into labeled sections.

## Sections & new settings
- **General** — Timezone (existing)
- **Appearance** — Theme (existing) + **Chart palette** (`default` / `colorblind-safe` (Okabe-Ito) / `monochrome`)
- **Units** — **Byte sizes** (`binary` KiB / `decimal` KB) and **Large numbers** (`abbreviated` / `full`), each with a live `1.5 GiB ↔ 1.6 GB` / `1.2M ↔ 1,200,000` preview
- **Layout** — **Table density** (`comfortable` / `compact`) and **Default time range** (`1h`…`30d`)
- **Integrations** — MCP Server (existing)

2–3 choice toggles use a new shared `SegmentedControl` (theme-picker card look); the 5-way default-time-range uses `Select`. Each control has a one-line muted description.

## Invariant kept (defaults reproduce today byte-for-byte)
Every default matches prior behaviour: `byteUnit: binary`, `numberFormat: abbreviated`, `chartPalette: default` (html attribute absent), `tableDensity: comfortable` (attribute absent), `defaultTimeRange: 24h`. A user who never opens Settings sees zero change. Unit tests assert `formatReadableSize(1536)` → `1.5 KiB` and `formatReadableQuantity(123456789)` → `123M` unchanged.

## Plumbing
- `lib/format-settings.ts` — module-level snapshot (`get/setFormatSettings`); `formatReadableSize` / `formatReadableQuantity` read it as their default when no explicit override arg is passed. `AppearanceSettingsProvider` (mounted at `__root`) syncs it on load + change.
- **Chart palette** → `data-chart-palette` on `<html>`; `styles.css` overrides `--chart-1..13` under `:root[data-chart-palette='…']` (after `:root`/`.dark`).
- **Table density** → `data-density` on `<html>`; `styles.css` tightens `data-slot='table-cell'/'table-head'` padding under `[data-density='compact']` — no `components/ui/table.tsx` edit.
- **Default time range** → read as the *initial* value only in `time-range-context.tsx`, after `?range=` and any persisted click, so an explicit choice is never overridden.
- Legacy stored settings tolerated via `mergeUserSettings` (missing keys → defaults).

## Tests
- `format-readable.test.ts` — decimal/full modes, default-preservation, explicit-override precedence, snapshot wiring.
- `user-settings.test.ts` — legacy-blob merge, override merge, null/junk → defaults.

## Honest limitations (acceptable v1)
- The units snapshot is **not reactive**: changing Byte/Number format updates already-rendered tables on their **next data refresh**, not instantly. The Settings dialog's own live preview does update immediately. Most tables auto-refresh (~30s), so they converge without a manual reload.
- Density applies globally via the shared data-table `data-slot` markers.

## Verification
`bun test` (format + settings suites, 27 pass), `tsc --noEmit` clean on all changed files (remaining repo type errors are the pre-existing missing generated `routeTree.gen` build artifact, resolved by the CI build), and Biome check clean. Live browser check not run in this isolated worktree; relying on the `dashboard` CI build.

Docs: updated `docs/knowledge/product-design.md` + the `product-design` skill.
