### PR TITLE
feat(peerdb): per-connection config + bearer auth

### DIFF
--- a/apps/dashboard/src/components/connections/add-host-dialog.tsx
+++ b/apps/dashboard/src/components/connections/add-host-dialog.tsx
@@ -179,6 +179,7 @@ export function AddHostDialog({
               dbStorageRequiresSignIn={dbStorageConfigured && !isSignedIn}
               showSamplePreset={showSamplePreset}
               allowPostgres={allowPostgres}
+              allowPeerdb
               initialPreset={initialEngine}
               onEngineChange={setEngine}
             />

--- a/apps/dashboard/src/components/connections/connection-form.tsx
+++ b/apps/dashboard/src/components/connections/connection-form.tsx
@@ -1,11 +1,13 @@
 import {
   ArrowUpRight,
   Check,
+  ChevronDown,
   Eye,
   EyeOff,
   FlaskConical,
   Globe,
   Loader2,
+  Waypoints,
 } from 'lucide-react'
 
 import type { BrowserConnection } from '@/lib/types/browser-connection'
@@ -23,6 +25,11 @@ import {
 import { SAMPLE_CLUSTER_PRESET } from './sample-preset'
 import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import {
@@ -59,7 +66,13 @@ export type ConnectionFormData = Pick<
   | 'port'
   | 'database'
   | 'sslmode'
+  | 'peerdbApiUrl'
+  | 'peerdbAuthScheme'
+  | 'peerdbAuthSecret'
 >
+
+/** UI value for the PeerDB auth selector; `none` maps to no stored secret. */
+type PeerdbAuthUi = 'none' | 'basic' | 'bearer'
 
 /** libpq sslmodes surfaced in the Postgres preset's SSL dropdown. */
 const POSTGRES_SSLMODES = ['require', 'disable', 'verify-full'] as const
@@ -92,6 +105,13 @@ interface ConnectionFormProps {
    * only UI, so there is zero visual change when the flag is off.
    */
   allowPostgres?: boolean
+  /**
+   * Show the "Advanced" collapsible with the optional "PeerDB monitoring"
+   * fields (API URL + auth + Test PeerDB). Off by default; the "add new host"
+   * path (`AddHostDialog`) opts in. Editing dialogs leave it off for now — the
+   * PeerDB link is set at create time (see PR notes / follow-up).
+   */
+  allowPeerdb?: boolean
   /**
    * Connection-type tab to start on (e.g. the setup page's "Connect Postgres"
    * CTA opens the dialog straight on the Postgres tab). Users can still switch
@@ -138,6 +158,7 @@ export function ConnectionForm({
   dbStorageRequiresSignIn = false,
   showSamplePreset = false,
   allowPostgres = false,
+  allowPeerdb = false,
   initialPreset = 'self-hosted',
   onEngineChange,
 }: ConnectionFormProps) {
@@ -159,6 +180,20 @@ export function ConnectionForm({
   const [showPassword, setShowPassword] = useState(false)
   const [testStatus, setTestStatus] = useState<TestStatus>({ state: 'idle' })
   const [preset, setPreset] = useState<ConnectionPreset>(initialPreset)
+
+  // Advanced → PeerDB monitoring (optional). `none` means "no auth" (open
+  // flow-api); the secret is only kept for `basic`/`bearer`.
+  const [advancedOpen, setAdvancedOpen] = useState(false)
+  const [peerdbApiUrl, setPeerdbApiUrl] = useState(
+    initialValues?.peerdbApiUrl ?? ''
+  )
+  const [peerdbAuthUi, setPeerdbAuthUi] = useState<PeerdbAuthUi>(
+    initialValues?.peerdbAuthScheme ?? 'none'
+  )
+  const [peerdbSecret, setPeerdbSecret] = useState(
+    initialValues?.peerdbAuthSecret ?? ''
+  )
+  const [peerdbTest, setPeerdbTest] = useState<TestStatus>({ state: 'idle' })
 
   const isPostgres = preset === 'postgres'
 
@@ -273,10 +308,70 @@ export function ConnectionForm({
     }
   }
 
+  // Optional PeerDB monitoring link, folded into the saved envelope. Empty URL
+  // (or the section not shown) ⇒ no PeerDB fields; `none` ⇒ URL only (open).
+  const peerdbFields = (): Pick<
+    ConnectionFormData,
+    'peerdbApiUrl' | 'peerdbAuthScheme' | 'peerdbAuthSecret'
+  > => {
+    const url = peerdbApiUrl.trim()
+    if (!allowPeerdb || !url) return {}
+    if (peerdbAuthUi === 'none') return { peerdbApiUrl: url }
+    return {
+      peerdbApiUrl: url,
+      peerdbAuthScheme: peerdbAuthUi,
+      peerdbAuthSecret: peerdbSecret,
+    }
+  }
+
+  const peerdbValid =
+    !allowPeerdb || peerdbApiUrl.trim().length === 0
+      ? true
+      : isValidUrl(peerdbApiUrl.trim())
+
+  const handleTestPeerdb = async () => {
+    setPeerdbTest({ state: 'loading' })
+    try {
+      const response = await apiFetch('/api/v1/peerdb/validate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          apiUrl: peerdbApiUrl.trim(),
+          ...(peerdbAuthUi === 'none'
+            ? {}
+            : { authScheme: peerdbAuthUi, secret: peerdbSecret }),
+        }),
+      })
+      const json = (await response.json()) as {
+        ok?: boolean
+        version?: string
+        error?: string
+      }
+      if (json.ok) {
+        setPeerdbTest({
+          state: 'success',
+          message: json.version
+            ? `Reached PeerDB ${json.version}`
+            : 'Reached PeerDB',
+        })
+      } else {
+        setPeerdbTest({
+          state: 'error',
+          message: json.error ?? 'PeerDB check failed',
+        })
+      }
+    } catch (err) {
+      setPeerdbTest({
+        state: 'error',
+        message: err instanceof Error ? err.message : 'Network error',
+      })
+    }
+  }
+
   const [saving, setSaving] = useState(false)
 
   const handleSave = async () => {
-    if (!isFormValid(form, isPostgres) || saving) return
+    if (!isFormValid(form, isPostgres) || !peerdbValid || saving) return
     setSaving(true)
     try {
       await onSave(
@@ -290,6 +385,7 @@ export function ConnectionForm({
               port: form.port ?? POSTGRES_DEFAULT_PORT,
               database: (form.database ?? '').trim(),
               sslmode: form.sslmode,
+              ...peerdbFields(),
             }
           : {
               name: form.name.trim(),
@@ -297,6 +393,7 @@ export function ConnectionForm({
               user: form.user.trim(),
               password: form.password,
               engine: engineForPreset(preset),
+              ...peerdbFields(),
             }
       )
     } finally {
@@ -304,7 +401,8 @@ export function ConnectionForm({
     }
   }
 
-  const valid = isFormValid(form, isPostgres)
+  const chFormValid = isFormValid(form, isPostgres)
+  const valid = chFormValid && peerdbValid
 
   return (
     <div className="space-y-4">
@@ -578,6 +676,141 @@ export function ConnectionForm({
         </p>
       )}
 
+      {/* Advanced → PeerDB monitoring (optional). Collapsed by default; shown
+          for every connection type when the caller opts in. */}
+      {allowPeerdb && (
+        <Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
+          <CollapsibleTrigger className="flex w-full items-center justify-between rounded-md py-1 text-sm font-medium text-foreground">
+            <span>Advanced</span>
+            <ChevronDown
+              className={`size-4 text-muted-foreground transition-transform ${
+                advancedOpen ? 'rotate-180' : ''
+              }`}
+            />
+          </CollapsibleTrigger>
+          <CollapsibleContent className="space-y-3 pt-2">
+            <div className="space-y-3 rounded-md border border-border p-3">
+              <div className="flex items-start gap-2">
+                <Waypoints className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                <div className="space-y-0.5">
+                  <p className="text-sm font-medium">
+                    PeerDB monitoring (optional)
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    Link this connection&apos;s CDC replication — the PeerDB
+                    flow-api endpoint. Monitoring is view-only.
+                  </p>
+                </div>
+              </div>
+
+              {/* API URL */}
+              <div className="space-y-1.5">
+                <Label htmlFor="peerdb-url" className="text-sm font-medium">
+                  API URL
+                </Label>
+                <Input
+                  id="peerdb-url"
+                  placeholder="https://peerdb.example.com/api"
+                  value={peerdbApiUrl}
+                  onChange={(e) => {
+                    setPeerdbApiUrl(e.target.value)
+                    if (peerdbTest.state !== 'idle')
+                      setPeerdbTest({ state: 'idle' })
+                  }}
+                  autoComplete="off"
+                  type="url"
+                />
+                {peerdbApiUrl.trim().length > 0 &&
+                  !isValidUrl(peerdbApiUrl.trim()) && (
+                    <p className="text-xs text-destructive">
+                      Enter a valid HTTP or HTTPS URL
+                    </p>
+                  )}
+              </div>
+
+              {/* Auth scheme + secret */}
+              <div className="grid grid-cols-[minmax(0,9rem)_1fr] gap-3">
+                <div className="space-y-1.5">
+                  <Label htmlFor="peerdb-auth" className="text-sm font-medium">
+                    Auth
+                  </Label>
+                  <Select
+                    value={peerdbAuthUi}
+                    onValueChange={(v) => {
+                      setPeerdbAuthUi(v as PeerdbAuthUi)
+                      if (peerdbTest.state !== 'idle')
+                        setPeerdbTest({ state: 'idle' })
+                    }}
+                  >
+                    <SelectTrigger id="peerdb-auth">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="none">None</SelectItem>
+                      <SelectItem value="basic">Password</SelectItem>
+                      <SelectItem value="bearer">API token</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                {peerdbAuthUi !== 'none' && (
+                  <div className="space-y-1.5">
+                    <Label
+                      htmlFor="peerdb-secret"
+                      className="text-sm font-medium"
+                    >
+                      {peerdbAuthUi === 'bearer' ? 'API token' : 'Password'}
+                    </Label>
+                    <Input
+                      id="peerdb-secret"
+                      type="password"
+                      placeholder="••••••••"
+                      value={peerdbSecret}
+                      onChange={(e) => {
+                        setPeerdbSecret(e.target.value)
+                        if (peerdbTest.state !== 'idle')
+                          setPeerdbTest({ state: 'idle' })
+                      }}
+                      autoComplete="off"
+                    />
+                  </div>
+                )}
+              </div>
+
+              {/* Test PeerDB */}
+              <div className="flex items-center gap-3">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={handleTestPeerdb}
+                  disabled={
+                    peerdbApiUrl.trim().length === 0 ||
+                    !isValidUrl(peerdbApiUrl.trim()) ||
+                    peerdbTest.state === 'loading'
+                  }
+                >
+                  {peerdbTest.state === 'loading' ? (
+                    <Loader2 className="size-3.5 mr-1.5 animate-spin" />
+                  ) : null}
+                  Test PeerDB
+                </Button>
+                {peerdbTest.state === 'success' && (
+                  <span className="flex items-center gap-1.5 text-xs text-emerald-600 dark:text-emerald-400">
+                    <Check className="size-3.5" />
+                    {peerdbTest.message}
+                  </span>
+                )}
+                {peerdbTest.state === 'error' && (
+                  <span className="text-xs text-destructive">
+                    {peerdbTest.message}
+                  </span>
+                )}
+              </div>
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
+      )}
+
       {/* Test Connection */}
       <div className="flex items-center gap-3">
         <Button
@@ -585,7 +818,7 @@ export function ConnectionForm({
           variant="outline"
           size="sm"
           onClick={handleTest}
-          disabled={!valid || testStatus.state === 'loading'}
+          disabled={!chFormValid || testStatus.state === 'loading'}
         >
           {testStatus.state === 'loading' ? (
             <Loader2 className="size-3.5 mr-1.5 animate-spin" />

--- a/apps/dashboard/src/components/peerdb/peerdb-not-configured.tsx
+++ b/apps/dashboard/src/components/peerdb/peerdb-not-configured.tsx
@@ -34,6 +34,16 @@ export function PeerDBNotConfigured() {
 PEERDB_PASSWORD=your-peerdb-ui-password`}
       </pre>
 
+      <p className="text-xs text-muted-foreground">
+        Or attach PeerDB per connection: open a connection&apos;s{' '}
+        <span className="font-medium text-foreground">Advanced</span> section,
+        add its PeerDB API URL (Password or API token auth), then view it at{' '}
+        <code className="rounded bg-muted px-1">
+          /peerdb?connection=&lt;id&gt;
+        </code>
+        .
+      </p>
+
       <div className="flex flex-wrap items-center justify-center gap-2">
         <a
           href={docsSiteUrl('advanced/peerdb-monitoring')}

--- a/apps/dashboard/src/components/peerdb/use-peerdb-status.ts
+++ b/apps/dashboard/src/components/peerdb/use-peerdb-status.ts
@@ -3,6 +3,8 @@ import { useQuery } from '@tanstack/react-query'
 import type { ApiResponse } from '@/lib/api/types'
 import type { PeerDBStatusPayload } from '@/lib/peerdb/types'
 
+import { useSearchParams } from '@/lib/next-compat'
+import { PEERDB_CONNECTION_PARAM } from '@/lib/peerdb/peerdb-auth'
 import { apiFetch } from '@/lib/swr/api-fetch'
 
 const STATUS_URL = '/api/v1/peerdb-status'
@@ -32,11 +34,26 @@ async function fetchStatus(url: string): Promise<PeerDBStatusPayload> {
  * Shared SWR hook for the server-side PeerDB connection probe. Validates the
  * response shape so callers (the header pill + mirrors header chip) never
  * consume malformed data.
+ *
+ * `connection` targets a per-user connection's PeerDB link (`?connection=<id>`);
+ * omitted, it defaults to the active `?connection=` URL search param, and
+ * `null`/`''` forces the env-wide config.
  */
-export function usePeerDBStatus(refreshInterval = 60_000) {
+export function usePeerDBStatus(
+  refreshInterval = 60_000,
+  connection?: string | null
+) {
+  const searchParams = useSearchParams()
+  const activeConnection =
+    connection === undefined
+      ? (searchParams.get(PEERDB_CONNECTION_PARAM) ?? undefined)
+      : (connection ?? undefined)
+  const url = activeConnection
+    ? `${STATUS_URL}?${PEERDB_CONNECTION_PARAM}=${encodeURIComponent(activeConnection)}`
+    : STATUS_URL
   return useQuery<PeerDBStatusPayload>({
-    queryKey: [STATUS_URL],
-    queryFn: () => fetchStatus(STATUS_URL),
+    queryKey: [STATUS_URL, activeConnection ?? ''],
+    queryFn: () => fetchStatus(url),
     refetchInterval: refreshInterval,
     retry: false,
   })

--- a/apps/dashboard/src/lib/connection-store/__tests__/crypto.test.ts
+++ b/apps/dashboard/src/lib/connection-store/__tests__/crypto.test.ts
@@ -45,6 +45,35 @@ describe('connection-store crypto', () => {
     expect(decrypted).toEqual(input)
   })
 
+  // PeerDB monitoring link: the optional peerdb* fields round-trip inside the
+  // encrypted envelope (they are the only home for the secret).
+  it('round-trips an envelope with a PeerDB link (bearer)', async () => {
+    const input = {
+      host: 'https://clickhouse.example.com:8443',
+      user: 'default',
+      password: 'secret',
+      peerdbApiUrl: 'https://peerdb.example.com/api',
+      peerdbAuthScheme: 'bearer' as const,
+      peerdbAuthSecret: 'tok_abc123',
+    }
+    const encrypted = await encryptCredentials(input)
+    const decrypted = await decryptCredentials(encrypted)
+    expect(decrypted).toEqual(input)
+  })
+
+  it('round-trips an envelope with a PeerDB link and no secret (open)', async () => {
+    const input = {
+      host: 'https://clickhouse.example.com:8443',
+      user: 'default',
+      password: 'secret',
+      peerdbApiUrl: 'http://localhost:8113',
+    }
+    const encrypted = await encryptCredentials(input)
+    const decrypted = await decryptCredentials(encrypted)
+    expect(decrypted).toEqual(input)
+    expect(decrypted.peerdbAuthSecret).toBeUndefined()
+  })
+
   // Back-compat: a v1 payload (no `kind`) still decrypts, and its absent `kind`
   // is what lets every reader treat legacy rows as ClickHouse.
   it('decrypts a v1 payload with no kind (reads back as ClickHouse)', async () => {

--- a/apps/dashboard/src/lib/connection-store/types.ts
+++ b/apps/dashboard/src/lib/connection-store/types.ts
@@ -38,6 +38,19 @@ export interface ConnectionCredentials {
   database?: string
   /** libpq `sslmode` (v2, Postgres only): `disable` | `require` | `verify-full`. */
   sslmode?: string
+  /**
+   * Optional PeerDB monitoring link (any engine). Attaches a PeerDB flow-api
+   * deployment to this connection so the /peerdb pages can read CDC mirrors via
+   * `?connection=<id>` instead of the single env-wide `PEERDB_API_URL`. Flat
+   * optional fields mirror the Postgres precedent (`port`/`database`/`sslmode`)
+   * so old ciphertext round-trips without a re-key. The secret lives ONLY here
+   * in the encrypted payload — list APIs never return it.
+   */
+  peerdbApiUrl?: string
+  /** PeerDB auth scheme: `basic` (empty-user password) or `bearer` (API token). */
+  peerdbAuthScheme?: 'basic' | 'bearer'
+  /** PeerDB Basic password or Bearer token. Absent ⇒ an open (auth-less) flow-api. */
+  peerdbAuthSecret?: string
 }
 
 /** Public-facing connection metadata (no password). */

--- a/apps/dashboard/src/lib/hooks/use-user-connections.ts
+++ b/apps/dashboard/src/lib/hooks/use-user-connections.ts
@@ -92,6 +92,10 @@ export function useUserConnectionsMutations() {
     port?: number
     database?: string
     sslmode?: string
+    /** Optional PeerDB monitoring link (any engine). */
+    peerdbApiUrl?: string
+    peerdbAuthScheme?: 'basic' | 'bearer'
+    peerdbAuthSecret?: string
   }): Promise<{
     success: boolean
     data: UserConnectionInfo

--- a/apps/dashboard/src/lib/peerdb/peerdb-auth.test.ts
+++ b/apps/dashboard/src/lib/peerdb/peerdb-auth.test.ts
@@ -1,0 +1,175 @@
+import {
+  buildPeerDBAuthHeader,
+  buildPeerdbCredentialFields,
+  envPeerDBConfig,
+  parsePeerDBAuthScheme,
+  peerdbConfigFromCredentials,
+  selectPeerDBSource,
+} from './peerdb-auth'
+import { describe, expect, test } from 'bun:test'
+
+describe('parsePeerDBAuthScheme', () => {
+  test('defaults to basic', () => {
+    expect(parsePeerDBAuthScheme(undefined)).toBe('basic')
+    expect(parsePeerDBAuthScheme('')).toBe('basic')
+    expect(parsePeerDBAuthScheme('anything')).toBe('basic')
+  })
+  test('recognises bearer (case/space-insensitive)', () => {
+    expect(parsePeerDBAuthScheme('bearer')).toBe('bearer')
+    expect(parsePeerDBAuthScheme('  Bearer ')).toBe('bearer')
+  })
+})
+
+describe('buildPeerDBAuthHeader', () => {
+  test('basic uses an empty username: base64(":" + secret)', () => {
+    const header = buildPeerDBAuthHeader({ authScheme: 'basic', secret: 'pw' })
+    expect(header.Authorization).toBe(`Basic ${btoa(':pw')}`)
+  })
+  test('default scheme (undefined) is treated as basic', () => {
+    const header = buildPeerDBAuthHeader({ secret: 'pw' })
+    expect(header.Authorization).toBe(`Basic ${btoa(':pw')}`)
+  })
+  test('bearer emits a Bearer token', () => {
+    const header = buildPeerDBAuthHeader({
+      authScheme: 'bearer',
+      secret: 'tok',
+    })
+    expect(header.Authorization).toBe('Bearer tok')
+  })
+  test('no secret ⇒ no header (open flow-api)', () => {
+    expect(buildPeerDBAuthHeader({ authScheme: 'bearer' })).toEqual({})
+    expect(buildPeerDBAuthHeader({ secret: '   ' })).toEqual({})
+  })
+})
+
+describe('envPeerDBConfig', () => {
+  test('null when PEERDB_API_URL is unset/blank', () => {
+    expect(envPeerDBConfig({})).toBeNull()
+    expect(envPeerDBConfig({ PEERDB_API_URL: '  ' })).toBeNull()
+  })
+  test('strips trailing slashes and reads the password', () => {
+    const cfg = envPeerDBConfig({
+      PEERDB_API_URL: 'http://flow-api:8113///',
+      PEERDB_PASSWORD: 'pw',
+    })
+    expect(cfg).toEqual({
+      baseUrl: 'http://flow-api:8113',
+      authScheme: 'basic',
+      secret: 'pw',
+    })
+  })
+  test('honours PEERDB_AUTH_SCHEME=bearer', () => {
+    const cfg = envPeerDBConfig({
+      PEERDB_API_URL: 'http://flow-api:8113',
+      PEERDB_PASSWORD: 'tok',
+      PEERDB_AUTH_SCHEME: 'bearer',
+    })
+    expect(cfg?.authScheme).toBe('bearer')
+  })
+  test('no scheme when there is no password', () => {
+    const cfg = envPeerDBConfig({ PEERDB_API_URL: 'http://flow-api:8113' })
+    expect(cfg).toEqual({
+      baseUrl: 'http://flow-api:8113',
+      authScheme: undefined,
+      secret: undefined,
+    })
+  })
+})
+
+describe('peerdbConfigFromCredentials', () => {
+  test('null when no peerdbApiUrl', () => {
+    expect(peerdbConfigFromCredentials({})).toBeNull()
+  })
+  test('resolves url + scheme + secret', () => {
+    const cfg = peerdbConfigFromCredentials({
+      peerdbApiUrl: 'https://peerdb.example.com/api/',
+      peerdbAuthScheme: 'bearer',
+      peerdbAuthSecret: 'tok',
+    })
+    expect(cfg).toEqual({
+      baseUrl: 'https://peerdb.example.com/api',
+      authScheme: 'bearer',
+      secret: 'tok',
+    })
+  })
+  test('url only ⇒ open (no scheme/secret)', () => {
+    const cfg = peerdbConfigFromCredentials({
+      peerdbApiUrl: 'http://localhost:8113',
+    })
+    expect(cfg).toEqual({
+      baseUrl: 'http://localhost:8113',
+      authScheme: undefined,
+      secret: undefined,
+    })
+  })
+})
+
+describe('buildPeerdbCredentialFields', () => {
+  test('no apiUrl ⇒ no fields', () => {
+    expect(buildPeerdbCredentialFields({})).toEqual({ fields: {} })
+    expect(buildPeerdbCredentialFields({ apiUrl: '   ' })).toEqual({
+      fields: {},
+    })
+  })
+  test('rejects an unknown scheme', () => {
+    const res = buildPeerdbCredentialFields({
+      apiUrl: 'https://x',
+      scheme: 'weird',
+    })
+    expect(res.error).toBeDefined()
+    expect(res.fields).toEqual({})
+  })
+  test('apiUrl only ⇒ url field, no secret', () => {
+    const res = buildPeerdbCredentialFields({ apiUrl: ' https://x ' })
+    expect(res.error).toBeUndefined()
+    expect(res.fields).toEqual({ peerdbApiUrl: 'https://x' })
+  })
+  test('apiUrl + secret defaults scheme to basic', () => {
+    const res = buildPeerdbCredentialFields({
+      apiUrl: 'https://x',
+      secret: 'pw',
+    })
+    expect(res.fields).toEqual({
+      peerdbApiUrl: 'https://x',
+      peerdbAuthScheme: 'basic',
+      peerdbAuthSecret: 'pw',
+    })
+  })
+  test('empty secret is dropped (URL-only)', () => {
+    const res = buildPeerdbCredentialFields({
+      apiUrl: 'https://x',
+      scheme: 'bearer',
+      secret: '',
+    })
+    expect(res.fields).toEqual({ peerdbApiUrl: 'https://x' })
+  })
+})
+
+describe('selectPeerDBSource (fallback logic)', () => {
+  const env = { baseUrl: 'http://env:8113' }
+  const conn = { baseUrl: 'http://conn:8113' }
+
+  test('no selector ⇒ env config', () => {
+    expect(selectPeerDBSource({ connectionConfig: null, envConfig: env })).toBe(
+      env
+    )
+  })
+  test('selector ⇒ the connection config (never falls back to env)', () => {
+    expect(
+      selectPeerDBSource({
+        connectionId: 'abc',
+        connectionConfig: conn,
+        envConfig: env,
+      })
+    ).toBe(conn)
+  })
+  test('selector with no connection config ⇒ null (not env)', () => {
+    expect(
+      selectPeerDBSource({
+        connectionId: 'abc',
+        connectionConfig: null,
+        envConfig: env,
+      })
+    ).toBeNull()
+  })
+})

--- a/apps/dashboard/src/lib/peerdb/peerdb-auth.ts
+++ b/apps/dashboard/src/lib/peerdb/peerdb-auth.ts
@@ -1,0 +1,174 @@
+/**
+ * Workers-safe PeerDB auth + config resolution shared by the two proxy routes
+ * (`api/v1/peerdb/$.ts`, `api/v1/peerdb-status.ts`) and the "Test PeerDB"
+ * validation route.
+ *
+ * Pure and dependency-free — no node built-ins, no baked-in `process.env`
+ * reads (callers pass the bindings / decrypted credentials) — so it runs
+ * unchanged in the Cloudflare Workers runtime. `btoa` is available in every
+ * Workers runtime, so no `Buffer` is needed for the Basic header.
+ *
+ * Two auth schemes are supported:
+ * - `basic`  — the self-hosted default: HTTP Basic with an EMPTY username,
+ *   `base64(':' + secret)`, matching the single-instance env behaviour.
+ * - `bearer` — `Authorization: Bearer <token>`, for PeerDB Enterprise / BYOC
+ *   deployments that sit behind an auth proxy.
+ */
+
+import type { ConnectionCredentials } from '@/lib/connection-store/types'
+
+/**
+ * Query-param name carrying the active PeerDB source connection id
+ * (`?connection=<id>`). Client-safe home so both the browser hooks and the
+ * server proxy share one literal.
+ */
+export const PEERDB_CONNECTION_PARAM = 'connection'
+
+export type PeerDBAuthScheme = 'basic' | 'bearer'
+
+export interface ResolvedPeerDBConfig {
+  /** Flow-api base URL, trailing slashes stripped. */
+  baseUrl: string
+  /** Auth scheme; absent ⇒ no Authorization header (open flow-api). */
+  authScheme?: PeerDBAuthScheme
+  /** Basic password (empty-user) or Bearer token. Absent ⇒ open. */
+  secret?: string
+}
+
+/** Narrow an arbitrary string to a known auth scheme (default `basic`). */
+export function parsePeerDBAuthScheme(
+  value: string | undefined | null
+): PeerDBAuthScheme {
+  return value?.trim().toLowerCase() === 'bearer' ? 'bearer' : 'basic'
+}
+
+/** Strip trailing slashes so `${baseUrl}${path}` never doubles a slash. */
+function normalizeBaseUrl(url: string): string {
+  return url.trim().replace(/\/+$/, '')
+}
+
+/**
+ * Build the Authorization header for a resolved PeerDB config.
+ * - `basic`: HTTP Basic with an EMPTY username — `base64(':' + secret)`.
+ * - `bearer`: `Bearer <secret>`.
+ * - no secret: no header (open flow-api).
+ */
+export function buildPeerDBAuthHeader(
+  config: Pick<ResolvedPeerDBConfig, 'authScheme' | 'secret'>
+): Record<string, string> {
+  const secret = config.secret?.trim()
+  if (!secret) return {}
+  if (config.authScheme === 'bearer') {
+    return { Authorization: `Bearer ${secret}` }
+  }
+  // basic (default): empty username → base64(":" + password)
+  return { Authorization: `Basic ${btoa(`:${secret}`)}` }
+}
+
+/**
+ * Resolve env-based PeerDB config from Worker bindings (or a `process.env`-like
+ * record). Returns `null` when `PEERDB_API_URL` is unset — the not-configured
+ * signal. `PEERDB_AUTH_SCHEME` (optional, default `basic`) lets an env
+ * deployment behind an auth proxy send `PEERDB_PASSWORD` as a Bearer token.
+ */
+export function envPeerDBConfig(
+  bindings: Record<string, string | undefined>
+): ResolvedPeerDBConfig | null {
+  const baseUrl = bindings.PEERDB_API_URL?.trim()
+  if (!baseUrl) return null
+  const secret = bindings.PEERDB_PASSWORD?.trim() || undefined
+  return {
+    baseUrl: normalizeBaseUrl(baseUrl),
+    authScheme: secret
+      ? parsePeerDBAuthScheme(bindings.PEERDB_AUTH_SCHEME)
+      : undefined,
+    secret,
+  }
+}
+
+/**
+ * Resolve PeerDB config from a stored connection credential envelope. Returns
+ * `null` when the connection has no PeerDB monitoring link (`peerdbApiUrl`
+ * unset).
+ */
+export function peerdbConfigFromCredentials(
+  creds: Pick<
+    ConnectionCredentials,
+    'peerdbApiUrl' | 'peerdbAuthScheme' | 'peerdbAuthSecret'
+  >
+): ResolvedPeerDBConfig | null {
+  const baseUrl = creds.peerdbApiUrl?.trim()
+  if (!baseUrl) return null
+  const secret = creds.peerdbAuthSecret?.trim() || undefined
+  return {
+    baseUrl: normalizeBaseUrl(baseUrl),
+    authScheme: secret
+      ? parsePeerDBAuthScheme(creds.peerdbAuthScheme)
+      : undefined,
+    secret,
+  }
+}
+
+/**
+ * Validate + shape the optional PeerDB credential fields from a create/update
+ * request body. Pure and synchronous — the URL's http(s)/SSRF check is the
+ * route's job (via `validateHostUrl`); this only vets the auth scheme and
+ * decides which fields to persist:
+ * - no `apiUrl` ⇒ no PeerDB fields (nothing to store / clears the link).
+ * - `apiUrl` + no secret ⇒ URL only (open flow-api).
+ * - `apiUrl` + secret ⇒ URL + scheme (default `basic`) + secret.
+ */
+export function buildPeerdbCredentialFields(input: {
+  apiUrl?: string
+  scheme?: string
+  secret?: string
+}): {
+  error?: string
+  fields: Pick<
+    ConnectionCredentials,
+    'peerdbApiUrl' | 'peerdbAuthScheme' | 'peerdbAuthSecret'
+  >
+} {
+  const apiUrl = input.apiUrl?.trim()
+  if (!apiUrl) return { fields: {} }
+  if (
+    input.scheme !== undefined &&
+    input.scheme !== 'basic' &&
+    input.scheme !== 'bearer'
+  ) {
+    return { error: 'peerdbAuthScheme must be "basic" or "bearer"', fields: {} }
+  }
+  const secret =
+    typeof input.secret === 'string' && input.secret.length > 0
+      ? input.secret
+      : undefined
+  return {
+    fields: {
+      peerdbApiUrl: apiUrl,
+      ...(secret
+        ? {
+            peerdbAuthScheme: (input.scheme as PeerDBAuthScheme) ?? 'basic',
+            peerdbAuthSecret: secret,
+          }
+        : {}),
+    },
+  }
+}
+
+/**
+ * Pure source-selection: which PeerDB config a request should use.
+ *
+ * - An explicit `?connection=<id>` selects THAT connection's config (or `null`
+ *   when it has no PeerDB link / isn't resolvable — the caller then reports
+ *   not-configured; the env config is never used as a silent fallback for an
+ *   explicit connection, so one user's env can't leak into another's request).
+ * - No selector ⇒ the env config (fallback, zero regression from today).
+ */
+export function selectPeerDBSource(args: {
+  connectionId?: string | null
+  connectionConfig: ResolvedPeerDBConfig | null
+  envConfig: ResolvedPeerDBConfig | null
+}): ResolvedPeerDBConfig | null {
+  if (args.connectionId) return args.connectionConfig
+  return args.envConfig
+}

--- a/apps/dashboard/src/lib/peerdb/resolve-request-config.ts
+++ b/apps/dashboard/src/lib/peerdb/resolve-request-config.ts
@@ -1,0 +1,51 @@
+/**
+ * Resolve the PeerDB config a proxy request should use — either a per-user
+ * connection's stored config (`?connection=<id>`) or the env-wide default.
+ *
+ * Server-only (imports the D1/Postgres connection store + Clerk auth). Runs in
+ * the same Cloudflare Workers runtime as `api/v1/user-connections.ts`, which
+ * already resolves user credentials this way.
+ *
+ * Fail-closed: a `?connection=<id>` that can't be resolved (not signed in, not
+ * owned, no PeerDB link, or user-connection storage disabled) returns `null`,
+ * so the caller reports not-configured and never leaks whether the connection
+ * exists. `store.getCredentials(userId, id)` is scoped to the signed-in user,
+ * so ownership is enforced by the query itself.
+ */
+
+import {
+  envPeerDBConfig,
+  PEERDB_CONNECTION_PARAM,
+  peerdbConfigFromCredentials,
+  type ResolvedPeerDBConfig,
+} from './peerdb-auth'
+import { resolveConnectionUserId } from '@/lib/connection-store/auth'
+import { resolveConnectionStore } from '@/lib/connection-store/resolve-store'
+import { getUserConnectionsServerConfig } from '@/lib/connection-store/server-feature'
+
+export { PEERDB_CONNECTION_PARAM }
+
+export async function resolvePeerDBRequestConfig(
+  request: Request,
+  bindings: Record<string, string | undefined>
+): Promise<ResolvedPeerDBConfig | null> {
+  const connectionId = new URL(request.url).searchParams.get(
+    PEERDB_CONNECTION_PARAM
+  )
+
+  // No selector → env-wide config (unchanged from today).
+  if (!connectionId) return envPeerDBConfig(bindings)
+
+  // Per-connection: read the PeerDB link from the owner's encrypted envelope.
+  if (!getUserConnectionsServerConfig().dbStorageEnabled) return null
+  try {
+    const userId = await resolveConnectionUserId(request)
+    const store = await resolveConnectionStore()
+    const creds = await store.getCredentials(userId, connectionId)
+    if (!creds) return null
+    return peerdbConfigFromCredentials(creds)
+  } catch {
+    // Unauthorized / store error / lookup miss all fail closed.
+    return null
+  }
+}

--- a/apps/dashboard/src/lib/swr/use-peerdb-data.ts
+++ b/apps/dashboard/src/lib/swr/use-peerdb-data.ts
@@ -6,6 +6,8 @@ import { apiFetch } from './api-fetch'
 import { visibilityAwareInterval } from './config'
 import { type FetchError, throwIfNotOk } from './fetch-error'
 import { useCallback } from 'react'
+import { useSearchParams } from '@/lib/next-compat'
+import { PEERDB_CONNECTION_PARAM } from '@/lib/peerdb/peerdb-auth'
 
 /**
  * SWR hook for the view-only PeerDB proxy at `/api/v1/peerdb/*`.
@@ -17,12 +19,18 @@ import { useCallback } from 'react'
  *
  * The proxy wraps payloads in the standard `ApiResponse` envelope, so the
  * fetcher unwraps `.data` and returns the bare PeerDB payload.
+ *
+ * `options.connection` targets a per-user connection's PeerDB link
+ * (`?connection=<id>`). When omitted it defaults to the active `?connection=`
+ * URL search param, so a page needs no wiring to honour the selector; passing
+ * `null`/`''` forces the env-wide config.
  */
 export function usePeerDB<T = unknown>(
   path: string | null,
   options?: {
     body?: unknown
     refreshInterval?: number
+    connection?: string | null
   }
 ) {
   const { body, refreshInterval } = options ?? {}
@@ -30,21 +38,35 @@ export function usePeerDB<T = unknown>(
   const method = hasBody ? 'POST' : 'GET'
   const bodyKey = hasBody ? JSON.stringify(body) : ''
 
+  const searchParams = useSearchParams()
+  const connection =
+    options && 'connection' in options
+      ? (options.connection ?? undefined)
+      : (searchParams.get(PEERDB_CONNECTION_PARAM) ?? undefined)
+  const connectionQuery = connection
+    ? `?${PEERDB_CONNECTION_PARAM}=${encodeURIComponent(connection)}`
+    : ''
+
   // Tolerate callers passing `mirrors/list` or `/mirrors/list` alike so the
   // proxy URL never collapses to `/api/v1/peerdbmirrors/list`.
   const normalizedPath =
     path === null ? null : path.startsWith('/') ? path : `/${path}`
   const key =
-    normalizedPath === null ? null : ['peerdb', normalizedPath, method, bodyKey]
+    normalizedPath === null
+      ? null
+      : ['peerdb', normalizedPath, method, bodyKey, connection ?? '']
 
   const fetcher = useCallback(async (): Promise<T> => {
     try {
-      const response = await apiFetch(`/api/v1/peerdb${normalizedPath}`, {
-        method,
-        ...(hasBody
-          ? { headers: { 'Content-Type': 'application/json' }, body: bodyKey }
-          : {}),
-      })
+      const response = await apiFetch(
+        `/api/v1/peerdb${normalizedPath}${connectionQuery}`,
+        {
+          method,
+          ...(hasBody
+            ? { headers: { 'Content-Type': 'application/json' }, body: bodyKey }
+            : {}),
+        }
+      )
       await throwIfNotOk(response, `Failed to fetch PeerDB ${normalizedPath}`)
       const json = (await response.json()) as ApiResponse<T>
       return json.data as T
@@ -63,7 +85,7 @@ export function usePeerDB<T = unknown>(
       wrapped.details = src.details
       throw wrapped
     }
-  }, [normalizedPath, method, bodyKey, hasBody])
+  }, [normalizedPath, connectionQuery, method, bodyKey, hasBody])
 
   const queryClient = useQueryClient()
 

--- a/apps/dashboard/src/lib/types/browser-connection.ts
+++ b/apps/dashboard/src/lib/types/browser-connection.ts
@@ -22,6 +22,17 @@ export interface BrowserConnection {
   database?: string
   /** Postgres-only: libpq `sslmode` (`disable` | `require` | `verify-full`). */
   sslmode?: string
+  /**
+   * Optional PeerDB monitoring link (any engine) — mirrors the server envelope
+   * (`ConnectionCredentials`). Encrypted as-is with the rest of the object
+   * (browser-crypto envelope v2), so these optional fields need no serialization
+   * change. The secret stays inside the encrypted blob only.
+   */
+  peerdbApiUrl?: string
+  /** PeerDB auth scheme: `basic` (empty-user password) or `bearer` (API token). */
+  peerdbAuthScheme?: 'basic' | 'bearer'
+  /** PeerDB Basic password or Bearer token. Absent ⇒ an open (auth-less) flow-api. */
+  peerdbAuthSecret?: string
 }
 
 export const BROWSER_CONNECTIONS_STORAGE_KEY =

--- a/apps/dashboard/src/routes/api/v1/peerdb-status.ts
+++ b/apps/dashboard/src/routes/api/v1/peerdb-status.ts
@@ -11,6 +11,11 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { env } from 'cloudflare:workers'
 import { generateRequestId } from '@chm/logger'
+import {
+  buildPeerDBAuthHeader,
+  type ResolvedPeerDBConfig,
+} from '@/lib/peerdb/peerdb-auth'
+import { resolvePeerDBRequestConfig } from '@/lib/peerdb/resolve-request-config'
 
 /** Browser-safe PeerDB connection status payload. */
 interface PeerDBStatusPayload {
@@ -22,10 +27,7 @@ interface PeerDBStatusPayload {
   error?: string
 }
 
-interface PeerDBConfig {
-  baseUrl: string
-  password?: string
-}
+type PeerDBConfig = ResolvedPeerDBConfig
 
 interface VersionResponse {
   version?: string
@@ -55,25 +57,6 @@ function sanitizeHost(baseUrl: string): string {
   }
 }
 
-function getPeerDBConfig(
-  bindings: Record<string, string | undefined>
-): PeerDBConfig | null {
-  const baseUrl = bindings.PEERDB_API_URL?.trim()
-  if (!baseUrl) return null
-  return {
-    baseUrl: baseUrl.replace(/\/+$/, ''),
-    password: bindings.PEERDB_PASSWORD?.trim() || undefined,
-  }
-}
-
-function authHeader(config: PeerDBConfig): Record<string, string> {
-  if (!config.password) return {}
-  // PeerDB uses Basic auth with an empty username: base64(':' + password)
-  // btoa is available in all Workers runtimes (no Buffer needed)
-  const token = btoa(`:${config.password}`)
-  return { Authorization: `Basic ${token}` }
-}
-
 const FETCH_TIMEOUT_MS = 10_000
 
 async function peerdbFetch<T = unknown>(
@@ -90,7 +73,7 @@ async function peerdbFetch<T = unknown>(
       signal: controller.signal,
       headers: {
         'Content-Type': 'application/json',
-        ...authHeader(config),
+        ...buildPeerDBAuthHeader(config),
       },
     })
   } catch (err) {
@@ -120,11 +103,13 @@ async function peerdbFetch<T = unknown>(
 export const Route = createFileRoute('/api/v1/peerdb-status')({
   server: {
     handlers: {
-      GET: async () => {
+      GET: async ({ request }) => {
         const bindings = env as Record<string, string | undefined>
         const requestId = generateRequestId()
 
-        const config = getPeerDBConfig(bindings)
+        // Env config, OR a per-connection PeerDB link when `?connection=<id>`
+        // is present and the signed-in user owns that connection.
+        const config = await resolvePeerDBRequestConfig(request, bindings)
 
         if (!config) {
           const payload: PeerDBStatusPayload = {

--- a/apps/dashboard/src/routes/api/v1/peerdb/$.ts
+++ b/apps/dashboard/src/routes/api/v1/peerdb/$.ts
@@ -18,15 +18,22 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { env } from 'cloudflare:workers'
 import { generateRequestId } from '@chm/logger'
+import {
+  buildPeerDBAuthHeader,
+  type ResolvedPeerDBConfig,
+} from '@/lib/peerdb/peerdb-auth'
+import {
+  PEERDB_CONNECTION_PARAM,
+  resolvePeerDBRequestConfig,
+} from '@/lib/peerdb/resolve-request-config'
 
 // ---------------------------------------------------------------------------
-// Inlined Workers-safe PeerDB config + fetch (mirrors peerdb-status.ts pattern)
+// Workers-safe PeerDB fetch. Config (env or per-connection `?connection=<id>`)
+// is resolved by the shared helper; the Basic/Bearer header comes from
+// buildPeerDBAuthHeader.
 // ---------------------------------------------------------------------------
 
-interface PeerDBConfig {
-  baseUrl: string
-  password?: string
-}
+type PeerDBConfig = ResolvedPeerDBConfig
 
 class PeerDBError extends Error {
   constructor(
@@ -36,25 +43,6 @@ class PeerDBError extends Error {
     super(message)
     this.name = 'PeerDBError'
   }
-}
-
-function getPeerDBConfig(
-  bindings: Record<string, string | undefined>
-): PeerDBConfig | null {
-  const baseUrl = bindings.PEERDB_API_URL?.trim()
-  if (!baseUrl) return null
-  return {
-    baseUrl: baseUrl.replace(/\/+$/, ''),
-    password: bindings.PEERDB_PASSWORD?.trim() || undefined,
-  }
-}
-
-function authHeader(config: PeerDBConfig): Record<string, string> {
-  if (!config.password) return {}
-  // PeerDB uses Basic auth with an empty username: base64(':' + password).
-  // btoa is available in all Workers runtimes (no Buffer needed).
-  const token = btoa(`:${config.password}`)
-  return { Authorization: `Basic ${token}` }
 }
 
 const FETCH_TIMEOUT_MS = 10_000
@@ -76,7 +64,7 @@ async function peerdbFetch(
       signal: controller.signal,
       headers: {
         'Content-Type': 'application/json',
-        ...authHeader(config),
+        ...buildPeerDBAuthHeader(config),
       },
     })
   } catch (err) {
@@ -162,7 +150,9 @@ async function handle(
 ): Promise<Response> {
   const requestId = generateRequestId()
   const bindings = env as Record<string, string | undefined>
-  const config = getPeerDBConfig(bindings)
+  // Resolve env config, OR a per-connection PeerDB link when `?connection=<id>`
+  // is present and the signed-in user owns that connection.
+  const config = await resolvePeerDBRequestConfig(request, bindings)
 
   if (!config) {
     return Response.json(
@@ -184,8 +174,12 @@ async function handle(
     )
   }
 
+  // Forward the caller's query string EXCEPT our own `connection` selector,
+  // which is a CHM routing param and must never reach the PeerDB upstream.
   const url = new URL(request.url)
-  const upstreamPath = url.search ? `${path}${url.search}` : path
+  url.searchParams.delete(PEERDB_CONNECTION_PARAM)
+  const forwardedSearch = url.searchParams.toString()
+  const upstreamPath = forwardedSearch ? `${path}?${forwardedSearch}` : path
 
   try {
     const body = method === 'POST' ? await request.text() : undefined

--- a/apps/dashboard/src/routes/api/v1/peerdb/validate.ts
+++ b/apps/dashboard/src/routes/api/v1/peerdb/validate.ts
@@ -1,0 +1,126 @@
+/**
+ * "Test PeerDB" endpoint.
+ * POST /api/v1/peerdb/validate
+ *
+ * Validates a user-supplied PeerDB flow-api link from the connection form's
+ * Advanced section: SSRF-guards the URL (same policy as ClickHouse hosts /
+ * Postgres sources — http(s) only, no internal targets) and probes
+ * `/v1/version` server-side with the supplied Basic/Bearer auth. The secret is
+ * used only for this probe and never logged or echoed back.
+ *
+ * Always responds HTTP 200 with `{ ok, version?, error? }` (mirrors
+ * `browser-connections/test`) so the client renders the outcome inline.
+ *
+ * A dedicated static route wins over the read-only splat proxy (`peerdb/$.ts`)
+ * for this path.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { createValidationError } from '@/lib/api/error-handler'
+import { validateHostUrl } from '@/lib/browser-connections/host-url'
+import {
+  buildPeerDBAuthHeader,
+  parsePeerDBAuthScheme,
+} from '@/lib/peerdb/peerdb-auth'
+
+const ROUTE_CONTEXT = {
+  route: '/api/v1/peerdb/validate',
+  method: 'POST',
+} as const
+
+const PROBE_TIMEOUT_MS = 10_000
+
+interface ValidateRequest {
+  apiUrl: string
+  /** `basic` (default) or `bearer`. Ignored when no secret is supplied. */
+  authScheme?: string
+  /** Basic password or Bearer token; omit for an open flow-api. */
+  secret?: string
+}
+
+interface ValidateResponse {
+  ok: boolean
+  version?: string
+  error?: string
+}
+
+async function handlePost(request: Request): Promise<Response> {
+  let body: Partial<ValidateRequest>
+  try {
+    body = (await request.json()) as Partial<ValidateRequest>
+  } catch {
+    return createValidationError(
+      'Request body must be valid JSON',
+      ROUTE_CONTEXT
+    )
+  }
+
+  const apiUrl = body.apiUrl?.trim()
+  if (!apiUrl) {
+    return createValidationError(
+      'Missing required field: apiUrl',
+      ROUTE_CONTEXT
+    )
+  }
+
+  // http(s)-only + SSRF guard, identical to how ClickHouse host URLs are vetted.
+  const ssrfError = await validateHostUrl(apiUrl)
+  if (ssrfError) {
+    return createValidationError(ssrfError, ROUTE_CONTEXT)
+  }
+
+  const secret = body.secret?.trim() || undefined
+  const authScheme = secret ? parsePeerDBAuthScheme(body.authScheme) : undefined
+  const baseUrl = apiUrl.replace(/\/+$/, '')
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS)
+  try {
+    const response = await fetch(`${baseUrl}/v1/version`, {
+      signal: controller.signal,
+      headers: {
+        'Content-Type': 'application/json',
+        ...buildPeerDBAuthHeader({ authScheme, secret }),
+      },
+    })
+
+    if (!response.ok) {
+      const auth = response.status === 401 || response.status === 403
+      const result: ValidateResponse = {
+        ok: false,
+        error: auth
+          ? `Authentication failed (HTTP ${response.status}). Check the auth scheme and secret.`
+          : `PeerDB API error ${response.status}: ${response.statusText}`,
+      }
+      return Response.json(result, { status: 200 })
+    }
+
+    const json = (await response.json().catch(() => ({}))) as {
+      version?: string
+    }
+    const result: ValidateResponse = { ok: true, version: json.version }
+    return Response.json(result, { status: 200 })
+  } catch (err) {
+    const aborted = err instanceof Error && err.name === 'AbortError'
+    const result: ValidateResponse = {
+      ok: false,
+      error: aborted
+        ? `PeerDB request timed out after ${PROBE_TIMEOUT_MS}ms`
+        : `Failed to reach PeerDB: ${
+            err instanceof Error ? err.message : 'unknown error'
+          }`,
+    }
+    return Response.json(result, { status: 200 })
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+export const Route = createFileRoute('/api/v1/peerdb/validate')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => handlePost(request),
+    },
+  },
+})

--- a/apps/dashboard/src/routes/api/v1/user-connections.ts
+++ b/apps/dashboard/src/routes/api/v1/user-connections.ts
@@ -35,6 +35,7 @@ import { resolveConnectionStore } from '@/lib/connection-store/resolve-store'
 import { getUserConnectionsServerConfig } from '@/lib/connection-store/server-feature'
 import { ConnectionStoreError } from '@/lib/connection-store/types'
 import { emitEvent } from '@/lib/events/outbound-bus'
+import { buildPeerdbCredentialFields } from '@/lib/peerdb/peerdb-auth'
 
 const ROUTE_GET = { route: '/api/v1/user-connections', method: 'GET' }
 const ROUTE_POST = { route: '/api/v1/user-connections', method: 'POST' }
@@ -84,6 +85,10 @@ interface CreateRequest {
   port?: number
   database?: string
   sslmode?: string
+  /** Optional PeerDB monitoring link (any engine). */
+  peerdbApiUrl?: string
+  peerdbAuthScheme?: string
+  peerdbAuthSecret?: string
 }
 
 /**
@@ -315,6 +320,38 @@ async function handlePost(request: Request): Promise<Response> {
         engine,
       }
     }
+
+    // Optional PeerDB monitoring link (any engine): validate the scheme + shape
+    // the fields, SSRF-guard the URL like a ClickHouse host, then fold into the
+    // encrypted envelope. The secret lives only in the payload — GET never
+    // returns it.
+    const peerdb = buildPeerdbCredentialFields({
+      apiUrl: body.peerdbApiUrl,
+      scheme: body.peerdbAuthScheme,
+      secret: body.peerdbAuthSecret,
+    })
+    if (peerdb.error) {
+      return createApiErrorResponse(
+        { type: ApiErrorType.ValidationError, message: peerdb.error },
+        400,
+        ROUTE_POST
+      )
+    }
+    if (peerdb.fields.peerdbApiUrl) {
+      const peerdbSsrf = await validateHostUrl(peerdb.fields.peerdbApiUrl)
+      if (peerdbSsrf) {
+        return createApiErrorResponse(
+          {
+            type: ApiErrorType.ValidationError,
+            message: `PeerDB API URL: ${peerdbSsrf}`,
+          },
+          400,
+          ROUTE_POST
+        )
+      }
+      input.credentials = { ...input.credentials, ...peerdb.fields }
+    }
+
     let created
     try {
       created = await store.create(userId, input, {

--- a/docs/content/guide/features/peerdb.mdx
+++ b/docs/content/guide/features/peerdb.mdx
@@ -41,12 +41,19 @@ The PeerDB section does not appear in the navigation when `PEERDB_API_URL` is un
 <Step>
 ### Point chmonitor at your PeerDB API
 
-Set `PEERDB_API_URL` (include the `/api` suffix for the UI API). Add `PEERDB_PASSWORD` if the API requires HTTP Basic auth:
+Set `PEERDB_API_URL` (include the `/api` suffix for the UI API). Add `PEERDB_PASSWORD` if the API requires auth:
 
 ```bash
 PEERDB_API_URL=https://peerdb.example.com/api
 PEERDB_PASSWORD=my-peerdb-password
 PEERDB_CACHE_TTL_MS=15000
+```
+
+By default the password is sent as HTTP Basic auth with an empty username (the self-hosted flow-api convention). For PeerDB Enterprise / BYOC deployments that sit behind an auth proxy, set `PEERDB_AUTH_SCHEME=bearer` to send `PEERDB_PASSWORD` as an `Authorization: Bearer <token>` instead:
+
+```bash
+PEERDB_AUTH_SCHEME=bearer
+PEERDB_PASSWORD=my-api-token
 ```
 
 </Step>
@@ -60,6 +67,21 @@ Once `PEERDB_API_URL` is set, the PeerDB section appears in the nav. Open `/peer
 ### Inspect peers and lag
 
 Open `/peerdb/peers` to list source and destination peers, replication slot lag, and the mirror connectivity graph.
+
+</Step>
+<Step>
+### (Optional) Attach PeerDB per connection
+
+Instead of the single deployment-wide `PEERDB_API_URL`, you can attach a PeerDB deployment to an individual saved connection (linking its Postgres source and ClickHouse destination). This needs [user connections](/guide/features/user-connections) enabled.
+
+When adding a connection, open the **Advanced** section and fill in **PeerDB monitoring**:
+
+- **API URL** — the PeerDB flow-api endpoint (same value you'd put in `PEERDB_API_URL`).
+- **Auth** — `None`, `Password` (empty-user HTTP Basic), or `API token` (Bearer, for Enterprise / BYOC behind an auth proxy).
+
+Click **Test PeerDB** to verify the endpoint, then save. The URL is SSRF-validated and the secret is stored only inside the connection's encrypted payload — it is never returned by the connections API.
+
+View that connection's mirrors at `/peerdb?connection=<connectionId>`. When no `?connection=` is present, the pages fall back to the env-wide `PEERDB_API_URL`.
 
 </Step>
 </Steps>
@@ -100,7 +122,8 @@ access = "authenticated"
 <TypeTable
   data={{
     PEERDB_API_URL: { type: "string", description: "PeerDB API base URL. Include the /api suffix for the UI API (e.g. https://peerdb.example.com/api). When unset, the PeerDB section is hidden entirely. Default: unset." },
-    PEERDB_PASSWORD: { type: "string", description: "HTTP Basic auth password. The username is left empty. Default: unset." },
+    PEERDB_PASSWORD: { type: "string", description: "Auth secret. Used as the HTTP Basic password (empty username) by default, or as the Bearer token when PEERDB_AUTH_SCHEME=bearer. Default: unset." },
+    PEERDB_AUTH_SCHEME: { type: "string", description: "Auth scheme for PEERDB_PASSWORD: 'basic' (empty-user HTTP Basic, the default) or 'bearer' (Authorization: Bearer <token>) for deployments behind an auth proxy (PeerDB Enterprise / BYOC). Default: basic." },
     PEERDB_CACHE_TTL_MS: { type: "number", description: "Response cache TTL in milliseconds. Default: 10000." },
     PEERDB_CACHE_MAX_ENTRIES: { type: "number", description: "Maximum number of cached responses. Default: 500." },
     PEERDB_FETCH_TIMEOUT_MS: { type: "number", description: "Timeout for proxied PeerDB API requests. Default: 10000." },


### PR DESCRIPTION
## What

Adds **per-connection PeerDB configuration** so a saved connection can carry its own PeerDB (Postgres→ClickHouse CDC) deployment, plus **token (Bearer) auth** for PeerDB Enterprise / BYOC deployments behind an auth proxy. PeerDB config was previously env-only (`PEERDB_API_URL` / `PEERDB_PASSWORD`, single instance, HTTP Basic only).

## Field design (flat, matching the envelope precedent)

Three optional flat fields on both credential envelopes (`ConnectionCredentials` server, `BrowserConnection` browser) — matching the existing flat Postgres precedent (`port`/`database`/`sslmode`, migration 0018), so old ciphertext round-trips with no re-key:

- `peerdbApiUrl?: string`
- `peerdbAuthScheme?: 'basic' | 'bearer'`
- `peerdbAuthSecret?: string`

Chose flat over a nested `peerdbAuth` object to mirror the envelope's existing style and avoid nested-serialization concerns; scheme/secret are only stored when a secret is present (`None` = open flow-api).

## Selector design & fallback semantics

- Proxy routes (`/api/v1/peerdb/*`, `/api/v1/peerdb-status`) accept an optional `?connection=<id>`.
- **Present** → resolve the PeerDB link from that user connection's encrypted envelope via the existing `getCredentials(userId, id)` path (ownership enforced by the per-user query). The `connection` param is stripped before forwarding upstream.
- **Absent** → env-wide `PEERDB_API_URL` exactly as today (zero regression).
- An explicit selector **never** falls back to env (one user's env can't leak into another's request); it fails closed to *not-configured* on any unresolved/unauthorized/disabled case, without leaking whether the connection exists.
- Client hooks (`usePeerDB`, `usePeerDBStatus`) forward the selector, defaulting to the active `?connection=` URL param — so `/peerdb?connection=<id>` works with **no page edits** (avoids conflicts with the parallel `feat/peerdb-monitoring-views` PR). No source-picker was added to the pages: deferred as not-trivial without a `peerdbConfigured` flag on the list API (see follow-ups).

## Auth

`buildPeerDBAuthHeader` supports `basic` (empty-user `base64(':'+secret)`, the default) and `bearer` (`Authorization: Bearer <token>`). Env deployments can opt into bearer via a new optional `PEERDB_AUTH_SCHEME`.

## UI

Collapsed **Advanced** section in the add-connection form (all connection types): PeerDB API URL, auth selector (None / Password / API token), secret field, helper copy, and a **Test PeerDB** button hitting the new `POST /api/v1/peerdb/validate` (SSRF-guards the URL, probes `/v1/version` server-side). The not-configured empty state now mentions the per-connection path.

## Security notes

- The PeerDB secret lives **only** in the encrypted envelope; the user-connections **GET returns metadata only** (no credentials, no secret) — unchanged.
- User-supplied PeerDB URLs are validated with `validateHostUrl` (http/https + SSRF, the same policy as ClickHouse hosts) on create and in the validate route.
- Per-connection resolution is scoped to the signed-in owner; fails closed.

## Scope / follow-ups

- **Create-time only** for now: editing an existing connection's PeerDB link (credential-merge + keep-secret-blank semantics) is a clean follow-up; the Advanced section is shown only in the add dialog.
- Per-connection resolution targets **D1 user connections** (the precedented server-resolvable store). Browser-only connections save the fields (forward-compat) but aren't server-resolvable without a session token — follow-up.
- Optional source-picker on the pages once the list API surfaces a `peerdbConfigured` boolean (kept out to avoid leaking secrets and to minimize conflicts with the parallel peerdb-views PR).

## Tests

- Envelope round-trip with the new optional fields (server crypto; bearer + open).
- Auth-header builder (basic / bearer / none) + env/credential config resolution + credential-field validation + selector fallback (pure fns).
- Existing user-connections POST/PATCH suites still green (48 pass).

## Verification

- `biome check` clean on changed files; targeted `bun test` green (26 + 48 pass).
- `tsc --noEmit` shows only pre-existing stale `routeTree.gen.ts` errors (build-time artifact; untouched files like `version.ts`/`index.tsx` show the same) — none from this change.
- `pnpm run build` intentionally not run per task constraints.

## Docs

Updated `docs/content/guide/features/peerdb.mdx` configuration section (per-connection option, `PEERDB_AUTH_SCHEME`, token auth). Extended the existing `TypeTable` (this file uses `data=`; matched its working convention rather than mixing in a `type=` table).
