### PR TITLE
fix(queries): running-queries empty on ClickHouse 26.3

### DIFF
--- a/apps/dashboard/src/lib/api/__tests__/query-cache-settings.test.ts
+++ b/apps/dashboard/src/lib/api/__tests__/query-cache-settings.test.ts
@@ -98,4 +98,26 @@ describe('buildQueryCacheSettings', () => {
       'save'
     )
   })
+
+  test('omits query_cache_system_table_handling before 24.4', () => {
+    // The setting does not exist before 24.4; sending it would fail the query
+    // with "Unknown setting". Pre-24.4 hosts skip caching system-table queries
+    // without throwing, so leaving it unset is safe.
+    for (const v of [version(23, 5), version(24, 2), version(24, 3, 9)]) {
+      const settings = buildQueryCacheSettings({ version: v, ttlSeconds: 30 })
+      expect(settings.query_cache_system_table_handling).toBeUndefined()
+    }
+  })
+
+  test("sets query_cache_system_table_handling: 'save' from 24.4 onward", () => {
+    // Regression: without this, `use_query_cache=1` on any system.* query
+    // (e.g. the Running Queries page's system.processes scan) throws error 719
+    // QUERY_CACHE_USED_WITH_SYSTEM_TABLE on ClickHouse 24.4+ — the query
+    // returned zero rows on ClickHouse 26.3 for exactly this reason.
+    for (const v of [version(24, 4), version(24, 8), version(26, 3, 9)]) {
+      const settings = buildQueryCacheSettings({ version: v, ttlSeconds: 30 })
+      expect(settings.use_query_cache).toBe(1)
+      expect(settings.query_cache_system_table_handling).toBe('save')
+    }
+  })
 })

--- a/apps/dashboard/src/lib/api/query-cache-settings.ts
+++ b/apps/dashboard/src/lib/api/query-cache-settings.ts
@@ -35,6 +35,18 @@
  * whose default (`false`) is safe (silently skips caching, never throws), so
  * it is set explicitly for parity on those hosts too.
  *
+ * Similarly, essentially EVERY dashboard query reads a `system.*` table. Since
+ * ClickHouse 24.4 (https://github.com/ClickHouse/ClickHouse/pull/62376), the
+ * query cache refuses to cache any query that touches a system table, and the
+ * default `query_cache_system_table_handling = 'throw'` makes the query FAIL
+ * with error 719 (`QUERY_CACHE_USED_WITH_SYSTEM_TABLE`) the moment
+ * `use_query_cache=1` is set — e.g. the Running Queries page's
+ * `system.processes` scan returned no rows on ClickHouse 26.3 for exactly this
+ * reason. `'save'` is required for correctness here too (cache the result,
+ * bounded by the same short TTL). Pre-24.4 hosts don't have that setting and
+ * simply skip caching system-table queries without throwing, so it is omitted
+ * there — sending an unknown setting name would itself fail the query.
+ *
  * ASSUMPTION (flagged per the #2182 review request): whether the demo
  * ClickHouse host has the *server-side* query cache enabled/sized
  * (`query_cache_max_size_in_bytes` / config-level toggle, as opposed to the
@@ -57,6 +69,13 @@ const MIN_QUERY_CACHE_VERSION = { major: 23, minor: 5 } as const
 
 /** `query_cache_nondeterministic_function_handling` enum landed in 24.2. */
 const MIN_NONDETERMINISTIC_ENUM_VERSION = { major: 24, minor: 2 } as const
+
+/**
+ * `query_cache_system_table_handling` (and the default-`throw` rejection of
+ * caching system-table queries, error 719) landed in ClickHouse 24.4
+ * (PR #62376).
+ */
+const MIN_SYSTEM_TABLE_HANDLING_VERSION = { major: 24, minor: 4 } as const
 
 export interface QueryCacheSettingsOptions {
   /** Detected ClickHouse version for the target host, or null if unknown. */
@@ -106,6 +125,21 @@ export function buildQueryCacheSettings({
     settings.query_cache_nondeterministic_function_handling = 'save'
   } else {
     settings.query_cache_store_results_of_queries_with_nondeterministic_functions = 1
+  }
+
+  // ClickHouse 24.4+ rejects caching queries that read system tables unless
+  // told otherwise (error 719). Almost every dashboard query reads system.*,
+  // so without this the query cache fails those queries outright rather than
+  // just skipping the cache. Pre-24.4 hosts don't have the setting and skip
+  // caching system-table queries silently, so it is left unset there.
+  if (
+    meetsMinVersion(
+      version,
+      MIN_SYSTEM_TABLE_HANDLING_VERSION.major,
+      MIN_SYSTEM_TABLE_HANDLING_VERSION.minor
+    )
+  ) {
+    settings.query_cache_system_table_handling = 'save'
   }
 
   return settings


### PR DESCRIPTION
## Root cause

The Running Queries page (and other read-only GET query paths, #2182) opt into
the ClickHouse **query cache** via `buildQueryCacheSettings`. That builder
handled the non-deterministic-function throw
(`query_cache_nondeterministic_function_handling`, 24.2+) but **not** the
system-table throw introduced in **ClickHouse 24.4** (PR #62376).

Since 24.4, with the default `query_cache_system_table_handling = 'throw'`,
setting `use_query_cache=1` on any query that reads a `system.*` table fails
outright with **error 719 `QUERY_CACHE_USED_WITH_SYSTEM_TABLE`**. Essentially
every dashboard query reads system tables, so on 24.4+ (reported on **26.3**)
a cached `system.processes` scan fails / returns no rows → the page shows the
"No queries running" empty state even while queries are executing.

### Evidence (reproduced on `clickhouse/clickhouse-server:26.3.17`)

- The running-queries base SQL (`since: 23.8` variant, correctly selected for
  26.3.9.8) runs fine and returns rows in isolation — the SQL/version-selection
  is **not** the bug.
- `SELECT count() FROM system.processes` with `use_query_cache=1` →
  `HTTP 500 Code: 719 QUERY_CACHE_USED_WITH_SYSTEM_TABLE`.
- The overview "N running" count uses a path that doesn't enable the cache, so
  it kept working — which is why the count and the table disagreed.

## Fix

Set `query_cache_system_table_handling: 'save'` for hosts **>= 24.4**,
version-gated exactly like the existing non-deterministic handling. Pre-24.4
hosts skip caching system-table queries without throwing and lack the setting,
so it is omitted there (sending an unknown setting name would itself fail the
query). No SQL/QueryConfig changes — older versions' behaviour is unchanged.

## Tests

Added regression tests to `query-cache-settings.test.ts` (omitted <24.4, set
'save' >=24.4). `bun test src/lib/api/__tests__/` → 542 pass.

https://claude.ai/code/session_011a1CRbruQCZCPdjj2ntKjZ