### PR TITLE
feat(insights): clickable findings open a detail dialog with explanatory charts

### DIFF
--- a/apps/dashboard/src/components/insights/insight-card.tsx
+++ b/apps/dashboard/src/components/insights/insight-card.tsx
@@ -2,6 +2,8 @@ import { ArrowRight, X } from 'lucide-react'
 
 import type { InsightCard as InsightCardData } from '@/lib/insights/types'
 
+import { useState } from 'react'
+import { InsightDetailDialog } from '@/components/insights/insight-detail-dialog'
 import { SEVERITY_META } from '@/components/insights/severity-meta'
 import { AppLink as Link } from '@/components/ui/app-link'
 import { Badge } from '@/components/ui/badge'
@@ -31,6 +33,7 @@ export function InsightCard({
   className,
   linkSearch,
 }: InsightCardProps) {
+  const [detailOpen, setDetailOpen] = useState(false)
   const style = SEVERITY_META[insight.severity]
   const Icon = style.icon
 
@@ -49,8 +52,18 @@ export function InsightCard({
 
   return (
     <Card
+      role="button"
+      tabIndex={0}
+      aria-label={`View insight: ${insight.title}`}
+      onClick={() => setDetailOpen(true)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          setDetailOpen(true)
+        }
+      }}
       className={cn(
-        'h-full gap-0 border-l-0 p-4 transition-colors',
+        'h-full cursor-pointer gap-0 border-l-0 p-4 transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
         style.accent,
         className
       )}
@@ -70,7 +83,10 @@ export function InsightCard({
           size="icon"
           className="-mr-1.5 -mt-1.5 size-7 shrink-0 text-muted-foreground/50 hover:text-muted-foreground"
           aria-label={`Dismiss insight: ${insight.title}`}
-          onClick={() => onDismiss(insight)}
+          onClick={(e) => {
+            e.stopPropagation()
+            onDismiss(insight)
+          }}
         >
           <X className="size-3.5" />
         </Button>
@@ -106,13 +122,24 @@ export function InsightCard({
             variant="ghost"
             size="sm"
             className="h-6 gap-1 px-0 text-xs font-normal text-muted-foreground hover:text-foreground"
-            render={<Link href={actionHref} />}
+            render={
+              <Link href={actionHref} onClick={(e) => e.stopPropagation()} />
+            }
           >
             {action.label}
             <ArrowRight className="size-3" />
           </Button>
         ) : null}
       </div>
+
+      <InsightDetailDialog
+        insight={insight}
+        hostId={hostId}
+        open={detailOpen}
+        onOpenChange={setDetailOpen}
+        onDismiss={onDismiss}
+        linkSearch={linkSearch}
+      />
     </Card>
   )
 }

--- a/apps/dashboard/src/components/insights/insight-detail-dialog.tsx
+++ b/apps/dashboard/src/components/insights/insight-detail-dialog.tsx
@@ -1,0 +1,202 @@
+/**
+ * Insight detail dialog.
+ *
+ * Opened by clicking a finding — either a row in the header `InsightsPopover` or
+ * an `InsightCard` on the overview strip / insights board. Shows the full,
+ * untruncated finding (title + severity + description + timestamp + category /
+ * metric), the finding's existing deep-link action, an optional dismiss action
+ * (reusing the same per-user dismissal mutation as the card/popover), and — when
+ * the finding maps to one — the explanatory chart(s) that visualize it
+ * (`lib/insights/insight-charts`, rendered via the chart registry). Findings
+ * with no mapped chart simply omit the charts section.
+ */
+
+import { ArrowRight, X } from 'lucide-react'
+
+import type { InsightCard as InsightCardData } from '@/lib/insights/types'
+
+import { Suspense } from 'react'
+import { getChartComponent } from '@/components/charts/chart-registry'
+import { SEVERITY_META } from '@/components/insights/severity-meta'
+import { DynamicChart } from '@/components/layout/query-page/dynamic-chart'
+import { ChartSkeleton } from '@/components/skeletons/chart'
+import { AppLink as Link } from '@/components/ui/app-link'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Separator } from '@/components/ui/separator'
+import { insightChartNames } from '@/lib/insights/insight-charts'
+import { buildUrl } from '@/lib/url/url-builder'
+import { cn } from '@/lib/utils'
+import { formatRelativeTime } from '@/lib/utils/format-relative-time'
+
+interface InsightDetailDialogProps {
+  insight: InsightCardData
+  hostId: number
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Reuse the caller's per-user dismissal. When omitted, no dismiss button. */
+  onDismiss?: (insight: InsightCardData) => void
+  /**
+   * Search params for the action deep-link, overriding the default
+   * `{ host: hostId }` (Postgres insights pass their `?pg=` source). Mirrors
+   * `InsightCard`'s `linkSearch`.
+   */
+  linkSearch?: Record<string, string | number>
+}
+
+function titleCase(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1)
+}
+
+export function InsightDetailDialog({
+  insight,
+  hostId,
+  open,
+  onOpenChange,
+  onDismiss,
+  linkSearch,
+}: InsightDetailDialogProps) {
+  const style = SEVERITY_META[insight.severity]
+  const Icon = style.icon
+
+  const generatedMs = insight.generatedAt
+    ? new Date(insight.generatedAt).getTime()
+    : Number.NaN
+  const hasGeneratedAt = Number.isFinite(generatedMs)
+
+  const linkParams = linkSearch ?? { host: hostId }
+  const action = insight.action
+  const actionHref = action?.href
+    ? buildUrl(action.href, linkParams)
+    : action?.prompt
+      ? buildUrl('/agents', linkParams)
+      : undefined
+
+  // Only render charts that actually exist in the registry, so an unknown key
+  // never produces a broken chart.
+  const chartNames = insightChartNames(insight).filter((name) =>
+    Boolean(getChartComponent(name))
+  )
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <div className="flex items-start gap-3">
+            <div
+              className={cn(
+                'mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md',
+                style.iconBg
+              )}
+            >
+              <Icon className={cn('size-4', style.iconColor)} />
+            </div>
+            <div className="min-w-0 flex-1">
+              <DialogTitle className="text-base leading-snug">
+                {insight.title}
+              </DialogTitle>
+              <div className="mt-2 flex flex-wrap items-center gap-2">
+                <Badge
+                  variant="outline"
+                  className={cn('text-[10px] font-medium', style.badge)}
+                >
+                  {style.label}
+                </Badge>
+                <Badge variant="secondary" className="text-[10px] font-medium">
+                  {titleCase(insight.category)}
+                </Badge>
+                {insight.metric ? (
+                  <Badge
+                    variant="outline"
+                    className="font-mono text-[10px] text-muted-foreground"
+                  >
+                    {insight.metric}
+                  </Badge>
+                ) : null}
+                {hasGeneratedAt ? (
+                  <time
+                    dateTime={insight.generatedAt}
+                    title={new Date(generatedMs).toLocaleString()}
+                    className="text-[11px] text-muted-foreground/80"
+                  >
+                    {formatRelativeTime(generatedMs)}
+                  </time>
+                ) : null}
+              </div>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <DialogDescription className="whitespace-pre-wrap text-sm leading-relaxed text-foreground">
+          {insight.detail}
+        </DialogDescription>
+
+        {chartNames.length > 0 ? (
+          <>
+            <Separator />
+            <div className="space-y-2">
+              <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                {chartNames.length > 1 ? 'Related charts' : 'Related chart'}
+              </p>
+              <div
+                className={cn(
+                  'grid gap-3',
+                  chartNames.length > 1 ? 'sm:grid-cols-2' : 'grid-cols-1'
+                )}
+              >
+                {chartNames.map((name) => (
+                  <div key={name} className="rounded-lg border bg-card p-3">
+                    <Suspense fallback={<ChartSkeleton />}>
+                      <DynamicChart chartName={name} />
+                    </Suspense>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </>
+        ) : null}
+
+        <DialogFooter className="gap-2 sm:justify-between">
+          {onDismiss ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="gap-1.5 text-muted-foreground hover:text-foreground"
+              onClick={() => {
+                onDismiss(insight)
+                onOpenChange(false)
+              }}
+            >
+              <X className="size-3.5" />
+              Dismiss
+            </Button>
+          ) : (
+            <span />
+          )}
+          {action && actionHref ? (
+            <Button
+              type="button"
+              size="sm"
+              className="gap-1.5"
+              render={
+                <Link href={actionHref} onClick={() => onOpenChange(false)} />
+              }
+            >
+              {action.label}
+              <ArrowRight className="size-3.5" />
+            </Button>
+          ) : null}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/dashboard/src/components/insights/insights-popover.tsx
+++ b/apps/dashboard/src/components/insights/insights-popover.tsx
@@ -22,6 +22,7 @@ import {
 import type { InsightCard, InsightSeverity } from '@/lib/insights/types'
 
 import { useState } from 'react'
+import { InsightDetailDialog } from '@/components/insights/insight-detail-dialog'
 import { AppLink as Link } from '@/components/ui/app-link'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -67,6 +68,7 @@ export function InsightsPopover() {
     refresh,
     generate,
     isGenerating,
+    dismiss,
   } = useInsights(hostId)
 
   const total = counts.critical + counts.warning + counts.info
@@ -185,7 +187,8 @@ export function InsightsPopover() {
                 key={insight.key}
                 insight={insight}
                 hostId={hostId}
-                onNavigate={() => setIsOpen(false)}
+                onDismiss={dismiss}
+                onOpenDetail={() => setIsOpen(false)}
               />
             ))}
           </div>
@@ -227,40 +230,63 @@ export function InsightsPopover() {
 function InsightsPopoverItem({
   insight,
   hostId,
-  onNavigate,
+  onDismiss,
+  onOpenDetail,
 }: {
   insight: InsightCard
   hostId: number
-  onNavigate: () => void
+  onDismiss: (insight: InsightCard) => void
+  /** Called when the detail dialog opens, so the popover can close behind it. */
+  onOpenDetail: () => void
 }) {
+  const [detailOpen, setDetailOpen] = useState(false)
   const Icon = SEVERITY_ICON[insight.severity]
-  // Link to the insight's own action when it has one, else the overview panel.
-  const href = insight.action?.href
-    ? buildUrl(insight.action.href, { host: hostId })
-    : buildUrl('/overview', { host: hostId })
+
+  const open = () => {
+    setDetailOpen(true)
+    onOpenDetail()
+  }
 
   return (
-    <Link
-      href={href}
-      onClick={onNavigate}
-      className="group relative block rounded-md transition-colors hover:bg-muted/50"
-    >
-      <div className="flex items-start gap-3 px-3 py-2.5">
-        <div
-          className={cn(
-            'mt-0.5 shrink-0 rounded-md p-1.5',
-            SEVERITY_BG[insight.severity]
-          )}
-        >
-          <Icon className={cn('size-4', SEVERITY_COLOR[insight.severity])} />
-        </div>
-        <div className="min-w-0 flex-1 space-y-0.5">
-          <p className="truncate text-sm font-medium">{insight.title}</p>
-          <p className="line-clamp-2 text-xs text-muted-foreground">
-            {insight.detail}
-          </p>
+    <>
+      <div
+        role="button"
+        tabIndex={0}
+        aria-label={`View insight: ${insight.title}`}
+        onClick={open}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            open()
+          }
+        }}
+        className="group relative block cursor-pointer rounded-md transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <div className="flex items-start gap-3 px-3 py-2.5">
+          <div
+            className={cn(
+              'mt-0.5 shrink-0 rounded-md p-1.5',
+              SEVERITY_BG[insight.severity]
+            )}
+          >
+            <Icon className={cn('size-4', SEVERITY_COLOR[insight.severity])} />
+          </div>
+          <div className="min-w-0 flex-1 space-y-0.5">
+            <p className="truncate text-sm font-medium">{insight.title}</p>
+            <p className="line-clamp-2 text-xs text-muted-foreground">
+              {insight.detail}
+            </p>
+          </div>
         </div>
       </div>
-    </Link>
+
+      <InsightDetailDialog
+        insight={insight}
+        hostId={hostId}
+        open={detailOpen}
+        onOpenChange={setDetailOpen}
+        onDismiss={onDismiss}
+      />
+    </>
   )
 }

--- a/apps/dashboard/src/lib/insights/insight-charts.test.ts
+++ b/apps/dashboard/src/lib/insights/insight-charts.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'bun:test'
+import { getRegisteredChartNames } from '@/components/charts/chart-registry'
+import { insightChartNames } from '@/lib/insights/insight-charts'
+
+describe('insightChartNames', () => {
+  test('maps a known metric to its specific charts', () => {
+    expect(
+      insightChartNames({
+        category: 'reliability',
+        metric: 'max_replication_delay',
+      })
+    ).toEqual(['replication-queue-count', 'replication-summary-table'])
+    expect(
+      insightChartNames({ category: 'storage', metric: 'detached_parts' })
+    ).toEqual(['parts-per-table', 'new-parts-created'])
+    expect(
+      insightChartNames({ category: 'anomaly', metric: 'memory_usage' })
+    ).toEqual(['memory-usage'])
+  })
+
+  test('metric mapping wins over category fallback', () => {
+    // error_rate lives under an anomaly finding but has its own chart set,
+    // which must take precedence over the generic anomaly fallback.
+    expect(
+      insightChartNames({ category: 'anomaly', metric: 'error_rate' })
+    ).toEqual(['failed-query-count', 'query-count'])
+  })
+
+  test('falls back to category charts for an unmapped metric', () => {
+    expect(
+      insightChartNames({ category: 'storage', metric: 'some_new_metric' })
+    ).toEqual(['top-table-size', 'disk-size'])
+  })
+
+  test('falls back to category charts for a narrative-only finding (no metric)', () => {
+    expect(insightChartNames({ category: 'performance' })).toEqual([
+      'query-duration-percentiles',
+      'query-count',
+    ])
+  })
+
+  test('returns [] for an unknown category with no metric', () => {
+    expect(insightChartNames({ category: 'mystery' })).toEqual([])
+  })
+
+  test('returns [] for Postgres findings (no ClickHouse chart)', () => {
+    expect(
+      insightChartNames({
+        category: 'reliability',
+        metric: 'pg_replication_lag',
+      })
+    ).toEqual([])
+    expect(
+      insightChartNames({
+        category: 'performance',
+        metric: 'pg_connection_saturation',
+      })
+    ).toEqual([])
+  })
+
+  test('returns at most two charts', () => {
+    for (const category of [
+      'storage',
+      'performance',
+      'reliability',
+      'anomaly',
+    ]) {
+      expect(
+        insightChartNames({ category, metric: 'anything' }).length
+      ).toBeLessThanOrEqual(2)
+    }
+  })
+
+  test('every referenced chart key exists in the chart registry', () => {
+    const registered = new Set(getRegisteredChartNames())
+    const cases: Array<
+      Pick<Parameters<typeof insightChartNames>[0], never> & {
+        category: string
+        metric?: string
+      }
+    > = [
+      { category: 'anomaly', metric: 'error_rate' },
+      { category: 'anomaly', metric: 'query_duration_p95' },
+      { category: 'anomaly', metric: 'memory_usage' },
+      { category: 'anomaly', metric: 'insert_throughput' },
+      { category: 'storage', metric: 'disk_free_pct' },
+      { category: 'storage', metric: 'max_active_parts' },
+      { category: 'storage', metric: 'detached_parts' },
+      { category: 'storage', metric: 'worst_compression_ratio' },
+      { category: 'reliability', metric: 'readonly_replicas' },
+      { category: 'reliability', metric: 'max_replication_delay' },
+      { category: 'reliability', metric: 'stuck_mutations' },
+      { category: 'reliability', metric: 'failed_dictionaries' },
+      { category: 'performance', metric: 'longest_running_query' },
+      { category: 'storage' },
+      { category: 'performance' },
+      { category: 'reliability' },
+      { category: 'anomaly' },
+      { category: 'queries' },
+      { category: 'optimization' },
+      { category: 'cost' },
+    ]
+    for (const c of cases) {
+      for (const name of insightChartNames(c)) {
+        expect(registered.has(name)).toBe(true)
+      }
+    }
+  })
+})

--- a/apps/dashboard/src/lib/insights/insight-charts.ts
+++ b/apps/dashboard/src/lib/insights/insight-charts.ts
@@ -1,0 +1,82 @@
+/**
+ * Map an insight finding to the explanatory chart(s) that visualize it.
+ *
+ * The insight detail dialog renders these charts underneath the finding so the
+ * operator can see the trend behind, say, "Replication is lagging" or "26422
+ * detached parts need review". The mapping is a pure function of the finding's
+ * `metric` (most specific) with a `category` fallback, returning chart-registry
+ * keys (see `components/charts/chart-registry`). A finding with no sensible
+ * chart returns `[]` — the dialog then omits the charts section entirely rather
+ * than rendering an empty/broken chart.
+ *
+ * Only ClickHouse charts exist in the registry, so Postgres findings (metric
+ * prefixed `pg_`) intentionally map to `[]`.
+ */
+
+import type { InsightCandidate } from '@/lib/insights/types'
+
+/** At most this many charts per finding, to keep the dialog focused. */
+const MAX_CHARTS = 2
+
+/**
+ * Metric → chart keys. Keyed by the machine `metric` name emitted by the
+ * collectors (`lib/insights/collectors.ts`, `operational-checks.ts`, …). The
+ * chart keys here must exist in the chart registry.
+ */
+const METRIC_CHARTS: Record<string, readonly string[]> = {
+  // Anomaly collectors
+  error_rate: ['failed-query-count', 'query-count'],
+  query_duration_p95: ['query-duration-percentiles', 'query-duration'],
+  memory_usage: ['memory-usage'],
+  insert_throughput: ['new-parts-created'],
+  disk_free_pct: ['disks-usage', 'disk-size'],
+  // Storage collectors
+  max_active_parts: ['parts-per-table', 'merge-count'],
+  detached_parts: ['parts-per-table', 'new-parts-created'],
+  worst_compression_ratio: ['top-table-size', 'disk-usage-by-database'],
+  // Reliability collectors
+  readonly_replicas: ['readonly-replica', 'replication-summary-table'],
+  max_replication_delay: [
+    'replication-queue-count',
+    'replication-summary-table',
+  ],
+  stuck_mutations: ['summary-stuck-mutations', 'merge-count'],
+  failed_dictionaries: ['dictionary-count'],
+  // Performance collectors
+  longest_running_query: ['query-duration', 'summary-used-by-running-queries'],
+}
+
+/**
+ * Category → chart keys. Used when the finding's `metric` has no specific
+ * mapping (e.g. narrative-only insights, or new metrics). Coarser but never
+ * wrong for the category.
+ */
+const CATEGORY_CHARTS: Record<string, readonly string[]> = {
+  storage: ['top-table-size', 'disk-size'],
+  performance: ['query-duration-percentiles', 'query-count'],
+  reliability: ['failed-query-count'],
+  anomaly: ['query-count'],
+  queries: ['query-count', 'query-duration'],
+  optimization: ['parts-per-table'],
+  cost: ['disk-usage-by-database'],
+}
+
+/**
+ * Resolve the explanatory chart keys for an insight finding.
+ *
+ * Returns up to {@link MAX_CHARTS} chart-registry keys, or `[]` when the finding
+ * has no sensible chart (narrative-only, unknown category, or a Postgres `pg_*`
+ * metric — the registry only has ClickHouse charts).
+ */
+export function insightChartNames(
+  insight: Pick<InsightCandidate, 'category' | 'metric'>
+): string[] {
+  const metric = insight.metric?.trim()
+
+  // Postgres findings have no ClickHouse chart to explain them.
+  if (metric && metric.startsWith('pg_')) return []
+
+  const byMetric = metric ? METRIC_CHARTS[metric] : undefined
+  const charts = byMetric ?? CATEGORY_CHARTS[insight.category] ?? []
+  return charts.slice(0, MAX_CHARTS)
+}


### PR DESCRIPTION
## What

Each **AI Insights** finding is now **clickable** and opens a detail dialog with the full finding plus the chart(s) that explain it. Two entry points, one shared `InsightDetailDialog`:

- **Header AI Insights popover** rows — clicking a row (previously a deep-link) now opens the dialog.
- **Overview strip + `/insights` board `InsightCard`s** — clicking the card body opens the same dialog. The inline dismiss X and action link still work (stopPropagation).

## Dialog contents

Full untruncated title + severity badge, complete description, timestamp (relative + absolute `title`), category + metric badges, the finding's existing deep-link action (`View replicas →` etc.), a **Dismiss** action reusing the same per-user dismissal mutation, and **1–2 explanatory charts** mapped from the finding kind. Findings with no mapped chart simply omit the charts section (never a broken chart).

## kind → chart mapping (`lib/insights/insight-charts.ts`, pure + bun-tested)

Keyed by machine `metric` first, `category` fallback second:

| finding metric | charts |
|---|---|
| `error_rate` | failed-query-count, query-count |
| `query_duration_p95` | query-duration-percentiles, query-duration |
| `memory_usage` | memory-usage |
| `insert_throughput` | new-parts-created |
| `disk_free_pct` | disks-usage, disk-size |
| `max_active_parts` | parts-per-table, merge-count |
| `detached_parts` | parts-per-table, new-parts-created |
| `worst_compression_ratio` | top-table-size, disk-usage-by-database |
| `readonly_replicas` | readonly-replica, replication-summary-table |
| `max_replication_delay` | replication-queue-count, replication-summary-table |
| `stuck_mutations` | summary-stuck-mutations, merge-count |
| `failed_dictionaries` | dictionary-count |
| `longest_running_query` | query-duration, summary-used-by-running-queries |
| _category fallback_ | storage→top-table-size,disk-size · performance→query-duration-percentiles,query-count · reliability→failed-query-count · anomaly→query-count · queries→query-count,query-duration · optimization→parts-per-table · cost→disk-usage-by-database |
| `pg_*` (Postgres) / unknown | `[]` (no ClickHouse chart → section omitted) |

Charts render via the existing chart registry (`DynamicChart`, `hostId` from `useHostId()` at the deepest consumer) and are filtered by `getChartComponent` so an unknown key can never render.

## Accessibility

Popover rows and cards become whole-target `role="button"` with `tabIndex`, Enter/Space handlers, and a focus ring. Inner dismiss/action controls call `stopPropagation`. The dialog portals out of the card, so no nested-`<button>` violation.

## Tests / verification

- `bun test src/lib/insights/insight-charts.test.ts` — 8 pass (mapping precedence, category fallback, Postgres `[]`, ≤2 charts, and every referenced key exists in the chart registry).
- `pnpm run type-check` — clean.
- `pnpm run build` — succeeds (prerender OK).
- Biome check clean on changed files.

https://claude.ai/code/session_011a1CRbruQCZCPdjj2ntKjZ