### PR TITLE
feat(cloud): enable Postgres source (beta) by default on cloud

### DIFF
--- a/apps/dashboard/.env.production
+++ b/apps/dashboard/.env.production
@@ -40,6 +40,10 @@ CHM_DEPLOYMENT_MODE=cloud
 # AI agent access: public | authenticated. Cloud keeps the agent sign-in-gated
 # (anonymous visitors get read-only browsing, not the write-capable agent).
 CHM_FEATURE_AGENT_ACCESS=authenticated
+# Postgres as a monitored source (beta) — on for cloud. Enables the setup-page
+# engine chooser, per-user Postgres connections, /postgres pages, pg insights,
+# and the agent's postgres tools. OSS stays fail-closed (off unless set).
+CHM_FEATURE_POSTGRES_SOURCE=true
 
 # ── ClickHouse (demo host) ──────────────────────────────────────────────────
 # Localhost placeholders — the real demo host topology is injected at deploy from


### PR DESCRIPTION
Turns on `CHM_FEATURE_POSTGRES_SOURCE` for dash.chmonitor.dev via the committed `.env.production` (single source: client VITE_ derivation + Worker [vars] injection). Preview deploys inherit through the `.env.preview` overlay. Self-hosted/OSS behavior unchanged — the flag stays fail-closed off unless the operator sets it.

Unlocks on cloud: setup-page engine chooser (Connect ClickHouse / Connect Postgres), per-user Postgres connections, /postgres/queries + /postgres/activity pages, postgres AI insights (#2580), and the agent's postgres tools.