### PR TITLE
fix(peerdb): load page-level metrics without row expansion

### DIFF
--- a/apps/dashboard/src/components/peerdb/peerdb-derive.test.ts
+++ b/apps/dashboard/src/components/peerdb/peerdb-derive.test.ts
@@ -1,8 +1,10 @@
 import {
   batchDurationSec,
   cloneProgress,
+  EAGER_METRICS_LIMIT,
   SLOT_LAG_CRITICAL_MB,
   SLOT_LAG_WARN_MB,
+  shouldEagerLoadMetrics,
   slotHealth,
 } from './peerdb-derive'
 import { describe, expect, test } from 'bun:test'
@@ -136,5 +138,35 @@ describe('slotHealth', () => {
     expect(
       slotHealth({ lagInMb: 2, active: false, walStatus: 'reserved' })
     ).toBe('ok')
+  })
+})
+
+describe('shouldEagerLoadMetrics', () => {
+  // Regression: page-level KPIs/sparklines/lag-triage aggregate from per-row
+  // metrics. Before the fix, a fleet larger than the budget loaded NO row
+  // metrics until a row was expanded, so every page total rendered as 0.
+  test('the first row always loads on mount, even for huge fleets', () => {
+    // A 500-mirror fleet must still populate at least the top rows on mount so
+    // the header totals are non-zero before any expansion.
+    expect(shouldEagerLoadMetrics(0)).toBe(true)
+    expect(shouldEagerLoadMetrics(EAGER_METRICS_LIMIT - 1)).toBe(true)
+  })
+
+  test('rows past the budget load lazily (on expand), capping API fan-out', () => {
+    expect(shouldEagerLoadMetrics(EAGER_METRICS_LIMIT)).toBe(false)
+    expect(shouldEagerLoadMetrics(499)).toBe(false)
+  })
+
+  test('small fleets load every row eagerly', () => {
+    // A 10-mirror fleet: indices 0..9 are all within the budget.
+    for (let i = 0; i < 10; i++) {
+      expect(shouldEagerLoadMetrics(i)).toBe(true)
+    }
+  })
+
+  test('respects a custom limit and rejects negative indices', () => {
+    expect(shouldEagerLoadMetrics(4, 5)).toBe(true)
+    expect(shouldEagerLoadMetrics(5, 5)).toBe(false)
+    expect(shouldEagerLoadMetrics(-1)).toBe(false)
   })
 })

--- a/apps/dashboard/src/components/peerdb/peerdb-derive.ts
+++ b/apps/dashboard/src/components/peerdb/peerdb-derive.ts
@@ -43,6 +43,29 @@ export function cloneProgress(summary: CloneTableSummary): CloneProgress {
   }
 }
 
+/**
+ * Cap on how many mirror rows fetch live metrics eagerly on page mount.
+ * Bounds the PeerDB API fan-out for huge fleets while still populating the
+ * page-level KPI totals, sparklines, and lag-triage strip BEFORE any row is
+ * expanded. Fleets larger than the limit render a "N/total loaded" partial.
+ */
+export const EAGER_METRICS_LIMIT = 24
+
+/**
+ * Whether the mirror at `visibleIndex` should fetch its metrics eagerly, i.e.
+ * without waiting for the user to expand the row. The first EAGER_METRICS_LIMIT
+ * rows always load so the header KPIs / sparklines / lag triage are non-zero on
+ * mount — regardless of fleet size. Previously this was gated on the WHOLE
+ * fleet being <= the limit, which left every row (and thus every page-level
+ * total) at zero until a row was expanded on large fleets.
+ */
+export function shouldEagerLoadMetrics(
+  visibleIndex: number,
+  limit: number = EAGER_METRICS_LIMIT
+): boolean {
+  return visibleIndex >= 0 && visibleIndex < limit
+}
+
 export type SlotHealth = 'ok' | 'warn' | 'critical'
 
 /** Lag thresholds (MiB) for replication-slot health classification. */

--- a/apps/dashboard/src/routes/(peerdb)/peerdb/index.tsx
+++ b/apps/dashboard/src/routes/(peerdb)/peerdb/index.tsx
@@ -19,6 +19,10 @@ import { FleetLogsFeed } from '@/components/peerdb/fleet-logs-feed'
 import { KpiCard } from '@/components/peerdb/kpi-card'
 import { MirrorRow } from '@/components/peerdb/mirror-row'
 import { PeerGraph } from '@/components/peerdb/peer-graph'
+import {
+  EAGER_METRICS_LIMIT,
+  shouldEagerLoadMetrics,
+} from '@/components/peerdb/peerdb-derive'
 import { PeerDBNotConfigured } from '@/components/peerdb/peerdb-not-configured'
 import {
   DESIGN_STATUS_META,
@@ -205,8 +209,13 @@ function PeerDBMirrorsPage() {
     return <PeerDBNotConfigured />
   }
 
-  // Small fleets eagerly load per-row metrics; large fleets load lazily on expand.
-  const eagerMetrics = mirrors.length > 0 && mirrors.length <= 24
+  // The first EAGER_METRICS_LIMIT rows always load metrics on mount so the
+  // header KPIs, sparklines, and lag triage are populated before any row is
+  // expanded; the rest load lazily on expand to cap the PeerDB API fan-out.
+  // `eagerMetrics` here means "the whole fleet fits the eager budget" and only
+  // drives the KPI sub-label (all vs partial), not the per-row gating.
+  const eagerMetrics =
+    mirrors.length > 0 && mirrors.length <= EAGER_METRICS_LIMIT
 
   const toggleRow = (id: string) =>
     setExpanded((prev) => {
@@ -513,13 +522,13 @@ function PeerDBMirrorsPage() {
               </tr>
             </thead>
             <tbody>
-              {visible.map((m) => (
+              {visible.map((m, i) => (
                 <MirrorRow
                   key={m.name}
                   mirror={m}
                   expanded={expanded.has(m.name)}
                   onToggle={() => toggleRow(m.name)}
-                  loadMetrics={eagerMetrics}
+                  loadMetrics={shouldEagerLoadMetrics(i)}
                   onMetrics={onMetrics}
                 />
               ))}


### PR DESCRIPTION
## Problem

On the PeerDB monitoring page (`apps/dashboard`), the page-level metrics all rendered as **0** until the user expanded a row in the mirrors table:
- "Rows synced (trend)" = 0, "Throughput" = 0, all KPI totals/counts = 0
- Sparklines rendered as flat zero lines

Expanding any row made real values appear.

## Root cause

The page header KPIs (`totals.rowsPerSec` / `totals.rowsSynced` / `totals.aggTrend`), the `KpiCard` sparklines, and the `FleetLagTriage` strip all aggregate from a `metrics` map populated by each `MirrorRow` via its `onMetrics` callback. But `MirrorRow` only fetches its metrics (`useMirrorMetrics(..., loadMetrics || expanded)`) when the row is expanded **or** when the *entire fleet* fit an eager budget:

```ts
const eagerMetrics = mirrors.length > 0 && mirrors.length <= 24
// ...
loadMetrics={eagerMetrics}
```

For any fleet larger than 24 mirrors, `eagerMetrics` was `false` for **every** row, so no row fetched metrics on mount and every page-level aggregate stayed at 0 until a row was expanded.

## Fix

Gate eager loading **per-row** instead of **per-fleet**. The first `EAGER_METRICS_LIMIT` (24) visible rows always load their metrics on mount, so the header KPIs, sparklines, and lag triage populate before any expansion — while rows beyond the budget still load lazily on expand, preserving the API fan-out cap. Large fleets now show the existing `"N/total loaded"` partial label instead of zeros.

The decision is extracted into a pure, unit-tested `shouldEagerLoadMetrics(index)` helper in `peerdb-derive.ts`. No duplicate polling is introduced — each mirror is still one SWR-deduped fetch set; the expanded-row detail fetch is unchanged.

## Test evidence

- New `shouldEagerLoadMetrics` suite in `peerdb-derive.test.ts` encodes the regression ("the first row always loads on mount, even for huge fleets"). `bun test` → 19 pass / 0 fail.
- `pnpm run type-check` clean (after route-tree generation via `pnpm run build`, which succeeded and prerendered all peerdb pages).
- Biome check clean.

https://claude.ai/code/session_011a1CRbruQCZCPdjj2ntKjZ