### PR TITLE
fix(api): disable query cache when table row cap sets a non-throw overflow mode

### DIFF
--- a/apps/dashboard/src/lib/api/__tests__/query-executor.query-cache.test.ts
+++ b/apps/dashboard/src/lib/api/__tests__/query-executor.query-cache.test.ts
@@ -59,16 +59,31 @@ describe('query-executor ClickHouse query-cache wiring (#2182)', () => {
     mockFetchJsonEachRow.mockClear()
   })
 
-  test('executeTableConfig applies use_query_cache with the config refreshInterval as TTL', async () => {
-    await executeTableConfig(
-      { name: 't', sql: 'SELECT 1', columns: [], refreshInterval: 15000 },
-      0,
-      undefined
-    )
+  test('executeTableConfig applies use_query_cache with the config refreshInterval as TTL when the row cap is disabled', async () => {
+    // The default row cap (#2490) sets result_overflow_mode: 'break', which
+    // ClickHouse forbids combining with use_query_cache (error 731) — see
+    // the dedicated regression test below. Disable the cap here
+    // (CHM_TABLE_MAX_RESULT_ROWS=0) to exercise the cache-applies path.
+    const prevCap = process.env.CHM_TABLE_MAX_RESULT_ROWS
+    process.env.CHM_TABLE_MAX_RESULT_ROWS = '0'
+    try {
+      await executeTableConfig(
+        { name: 't', sql: 'SELECT 1', columns: [], refreshInterval: 15000 },
+        0,
+        undefined
+      )
+    } finally {
+      if (prevCap === undefined) {
+        delete process.env.CHM_TABLE_MAX_RESULT_ROWS
+      } else {
+        process.env.CHM_TABLE_MAX_RESULT_ROWS = prevCap
+      }
+    }
 
     const settings = mockFetchData.mock.calls[0]?.[0]?.clickhouse_settings as
       | Record<string, unknown>
       | undefined
+    expect(settings?.result_overflow_mode).toBeUndefined()
     expect(settings?.use_query_cache).toBe(1)
     expect(settings?.query_cache_ttl).toBe(15)
     expect(settings?.query_cache_nondeterministic_function_handling).toBe(
@@ -105,6 +120,26 @@ describe('query-executor ClickHouse query-cache wiring (#2182)', () => {
       | Record<string, unknown>
       | undefined
     expect(settings?.use_query_cache).toBe(0)
+  })
+
+  test('executeTableConfig skips the query cache when the row cap sets a non-throw overflow mode (#history-queries timeout)', async () => {
+    // Regression test: ClickHouse throws error 731
+    // (QUERY_CACHE_USED_WITH_NON_THROW_OVERFLOW_MODE) when use_query_cache
+    // and a non-'throw' overflow mode are combined. The default row cap
+    // (#2490) sets result_overflow_mode: 'break', so every capped table
+    // query used to fail once the query cache (#2182) was also enabled.
+    await executeTableConfig(
+      { name: 't', sql: 'SELECT 1', columns: [], refreshInterval: 15000 },
+      0,
+      undefined
+    )
+
+    const settings = mockFetchData.mock.calls[0]?.[0]?.clickhouse_settings as
+      | Record<string, unknown>
+      | undefined
+    expect(settings?.result_overflow_mode).toBe('break')
+    expect(settings?.use_query_cache).toBeUndefined()
+    expect(settings?.query_cache_ttl).toBeUndefined()
   })
 
   test('executeChartQuery applies use_query_cache using the passed ttlSeconds', async () => {

--- a/apps/dashboard/src/lib/api/query-executor.ts
+++ b/apps/dashboard/src/lib/api/query-executor.ts
@@ -170,15 +170,6 @@ export async function executeTableConfig<
     clickhouseVersion,
   } = await selectSqlForHost(queryConfig.sql, numericHostId)
 
-  // Read-only GET path (routes/api/v1/tables/$name.ts, explorer/*): safe to
-  // opt into the ClickHouse query cache (#2182). `queryConfig.clickhouseSettings`
-  // is spread after so a config can still override any of these explicitly.
-  const cacheSettings = buildQueryCacheSettings({
-    version: clickhouseVersion,
-    ttlSeconds: tableCacheTtlSeconds(queryConfig.refreshInterval),
-    disabled: queryConfig.disableQueryCache,
-  })
-
   // Server-side row cap (#2490): stop ClickHouse from shipping unbounded
   // result sets for `SELECT *`-style table configs. `result_overflow_mode:
   // 'break'` makes the server truncate instead of erroring, and the
@@ -193,6 +184,26 @@ export async function executeTableConfig<
     options.timezone,
     maxResultRows
   )
+
+  // ClickHouse rejects `use_query_cache` combined with a non-'throw'
+  // `result_overflow_mode` (error 731,
+  // QUERY_CACHE_USED_WITH_NON_THROW_OVERFLOW_MODE) — and the row cap above
+  // sets `result_overflow_mode: 'break'` whenever it's active, which fails
+  // EVERY capped table query outright once the query cache (#2182) is also
+  // enabled (e.g. history-queries). The row cap wins: skip the query cache
+  // for any query where a non-throw overflow mode is in effect.
+  const overflowModeBlocksCache =
+    tableSettings.result_overflow_mode !== undefined &&
+    tableSettings.result_overflow_mode !== 'throw'
+
+  // Read-only GET path (routes/api/v1/tables/$name.ts, explorer/*): safe to
+  // opt into the ClickHouse query cache (#2182). `queryConfig.clickhouseSettings`
+  // is spread after so a config can still override any of these explicitly.
+  const cacheSettings = buildQueryCacheSettings({
+    version: clickhouseVersion,
+    ttlSeconds: tableCacheTtlSeconds(queryConfig.refreshInterval),
+    disabled: queryConfig.disableQueryCache || overflowModeBlocksCache,
+  })
 
   const result = await withClickHouseQuerySpan(() =>
     fetchData<T[]>({


### PR DESCRIPTION
## Summary

`/history-queries` (and other table pages) were failing with ClickHouse error 731 `QUERY_CACHE_USED_WITH_NON_THROW_OVERFLOW_MODE` because two independently-shipped features collided: the read-only query cache (#2182, `use_query_cache: 1`) and the server-side row cap (#2490, `result_overflow_mode: 'break'`). ClickHouse rejects any query combining `use_query_cache` with a non-`'throw'` overflow mode, so every capped table query started failing outright. Fixes #2596.

## Changes

- `apps/dashboard/src/lib/api/query-executor.ts`: in `executeTableConfig`, compute the row-cap table settings first, then disable the query cache whenever `result_overflow_mode` is set to a non-`'throw'` value (i.e. whenever the row cap is actually active — the default for all table queries). Chart queries (`executeChartQuery` / `executeMultiChartQuery`) are untouched since they never set an overflow mode.
- `apps/dashboard/src/lib/api/__tests__/query-executor.query-cache.test.ts`: updated the existing cache-applies test to disable the row cap (`CHM_TABLE_MAX_RESULT_ROWS=0`) since that's now required for the cache to apply to a table query; added a regression test asserting the cache is skipped (and `result_overflow_mode: 'break'` still applied) under the default capped config.

## Test plan

- [x] `pnpm run lint` passes with no errors
- [x] `pnpm run build` passes (includes `tsc --noEmit`)
- [x] `pnpm run test:unit` (targeted: `bun test src/lib/api` — 950 pass, 0 fail; full `src/` run has pre-existing unrelated failures reproduced identically on `main` — sandboxed test-runner issue, `ReferenceError: URL is not defined`, unrelated to this change)
- [ ] Tested manually in local dev (`pnpm run dev`) — not run in this environment; verified against the reported live deployment symptom
- [ ] Docs updated in `docs/content/` if behaviour or config changed — not applicable, internal-only fix
- [ ] `docs/content/ai-agent.mdx` updated if agent tools/skills/env vars changed — not applicable

## Notes for reviewer

The row cap is on by default for essentially all table queries, so this effectively disables the query cache for table pages (charts keep it). That's the only correct outcome given ClickHouse's hard constraint — the row-cap's graceful truncation is a stronger guarantee than the caching optimization, and the two settings are not simultaneously satisfiable server-side.

---

Co-Authored-By: duyetbot <bot@duyet.net>


---
_Generated by [Claude Code](https://claude.ai/code/session_01VFzH8zXTSwzGCWmoWmpMuH)_