### PR TITLE
fix(docs): TypeTable prop crash + build-time render-crash detection

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,3 +45,9 @@ jobs:
 
       - name: Build
         run: pnpm run build
+
+      - name: Install Chromium (for smoke test)
+        run: pnpm exec playwright-core install --with-deps chromium
+
+      - name: Smoke test (crawl every doc page, fail on render errors)
+        run: pnpm run smoke

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -12,7 +12,8 @@
     "start": "vite preview",
     "preview": "vite preview",
     "cf:deploy": "wrangler deploy",
-    "types:check": "fumadocs-mdx && tsc --noEmit"
+    "types:check": "fumadocs-mdx && tsc --noEmit",
+    "smoke": "node scripts/smoke-crawl.mjs"
   },
   "dependencies": {
     "@takumi-rs/image-response": "^1.8.7",
@@ -39,6 +40,7 @@
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.5",
     "@vitejs/plugin-react": "^6.0.0",
+    "playwright-core": "^1.56.0",
     "tailwindcss": "^4.1.11",
     "twoslash": "^0.3.0",
     "typescript": "^6.0.0",

--- a/apps/docs/pnpm-lock.yaml
+++ b/apps/docs/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.0
         version: 6.0.3(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0))
+      playwright-core:
+        specifier: ^1.56.0
+        version: 1.61.1
       tailwindcss:
         specifier: ^4.1.11
         version: 4.3.2
@@ -2655,6 +2658,11 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
@@ -5957,6 +5965,8 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.5: {}
+
+  playwright-core@1.61.1: {}
 
   points-on-curve@0.2.0: {}
 

--- a/apps/docs/scripts/discover-doc-pages.mjs
+++ b/apps/docs/scripts/discover-doc-pages.mjs
@@ -1,0 +1,59 @@
+// Enumerate every generated doc page (content/docs/**/*.mdx) as a URL path,
+// so the TanStack Start prerender can be told about all of them explicitly
+// via the `pages` option.
+//
+// Why: the crawl-based prerender (`crawlLinks: true`, following <a href> tags
+// found in rendered HTML starting from `/`) silently prerenders ONLY the
+// pages it can reach. The docs landing page renders its nav client-side, so
+// the raw server-rendered HTML for `/` has zero <a href> links — the crawl
+// never reaches any of the 90 content pages, and a render crash on any of
+// them (e.g. the TypeTable `data=` vs `type=` prop bug) never fails the
+// build. Declaring every page explicitly via `pages` makes the (already
+// `failOnError: true` by default) prerender step actually cover them.
+//
+// Must stay in sync with the slug rule in src/lib/source.ts
+// (markdownPathToSlugs: drop the extension, `index` maps to the parent dir).
+
+import { readdirSync, statSync } from 'node:fs'
+import { dirname, join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const CONTENT_DOCS_DIR = join(__dirname, '../content/docs')
+
+function walkMdxFiles(dir) {
+  let entries
+  try {
+    entries = readdirSync(dir)
+  } catch {
+    return []
+  }
+
+  const files = []
+  for (const entry of entries) {
+    const fullPath = join(dir, entry)
+    if (statSync(fullPath).isDirectory()) {
+      files.push(...walkMdxFiles(fullPath))
+    } else if (entry.endsWith('.mdx')) {
+      files.push(fullPath)
+    }
+  }
+  return files
+}
+
+function toUrlPath(mdxFilePath) {
+  const rel = relative(CONTENT_DOCS_DIR, mdxFilePath).split('\\').join('/')
+  const withoutExt = rel.replace(/\.mdx$/, '')
+  const segments = withoutExt.split('/').filter((s) => s !== 'index')
+  return `/${segments.join('/')}`
+}
+
+// Returns page entries in the shape TanStack Start's `pages` option expects,
+// e.g. [{ path: '/guide/features/peerdb' }, ...]. Empty when content/docs
+// hasn't been generated yet (sync-docs.mjs must run first).
+export function discoverDocPages() {
+  return walkMdxFiles(CONTENT_DOCS_DIR)
+    .map(toUrlPath)
+    .sort()
+    .map((path) => ({ path }))
+}

--- a/apps/docs/scripts/smoke-crawl.mjs
+++ b/apps/docs/scripts/smoke-crawl.mjs
@@ -1,0 +1,190 @@
+// Post-build smoke test: catch docs pages that crash instead of rendering.
+//
+// Why a real browser, not a plain fetch: this docs site prerenders a static
+// SHELL for every page (see vite.config.ts `pages`/`prerender`), but the MDX
+// body — including client components like fumadocs-ui's TypeTable
+// ("use client") — only renders after the page hydrates in the browser. A
+// crash there (e.g. the TypeTable `data=` vs `type=` prop bug, which throws
+// "Cannot convert undefined or null to object" and trips the router's error
+// boundary) never appears in the server-rendered HTML a plain `fetch()`
+// would see — it only exists in the live DOM after hydration and shows up as
+// a console error. Confirmed empirically while building this script: a page
+// with the broken prop returns HTTP 200 with clean-looking prerendered HTML,
+// but Chromium logs `TypeError: Cannot convert undefined or null to object`
+// and renders the fumadocs/TanStack error boundary ("Something went wrong!")
+// once client JS takes over. Only a headless browser catches that.
+//
+// Usage: run after `pnpm run build` (needs dist/ to exist). Starts its own
+// `vite preview` server, visits every doc page from discoverDocPages(), and
+// fails (exit 1, listing every failing URL) on:
+//   - non-200 HTTP status
+//   - a console error during load
+//   - an error-boundary marker in the rendered DOM ("Something went wrong",
+//     "Cannot convert", "Application error")
+//
+// Keep this fast: pages are checked with bounded concurrency and a per-page
+// timeout so a full crawl of ~90 pages stays well under 2 minutes.
+
+import { spawn } from 'node:child_process'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { chromium } from 'playwright-core'
+import { discoverDocPages } from './discover-doc-pages.mjs'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const APP_ROOT = join(__dirname, '..')
+
+const PORT = Number(process.env.SMOKE_PORT ?? 4173)
+const BASE_URL = `http://localhost:${PORT}`
+const CONCURRENCY = Number(process.env.SMOKE_CONCURRENCY ?? 8)
+const PAGE_TIMEOUT_MS = 15_000
+const SERVER_START_TIMEOUT_MS = 30_000
+
+const ERROR_MARKERS = [
+  'Something went wrong',
+  'Cannot convert undefined or null to object',
+  'Application error',
+]
+
+function startPreviewServer() {
+  const proc = spawn(
+    'pnpm',
+    ['exec', 'vite', 'preview', '--port', String(PORT), '--strictPort'],
+    { cwd: APP_ROOT, stdio: ['ignore', 'pipe', 'pipe'] },
+  )
+
+  let output = ''
+  proc.stdout.on('data', (chunk) => {
+    output += chunk.toString()
+  })
+  proc.stderr.on('data', (chunk) => {
+    output += chunk.toString()
+  })
+
+  return new Promise((resolve, reject) => {
+    const start = Date.now()
+    const check = setInterval(() => {
+      if (output.includes('Local:') || output.includes(`:${PORT}`)) {
+        clearInterval(check)
+        // Give the server a moment past the log line before hitting it.
+        setTimeout(() => resolve(proc), 300)
+        return
+      }
+      if (Date.now() - start > SERVER_START_TIMEOUT_MS) {
+        clearInterval(check)
+        reject(
+          new Error(
+            `preview server did not start within ${SERVER_START_TIMEOUT_MS}ms:\n${output}`,
+          ),
+        )
+      }
+    }, 200)
+
+    proc.on('exit', (code) => {
+      clearInterval(check)
+      if (code !== 0) {
+        reject(new Error(`preview server exited early (code ${code}):\n${output}`))
+      }
+    })
+  })
+}
+
+async function checkPage(browser, path) {
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  const consoleErrors = []
+
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text())
+  })
+  page.on('pageerror', (err) => {
+    consoleErrors.push(err.message)
+  })
+
+  try {
+    const response = await page.goto(`${BASE_URL}${path}`, {
+      waitUntil: 'networkidle',
+      timeout: PAGE_TIMEOUT_MS,
+    })
+
+    const status = response?.status() ?? 0
+    if (status < 200 || status >= 400) {
+      return { path, ok: false, reason: `HTTP ${status}` }
+    }
+
+    // Let client hydration finish and any render error surface.
+    await page.waitForTimeout(300)
+
+    const bodyText = await page.evaluate(() => document.body.innerText)
+    const marker = ERROR_MARKERS.find((m) => bodyText.includes(m))
+    if (marker) {
+      return { path, ok: false, reason: `error boundary in DOM: "${marker}"` }
+    }
+
+    if (consoleErrors.length > 0) {
+      return { path, ok: false, reason: `console error: ${consoleErrors[0]}` }
+    }
+
+    return { path, ok: true }
+  } catch (error) {
+    return { path, ok: false, reason: error instanceof Error ? error.message : String(error) }
+  } finally {
+    await context.close()
+  }
+}
+
+async function runWithConcurrency(items, limit, worker) {
+  const results = []
+  let index = 0
+
+  async function next() {
+    while (index < items.length) {
+      const current = index++
+      results[current] = await worker(items[current])
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, next))
+  return results
+}
+
+async function main() {
+  const pages = discoverDocPages()
+  if (pages.length === 0) {
+    console.error(
+      '[smoke] discoverDocPages() found 0 pages — did `pnpm run build` run first?',
+    )
+    process.exit(1)
+  }
+
+  console.log(`[smoke] Starting preview server on :${PORT}...`)
+  const server = await startPreviewServer()
+
+  console.log(`[smoke] Launching Chromium, crawling ${pages.length} pages (concurrency ${CONCURRENCY})...`)
+  const browser = await chromium.launch()
+
+  let results
+  try {
+    results = await runWithConcurrency(pages, CONCURRENCY, (p) => checkPage(browser, p.path))
+  } finally {
+    await browser.close()
+    server.kill()
+  }
+
+  const failures = results.filter((r) => !r.ok)
+
+  if (failures.length > 0) {
+    console.error(`\n[smoke] FAILED: ${failures.length}/${results.length} page(s) errored:\n`)
+    for (const f of failures) {
+      console.error(`  ${f.path} — ${f.reason}`)
+    }
+    process.exit(1)
+  }
+
+  console.log(`[smoke] OK: all ${results.length} pages rendered cleanly.`)
+}
+
+main().catch((error) => {
+  console.error('[smoke] crawl failed to run:', error)
+  process.exit(1)
+})

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -1,3 +1,4 @@
+import { discoverDocPages } from './scripts/discover-doc-pages.mjs'
 import { fileURLToPath } from 'node:url'
 import { cloudflare } from '@cloudflare/vite-plugin'
 import tailwindcss from '@tailwindcss/vite'
@@ -32,9 +33,18 @@ export default defineConfig({
     mdx(),
     cloudflare({ viteEnvironment: { name: 'ssr' } }),
     tanstackStart({
+      // Explicitly enumerate every generated doc page (content/docs/**/*.mdx)
+      // so prerender covers all of them, not just what the crawl can reach.
+      // The docs landing page renders its nav client-side, so `/` has no
+      // server-rendered <a href> links for the crawl to follow — without this,
+      // crawlLinks silently prerenders only `/` and a render crash on any
+      // content page never fails the build. See scripts/discover-doc-pages.mjs.
+      pages: discoverDocPages(),
       prerender: {
         // Prerender all doc pages at build time for fast first paint.
-        // The crawl follows <a> links starting from /.
+        // The crawl still follows <a> links starting from /, on top of the
+        // explicit `pages` list above. failOnError defaults to true, so a
+        // page that throws while rendering fails `pnpm run build`.
         enabled: true,
         crawlLinks: true,
         filter: (page: { path: string }) =>

--- a/docs/content/guide/features/browser-connections.mdx
+++ b/docs/content/guide/features/browser-connections.mdx
@@ -7,7 +7,7 @@ title: Browser Connections
 Add personal ClickHouse connections directly in your browser and query them through the chmonitor proxy — without touching server config.
 
 <TypeTable
-  data={{
+  type={{
     Routes: { type: "App shell", description: "Connection selector in the header" },
     "Feature id": { type: "None", description: "Part of the app shell, not a gated feature" },
     "Default access": { type: "public", description: "Anonymous access allowed by default" },

--- a/docs/content/guide/features/cluster.mdx
+++ b/docs/content/guide/features/cluster.mdx
@@ -7,7 +7,7 @@ title: Cluster
 See what nodes make up your cluster and how Keeper/ZooKeeper coordinates them — shard/replica topology, coordination health, the znode tree, and connection history.
 
 <TypeTable
-  data={{
+  type={{
     Routes: { type: "/clusters, /keeper/overview, /keeper, /keeper/info, /keeper/connections, /keeper/connection-log, /keeper/log, /keeper/watches", description: "Pages in this section" },
     "Feature id": { type: "cluster", description: "Used by permission env vars and config" },
     "Default access": { type: "public", description: "Set CHM_FEATURE_CLUSTER_ACCESS=authenticated to gate" },

--- a/docs/content/guide/features/health.mdx
+++ b/docs/content/guide/features/health.mdx
@@ -7,7 +7,7 @@ title: Health
 Get a single status grid of cluster health across replication, merges, errors, disks, load, and parts — plus a headless sweep endpoint that fires webhook alerts on a schedule.
 
 <TypeTable
-  data={{
+  type={{
     Routes: { type: "/health", description: "The health status grid" },
     "Feature id": { type: "health", description: "Used by permission env vars and config" },
     "Default access": { type: "public", description: "Set CHM_FEATURE_HEALTH_ACCESS=authenticated to gate" },

--- a/docs/content/guide/features/insights.mdx
+++ b/docs/content/guide/features/insights.mdx
@@ -7,7 +7,7 @@ title: Insights
 Aggregate query history to see which tables and columns your workload hits most, and how activity trends over time.
 
 <TypeTable
-  data={{
+  type={{
     Routes: { type: "/insights", description: "The insights analytics page" },
     "Feature id": { type: "insights", description: "Used by permission env vars and config" },
     "Default access": { type: "public", description: "Set CHM_FEATURE_INSIGHTS_ACCESS=authenticated to gate" },

--- a/docs/content/guide/features/logs.mdx
+++ b/docs/content/guide/features/logs.mdx
@@ -7,7 +7,7 @@ title: Logs
 Read server-level diagnostics — structured text logs, live thread stack traces, and historical crash reports — straight from the dashboard, with no SSH access or log-file parsing.
 
 <TypeTable
-  data={{
+  type={{
     Routes: { type: "/logs/text-log, /logs/stack-traces, /logs/crashes", description: "Pages in this section" },
     "Feature id": { type: "logs", description: "Used by permission env vars and config" },
     "Default access": { type: "public", description: "Set CHM_FEATURE_LOGS_ACCESS=authenticated to gate" },

--- a/docs/content/guide/features/mcp.mdx
+++ b/docs/content/guide/features/mcp.mdx
@@ -7,7 +7,7 @@ title: MCP Server
 Turn your chmonitor instance into a remote Model Context Protocol server so AI assistants — Claude Desktop, Cursor, or any MCP client — can run tools against your ClickHouse cluster without direct database access.
 
 <TypeTable
-  data={{
+  type={{
     Routes: { type: "/mcp", description: "UI info page (protocol endpoint is /api/mcp)" },
     "Feature id": { type: "mcp", description: "Used by permission env vars and config" },
     "Default access": { type: "Closed (401)", description: "Requires CHM_API_KEY_SECRET, CLERK_SECRET_KEY, or CHM_MCP_PUBLIC=true" },
@@ -134,7 +134,7 @@ enabled = true
 ## Configuration
 
 <TypeTable
-  data={{
+  type={{
     CHM_API_KEY_SECRET: { type: "string", description: "Enables API key authentication for all /api/v1/* routes including /api/mcp. Required for production use without Clerk." },
     CLERK_SECRET_KEY: { type: "string", description: "Enables Clerk OAuth token verification. Used for Clerk OAuth token introspection." },
     CHM_MCP_PUBLIC: { type: "boolean", description: "Set to true to allow anonymous access when no auth scheme is configured. Only appropriate for trusted private networks. A warning is logged on every request when active." },

--- a/docs/content/guide/features/metrics.mdx
+++ b/docs/content/guide/features/metrics.mdx
@@ -7,7 +7,7 @@ title: Metrics
 See live server counters, background-calculated resource metrics, and per-processor CPU profiling — three views of server-level performance.
 
 <TypeTable
-  data={{
+  type={{
     Routes: { type: "/metrics, /asynchronous-metrics, /profiler", description: "Pages in this section" },
     "Feature id": { type: "metrics", description: "Used by permission env vars and config" },
     "Default access": { type: "public", description: "Set CHM_FEATURE_METRICS_ACCESS=authenticated to gate" },

--- a/docs/content/guide/features/operations.mdx
+++ b/docs/content/guide/features/operations.mdx
@@ -7,7 +7,7 @@ title: Operations
 Watch the background work MergeTree engines do continuously — merges, mutations, part moves — and audit the full part-event timeline for every table.
 
 <TypeTable
-  data={{
+  type={{
     Routes: { type: "/merges, /merge-performance, /mutations, /moves, /part-log", description: "Pages in this section" },
     "Feature id": { type: "operations", description: "Used by permission env vars and config" },
     "Default access": { type: "public", description: "Set CHM_FEATURE_OPERATIONS_ACCESS=authenticated to gate" },

--- a/docs/content/guide/features/peerdb.mdx
+++ b/docs/content/guide/features/peerdb.mdx
@@ -7,7 +7,7 @@ title: PeerDB
 Monitor PeerDB replication mirrors and peers without leaving chmonitor — an optional, read-only integration that proxies the PeerDB API server-side.
 
 <TypeTable
-  data={{
+  type={{
     Routes: { type: "/peerdb, /peerdb/peers", description: "Pages in this section" },
     "Feature id": { type: "peerdb", description: "Used by permission env vars and config" },
     "Default access": { type: "public", description: "Set CHM_FEATURE_PEERDB_ACCESS=authenticated to gate" },
@@ -98,7 +98,7 @@ access = "authenticated"
 ## Configuration
 
 <TypeTable
-  data={{
+  type={{
     PEERDB_API_URL: { type: "string", description: "PeerDB API base URL. Include the /api suffix for the UI API (e.g. https://peerdb.example.com/api). When unset, the PeerDB section is hidden entirely. Default: unset." },
     PEERDB_PASSWORD: { type: "string", description: "HTTP Basic auth password. The username is left empty. Default: unset." },
     PEERDB_CACHE_TTL_MS: { type: "number", description: "Response cache TTL in milliseconds. Default: 10000." },

--- a/docs/content/guide/features/postgres.mdx
+++ b/docs/content/guide/features/postgres.mdx
@@ -11,7 +11,7 @@ Postgres support is new. Expect rough edges, and treat the feature flag as "on f
 </Callout>
 
 <TypeTable
-  data={{
+  type={{
     Routes: { type: "/postgres/queries, /postgres/activity", description: "Pages shown when a Postgres source is selected" },
     "Feature id": { type: "postgres", description: "Gated by CHM_FEATURE_POSTGRES_SOURCE" },
     "Default access": { type: "off", description: "Feature flag defaults to false — nothing changes until you enable it" },
@@ -111,7 +111,7 @@ Every Postgres query goes through one path: `queryPostgres()`. It connects per r
 Three tools, gated off with the feature flag (they simply don't appear when it's disabled):
 
 <TypeTable
-  data={{
+  type={{
     run_postgres_select_query: { type: "tool", description: "Execute a read-only SELECT/WITH/SHOW/EXPLAIN/TABLE/VALUES query against a Postgres source." },
     get_postgres_metrics: { type: "tool", description: "Version, uptime, connection counts by state, cache hit ratio, commit/rollback/deadlock counts, database size and replication status." },
     list_postgres_slow_query_patterns: { type: "tool", description: "Slowest normalized query patterns from pg_stat_statements — returns a helpful message instead of an error if the extension isn't installed." },
@@ -127,7 +127,7 @@ Cross-source correlation (e.g. "compare this Postgres table to its ClickHouse mi
 ## Configuration
 
 <TypeTable
-  data={{
+  type={{
     CHM_FEATURE_POSTGRES_SOURCE: { type: "boolean", description: "Master switch for Postgres as a source. Default: false." },
     POSTGRES_HOST: { type: "string", description: "Comma-separated Postgres host(s), optionally host:port." },
     POSTGRES_PORT: { type: "number", description: "Port for hosts that don't specify one inline. Default: 5432." },

--- a/docs/content/guide/features/query-insights.mdx
+++ b/docs/content/guide/features/query-insights.mdx
@@ -4,7 +4,7 @@ icon: LayoutList
 title: Query Insights API
 ---
 
-Read the same normalized query-pattern data the [Slow Query Patterns](/slow-query-patterns) page shows, from two REST endpoints — a list of patterns and a per-pattern detail with recent executions.
+Read the same normalized query-pattern data the [Slow Query Patterns](https://dash.chmonitor.dev/slow-query-patterns) page shows, from two REST endpoints — a list of patterns and a per-pattern detail with recent executions.
 
 <TypeTable
   type={{
@@ -20,7 +20,7 @@ Read the same normalized query-pattern data the [Slow Query Patterns](/slow-quer
 
 `system.query_log` rows are aggregated by `normalized_query_hash` (mirroring ClickHouse Cloud's Query Insights "Slow Patterns" table) — one row per distinct query shape, with call counts, duration percentiles (p50/p95/p99), resource usage (memory, rows/bytes read, rows/bytes written), and error counts. The list endpoint returns this aggregation; the detail endpoint returns one pattern plus the individual `system.query_log` rows (executions) that contributed to it, most-recent first.
 
-Both endpoints reuse the exact SQL the [Slow Query Patterns](/slow-query-patterns) page runs (`buildQueryPatternsSql` in `lib/query-config/queries/slow-query-patterns.ts`) — the numbers always match what the page shows.
+Both endpoints reuse the exact SQL the [Slow Query Patterns](https://dash.chmonitor.dev/slow-query-patterns) page runs (`buildQueryPatternsSql` in `lib/query-config/queries/slow-query-patterns.ts`) — the numbers always match what the page shows.
 
 ### Pages
 

--- a/docs/content/guide/features/query-insights.mdx
+++ b/docs/content/guide/features/query-insights.mdx
@@ -7,7 +7,7 @@ title: Query Insights API
 Read the same normalized query-pattern data the [Slow Query Patterns](/slow-query-patterns) page shows, from two REST endpoints — a list of patterns and a per-pattern detail with recent executions.
 
 <TypeTable
-  data={{
+  type={{
     Routes: { type: "GET /api/v1/insights/query-patterns, GET /api/v1/insights/query-patterns/:normalized_query_hash", description: "List + detail endpoints" },
     "Feature id": { type: "queries", description: "Same feature gate as the Slow Query Patterns page" },
     "Default access": { type: "Same as the dashboard's `/api/v1/*` auth posture", description: "See Auth in the Getting Started guide" },
@@ -38,7 +38,7 @@ GET /api/v1/insights/query-patterns?hostId=0&range=24&sort=total_duration:desc
 ```
 
 <TypeTable
-  data={{
+  type={{
     hostId: { type: "integer, optional (default 0)", description: "Host index into CLICKHOUSE_HOST — must be a non-negative integer or the request is rejected with 400" },
     range: { type: "integer (hours), optional (default 24)", description: "Shorthand for `event_time=withinHours:<hours>` — how far back to aggregate" },
     sort: { type: "string, optional", description: "`column[:asc|desc]` — reorders the returned rows by any response column (default direction: desc). Omit to keep the SQL's default `total_duration DESC` order." },
@@ -77,7 +77,7 @@ GET /api/v1/insights/query-patterns/1234567890123456789?hostId=0&range=24
 ```
 
 <TypeTable
-  data={{
+  type={{
     normalized_query_hash: { type: "path param, required", description: "The pattern's hash — a numeric string. A non-numeric value returns 400; an unknown hash returns 404." },
     hostId: { type: "integer, optional (default 0)", description: "Same validation as the list endpoint" },
     range: { type: "integer (hours), optional (default 24)", description: "Time window for both the pattern's aggregation and the executions list" },

--- a/docs/content/guide/features/security.mdx
+++ b/docs/content/guide/features/security.mdx
@@ -7,7 +7,7 @@ title: Security
 Audit who has access to ClickHouse and what they have been doing — user and role definitions, session history, login attempts, and security-relevant events.
 
 <TypeTable
-  data={{
+  type={{
     Routes: { type: "/users, /roles, /security/sessions, /security/login-attempts, /security/audit-log", description: "Pages in this section" },
     "Feature id": { type: "security", description: "Used by permission env vars and config" },
     "Default access": { type: "public", description: "Set CHM_FEATURE_SECURITY_ACCESS=authenticated to gate" },

--- a/docs/content/guide/features/settings.mdx
+++ b/docs/content/guide/features/settings.mdx
@@ -7,7 +7,7 @@ title: Settings
 Audit ClickHouse configuration without SQL — see every server setting with non-default values highlighted, plus MergeTree and Replicated MergeTree engine settings.
 
 <TypeTable
-  data={{
+  type={{
     Routes: { type: "/settings, /mergetree-settings, /replicated-merge-tree-settings", description: "Pages in this section" },
     "Feature id": { type: "settings", description: "Used by permission env vars and config" },
     "Default access": { type: "public", description: "Set CHM_FEATURE_SETTINGS_ACCESS=authenticated to gate" },

--- a/docs/content/guide/features/user-connections.mdx
+++ b/docs/content/guide/features/user-connections.mdx
@@ -7,7 +7,7 @@ title: User Connections (Server Storage)
 Save personal ClickHouse hosts to the server so they sync across devices when signed in with Clerk — encrypted at rest with AES-256-GCM.
 
 <TypeTable
-  data={{
+  type={{
     "Feature id": { type: "None", description: "Gated by env flags, not a feature id" },
     "Default access": { type: "Authenticated", description: "Clerk users only" },
     "Requires auth": { type: "Yes (Clerk)", description: "Connections are keyed by the signed-in Clerk userId" },

--- a/docs/content/operate/index.mdx
+++ b/docs/content/operate/index.mdx
@@ -24,7 +24,7 @@ authentication and advanced configuration.
   />
   <Card
     title="Advanced"
-    href="/operate/advanced"
+    href="/operate/advanced/feature-permissions"
     description="Multi-host setups, feature permissions, editions, self-tracking, telemetry, and other operational knobs."
   />
 </Cards>

--- a/docs/content/reference/index.mdx
+++ b/docs/content/reference/index.mdx
@@ -35,5 +35,5 @@ Expose chmonitor to AI tools over the Model Context Protocol.
 <Card title="Grafana bridge" href="/reference/grafana-bridge" description="Bridge chmonitor data into Grafana." />
 <Card title="Catalog contributing" href="/reference/catalog-contributing" description="Contribute queries and dashboards." />
 <Card title="Releases" href="/reference/releases" description="Version history and changelog." />
-<Card title="Migrating" href="/reference/migrating" description="Upgrade between major versions." />
+<Card title="Migrating" href="/reference/migrating/v0-3" description="Upgrade between major versions." />
 </Cards>


### PR DESCRIPTION
## Root cause

fumadocs-ui's `TypeTable` component reads its rows from the **`type`** prop
(`Record<string, TypeNode>`), not `data` — confirmed against the installed
`fumadocs-ui` `type-table.d.ts`. 20 usages across 14 files in
`docs/content/guide/features/*.mdx` passed `data={{...}}` instead, so
`TypeTable` ran `Object.entries(undefined)` at render.

This is a **client-side hydration crash**: `TypeTable` is a `"use client"`
component, and this docs site prerenders a static shell per page — the MDX
body (including `TypeTable`) only renders after the page hydrates in the
browser. Reproduced live with a headless browser against
`/guide/features/peerdb`:

```
Something went wrong!
Cannot convert undefined or null to object
```
```
[error] TypeError: Cannot convert undefined or null to object
    at Object.entries (<anonymous>)
```

Fixed all 20 occurrences (browser-connections, cluster, health, insights,
logs, mcp ×2, metrics, operations, peerdb ×2, postgres ×3, query-insights
×3, security, settings, user-connections).

## Detection mechanism — two layers, because one alone doesn't catch this bug class

**1. Full explicit prerender (`apps/docs/vite.config.ts` + new
`apps/docs/scripts/discover-doc-pages.mjs`)**

The existing config already intended to prerender every doc page
(`crawlLinks: true`, comment said "Prerender all doc pages"), but the docs
landing page renders its nav client-side, so the raw SSR HTML for `/` has
**zero** `<a href>` links — the crawl silently prerendered only `/`, so a
broken content page never failed `pnpm run build`. Now every
`content/docs/**/*.mdx` path is passed explicitly via the `pages` option, so
TanStack Start's prerender (which already defaults `failOnError: true`)
actually covers all 90 pages.

Turning this on immediately surfaced (and this PR fixes) three pre-existing
dead links that had never been caught by anything:
- `/reference/migrating` → no landing page exists, only `/reference/migrating/v0-3` → fixed the `Card` href
- `/operate/advanced` → same issue → points at `/operate/advanced/feature-permissions`
- Two `/slow-query-patterns` markdown links in `query-insights.mdx` that
  actually reference a **dashboard app** route (`dash.chmonitor.dev`), not a
  docs page → converted to full `https://dash.chmonitor.dev/slow-query-patterns` URLs (matches the convention used elsewhere, e.g. `too-many-parts.mdx`)

**Proof:** temporarily reintroduced `data=` on `peerdb.mdx`'s first
`TypeTable` and reran `pnpm run build` — it still exited 0, because the
prerendered HTML for that page never contains the crash (confirmed: no
`TypeTable` content of any kind — correct or broken — appears in the static
HTML for any page, only the shell). This proved layer 1 alone is
insufficient for this specific bug class.

**2. Real-browser smoke crawl (`apps/docs/scripts/smoke-crawl.mjs`, new
`pnpm run smoke`)**

Launches headless Chromium (`playwright-core`, chromium only), starts its
own `vite preview` server, visits all 90 pages (`discoverDocPages()`,
concurrency 8), and fails on:
- non-200 HTTP status
- any console error during load
- an error-boundary marker in the live DOM (`Something went wrong`, `Cannot
  convert`, `Application error`)

With the bug reintroduced: `[smoke] FAILED: 1/90 page(s) errored: /guide/features/peerdb — error boundary in DOM: "Something went wrong"`
in ~28s total. With the fix: `[smoke] OK: all 90 pages rendered cleanly.`
Wired into `.github/workflows/docs.yml` as a step after `pnpm run build`
(installs chromium via `pnpm exec playwright-core install --with-deps
chromium` first).

Kept the existing `crawlLinks: true` crawl running alongside the explicit
`pages` list (harmless, catches any link not in the content tree).

## Test plan
- [x] `pnpm run build` (apps/docs) — prerenders all 90 pages, exits 0
- [x] Reintroduced the `data=` bug on peerdb.mdx → `pnpm run build` still
      passed (proves layer 1 doesn't catch client-hydration crashes) →
      `pnpm run smoke` caught it and failed correctly
- [x] Reverted the bug, rebuilt → `pnpm run smoke` passes clean (90/90, ~28s)
- [x] Verified via headless browser: `/guide/features/peerdb`,
      `/guide/features/postgres` render with no console errors, correct
      TypeTable content
- [x] `biome check` clean on all changed files