### PR TITLE
fix(running-queries): keep page toolbar visible on empty results

### DIFF
--- a/apps/dashboard/src/components/query-tables/empty-state.tsx
+++ b/apps/dashboard/src/components/query-tables/empty-state.tsx
@@ -1,6 +1,14 @@
 /** The default empty-state copy shared by the query tables. */
 export const NO_QUERIES_MESSAGE = 'No queries match your filters'
 
+/**
+ * Copy for when the underlying data set itself is empty (no rows fetched at
+ * all), as opposed to `NO_QUERIES_MESSAGE` which covers a non-empty data set
+ * filtered down to zero visible rows.
+ */
+export const NO_ACTIVE_QUERIES_MESSAGE =
+  'Nothing is executing on this host right now. New queries appear here automatically.'
+
 /** Empty-state for the card list — a centered muted message. */
 export function EmptyCards({
   message = NO_QUERIES_MESSAGE,

--- a/apps/dashboard/src/components/running-queries/running-queries-table.tsx
+++ b/apps/dashboard/src/components/running-queries/running-queries-table.tsx
@@ -6,6 +6,7 @@ import {
 } from 'lucide-react'
 
 import { downloadRunningCsv } from './table/csv'
+import { getEmptyMessage } from './table/empty-message'
 import { QueryCard } from './table/query-card'
 import { QueryRow } from './table/query-row'
 import { KindFilter } from './table/toolbar'
@@ -168,6 +169,11 @@ export const RunningQueriesTable = memo(function RunningQueriesTable({
   const moreFiltersActive = filterInterface !== 'all' || longRunningOnly
   const totalColumns =
     BASE_COLUMN_COUNT + (OPTIONAL_COLUMNS.length - hiddenColumns.size)
+  // No queries executing at all (vs. a non-empty list filtered down to zero)
+  // gets friendlier copy — the toolbar/table shell still renders either way so
+  // search, filters, column visibility and export stay reachable while waiting
+  // for queries to appear.
+  const emptyMessage = getEmptyMessage(rows.length, doneRows.length)
 
   const handleSort = useCallback((key: string) => {
     const k = key as SortKey
@@ -347,7 +353,9 @@ export const RunningQueriesTable = memo(function RunningQueriesTable({
               onToggle={() => onToggle(d.key)}
             />
           ))}
-          {visible.length === 0 && derivedDone.length === 0 && <EmptyCards />}
+          {visible.length === 0 && derivedDone.length === 0 && (
+            <EmptyCards message={emptyMessage} />
+          )}
         </div>
       ) : (
         /* Table — table-fixed so the Query column truncates instead of pushing
@@ -464,7 +472,7 @@ export const RunningQueriesTable = memo(function RunningQueriesTable({
                 />
               ))}
               {visible.length === 0 && derivedDone.length === 0 && (
-                <EmptyTableRow colSpan={totalColumns} />
+                <EmptyTableRow colSpan={totalColumns} message={emptyMessage} />
               )}
             </tbody>
           </table>

--- a/apps/dashboard/src/components/running-queries/running-queries-view.tsx
+++ b/apps/dashboard/src/components/running-queries/running-queries-view.tsx
@@ -356,25 +356,18 @@ export const RunningQueriesView = function RunningQueriesView() {
                 onExpand={() => setChartsOpen(true)}
               />
             )}
-            {rows.length === 0 && doneRowsArr.length === 0 ? (
-              <Card className="rounded-xl border-dashed">
-                <CardContent className="p-6">
-                  <EmptyState
-                    variant="no-data"
-                    title="No queries running"
-                    description="Nothing is executing on this host right now. New queries appear here automatically."
-                  />
-                </CardContent>
-              </Card>
-            ) : (
-              <RunningQueriesTable
-                rows={rows}
-                doneRows={doneRowsArr}
-                expanded={expanded}
-                onToggle={toggleExpanded}
-                onDismiss={dismissDone}
-              />
-            )}
+            {/* The table renders its own toolbar (search, filters, column
+                visibility, export) regardless of row count — an empty
+                live/done set only swaps the body region for an inline empty
+                message, so those controls stay reachable while waiting for
+                queries to appear. */}
+            <RunningQueriesTable
+              rows={rows}
+              doneRows={doneRowsArr}
+              expanded={expanded}
+              onToggle={toggleExpanded}
+              onDismiss={dismissDone}
+            />
             <CompletedQueriesTable
               rows={mergedCompleted}
               justFinishedIds={justFinishedIds}

--- a/apps/dashboard/src/components/running-queries/table/empty-message.test.ts
+++ b/apps/dashboard/src/components/running-queries/table/empty-message.test.ts
@@ -1,0 +1,17 @@
+import { getEmptyMessage } from './empty-message'
+import { describe, expect, test } from 'bun:test'
+import { NO_ACTIVE_QUERIES_MESSAGE } from '@/components/query-tables/empty-state'
+
+describe('getEmptyMessage — running-queries table body copy', () => {
+  test('returns the "nothing running" message when there are no live or done rows', () => {
+    expect(getEmptyMessage(0, 0)).toBe(NO_ACTIVE_QUERIES_MESSAGE)
+  })
+
+  test('falls back to the default "no matches" copy when live rows exist but are filtered out', () => {
+    expect(getEmptyMessage(3, 0)).toBeUndefined()
+  })
+
+  test('falls back to the default copy when only retained Done rows exist', () => {
+    expect(getEmptyMessage(0, 1)).toBeUndefined()
+  })
+})

--- a/apps/dashboard/src/components/running-queries/table/empty-message.ts
+++ b/apps/dashboard/src/components/running-queries/table/empty-message.ts
@@ -1,0 +1,20 @@
+import { NO_ACTIVE_QUERIES_MESSAGE } from '@/components/query-tables/empty-state'
+
+/**
+ * Pick the empty-state copy for the running-queries table body.
+ *
+ * The table always renders its toolbar (search, filters, column visibility,
+ * export) regardless of row count — only the body region swaps to an empty
+ * message. That message differs by cause:
+ * - No live or retained-Done rows at all → friendlier "nothing running" copy.
+ * - Otherwise (a non-empty data set filtered down to zero) → `undefined`,
+ *   letting the caller fall back to the shared "no matches" default.
+ */
+export function getEmptyMessage(
+  rowCount: number,
+  doneRowCount: number
+): string | undefined {
+  return rowCount === 0 && doneRowCount === 0
+    ? NO_ACTIVE_QUERIES_MESSAGE
+    : undefined
+}


### PR DESCRIPTION
## Summary
- On `/running-queries?host=0`, an empty running-queries list used to unmount the whole `RunningQueriesTable` (search, kind/user/interface filters, column-visibility menu, CSV export) in favor of a standalone `EmptyState` card — the page's only toolbar lived inside that table, so it vanished along with the rows.
- The table now always renders its toolbar/shell; only the body region (cards grid or `<tbody>`) swaps to an inline empty message when there are no live or retained-Done rows.
- Added `NO_ACTIVE_QUERIES_MESSAGE` (nothing-running copy) alongside the existing `NO_QUERIES_MESSAGE` (filtered-to-zero copy) in the shared `components/query-tables/empty-state.tsx`, and a small pure `getEmptyMessage(rowCount, doneRowCount)` helper (mirroring the existing `done-retention.ts` pattern) to pick between them.

## Root cause / scope
This page (`running-queries-view.tsx` / `running-queries-table.tsx`) is a bespoke layout, not the shared `PageLayout` (`components/layout/query-page/`) used by most config-driven pages — so this is a **page-specific** fix, not a generic data-table/PageLayout bug. Verified no other page shares this empty-replaces-toolbar pattern (`expensive-queries-table.tsx` reuses the same `EmptyCards`/`EmptyTableRow` primitives but was never affected, since its parent view didn't have the whole-table replacement).

## Test plan
- [x] `bun test src/components/running-queries/table/empty-message.test.ts src/components/running-queries/table/done-retention.test.ts` — 11 pass
- [x] Full `bun test` suite (via pre-push hook) — 962 pass, 0 fail
- [x] `pnpm run type-check` — no new errors introduced (pre-existing unrelated `routeTree.gen` noise across all `src/routes/**` files, present before this change)

https://claude.ai/code/session_011a1CRbruQCZCPdjj2ntKjZ