### PR TITLE
fix(sidebar): footer links as 2-col grid to save vertical space

### DIFF
--- a/apps/dashboard/src/components/app-sidebar.tsx
+++ b/apps/dashboard/src/components/app-sidebar.tsx
@@ -53,8 +53,12 @@ export function AppSidebar() {
             drift apart. Rows use the default SidebarMenuButton size (same as
             the body menu in nav-main/menu-item.tsx) so the footer reads as a
             continuation of the menu list, not a separate compact widget. The
-            user button below stays its own block. */}
-        <SidebarMenu>
+            user button below stays its own block.
+            Laid out as a 2-col grid (2x2 for the full 4-item set) so the
+            footer stops eating vertical space the main menu needs on short
+            screens; collapsed icon mode reverts to a single column since the
+            3rem icon rail only has room for one icon per row. */}
+        <SidebarMenu className="grid grid-cols-2 gap-0.5 group-data-[collapsible=icon]:grid-cols-1 group-data-[collapsible=icon]:gap-0">
           {footerItems.map((item) => (
             <SidebarMenuItem key={item.href}>
               <SidebarMenuButton


### PR DESCRIPTION
## Summary
- Sidebar footer (Billing / Organization / About + Docs, filtered by permission/cloudOnly) previously stacked as a vertical list of rows, eating vertical space the main menu needs on short screens.
- Renders the footer `SidebarMenu` as a 2-column grid instead (2x2 when all 4 items are visible).

## Details
- `SidebarMenu` already forwards `className` (`ui/sidebar.tsx`), and `cn()` uses `tailwind-merge`, so `grid grid-cols-2 gap-0.5` cleanly overrides the component's base `flex ... flex-col` layout (verified via computed styles: `display: grid`, two equal-width columns).
- **Collapsed icon mode**: the icon rail is only `3rem` wide (`SIDEBAR_WIDTH_ICON`), too narrow for two `size-8` icon squares side by side, so collapsed mode reverts to a single column via `group-data-[collapsible=icon]:grid-cols-1 group-data-[collapsible=icon]:gap-0` — verified this renders as a single 34px column with items stacked vertically, same as before the change.
- No special-casing for odd item counts (e.g. OSS showing only About + Docs) — a lone/odd item simply falls into the next grid cell, verified visually.
- Layout-only change; `menu.ts`, `NavUser`, and `components/ui/` untouched.

## Verification
- Ran the dev server against a live ClickHouse host and checked, via a mix of screenshots and computed-style JS inspection:
  - Expanded desktop: footer renders "About" + "Docs" side by side in a 2-col grid (`grid-template-columns: 111px 111px`).
  - Collapsed icon mode: reverts to a single 34px column, items stacked vertically, no overflow of the icon rail.
  - Mobile sheet (375px viewport): footer renders the same 2-col grid.
- `pnpm exec biome check` on the changed file: clean.

## Test plan
- [x] Expanded desktop sidebar footer renders as 2-col grid
- [x] Collapsed icon mode footer stays single-column (no icon-rail overflow)
- [x] Mobile sheet footer renders as 2-col grid
- [x] Biome check clean