### PR TITLE
docs(blog): introduce PeerDB monitoring — blog post + marketing content

### DIFF
--- a/apps/blog/src/content/blog/peerdb-monitoring.md
+++ b/apps/blog/src/content/blog/peerdb-monitoring.md
@@ -1,0 +1,79 @@
+---
+title: "Monitoring PeerDB: snapshot progress, batch history, fleet lag, and slot health"
+description: "chmonitor's PeerDB section grew up — per-table snapshot progress, CDC batch history, a fleet-wide lag triage strip, a logs feed, and replication slot health, all read-only."
+date: 2026-07-11
+tag: Feature
+---
+
+If you're moving data from Postgres into ClickHouse, there's a good chance
+[PeerDB](https://docs.peerdb.io) is doing the moving. It's the CDC engine
+[ClickHouse acquired in 2024](https://clickhouse.com/blog/clickhouse-welcomes-peerdb-adding-the-fastest-postgres-cdc-to-the-fastest-olap-database)
+and now runs as the connector behind ClickPipes for Postgres — [more than 400
+companies](https://clickhouse.com/blog/postgres-cdc-year-in-review-2025)
+replicate over 200 TB of Postgres data through it every month. PeerDB itself
+stays free and open source under ELv2, whether you run it standalone or as
+part of ClickHouse Cloud.
+
+chmonitor has shipped a read-only PeerDB section for a while — mirrors, peers,
+basic status. This release makes it a real operating surface: snapshot
+progress, CDC batch history, a fleet-wide lag triage strip, a unified logs
+feed, and replication slot health.
+
+## Why a CDC pipeline needs its own monitoring
+
+A logical-replication pipeline fails in ways a batch job doesn't:
+
+- **Lag creeps, then spikes.** A mirror can look healthy for days and then
+  fall behind when a downstream sink stalls or a source table gets a burst of
+  writes. Catching that early is the difference between a five-minute blip and
+  a stale dashboard.
+- **Replication slots don't clean up after themselves.** A logical
+  replication slot holds Postgres WAL until every subscriber has consumed it.
+  If a mirror pauses or lags long enough, [WAL can grow to hundreds of
+  gigabytes and take the source database down with
+  it](https://blog.peerdb.io/overcoming-pitfalls-of-postgres-logical-decoding) —
+  slot health isn't a nice-to-have metric, it's a guard against an outage on
+  the *source* system, not just the pipeline.
+- **Snapshots and batches fail quietly.** Initial loads and individual CDC
+  batches can stall or error without necessarily flipping the mirror to a
+  loud "down" state. You want to see partition progress and batch history
+  directly, not infer it from a stale row count.
+
+## What chmonitor shows now
+
+<div class="hl-grid">
+  <div class="hl"><b>Snapshot progress</b><span>Per-table initial-load progress from PeerDB's initial_load data — partitions completed, rows synced, average time per partition, and fetch/consolidate phase.</span></div>
+  <div class="hl"><b>CDC batch history</b><span>Recent batches with id, LSN range, rows, and duration, plus a rows-per-batch chart on the mirror detail page.</span></div>
+  <div class="hl"><b>Operation mix</b><span>Per-table insert/update/delete split, so you can see what kind of writes are actually flowing through a mirror.</span></div>
+  <div class="hl"><b>Fleet lag triage</b><span>A worst-lag strip on the mirrors index — the 5 mirrors furthest behind, deep-linked straight to their detail page.</span></div>
+  <div class="hl"><b>Fleet logs feed</b><span>A collapsible feed aggregating logs and alerts across every mirror, filterable by error / warn / info.</span></div>
+  <div class="hl"><b>Slot health</b><span>Replication slots across all Postgres peers, classified ok / warn / critical by lag, active state, and WAL status, worst-first, on the Peers page.</span></div>
+</div>
+
+Peer detail pages also show the peer's redacted config, server version, and
+active queries — so if a mirror looks slow, you can check what else is
+running on the source without leaving chmonitor.
+
+## Read-only, proxied, same as everything else
+
+chmonitor never talks to Postgres or ClickHouse directly for this section —
+it proxies a read-only allowlist of the PeerDB REST API
+(`app/api/v1/peerdb/[...slug]`). Mutating calls (create, drop, pause,
+maintenance) are rejected with `403` at the proxy layer, so there's no path
+for chmonitor to change what PeerDB is doing. The credential lives
+server-side only, and anything secret-shaped in peer config is masked before
+it reaches the browser.
+
+## Connect it
+
+Set `PEERDB_API_URL` (and `PEERDB_PASSWORD` if your API requires auth), or
+add a PeerDB monitoring link when creating a host from the connection form's
+Advanced section. Full setup, caching knobs, and troubleshooting are in the
+[PeerDB monitoring docs](https://docs.chmonitor.dev/operate/advanced/peerdb-monitoring).
+
+It pairs naturally with [Postgres as a monitored source
+(beta)](/blog/postgres-monitoring-beta) — monitor the source database and the
+mirror moving its data in the same dashboard.
+
+Try it on the [live dashboard](https://dash.chmonitor.dev), or open an issue
+on [GitHub](https://github.com/chmonitor/chmonitor) with feedback.

--- a/apps/blog/src/content/blog/postgres-monitoring-beta.md
+++ b/apps/blog/src/content/blog/postgres-monitoring-beta.md
@@ -65,7 +65,9 @@ what's slow, what's the cache hit ratio, what's currently running.
 If you're moving data from Postgres into ClickHouse, the agent's
 migration-planning skill now covers that path too, with
 [PeerDB](https://docs.chmonitor.dev/guide/features/peerdb) as the recommended
-CDC route.
+CDC route. Already running a CDC pipeline? See [Monitoring
+PeerDB](/blog/peerdb-monitoring) for snapshot progress, batch history, lag
+triage, and replication-slot health.
 
 ## Try it
 

--- a/apps/landing/src/components/Capabilities.astro
+++ b/apps/landing/src/components/Capabilities.astro
@@ -25,7 +25,7 @@
             <svg class="size-4 text-muted-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="12" cy="18" r="2"/><path d="M6 8v3a3 3 0 0 0 3 3h6a3 3 0 0 0 3-3V8"/><path d="M12 14v2"/></svg>
           </span>
           <h4 class="mt-4 font-semibold tracking-tight">PeerDB replication</h4>
-          <p class="mt-2 text-sm text-muted-foreground">Watch mirrors and peers with live status, rows-synced trend and routing, failures surface immediately.</p>
+          <p class="mt-2 text-sm text-muted-foreground">Watch mirrors and peers with live status, rows-synced trend and routing, plus snapshot progress, CDC batch history and replication-slot health, failures surface immediately.</p>
         </div>
         <div class="reveal rounded-xl border border-border bg-card p-6 shadow-sm transition-colors hover:border-ring/40">
           <span class="inline-flex size-9 items-center justify-center rounded-lg bg-muted">

--- a/docs/content/operate/advanced/peerdb-monitoring.mdx
+++ b/docs/content/operate/advanced/peerdb-monitoring.mdx
@@ -9,6 +9,10 @@ surfaces replication status, throughput, lag, and per-mirror detail from a
 [PeerDB](https://docs.peerdb.io) deployment. CHM never mutates PeerDB — it
 proxies a read-only allowlist of the PeerDB REST API.
 
+**Further reading**: see the [blog post](https://chmonitor.dev/blog/peerdb-monitoring)
+for why CDC pipelines need this kind of monitoring — lag, replication-slot
+growth, and batch failures — and a walkthrough of the views below.
+
 <Callout type="info">
 Open it at `/peerdb` once configured. The section is hidden until
 `PEERDB_API_URL` is set.
@@ -119,3 +123,5 @@ PEERDB_API_URL=http://localhost:8113 pnpm run dev     # → /peerdb
     description="Full reference for all PeerDB and connection variables."
   />
 </Cards>
+
+Blog: [Monitoring PeerDB: snapshot progress, batch history, fleet lag, and slot health](https://chmonitor.dev/blog/peerdb-monitoring)


### PR DESCRIPTION
## Summary
- New blog post `apps/blog/src/content/blog/peerdb-monitoring.md` announcing the richer PeerDB monitoring views shipped in #2594 (snapshot progress, CDC batch history, fleet lag triage, logs feed, replication-slot health), grounded in the actual features that shipped — no invented capabilities.
- `docs/content/operate/advanced/peerdb-monitoring.mdx` — added a cross-link to the new blog post (intro + Related section).
- `apps/blog/src/content/blog/postgres-monitoring-beta.md` — added a reciprocal link pointing readers running a CDC pipeline to the new PeerDB post.
- `apps/landing/src/components/Capabilities.astro` — extended the existing "PeerDB replication" capability card copy to mention snapshot progress, CDC batch history, and slot health.

## Research
- PeerDB is the open-source Postgres CDC engine ClickHouse acquired in 2024; it now powers the Postgres CDC connector in ClickPipes (GA May 2025), with 400+ companies replicating 200+ TB/month. Source: [ClickHouse blog](https://clickhouse.com/blog/clickhouse-welcomes-peerdb-adding-the-fastest-postgres-cdc-to-the-fastest-olap-database), [year-in-review](https://clickhouse.com/blog/postgres-cdc-year-in-review-2025).
- Replication-slot monitoring matters because an unconsumed logical slot retains Postgres WAL indefinitely — under load this can grow to hundreds of GB and crash the *source* database, not just stall the pipeline. Source: [PeerDB blog](https://blog.peerdb.io/overcoming-pitfalls-of-postgres-logical-decoding).

## Test plan
- [x] `pnpm run build` in `apps/blog` — succeeds, new post renders as `/peerdb-monitoring/index.html`
- [x] Cross-links verified between the two blog posts and the docs page
- [x] Pre-commit/pre-push hooks (Biome, type-check, dashboard unit tests) passed

https://claude.ai/code/session_011a1CRbruQCZCPdjj2ntKjZ