### PR TITLE
feat(peerdb): richer monitoring views (snapshot, batch history, fleet lag/logs, slot health)

### DIFF
--- a/apps/dashboard/src/components/peerdb/cdc-batch-history.tsx
+++ b/apps/dashboard/src/components/peerdb/cdc-batch-history.tsx
@@ -1,0 +1,107 @@
+import type { CDCBatch } from '@/lib/peerdb/types'
+
+import { PdbBarChart } from './pdb-charts'
+import { batchDurationSec } from './peerdb-derive'
+import {
+  pdbFmtClock,
+  pdbFmtDuration,
+  pdbFmtNum,
+  toNumber,
+} from './peerdb-utils'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+/**
+ * Recent CDC batch history — one row per batch (id, LSN range, rows, duration)
+ * plus a rows-per-batch bar chart. Presentational: the batches array is fetched
+ * once by the parent (`POST /v1/mirrors/cdc/batches`) and shared, never fetched
+ * twice.
+ */
+export function CdcBatchHistory({ batches }: { batches: CDCBatch[] }) {
+  if (batches.length === 0) {
+    return (
+      <p className="py-6 text-center text-sm text-muted-foreground">
+        No CDC batches recorded for this mirror yet.
+      </p>
+    )
+  }
+
+  // Oldest→newest for the chart so time reads left→right.
+  const chrono = [...batches].sort(
+    (a, b) => toNumber(a.batchId) - toNumber(b.batchId)
+  )
+  const chartData = chrono.map((b) => ({
+    x: pdbFmtClock(b.endTime ?? b.startTime),
+    y: toNumber(b.numRows),
+  }))
+
+  // Table shows newest first.
+  const rows = [...batches].sort(
+    (a, b) => toNumber(b.batchId) - toNumber(a.batchId)
+  )
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="rounded-lg border border-border bg-card p-3.5">
+        <div className="mb-2 flex items-center justify-between">
+          <span className="text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Rows per batch
+          </span>
+          <span className="text-[10.5px] tabular-nums text-muted-foreground">
+            {batches.length} batches
+          </span>
+        </div>
+        <PdbBarChart
+          data={chartData}
+          color="#3b82f6"
+          height={180}
+          valueFormatter={pdbFmtNum}
+        />
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Batch</TableHead>
+              <TableHead>LSN range</TableHead>
+              <TableHead className="text-right">Rows</TableHead>
+              <TableHead className="text-right">Duration</TableHead>
+              <TableHead className="text-right">Ended</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((b, i) => {
+              const dur = batchDurationSec(b)
+              return (
+                <TableRow key={b.batchId ?? i}>
+                  <TableCell className="font-mono text-xs tabular-nums">
+                    #{String(b.batchId ?? '—')}
+                  </TableCell>
+                  <TableCell className="font-mono text-[11px] text-muted-foreground">
+                    {b.startLsn ?? '—'} → {b.endLsn ?? '—'}
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {pdbFmtNum(toNumber(b.numRows))}
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {dur === null ? '—' : pdbFmtDuration(dur)}
+                  </TableCell>
+                  <TableCell className="text-right font-mono text-xs text-muted-foreground">
+                    {pdbFmtClock(b.endTime ?? b.startTime)}
+                  </TableCell>
+                </TableRow>
+              )
+            })}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/peerdb/fleet-lag-triage.tsx
+++ b/apps/dashboard/src/components/peerdb/fleet-lag-triage.tsx
@@ -1,0 +1,97 @@
+import { TriangleAlertIcon } from 'lucide-react'
+
+import type { MirrorListItem } from '@/lib/peerdb/types'
+import type { MirrorMetricsSummary } from './use-mirror-metrics'
+
+import { pdbFmtLag } from './peerdb-utils'
+import { AppLink } from '@/components/ui/app-link'
+
+/** Lag past this (seconds) is worth surfacing in the triage strip. */
+const LAG_FLOOR_SEC = 10
+const TOP_N = 5
+
+interface LagEntry {
+  name: string
+  lagSec: number
+  source?: string
+  destination?: string
+}
+
+/**
+ * Worst-lag triage strip for the mirrors index. Ranks mirrors by the per-row
+ * lag already derived (shared via `onMetrics`), surfaces the top offenders with
+ * deep links to the mirror detail page. Renders nothing when no mirror is
+ * meaningfully behind — a healthy fleet stays quiet.
+ */
+export function FleetLagTriage({
+  mirrors,
+  metrics,
+}: {
+  mirrors: MirrorListItem[]
+  metrics: Record<string, MirrorMetricsSummary>
+}) {
+  const entries: LagEntry[] = mirrors
+    .flatMap((m) => {
+      const lag = metrics[m.name]?.lagSec
+      if (lag == null || lag < LAG_FLOOR_SEC) return []
+      return [
+        {
+          name: m.name,
+          lagSec: lag,
+          source: m.sourceName,
+          destination: m.destinationName,
+        },
+      ]
+    })
+    .sort((a, b) => b.lagSec - a.lagSec)
+    .slice(0, TOP_N)
+
+  if (entries.length === 0) return null
+
+  return (
+    <div className="mb-4 overflow-hidden rounded-xl border border-amber-200 bg-amber-50/60 dark:border-amber-500/30 dark:bg-amber-500/5">
+      <div className="flex items-center gap-2 border-b border-amber-200/70 px-3 py-2 dark:border-amber-500/20">
+        <TriangleAlertIcon className="size-3.5 text-amber-600 dark:text-amber-400" />
+        <h2 className="text-[12px] font-semibold text-amber-800 dark:text-amber-300">
+          Lag triage
+        </h2>
+        <span className="text-[11px] text-amber-700/80 dark:text-amber-400/70">
+          {entries.length} mirror{entries.length === 1 ? '' : 's'} behind
+        </span>
+      </div>
+      <ul className="divide-y divide-amber-200/60 dark:divide-amber-500/15">
+        {entries.map((e) => {
+          const critical = e.lagSec > 60
+          return (
+            <li key={e.name}>
+              <AppLink
+                href={`/peerdb/mirror?name=${encodeURIComponent(e.name)}`}
+                className="flex flex-wrap items-center justify-between gap-2 px-3 py-2 transition-colors hover:bg-amber-100/50 dark:hover:bg-amber-500/10"
+              >
+                <div className="flex min-w-0 items-center gap-2">
+                  <span className="truncate font-mono text-[12px] font-semibold">
+                    {e.name}
+                  </span>
+                  {(e.source || e.destination) && (
+                    <span className="hidden truncate text-[10.5px] text-muted-foreground sm:inline">
+                      {e.source ?? '—'} → {e.destination ?? '—'}
+                    </span>
+                  )}
+                </div>
+                <span
+                  className={`shrink-0 font-mono text-[12px] font-semibold tabular-nums ${
+                    critical
+                      ? 'text-rose-600 dark:text-rose-400'
+                      : 'text-amber-700 dark:text-amber-400'
+                  }`}
+                >
+                  {pdbFmtLag(e.lagSec)}
+                </span>
+              </AppLink>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/peerdb/fleet-logs-feed.tsx
+++ b/apps/dashboard/src/components/peerdb/fleet-logs-feed.tsx
@@ -1,0 +1,197 @@
+import type { ListMirrorLogsResponse, MirrorLog } from '@/lib/peerdb/types'
+
+import {
+  LOG_LEVEL_META,
+  normalizePdbLogLevel,
+  parseTs,
+  pdbFmtClock,
+  pdbFmtRelative,
+} from './peerdb-utils'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { AppLink } from '@/components/ui/app-link'
+import { usePeerDB } from '@/lib/swr'
+
+type Level = 'all' | 'error' | 'warn' | 'info'
+const LEVELS: Level[] = ['all', 'error', 'warn', 'info']
+
+/** Bound the fan-out: only the first N mirrors contribute to the feed. */
+const MAX_SOURCES = 25
+const PAGE = 12
+
+interface FeedEntry extends MirrorLog {
+  mirror: string
+}
+
+/**
+ * Hidden per-mirror log fetcher (POST /v1/mirrors/logs). Reports its entries up
+ * so the feed can merge across the fleet without a bespoke aggregate endpoint.
+ */
+function LogSource({
+  mirror,
+  onLogs,
+}: {
+  mirror: string
+  onLogs: (mirror: string, logs: MirrorLog[]) => void
+}) {
+  const { data } = usePeerDB<ListMirrorLogsResponse>('/mirrors/logs', {
+    body: { flowJobName: mirror, page: 0, numPerPage: 50 },
+    refreshInterval: 60_000,
+  })
+  const errors = data?.errors
+  const key = errors?.length ?? -1
+  // Re-report whenever the returned set changes size (cheap change signal).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: errors tracked via key
+  useEffect(() => {
+    if (errors) onLogs(mirror, errors)
+  }, [mirror, key, onLogs])
+  return null
+}
+
+/**
+ * Unified logs / alerts feed across all mirrors on the index page. Aggregates
+ * `POST /v1/mirrors/logs` per mirror, merges newest-first, and filters by level
+ * (error / warn / info). Each row deep-links to its mirror detail page.
+ */
+export function FleetLogsFeed({ mirrors }: { mirrors: string[] }) {
+  const [level, setLevel] = useState<Level>('all')
+  const [showAll, setShowAll] = useState(false)
+  const [byMirror, setByMirror] = useState<Record<string, MirrorLog[]>>({})
+
+  const sources = mirrors.slice(0, MAX_SOURCES)
+
+  const onLogs = useCallback((mirror: string, logs: MirrorLog[]) => {
+    setByMirror((prev) => {
+      const cur = prev[mirror]
+      if (cur && cur.length === logs.length) return prev
+      return { ...prev, [mirror]: logs }
+    })
+  }, [])
+
+  const all: FeedEntry[] = useMemo(() => {
+    const out: FeedEntry[] = []
+    for (const m of sources) {
+      for (const l of byMirror[m] ?? []) out.push({ ...l, mirror: m })
+    }
+    return out.sort(
+      (a, b) =>
+        (parseTs(b.errorTimestamp) ?? 0) - (parseTs(a.errorTimestamp) ?? 0)
+    )
+  }, [sources, byMirror])
+
+  const counts = useMemo(() => {
+    const c: Record<Level, number> = { all: 0, error: 0, warn: 0, info: 0 }
+    for (const l of all) {
+      c.all++
+      c[normalizePdbLogLevel(l.errorType)]++
+    }
+    return c
+  }, [all])
+
+  const filtered =
+    level === 'all'
+      ? all
+      : all.filter((l) => normalizePdbLogLevel(l.errorType) === level)
+  const rows = showAll ? filtered : filtered.slice(0, PAGE)
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-border bg-card">
+      {sources.map((m) => (
+        <LogSource key={m} mirror={m} onLogs={onLogs} />
+      ))}
+      <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border bg-muted/40 px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Fleet logs & alerts
+          </span>
+          <span className="font-mono text-[10.5px] text-muted-foreground">
+            POST /v1/mirrors/logs · {sources.length} mirror
+            {sources.length === 1 ? '' : 's'}
+          </span>
+        </div>
+        <div className="flex items-center gap-0.5 rounded bg-muted p-0.5">
+          {LEVELS.map((lvl) => (
+            <button
+              key={lvl}
+              type="button"
+              onClick={() => setLevel(lvl)}
+              className={`inline-flex h-6 items-center gap-1 rounded px-2 text-[10.5px] font-medium ${
+                level === lvl
+                  ? 'bg-card text-foreground shadow-sm'
+                  : 'text-muted-foreground'
+              }`}
+            >
+              {lvl === 'all' ? 'All' : lvl.toUpperCase()}
+              <span className="text-[9.5px] tabular-nums opacity-70">
+                {counts[lvl]}
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="px-3 py-8 text-center text-[11.5px] text-muted-foreground">
+          No log entries at this level
+        </div>
+      ) : (
+        <ul className="divide-y divide-border">
+          {rows.map((l, i) => {
+            const lvl = normalizePdbLogLevel(l.errorType)
+            const meta = LOG_LEVEL_META[lvl]
+            return (
+              <li
+                key={`${l.mirror}-${l.id ?? i}`}
+                className="flex items-start gap-2.5 px-3 py-2"
+              >
+                <span
+                  className="mt-0.5 inline-flex h-4 shrink-0 items-center justify-center rounded px-1.5 font-mono text-[9.5px] font-bold"
+                  style={{
+                    background: `${meta.dot}14`,
+                    color: meta.dot,
+                    border: `1px solid ${meta.dot}40`,
+                  }}
+                >
+                  {meta.label}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div
+                    className="break-words font-mono text-[11.5px] leading-snug"
+                    style={lvl === 'error' ? { color: meta.dot } : undefined}
+                  >
+                    {l.errorMessage}
+                  </div>
+                  <div className="mt-0.5 flex flex-wrap items-center gap-x-1.5 text-[10px] tabular-nums text-muted-foreground/80">
+                    <AppLink
+                      href={`/peerdb/mirror?name=${encodeURIComponent(l.mirror)}`}
+                      className="font-mono font-medium text-primary hover:underline"
+                    >
+                      {l.mirror}
+                    </AppLink>
+                    <span>·</span>
+                    <span>{pdbFmtRelative(l.errorTimestamp)}</span>
+                    <span>·</span>
+                    <span className="font-mono">
+                      {pdbFmtClock(l.errorTimestamp)}
+                    </span>
+                  </div>
+                </div>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+
+      {filtered.length > PAGE && (
+        <div className="border-t border-border px-3 py-1.5 text-center">
+          <button
+            type="button"
+            onClick={() => setShowAll((v) => !v)}
+            className="text-[11px] text-muted-foreground hover:text-foreground"
+          >
+            {showAll ? 'Show fewer' : `Show all ${filtered.length} entries`}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/peerdb/mirror-row.tsx
+++ b/apps/dashboard/src/components/peerdb/mirror-row.tsx
@@ -47,11 +47,11 @@ export function MirrorRow({
   const panelId = useId()
 
   const trendKey = trend.join(',')
-  // Report metrics up so the page can aggregate KPI totals (deduped fetch).
+  // Report metrics up so the page can aggregate KPI totals + lag triage (deduped fetch).
   // biome-ignore lint/correctness/useExhaustiveDependencies: trend tracked via trendKey
   useEffect(() => {
-    onMetrics?.(mirror.name, { rowsPerSec, rowsSynced, trend })
-  }, [mirror.name, rowsPerSec, rowsSynced, trendKey, onMetrics])
+    onMetrics?.(mirror.name, { rowsPerSec, rowsSynced, trend, lagSec })
+  }, [mirror.name, rowsPerSec, rowsSynced, trendKey, lagSec, onMetrics])
 
   const lagAccent =
     lagSec == null

--- a/apps/dashboard/src/components/peerdb/operation-mix-chart.tsx
+++ b/apps/dashboard/src/components/peerdb/operation-mix-chart.tsx
@@ -1,0 +1,100 @@
+import type { CDCTableRowCounts } from '@/lib/peerdb/types'
+
+import { pdbFmtNum, toNumber } from './peerdb-utils'
+
+const OPS = [
+  { key: 'insertsCount', label: 'Inserts', color: '#10b981' },
+  { key: 'updatesCount', label: 'Updates', color: '#3b82f6' },
+  { key: 'deletesCount', label: 'Deletes', color: '#f43f5e' },
+] as const
+
+/**
+ * Per-table insert/update/delete operation mix as stacked horizontal bars,
+ * hand-rolled in the Pdb* CSS-bar style (no recharts). Data comes from
+ * `GET /v1/mirrors/cdc/table_total_counts/{flow}`, already fetched by the page.
+ */
+export function OperationMixChart({ tables }: { tables: CDCTableRowCounts[] }) {
+  const rows = tables
+    .map((t) => {
+      const inserts = toNumber(t.counts?.insertsCount)
+      const updates = toNumber(t.counts?.updatesCount)
+      const deletes = toNumber(t.counts?.deletesCount)
+      return {
+        name: t.tableName ?? '—',
+        inserts,
+        updates,
+        deletes,
+        total: inserts + updates + deletes,
+      }
+    })
+    .filter((r) => r.total > 0)
+
+  if (rows.length === 0) {
+    return (
+      <p className="py-6 text-center text-sm text-muted-foreground">
+        No operation counts available.
+      </p>
+    )
+  }
+
+  const max = Math.max(...rows.map((r) => r.total), 1)
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-border bg-card p-3.5">
+      {/* legend */}
+      <div className="flex flex-wrap items-center gap-3 text-[10.5px] text-muted-foreground">
+        {OPS.map((op) => (
+          <span key={op.key} className="inline-flex items-center gap-1.5">
+            <span
+              className="size-2 rounded-sm"
+              style={{ background: op.color }}
+            />
+            {op.label}
+          </span>
+        ))}
+      </div>
+
+      <div className="flex flex-col gap-2.5">
+        {rows.map((r) => (
+          <div key={r.name} className="flex flex-col gap-1">
+            <div className="flex items-baseline justify-between gap-2">
+              <span className="truncate font-mono text-[11.5px] font-medium">
+                {r.name}
+              </span>
+              <span className="shrink-0 text-[10.5px] tabular-nums text-muted-foreground">
+                {pdbFmtNum(r.total)}
+              </span>
+            </div>
+            <div
+              className="flex h-3 overflow-hidden rounded-sm bg-muted"
+              style={{ width: `${(r.total / max) * 100}%`, minWidth: '2px' }}
+              title={`${r.name}: ${pdbFmtNum(r.inserts)} ins · ${pdbFmtNum(
+                r.updates
+              )} upd · ${pdbFmtNum(r.deletes)} del`}
+            >
+              {OPS.map((op) => {
+                const v =
+                  r[
+                    op.key === 'insertsCount'
+                      ? 'inserts'
+                      : op.key === 'updatesCount'
+                        ? 'updates'
+                        : 'deletes'
+                  ]
+                const pct = r.total ? (v / r.total) * 100 : 0
+                if (pct <= 0) return null
+                return (
+                  <div
+                    key={op.key}
+                    className="h-full"
+                    style={{ width: `${pct}%`, background: op.color }}
+                  />
+                )
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/peerdb/peerdb-derive.test.ts
+++ b/apps/dashboard/src/components/peerdb/peerdb-derive.test.ts
@@ -1,0 +1,140 @@
+import {
+  batchDurationSec,
+  cloneProgress,
+  SLOT_LAG_CRITICAL_MB,
+  SLOT_LAG_WARN_MB,
+  slotHealth,
+} from './peerdb-derive'
+import { describe, expect, test } from 'bun:test'
+
+describe('batchDurationSec', () => {
+  test('computes seconds between ISO start and end', () => {
+    expect(
+      batchDurationSec({
+        startTime: '2026-07-11T00:00:00.000Z',
+        endTime: '2026-07-11T00:00:08.000Z',
+      })
+    ).toBe(8)
+  })
+
+  test('accepts epoch-second numeric strings', () => {
+    // parseTs treats < 1e11 as epoch seconds.
+    expect(batchDurationSec({ startTime: '1000', endTime: '1090' })).toBe(90)
+  })
+
+  test('returns null when an endpoint is missing', () => {
+    expect(batchDurationSec({ startTime: '2026-07-11T00:00:00Z' })).toBeNull()
+    expect(batchDurationSec({ endTime: '2026-07-11T00:00:00Z' })).toBeNull()
+    expect(batchDurationSec({})).toBeNull()
+  })
+
+  test('clamps negative spans (clock skew) to 0', () => {
+    expect(
+      batchDurationSec({
+        startTime: '2026-07-11T00:00:08.000Z',
+        endTime: '2026-07-11T00:00:00.000Z',
+      })
+    ).toBe(0)
+  })
+})
+
+describe('cloneProgress', () => {
+  test('percent from partitions completed vs total', () => {
+    const p = cloneProgress({
+      numPartitionsCompleted: 3,
+      numPartitionsTotal: 12,
+    })
+    expect(p.completed).toBe(3)
+    expect(p.total).toBe(12)
+    expect(p.pct).toBe(25)
+    expect(p.done).toBe(false)
+  })
+
+  test('done when fetch + consolidate complete, forces 100%', () => {
+    const p = cloneProgress({
+      numPartitionsCompleted: 8,
+      numPartitionsTotal: 10,
+      fetchCompleted: true,
+      consolidateCompleted: true,
+    })
+    expect(p.done).toBe(true)
+    expect(p.pct).toBe(100)
+  })
+
+  test('not done when only one phase complete', () => {
+    const p = cloneProgress({
+      numPartitionsCompleted: 5,
+      numPartitionsTotal: 10,
+      fetchCompleted: true,
+      consolidateCompleted: false,
+    })
+    expect(p.done).toBe(false)
+    expect(p.pct).toBe(50)
+  })
+
+  test('zero total yields 0% without dividing by zero', () => {
+    const p = cloneProgress({
+      numPartitionsCompleted: 0,
+      numPartitionsTotal: 0,
+    })
+    expect(p.pct).toBe(0)
+    expect(Number.isFinite(p.pct)).toBe(true)
+  })
+
+  test('clamps over-100 partition counters', () => {
+    const p = cloneProgress({
+      numPartitionsCompleted: 15,
+      numPartitionsTotal: 10,
+    })
+    expect(p.pct).toBe(100)
+  })
+})
+
+describe('slotHealth', () => {
+  test('ok for low lag, active, reserved', () => {
+    expect(
+      slotHealth({ lagInMb: 12, active: true, walStatus: 'reserved' })
+    ).toBe('ok')
+  })
+
+  test('warn once lag crosses the warning threshold', () => {
+    expect(
+      slotHealth({
+        lagInMb: SLOT_LAG_WARN_MB,
+        active: true,
+        walStatus: 'reserved',
+      })
+    ).toBe('warn')
+  })
+
+  test('critical once lag crosses the critical threshold', () => {
+    expect(
+      slotHealth({
+        lagInMb: SLOT_LAG_CRITICAL_MB,
+        active: true,
+        walStatus: 'reserved',
+      })
+    ).toBe('critical')
+  })
+
+  test('critical for unreserved / lost WAL regardless of lag', () => {
+    expect(slotHealth({ lagInMb: 1, walStatus: 'unreserved' })).toBe('critical')
+    expect(slotHealth({ lagInMb: 1, walStatus: 'lost' })).toBe('critical')
+  })
+
+  test('inactive slot holding WAL past warn is critical', () => {
+    expect(
+      slotHealth({
+        lagInMb: SLOT_LAG_WARN_MB,
+        active: false,
+        walStatus: 'reserved',
+      })
+    ).toBe('critical')
+  })
+
+  test('inactive slot with negligible lag is still ok', () => {
+    expect(
+      slotHealth({ lagInMb: 2, active: false, walStatus: 'reserved' })
+    ).toBe('ok')
+  })
+})

--- a/apps/dashboard/src/components/peerdb/peerdb-derive.ts
+++ b/apps/dashboard/src/components/peerdb/peerdb-derive.ts
@@ -1,0 +1,72 @@
+import type { CDCBatch, CloneTableSummary, SlotInfo } from '@/lib/peerdb/types'
+
+import { parseTs, toNumber } from './peerdb-utils'
+
+/**
+ * Wall-clock duration of a CDC batch in seconds, from start→end timestamps.
+ * Returns null when either endpoint is missing or unparseable so callers can
+ * render an em-dash rather than a bogus 0. Negative spans (clock skew) clamp
+ * to 0.
+ */
+export function batchDurationSec(batch: CDCBatch): number | null {
+  const start = parseTs(batch.startTime)
+  const end = parseTs(batch.endTime)
+  if (start == null || end == null) return null
+  return Math.max(0, (end - start) / 1000)
+}
+
+export interface CloneProgress {
+  completed: number
+  total: number
+  /** Percent of partitions completed, 0–100 (0 when total is unknown). */
+  pct: number
+  /** True once both fetch and consolidate phases report complete. */
+  done: boolean
+}
+
+/**
+ * Snapshot / initial-load progress for one cloned table. Percent is driven by
+ * partitions completed vs total; a table with fetch+consolidate both complete
+ * is treated as 100% done even if the partition counters lag.
+ */
+export function cloneProgress(summary: CloneTableSummary): CloneProgress {
+  const completed = toNumber(summary.numPartitionsCompleted)
+  const total = toNumber(summary.numPartitionsTotal)
+  const done = Boolean(summary.fetchCompleted && summary.consolidateCompleted)
+  let pct = total > 0 ? (completed / total) * 100 : 0
+  if (done) pct = 100
+  return {
+    completed,
+    total,
+    pct: Math.min(100, Math.max(0, pct)),
+    done,
+  }
+}
+
+export type SlotHealth = 'ok' | 'warn' | 'critical'
+
+/** Lag thresholds (MiB) for replication-slot health classification. */
+export const SLOT_LAG_WARN_MB = 512
+export const SLOT_LAG_CRITICAL_MB = 2048
+
+/**
+ * Classify a replication slot's health from its lag and WAL status.
+ *
+ * - `critical` — lag past the critical threshold, an inactive slot still
+ *   retaining WAL, or a non-`reserved`/`extended` WAL status ("unreserved" or
+ *   "lost" mean Postgres may drop or has dropped required WAL).
+ * - `warn` — lag past the warning threshold.
+ * - `ok` — otherwise.
+ */
+export function slotHealth(slot: SlotInfo): SlotHealth {
+  const lag = toNumber(slot.lagInMb)
+  const wal = (slot.walStatus ?? '').toLowerCase()
+  const active = slot.active !== false
+
+  if (wal === 'unreserved' || wal === 'lost') return 'critical'
+  if (lag >= SLOT_LAG_CRITICAL_MB) return 'critical'
+  // An inactive slot that is still holding meaningful WAL is a leak risk.
+  if (!active && lag >= SLOT_LAG_WARN_MB) return 'critical'
+  if (lag >= SLOT_LAG_WARN_MB) return 'warn'
+  return 'ok'
+}

--- a/apps/dashboard/src/components/peerdb/slot-health-table.tsx
+++ b/apps/dashboard/src/components/peerdb/slot-health-table.tsx
@@ -1,0 +1,185 @@
+import type {
+  PeerListItem,
+  PeerSlotResponse,
+  SlotInfo,
+} from '@/lib/peerdb/types'
+
+import { type SlotHealth, slotHealth } from './peerdb-derive'
+import { normalizeDbType, pdbFmtBytes } from './peerdb-utils'
+import { useCallback, useEffect, useState } from 'react'
+import { AppLink } from '@/components/ui/app-link'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { usePeerDB } from '@/lib/swr'
+
+const HEALTH_META: Record<
+  SlotHealth,
+  { label: string; dot: string; text: string }
+> = {
+  ok: {
+    label: 'OK',
+    dot: '#10b981',
+    text: 'text-emerald-600 dark:text-emerald-400',
+  },
+  warn: {
+    label: 'WARN',
+    dot: '#f59e0b',
+    text: 'text-amber-700 dark:text-amber-400',
+  },
+  critical: {
+    label: 'CRITICAL',
+    dot: '#f43f5e',
+    text: 'text-rose-600 dark:text-rose-400',
+  },
+}
+
+interface SlotRow extends SlotInfo {
+  peer: string
+}
+
+/** Hidden per-peer slot fetcher (GET /v1/peers/slots/{peer}). */
+function SlotSource({
+  peer,
+  onSlots,
+}: {
+  peer: string
+  onSlots: (peer: string, slots: SlotInfo[]) => void
+}) {
+  const { data } = usePeerDB<PeerSlotResponse>(
+    `/peers/slots/${encodeURIComponent(peer)}`,
+    { refreshInterval: 30_000 }
+  )
+  const slots = data?.slotData
+  const key = slots?.length ?? -1
+  // biome-ignore lint/correctness/useExhaustiveDependencies: slots tracked via key
+  useEffect(() => {
+    if (slots) onSlots(peer, slots)
+  }, [peer, key, onSlots])
+  return null
+}
+
+/**
+ * Fleet-wide replication-slot health across all Postgres peers. Aggregates
+ * `GET /v1/peers/slots/{peer}`, classifies each slot (ok / warn / critical) via
+ * `slotHealth`, and surfaces lag, active state, and WAL status with warning
+ * tones. Sorted worst-first so risky slots (inactive, unreserved WAL, high lag)
+ * rise to the top.
+ */
+export function SlotHealthTable({ peers }: { peers: PeerListItem[] }) {
+  const [byPeer, setByPeer] = useState<Record<string, SlotInfo[]>>({})
+
+  const pgPeers = peers.filter((p) => normalizeDbType(p.type) === 'POSTGRES')
+
+  const onSlots = useCallback((peer: string, slots: SlotInfo[]) => {
+    setByPeer((prev) => {
+      const cur = prev[peer]
+      if (cur && cur.length === slots.length) return prev
+      return { ...prev, [peer]: slots }
+    })
+  }, [])
+
+  if (pgPeers.length === 0) return null
+
+  const rows: SlotRow[] = []
+  for (const p of pgPeers) {
+    for (const s of byPeer[p.name] ?? []) rows.push({ ...s, peer: p.name })
+  }
+  const rank: Record<SlotHealth, number> = { critical: 0, warn: 1, ok: 2 }
+  rows.sort((a, b) => rank[slotHealth(a)] - rank[slotHealth(b)])
+
+  return (
+    <section className="flex flex-col gap-2">
+      {pgPeers.map((p) => (
+        <SlotSource key={p.name} peer={p.name} onSlots={onSlots} />
+      ))}
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h2 className="text-sm font-semibold">Replication slot health</h2>
+        <span className="font-mono text-[10.5px] text-muted-foreground">
+          GET /v1/peers/slots/&lt;peer&gt;
+        </span>
+      </div>
+      <div className="overflow-x-auto rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Health</TableHead>
+              <TableHead>Peer</TableHead>
+              <TableHead>Slot</TableHead>
+              <TableHead>Active</TableHead>
+              <TableHead className="text-right">Lag</TableHead>
+              <TableHead>WAL status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={6}
+                  className="py-6 text-center text-sm text-muted-foreground"
+                >
+                  No replication slots across Postgres peers.
+                </TableCell>
+              </TableRow>
+            ) : (
+              rows.map((s) => {
+                const health = slotHealth(s)
+                const meta = HEALTH_META[health]
+                return (
+                  <TableRow key={`${s.peer}-${s.slotName}`}>
+                    <TableCell>
+                      <span
+                        className={`inline-flex items-center gap-1.5 text-xs font-semibold ${meta.text}`}
+                      >
+                        <span
+                          className="size-1.5 rounded-full"
+                          style={{ background: meta.dot }}
+                        />
+                        {meta.label}
+                      </span>
+                    </TableCell>
+                    <TableCell>
+                      <AppLink
+                        href={`/peerdb/peer?name=${encodeURIComponent(s.peer)}`}
+                        className="font-medium text-primary hover:underline"
+                      >
+                        {s.peer}
+                      </AppLink>
+                    </TableCell>
+                    <TableCell className="font-mono text-xs">
+                      {s.slotName ?? '—'}
+                    </TableCell>
+                    <TableCell className="text-xs">
+                      {s.active === false ? (
+                        <span className="text-rose-600 dark:text-rose-400">
+                          inactive
+                        </span>
+                      ) : (
+                        'active'
+                      )}
+                    </TableCell>
+                    <TableCell
+                      className={`text-right font-mono text-xs tabular-nums ${
+                        health !== 'ok' ? meta.text : ''
+                      }`}
+                    >
+                      {pdbFmtBytes(s.lagInMb)}
+                    </TableCell>
+                    <TableCell className="font-mono text-xs">
+                      {s.walStatus ?? '—'}
+                    </TableCell>
+                  </TableRow>
+                )
+              })
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </section>
+  )
+}

--- a/apps/dashboard/src/components/peerdb/snapshot-progress.tsx
+++ b/apps/dashboard/src/components/peerdb/snapshot-progress.tsx
@@ -1,0 +1,155 @@
+import type {
+  CloneTableSummary,
+  FlowStatus,
+  InitialLoadSummaryResponse,
+} from '@/lib/peerdb/types'
+
+import { cloneProgress } from './peerdb-derive'
+import {
+  pdbFmtDuration,
+  pdbFmtNum,
+  toDesignStatus,
+  toNumber,
+} from './peerdb-utils'
+import { usePeerDB } from '@/lib/swr'
+
+/** Fetch/consolidate phase pill. */
+function PhaseBadge({ label, done }: { label: string; done: boolean }) {
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-mono text-[9.5px] font-medium"
+      style={
+        done
+          ? {
+              background: 'rgba(16,185,129,0.12)',
+              color: '#10b981',
+              border: '1px solid rgba(16,185,129,0.35)',
+            }
+          : {
+              background: 'rgba(148,163,184,0.12)',
+              color: '#94a3b8',
+              border: '1px solid rgba(148,163,184,0.30)',
+            }
+      }
+    >
+      <span
+        className="size-1 rounded-full"
+        style={{ background: done ? '#10b981' : '#94a3b8' }}
+      />
+      {label}
+    </span>
+  )
+}
+
+function SnapshotRow({ summary }: { summary: CloneTableSummary }) {
+  const { completed, total, pct, done } = cloneProgress(summary)
+  const avgMs = toNumber(summary.avgTimePerPartitionMs)
+  const barColor = done ? '#10b981' : '#3b82f6'
+  return (
+    <div className="flex flex-col gap-1.5 border-b border-border px-3 py-2.5 last:border-b-0">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <span className="truncate font-mono text-[12px] font-semibold">
+          {summary.tableName ?? summary.sourceTable ?? '—'}
+        </span>
+        <div className="flex items-center gap-1.5">
+          <PhaseBadge label="fetch" done={Boolean(summary.fetchCompleted)} />
+          <PhaseBadge
+            label="consolidate"
+            done={Boolean(summary.consolidateCompleted)}
+          />
+        </div>
+      </div>
+      <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+        <div
+          className="h-full transition-all"
+          style={{ width: `${pct}%`, background: barColor }}
+        />
+      </div>
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-0.5 text-[10.5px] tabular-nums text-muted-foreground">
+        <span>
+          <span className="font-semibold text-foreground">
+            {completed}/{total || '—'}
+          </span>{' '}
+          partitions ({pct.toFixed(0)}%)
+        </span>
+        <span>
+          <span className="font-semibold text-foreground">
+            {pdbFmtNum(toNumber(summary.numRowsSynced))}
+          </span>{' '}
+          rows synced
+        </span>
+        {avgMs > 0 && (
+          <span>
+            avg{' '}
+            <span className="font-semibold text-foreground">
+              {pdbFmtDuration(avgMs / 1000)}
+            </span>
+            /partition
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Snapshot / initial-load progress — per-table clone summaries from
+ * `GET /v1/mirrors/cdc/initial_load/{flow}` (proto `InitialLoadSummary`).
+ *
+ * Snapshotting mirrors show almost nothing else today; this fills the gap with
+ * per-table partition progress, rows synced, avg time/partition, and
+ * fetch/consolidate phase badges. Rendered when the mirror is snapshotting OR
+ * whenever the initial-load endpoint still returns rows (a just-finished
+ * backfill remains visible until PeerDB clears it).
+ */
+export function SnapshotProgress({
+  flowJobName,
+  status,
+}: {
+  flowJobName: string
+  status?: FlowStatus
+}) {
+  const snapshotting = toDesignStatus(status) === 'snapshotting'
+  const { data } = usePeerDB<InitialLoadSummaryResponse>(
+    flowJobName
+      ? `/mirrors/cdc/initial_load/${encodeURIComponent(flowJobName)}`
+      : null,
+    { refreshInterval: snapshotting ? 15_000 : 60_000 }
+  )
+
+  const summaries = data?.tableSummaries ?? []
+  if (summaries.length === 0) return null
+
+  const totalTables = summaries.length
+  const doneTables = summaries.filter((s) => cloneProgress(s).done).length
+
+  return (
+    <section className="flex flex-col gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h2 className="text-sm font-semibold">Snapshot progress</h2>
+        <span className="font-mono text-[10.5px] text-muted-foreground">
+          GET /v1/mirrors/cdc/initial_load/&lt;flow&gt;
+        </span>
+      </div>
+      <div className="overflow-hidden rounded-lg border border-border bg-card">
+        <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border bg-muted/40 px-3 py-2">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Initial load
+          </span>
+          <span className="text-[11px] tabular-nums">
+            <span className="font-semibold text-emerald-600 dark:text-emerald-400">
+              {doneTables}
+            </span>
+            <span className="text-muted-foreground">
+              {' '}
+              / {totalTables} tables cloned
+            </span>
+          </span>
+        </div>
+        {summaries.map((s, i) => (
+          <SnapshotRow key={s.tableName ?? s.sourceTable ?? i} summary={s} />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/apps/dashboard/src/components/peerdb/use-mirror-metrics.ts
+++ b/apps/dashboard/src/components/peerdb/use-mirror-metrics.ts
@@ -20,11 +20,12 @@ export interface DerivedMetrics {
   loading: boolean
 }
 
-/** Summary surfaced to the page so it can aggregate KPI totals. */
+/** Summary surfaced to the page so it can aggregate KPI totals + lag triage. */
 export interface MirrorMetricsSummary {
   rowsPerSec: number
   rowsSynced: number
   trend: number[]
+  lagSec: number | null
 }
 
 /**

--- a/apps/dashboard/src/lib/peerdb/types.ts
+++ b/apps/dashboard/src/lib/peerdb/types.ts
@@ -127,6 +127,24 @@ export interface CloneTableSummary {
   consolidateCompleted?: boolean
 }
 
+/**
+ * `GET /v1/mirrors/cdc/initial_load/{flow}` — per-table clone summaries for the
+ * snapshot / initial-load phase (proto `InitialLoadSummaryResponse`).
+ */
+export interface InitialLoadSummaryResponse {
+  tableSummaries?: CloneTableSummary[]
+}
+
+/**
+ * `GET /v1/mirrors/total_rows_synced/{flow}` — authoritative cumulative rows
+ * synced for a mirror. Field name varies across PeerDB versions, so accept the
+ * known aliases and normalize at the edge (see `mirror` detail page).
+ */
+export interface TotalRowsSyncedResponse {
+  totalCount?: number | string
+  totalRowsSynced?: number | string
+}
+
 export interface CDCMirrorStatus {
   config?: Record<string, unknown>
   snapshotStatus?: { clones?: CloneTableSummary[] }

--- a/apps/dashboard/src/routes/(peerdb)/peerdb/index.tsx
+++ b/apps/dashboard/src/routes/(peerdb)/peerdb/index.tsx
@@ -14,6 +14,8 @@ import type { MirrorMetricsSummary } from '@/components/peerdb/mirror-row'
 import type { ListMirrorsResponse, ListPeersResponse } from '@/lib/peerdb/types'
 
 import { useEffect, useState } from 'react'
+import { FleetLagTriage } from '@/components/peerdb/fleet-lag-triage'
+import { FleetLogsFeed } from '@/components/peerdb/fleet-logs-feed'
 import { KpiCard } from '@/components/peerdb/kpi-card'
 import { MirrorRow } from '@/components/peerdb/mirror-row'
 import { PeerGraph } from '@/components/peerdb/peer-graph'
@@ -107,6 +109,7 @@ function PeerDBMirrorsPage() {
   const [statusFilter, setStatusFilter] = useState<DesignStatus | 'all'>('all')
   const [search, setSearch] = useState('')
   const [graphOpen, setGraphOpen] = useState(false)
+  const [logsOpen, setLogsOpen] = useState(false)
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE)
   const [metrics, setMetrics] = useState<Record<string, MirrorMetricsSummary>>(
     {}
@@ -123,6 +126,7 @@ function PeerDBMirrorsPage() {
         cur &&
         cur.rowsPerSec === m.rowsPerSec &&
         cur.rowsSynced === m.rowsSynced &&
+        cur.lagSec === m.lagSec &&
         sameTrend
       ) {
         return prev
@@ -377,6 +381,9 @@ function PeerDBMirrorsPage() {
         />
       </div>
 
+      {/* lag triage strip — worst-lag mirrors (quiet when the fleet is healthy) */}
+      <FleetLagTriage mirrors={mirrors} metrics={metrics} />
+
       {/* topology card — expand button centered on bottom border */}
       <div className="relative mb-6">
         <div className="overflow-hidden rounded-xl border border-border bg-card">
@@ -561,6 +568,26 @@ function PeerDBMirrorsPage() {
           </div>
         </div>
       </div>
+
+      {/* fleet logs & alerts — collapsed by default; mounted only when open so
+          the per-mirror log fetchers don't poll in the background. */}
+      {mirrors.length > 0 && (
+        <div className="mt-4">
+          <button
+            type="button"
+            onClick={() => setLogsOpen((v) => !v)}
+            className="mb-2 inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[11.5px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            {logsOpen ? (
+              <ChevronUpIcon className="size-3" />
+            ) : (
+              <ChevronDownIcon className="size-3" />
+            )}
+            {logsOpen ? 'Hide fleet logs' : 'Show fleet logs & alerts'}
+          </button>
+          {logsOpen && <FleetLogsFeed mirrors={mirrors.map((m) => m.name)} />}
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/dashboard/src/routes/(peerdb)/peerdb/mirror.tsx
+++ b/apps/dashboard/src/routes/(peerdb)/peerdb/mirror.tsx
@@ -2,13 +2,17 @@ import { createFileRoute, useSearch } from '@tanstack/react-router'
 
 import type {
   CDCTableTotalCountsResponse,
+  GetCDCBatchesResponse,
   GraphResponse,
   ListMirrorLogsResponse,
   MirrorStatusResponse,
+  TotalRowsSyncedResponse,
 } from '@/lib/peerdb/types'
 
 import { Suspense } from 'react'
+import { CdcBatchHistory } from '@/components/peerdb/cdc-batch-history'
 import { MirrorStatusBadge } from '@/components/peerdb/mirror-status-badge'
+import { OperationMixChart } from '@/components/peerdb/operation-mix-chart'
 import { PartitionTable } from '@/components/peerdb/partition-table'
 import { PeerDBNotConfigured } from '@/components/peerdb/peerdb-not-configured'
 import {
@@ -17,6 +21,7 @@ import {
   toNumber,
 } from '@/components/peerdb/peerdb-utils'
 import { RowsSyncedChart } from '@/components/peerdb/rows-synced-chart'
+import { SnapshotProgress } from '@/components/peerdb/snapshot-progress'
 import { AppLink } from '@/components/ui/app-link'
 import { Card, CardContent } from '@/components/ui/card'
 import {
@@ -73,6 +78,19 @@ function MirrorDetailContent() {
     enabled ? '/mirrors/logs' : null,
     { body: { flowJobName: name, level: 'error', page: 0, numPerPage: 20 } }
   )
+  // Authoritative cumulative rows synced (GET /v1/mirrors/total_rows_synced).
+  const totalSynced = usePeerDB<TotalRowsSyncedResponse>(
+    enabled ? `/mirrors/total_rows_synced/${encodeURIComponent(name)}` : null,
+    { refreshInterval: 60_000 }
+  )
+  // Recent CDC batches — fetched once here and shared with the batch history.
+  const batchesReq = usePeerDB<GetCDCBatchesResponse>(
+    enabled ? '/mirrors/cdc/batches' : null,
+    {
+      body: { flowJobName: name, page: 0, numPerPage: 20 },
+      refreshInterval: 30_000,
+    }
+  )
 
   if (isPeerDBNotConfigured(status.error)) {
     return <PeerDBNotConfigured />
@@ -85,10 +103,20 @@ function MirrorDetailContent() {
   const data = status.data
   const cdc = data?.cdcStatus
   const qrep = data?.qrepStatus
+  const isCdc = !qrep
   const partitions = qrep?.partitions ?? []
   const tables = tableCounts.data?.tablesData ?? []
   const errors = logs.data?.errors ?? []
-  const rowsSynced = toNumber(cdc?.rowsSynced)
+  const batches = batchesReq.data?.cdcBatches ?? cdc?.cdcBatches ?? []
+  // Prefer the authoritative total_rows_synced endpoint; fall back to the CDC
+  // status counter (older PeerDB / not-yet-loaded).
+  const authoritativeTotal =
+    totalSynced.data?.totalCount ?? totalSynced.data?.totalRowsSynced
+  const rowsSynced =
+    authoritativeTotal != null
+      ? toNumber(authoritativeTotal)
+      : toNumber(cdc?.rowsSynced)
+  const hasRowsSynced = authoritativeTotal != null || cdc?.rowsSynced != null
 
   return (
     <div className="flex flex-col gap-4">
@@ -114,12 +142,8 @@ function MirrorDetailContent() {
 
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
         <StatCard
-          label="Rows synced (CDC)"
-          value={
-            cdc?.rowsSynced !== undefined
-              ? formatReadableQuantity(rowsSynced)
-              : '—'
-          }
+          label="Rows synced (total)"
+          value={hasRowsSynced ? formatReadableQuantity(rowsSynced) : '—'}
         />
         <StatCard
           label="Tables"
@@ -135,15 +159,36 @@ function MirrorDetailContent() {
         />
       </div>
 
+      <SnapshotProgress flowJobName={name} status={data?.currentFlowState} />
+
       <section className="flex flex-col gap-2 rounded-lg border p-4">
         <h2 className="text-sm font-semibold">Rows synced over time</h2>
         <RowsSyncedChart data={graph.data?.data ?? []} />
       </section>
 
+      {isCdc && batches.length > 0 ? (
+        <section className="flex flex-col gap-2">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h2 className="text-sm font-semibold">CDC batch history</h2>
+            <span className="font-mono text-[10.5px] text-muted-foreground">
+              POST /v1/mirrors/cdc/batches
+            </span>
+          </div>
+          <CdcBatchHistory batches={batches} />
+        </section>
+      ) : null}
+
       {partitions.length > 0 ? (
         <section className="flex flex-col gap-2">
           <h2 className="text-sm font-semibold">Partitions</h2>
           <PartitionTable partitions={partitions} />
+        </section>
+      ) : null}
+
+      {tables.length > 0 ? (
+        <section className="flex flex-col gap-2">
+          <h2 className="text-sm font-semibold">Per-table operation mix</h2>
+          <OperationMixChart tables={tables} />
         </section>
       ) : null}
 

--- a/apps/dashboard/src/routes/(peerdb)/peerdb/peer.tsx
+++ b/apps/dashboard/src/routes/(peerdb)/peerdb/peer.tsx
@@ -9,6 +9,7 @@ import type {
 import { Suspense } from 'react'
 import { MiniAreaChart } from '@/components/charts/mini-charts'
 import { PeerDetailSkeleton } from '@/components/peerdb/peer-detail-skeleton'
+import { PeerInfoCard } from '@/components/peerdb/peer-info-card'
 import { PeerDBNotConfigured } from '@/components/peerdb/peerdb-not-configured'
 import {
   isPeerDBNotConfigured,
@@ -76,6 +77,21 @@ function PeerDetailContent() {
         </AppLink>
         <h1 className="text-2xl font-semibold">{name}</h1>
       </div>
+
+      <section className="flex flex-col gap-2">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h2 className="text-sm font-semibold">Peer info</h2>
+          <span className="font-mono text-[10.5px] text-muted-foreground">
+            GET /v1/peers/info/&lt;name&gt;
+          </span>
+        </div>
+        <div className="max-w-xl">
+          <PeerInfoCard
+            name={name}
+            peerRole={slotData.length > 0 ? 'source' : 'destination'}
+          />
+        </div>
+      </section>
 
       <section className="flex flex-col gap-2">
         <h2 className="text-sm font-semibold">Replication slots</h2>

--- a/apps/dashboard/src/routes/(peerdb)/peerdb/peers.tsx
+++ b/apps/dashboard/src/routes/(peerdb)/peerdb/peers.tsx
@@ -21,6 +21,7 @@ import {
   statusTone,
   TONE_COLOR,
 } from '@/components/peerdb/peerdb-utils'
+import { SlotHealthTable } from '@/components/peerdb/slot-health-table'
 import { AppLink } from '@/components/ui/app-link'
 import {
   Table,
@@ -138,6 +139,8 @@ function PeerDBPeersPage() {
       </div>
 
       <PeerGraph peers={peers} mirrors={mirrors} className="h-[460px]" />
+
+      <SlotHealthTable peers={peers} />
 
       <div className="overflow-x-auto rounded-lg border">
         <Table>

--- a/docs/content/guide/features/peerdb.mdx
+++ b/docs/content/guide/features/peerdb.mdx
@@ -21,8 +21,10 @@ Monitor PeerDB replication mirrors and peers without leaving chmonitor — an op
 
 When you set `PEERDB_API_URL`, chmonitor adds a PeerDB section to the navigation. It proxies read-only calls to the PeerDB API so you can monitor replication without leaving the chmonitor UI.
 
-- **Mirrors** (`/peerdb`) shows all configured replication mirrors with status, throughput, and per-table sync state.
-- **Peers** (`/peerdb/peers`) lists source and destination peers, replication slot lag, and a mirror connectivity graph.
+- **Mirrors** (`/peerdb`) shows all configured replication mirrors with status, throughput, and per-table sync state, plus a fleet **lag-triage strip** (worst-lag mirrors) and a collapsible **logs & alerts feed** aggregated across every mirror.
+- **Mirror detail** (`/peerdb/mirror?name=…`) adds **snapshot / initial-load progress** (per-table partition completion, fetch/consolidate phase, avg time per partition), **CDC batch history** (rows per batch, LSN range, duration), a per-table **operation mix** (insert/update/delete), and an authoritative rows-synced total.
+- **Peers** (`/peerdb/peers`) lists source and destination peers, a **replication slot health** table (lag, active state, WAL status classified ok / warn / critical), and a mirror connectivity graph.
+- **Peer detail** (`/peerdb/peer?name=…`) shows the peer's redacted config and server version, its replication slots, slot-lag history, and active queries.
 
 Mutation requests (create, delete, pause, resume) are blocked at the proxy layer and return HTTP 403. chmonitor only ever reads from PeerDB.
 
@@ -32,8 +34,10 @@ The PeerDB section does not appear in the navigation when `PEERDB_API_URL` is un
 
 | Page | Route | What it shows | System tables |
 |---|---|---|---|
-| Mirrors | `/peerdb` | Mirror status, throughput, per-table sync | — (PeerDB API) |
-| Peers | `/peerdb/peers` | Peer list, slot lag, mirror graph | — (PeerDB API) |
+| Mirrors | `/peerdb` | Mirror status, throughput, lag triage, fleet logs feed | — (PeerDB API) |
+| Mirror detail | `/peerdb/mirror` | Snapshot progress, CDC batch history, operation mix, rows-synced total | — (PeerDB API) |
+| Peers | `/peerdb/peers` | Peer list, slot health, mirror graph | — (PeerDB API) |
+| Peer detail | `/peerdb/peer` | Peer info + version, slots, slot-lag history, active queries | — (PeerDB API) |
 
 ## Using it
 

--- a/docs/content/operate/advanced/peerdb-monitoring.mdx
+++ b/docs/content/operate/advanced/peerdb-monitoring.mdx
@@ -14,6 +14,17 @@ Open it at `/peerdb` once configured. The section is hidden until
 `PEERDB_API_URL` is set.
 </Callout>
 
+## What you can see
+
+| View | Where | Highlights |
+|---|---|---|
+| Mirrors fleet | `/peerdb` | Status KPIs, per-mirror throughput, a **lag-triage strip** (worst-lag mirrors), and a collapsible **logs & alerts feed** aggregated across every mirror with error/warn/info filters. |
+| Snapshot progress | mirror detail | Per-table initial-load progress from `initial_load` — partitions completed, rows synced, avg time per partition, and fetch/consolidate phase badges. Fills the gap for snapshotting mirrors. |
+| CDC batch history | mirror detail | Recent CDC batches (id, LSN range, rows, duration) plus a rows-per-batch chart. |
+| Operation mix | mirror detail | Per-table insert / update / delete split from `table_total_counts`. |
+| Slot health | `/peerdb/peers` | Replication slots across Postgres peers classified **ok / warn / critical** by lag, active state, and WAL status; worst-first. |
+| Peer info | peer detail | Redacted peer config and server version from `peers/info`, alongside slots, slot-lag history, and active queries. |
+
 ## Configure
 
 <Steps>

--- a/scripts/peerdb-mock-server.ts
+++ b/scripts/peerdb-mock-server.ts
@@ -252,6 +252,48 @@ function partitions(m: MirrorFixture) {
   })
 }
 
+/**
+ * Per-table clone summaries for the snapshot / initial-load phase
+ * (GET /v1/mirrors/cdc/initial_load/{flow}). Snapshotting mirrors report tables
+ * mid-clone (partial partitions, fetch done but not consolidated); already
+ * running/streaming mirrors report every table fully cloned.
+ */
+function initialLoad(m: MirrorFixture) {
+  const now = Date.now()
+  const snapshotting =
+    m.status === 'STATUS_SNAPSHOT' || m.status === 'STATUS_SETUP'
+  const tableSummaries = m.tables.map((tableName, i) => {
+    const total = 8 + Math.round(seeded(i + 4) * 40)
+    // Snapshotting: the first table is nearly done, later tables trail behind.
+    const frac = snapshotting
+      ? Math.max(0.05, Math.min(1, 1 - i * 0.28 - seeded(i + 5) * 0.15))
+      : 1
+    const completed = Math.min(total, Math.round(total * frac))
+    const fetchCompleted = !snapshotting || frac > 0.5
+    const consolidateCompleted = !snapshotting || completed >= total
+    const rowsSynced = Math.round(
+      (9_400_000 + seeded(i + 6) * 3_200_000) * frac
+    )
+    return {
+      tableName,
+      sourceTable: tableName,
+      startTime: new Date(now - (m.tables.length - i) * 90_000).toISOString(),
+      numPartitionsCompleted: completed,
+      numPartitionsTotal: total,
+      numRowsSynced: rowsSynced,
+      avgTimePerPartitionMs: Math.round(1800 + seeded(i + 7) * 6400),
+      fetchCompleted,
+      consolidateCompleted,
+    }
+  })
+  return { tableSummaries }
+}
+
+/** Authoritative cumulative rows synced (GET /v1/mirrors/total_rows_synced/{flow}). */
+function totalRowsSynced(m: MirrorFixture) {
+  return { totalCount: m.rowsSynced }
+}
+
 function tableCounts(m: MirrorFixture) {
   const tablesData = m.tables.map((tableName, i) => {
     const inserts = Math.round(5000 + seeded(i + 1) * 200000)
@@ -463,13 +505,16 @@ function mirrorStatus(name: string) {
 
 function slots(peer: string) {
   if (!peer.startsWith('pg')) return { slotData: [] }
+  // pg-staging hosts the FAILED legacy_archive mirror — its slot is not draining
+  // and WAL is approaching max_wal_size, so it reads as the risky/critical case.
+  const risky = peer === 'pg-staging'
   return {
     slotData: [
       {
         slotName: `peerflow_slot_${peer}`,
-        active: true,
-        lagInMb: 18.4,
-        walStatus: 'reserved',
+        active: !risky,
+        lagInMb: risky ? 4180.6 : 18.4,
+        walStatus: risky ? 'unreserved' : 'reserved',
         redoLSN: '0/1A2B3C4D',
         restartLSN: '0/1A2B0000',
         confirmedFlushLSN: '0/1A2B3C00',
@@ -553,7 +598,15 @@ async function handle(req: Request): Promise<Response> {
       const flow = decodeURIComponent(seg[4] ?? '')
       const m = mirror(flow)
       if (seg[3] === 'table_total_counts' && m) return json(tableCounts(m))
-      if (seg[3] === 'initial_load' && m) return json({ tableSummaries: [] })
+      if (seg[3] === 'initial_load' && m) return json(initialLoad(m))
+    }
+    if (
+      seg[1] === 'mirrors' &&
+      seg[2] === 'total_rows_synced' &&
+      seg.length === 4
+    ) {
+      const m = mirror(decodeURIComponent(seg[3] ?? ''))
+      if (m) return json(totalRowsSynced(m))
     }
     if (seg[1] === 'peers') {
       const peer = decodeURIComponent(seg[3] ?? '')


### PR DESCRIPTION
## PeerDB monitoring views

Richer PeerDB (Postgres→ClickHouse CDC) monitoring, built entirely on the
read-proxy's existing allowlist (no allowlist changes) and the hand-rolled
`Pdb*` chart primitives.

### Shipped (all 8)
1. **Snapshot progress** (mirror detail) — per-table initial-load progress from `GET /v1/mirrors/cdc/initial_load/{flow}`: partition completion %, rows synced, avg time/partition, fetch/consolidate phase badges. Shown when snapshotting or when the endpoint returns rows.
2. **CDC batch history** (mirror detail) — recent batches table (id, LSN range, rows, duration) + rows-per-batch `PdbBarChart`. Batches fetched once and passed in (no double fetch).
3. **Fleet lag triage** (mirrors index) — worst-lag top 5 strip with deep links, driven by the per-row `lagSec` now shared via `onMetrics`. Quiet when the fleet is healthy.
4. **Unified logs/alerts feed** (mirrors index) — collapsible panel aggregating `POST /v1/mirrors/logs` across mirrors with error/warn/info filters + per-mirror deep links. Mounted only when open.
5. **Slot health table** (peers) — replication slots across Postgres peers classified ok/warn/critical by lag, active state, WAL status; worst-first.
6. **Per-table operation mix** (mirror detail) — stacked insert/update/delete bars per table from `table_total_counts`.
7. **Authoritative rows-synced KPI** (mirror detail) — wires `GET /v1/mirrors/total_rows_synced/{flow}`.
8. **Peer info card** (peer detail) — mounts the existing card: redacted config + server version.

### Tests
Pure derivations unit-tested with `bun test` (`peerdb-derive.test.ts`, 15 tests): `batchDurationSec`, `cloneProgress`, `slotHealth`.

### Verification
Ran the bundled mock (`bun scripts/peerdb-mock-server.ts`) + dev server with `PEERDB_API_URL` and walked every page: mirrors index (lag triage: 2 mirrors behind; fleet logs: 16 entries, level tabs), SNAPSHOT mirror `events_snapshot` (24/26 partitions 92%, fetch/consolidate badges, avg 7.0s), RUNNING mirror `orders_cdc` (12 batches, LSN ranges, operation mix, rows-synced total 18M), peers (pg-staging **CRITICAL** 4.08 GiB unreserved sorted first), peer detail (peer info + PostgreSQL 16.3 version). Mock extended with `initial_load` clone summaries, `total_rows_synced`, and a risky `pg-staging` slot fixture.

### Notes
- No `components/ui/` edits; `Pdb*` primitives kept (not ported to recharts).
- Docs updated: `guide/features/peerdb.mdx` + `operate/advanced/peerdb-monitoring.mdx`.
