### PR TITLE
fix(tooling): billing-webhook-core rootDir breaks root type-check

### DIFF
--- a/packages/billing-webhook-core/tsconfig.json
+++ b/packages/billing-webhook-core/tsconfig.json
@@ -2,10 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
-    "paths": {
-      "@chm/pricing": ["../pricing/src/index.ts"]
-    }
+    "rootDir": "./src"
   },
   "include": ["src/**/*"],
   "exclude": ["src/**/*.test.ts"]


### PR DESCRIPTION
## Summary
- Since PR #2606, the repo-root `pnpm run type-check` (run by the husky pre-commit hook) failed with a TS6059 `rootDir` error in `packages/billing-webhook-core`, forcing `--no-verify` on every local commit.
- Root cause: the package's `tsconfig.json` had a `paths` override (`@chm/pricing -> ../pricing/src/index.ts`) that bypassed normal module resolution and pulled `packages/pricing/src/*` directly into the program under `rootDir: ./src`. TypeScript then rejected those files as outside `rootDir`.
- The workspace already resolves `@chm/pricing` correctly via the pnpm symlink (`node_modules/@chm/pricing -> ../../../pricing`), so the `paths` override was redundant. Removing it fixes the root type-check without weakening strictness anywhere.

## Test plan
- [x] `pnpm install` at repo root
- [x] Repo-root `pnpm run type-check` passes (was failing with TS6059 before the fix)
- [x] `cd apps/dashboard && pnpm run type-check` passes
- [x] `cd apps/cloud-hooks && pnpm exec tsc --noEmit` passes
- [x] `cd packages/billing-webhook-core && bun test src/` — 28 pass, 0 fail
- [x] Pre-commit hook (husky `type-check`) ran clean, no `--no-verify` needed

https://claude.ai/code/session_011a1CRbruQCZCPdjj2ntKjZ