### PR TITLE
docs: split proxy auth setup into per-platform guides

### DIFF
--- a/docs/content/guide/guides/proxy-auth-cloudflare-access.mdx
+++ b/docs/content/guide/guides/proxy-auth-cloudflare-access.mdx
@@ -1,0 +1,180 @@
+---
+title: Proxy auth — Cloudflare Access + Tunnel
+description: Put chmonitor behind Cloudflare Access with a Cloudflare Tunnel — Zero Trust login, signed JWT verification, no shared secret needed.
+icon: Cloud
+---
+
+Cloudflare Access sits in front of chmonitor and does the real login (SSO, email OTP, GitHub/Google, etc.). It signs every authenticated request with a `Cf-Access-Jwt-Assertion` JWT. chmonitor's `proxy` auth provider verifies that JWT cryptographically against your team's JWKS — there is no shared secret to manage, the signature itself is the proof.
+
+<Callout type="info" title="When to pick this path">
+Use this when you already run (or want) Cloudflare Zero Trust, don't want to run your own OIDC/ForwardAuth service, and are fine exposing chmonitor to the internet only through a Cloudflare Tunnel (no inbound ports opened).
+</Callout>
+
+<Mermaid chart={`flowchart LR
+  B["Browser"] -->|"1. Request"| CF["Cloudflare Access"]
+  CF -->|"2. Login (SSO / OTP / IdP)"| B
+  B -->|"3. Cf-Access-Jwt-Assertion"| TUN["cloudflared Tunnel"]
+  TUN -->|"4. Forward"| CHM["chmonitor (proxy provider)"]
+  CHM -->|"5. Verify JWT via JWKS"| CF`} />
+
+## Prerequisites
+
+- A Cloudflare account with **Zero Trust** enabled (Access is available on the Free plan for small teams).
+- A domain managed on Cloudflare (for the Tunnel's public hostname).
+- `cloudflared` installed on the host/container that can reach chmonitor (`cloudflared tunnel` runs as a sidecar or on the same box).
+- chmonitor running somewhere `cloudflared` can reach over plain HTTP (Docker, Kubernetes Service, or bare metal) — it does **not** need to be reachable from the public internet directly.
+
+<Callout type="warn" title="Do not also expose chmonitor's port publicly">
+Access only protects requests that arrive through the Tunnel. If chmonitor's port is also reachable directly (a public LoadBalancer, a port-forwarded router, a Service of type NodePort), that path bypasses Access entirely. Keep chmonitor bound to localhost/an internal network and let the Tunnel be the only ingress.
+</Callout>
+
+## Setup
+
+<Steps>
+<Step>
+### Create an Access application
+
+In the Cloudflare Zero Trust dashboard:
+
+1. **Access → Applications → Add an application → Self-hosted**.
+2. Set the **Application domain** to the hostname you'll route through the Tunnel, e.g. `chmonitor.example.com`.
+3. Under **Session duration**, pick a reasonable window (e.g. 24 hours) — this controls how often users have to re-authenticate.
+4. Add an **Access policy**: e.g. "Allow" → Include → Emails ending in `@yourcompany.com`, or a specific Google/GitHub/SAML group.
+5. Save, then open the application's overview page and copy the **Application Audience (AUD) tag** — a 64-character hex string. You'll need it for `CHM_CF_ACCESS_AUD`.
+6. Note your **team domain** too (Zero Trust → Settings → Custom Pages, or the URL pattern `https://<your-team>.cloudflareaccess.com`).
+</Step>
+<Step>
+### Create a Cloudflare Tunnel
+
+```bash
+cloudflared tunnel login
+cloudflared tunnel create chmonitor
+cloudflared tunnel route dns chmonitor chmonitor.example.com
+```
+
+This creates a tunnel named `chmonitor`, provisions a DNS record for `chmonitor.example.com` pointing at the tunnel, and writes credentials to `~/.cloudflared/<tunnel-id>.json`.
+</Step>
+<Step>
+### Configure the tunnel ingress
+
+Create `~/.cloudflared/config.yml` (or mount it into the `cloudflared` container):
+
+```yaml
+tunnel: chmonitor
+credentials-file: /etc/cloudflared/<tunnel-id>.json
+
+ingress:
+  - hostname: chmonitor.example.com
+    service: http://chmonitor:8080   # chmonitor's internal address/port
+  - service: http_status:404          # catch-all, required as the last rule
+```
+
+Running as a container alongside chmonitor (docker-compose extract):
+
+```yaml
+services:
+  chmonitor:
+    image: ghcr.io/chmonitor/chmonitor:latest
+    # do not publish chmonitor's port on the host — the tunnel is the only ingress
+    environment:
+      CHM_AUTH_PROVIDER: proxy
+      CHM_CF_ACCESS_TEAM_DOMAIN: https://your-team.cloudflareaccess.com
+      CHM_CF_ACCESS_AUD: <64-char-aud-tag>
+
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    command: tunnel --config /etc/cloudflared/config.yml run
+    volumes:
+      - ./cloudflared:/etc/cloudflared
+    depends_on:
+      - chmonitor
+```
+
+Run it directly instead of via compose:
+
+```bash
+cloudflared tunnel --config ~/.cloudflared/config.yml run chmonitor
+```
+</Step>
+<Step>
+### Configure chmonitor
+
+<TypeTable
+  type={{
+    CHM_AUTH_PROVIDER: {
+      description: 'Set to proxy to enable the Cloudflare Access / trusted-header mechanisms.',
+      type: 'string',
+      default: 'none',
+    },
+    CHM_CF_ACCESS_TEAM_DOMAIN: {
+      description: "Your Cloudflare Zero Trust team domain, e.g. https://your-team.cloudflareaccess.com.",
+      type: 'string',
+    },
+    CHM_CF_ACCESS_AUD: {
+      description: 'The Access application Audience (AUD) tag copied in step 1.',
+      type: 'string',
+    },
+  }}
+/>
+
+```bash
+CHM_AUTH_PROVIDER=proxy
+CHM_CF_ACCESS_TEAM_DOMAIN=https://your-team.cloudflareaccess.com
+CHM_CF_ACCESS_AUD=<64-char-aud-tag>
+```
+
+On every request chmonitor verifies the `Cf-Access-Jwt-Assertion` header: checks the `RS256` signature against `https://your-team.cloudflareaccess.com/cdn-cgi/access/certs` (the JWKS endpoint, cached ~1 hour), then checks `aud` matches `CHM_CF_ACCESS_AUD`, `iss` matches the team domain, and `exp` hasn't passed. The authenticated subject is the JWT's `email` claim (falls back to `sub`). No shared secret is involved — an unset or wrong `CHM_CF_ACCESS_AUD`/`CHM_CF_ACCESS_TEAM_DOMAIN` simply disables the mechanism (fails closed).
+
+Set these as Worker secrets in production rather than plaintext config:
+
+```bash
+wrangler secret put CHM_CF_ACCESS_TEAM_DOMAIN
+wrangler secret put CHM_CF_ACCESS_AUD
+```
+</Step>
+<Step>
+### Redeploy and verify
+
+Open `https://chmonitor.example.com` in a browser — Cloudflare Access should show its login page before you ever reach chmonitor. After authenticating, you land on the dashboard with data loading normally.
+
+```bash
+# A request without the header is rejected
+curl -i https://chmonitor.example.com/api/v1/auth/me
+# → 401
+
+# A request carrying a valid Access JWT (e.g. copied from browser dev tools,
+# or via `cloudflared access curl`) returns the authenticated identity
+cloudflared access curl https://chmonitor.example.com/api/v1/auth/me
+```
+</Step>
+</Steps>
+
+## Troubleshooting
+
+<Accordions>
+<Accordion title="Every request returns 401 even after logging in through Access">
+Confirm `CHM_CF_ACCESS_TEAM_DOMAIN` has no trailing slash mismatch with the JWT's `iss` claim, and that `CHM_CF_ACCESS_AUD` exactly matches the AUD tag on the Access application (not the account ID or a different application's tag). A stale worker deploy that predates setting the secrets will also 401 — redeploy after `wrangler secret put`.
+</Accordion>
+<Accordion title="JWKS fetch failures / intermittent 401s right after key rotation">
+Cloudflare rotates signing keys roughly every 6 weeks; previous keys stay valid for 7 days after rotation. chmonitor caches the whole JWKS document for about 1 hour, so a rotation is picked up within that window automatically — no redeploy needed. If a client presents a genuinely unknown `kid` (forged or very stale token), chmonitor does not force a fresh JWKS fetch on that specific miss (a deliberate DoS mitigation); it will pick up new keys on the next natural cache refresh.
+</Accordion>
+<Accordion title="Header spoofing risk if the Tunnel is bypassed">
+The whole security model rests on `Cf-Access-Jwt-Assertion` only ever arriving from Cloudflare's edge. If chmonitor is *also* reachable directly (a public port, a misconfigured Kubernetes Service, a firewall rule opened for debugging), a client can send an arbitrary `Cf-Access-Jwt-Assertion` header — but verification will fail because they cannot produce a valid RS256 signature over their forged payload, so this specific mechanism doesn't have a forgery risk the way trusted-header does. The real risk is exposing an *unauthenticated* path to chmonitor in parallel (e.g. a raw port with no Access in front of it at all). Only the Tunnel should route to chmonitor.
+</Accordion>
+<Accordion title="Websocket / streaming passthrough for the AI agent chat">
+The agent chat streams its response as a long-lived HTTP request (SSE-style, not a websocket upgrade). Cloudflare Tunnel and Access both pass through streaming responses transparently — Access checks the JWT once, at the start of the request, not per chunk. No special `ingress` config is required beyond the standard `service: http://...` entry above. If you see the chat stall or truncate, check chmonitor's own request timeout config rather than the tunnel.
+</Accordion>
+<Accordion title="No sign-in button appears in the chmonitor header">
+That's expected — `VITE_AUTH_PROVIDER` does not need to be set for the `proxy` provider. Access handles the login page entirely outside chmonitor's UI, so chmonitor never renders its own sign-in button for this path.
+</Accordion>
+</Accordions>
+
+## Related
+
+<Cards>
+<Card title="Proxy auth overview" href="/guide/guides/proxy-auth-setup" description="Compare all three proxy patterns." />
+<Card title="nginx + oauth2-proxy" href="/guide/guides/proxy-auth-nginx-oauth2-proxy" description="Self-hosted OIDC login in front of nginx." />
+<Card title="Traefik ForwardAuth + OIDC" href="/guide/guides/proxy-auth-traefik-oidc" description="Traefik middleware forwarding an OIDC session." />
+<Card title="Cloudflare Access reference" href="/operate/authentication/cloudflare-access" description="Full env var reference for the proxy provider." />
+<Card title="Authentication overview" href="/operate/authentication" description="Compare all chmonitor auth providers." />
+</Cards>

--- a/docs/content/guide/guides/proxy-auth-nginx-oauth2-proxy.mdx
+++ b/docs/content/guide/guides/proxy-auth-nginx-oauth2-proxy.mdx
@@ -1,0 +1,239 @@
+---
+title: Proxy auth — nginx + oauth2-proxy
+description: Run oauth2-proxy alongside nginx for a self-hosted OIDC login in front of chmonitor, using nginx's auth_request to gate every request.
+icon: Server
+---
+
+[oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/) handles the OIDC login flow (Google, GitHub, Okta, Dex, Keycloak, any OIDC provider) and, once a session cookie is valid, emits identity headers on an internal auth-check endpoint. nginx uses `auth_request` to call that endpoint on every request; if it returns `200`, nginx copies the identity headers onto the real request to chmonitor along with a shared secret. chmonitor's `trusted` auth provider reads those headers into a full user profile (name, email, avatar, groups) and gates access on the shared secret.
+
+<Callout type="info" title="When to pick this path">
+Use this when you're already running nginx (or nginx-ingress) and want a self-hosted OIDC login without Cloudflare, and you want more than a bare identity — group-based access gating, display name, and avatar in the chmonitor UI.
+</Callout>
+
+<Mermaid chart={`sequenceDiagram
+  participant B as Browser
+  participant N as nginx
+  participant O as oauth2-proxy
+  participant A as chmonitor (trusted provider)
+  B->>N: request
+  N->>O: auth_request /oauth2/auth
+  alt no valid session
+    O-->>N: 401
+    N-->>B: redirect to /oauth2/start (login)
+  else valid session
+    O-->>N: 200 + X-Auth-Request-* headers
+    N->>A: forward + X-Forwarded-* + X-Chm-Proxy-Secret
+    A->>A: verify secret, build principal
+    A-->>B: 200 data
+  end`} />
+
+## Prerequisites
+
+- nginx (or nginx-ingress) able to run `auth_request` (built in to nginx's `http_auth_request_module`, enabled by default on most distro packages and the official nginx image).
+- An OIDC provider: Google Workspace, GitHub OAuth app, Okta, Keycloak, Dex, Authentik, or similar — you need a client ID + client secret from it.
+- Docker or a way to run the `oauth2-proxy` binary as a long-running process.
+
+## Setup
+
+<Steps>
+<Step>
+### Generate a cookie secret
+
+```bash
+python3 -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())'
+```
+
+Save the output — you'll pass it as `--cookie-secret`.
+</Step>
+<Step>
+### Run oauth2-proxy
+
+Example with Google as the OIDC provider (swap `--provider` and its flags for your IdP):
+
+```bash
+docker run -d \
+  --name oauth2-proxy \
+  -p 4180:4180 \
+  quay.io/oauth2-proxy/oauth2-proxy:latest \
+  --provider=google \
+  --client-id=YOUR_CLIENT_ID \
+  --client-secret=YOUR_CLIENT_SECRET \
+  --cookie-secret=<output-from-step-1> \
+  --email-domain=yourcompany.com \
+  --http-address=0.0.0.0:4180 \
+  --upstream=http://chmonitor:8080 \
+  --set-xauthrequest \
+  --pass-access-token=false \
+  --cookie-secure=true \
+  --redirect-url=https://chmonitor.yourcompany.com/oauth2/callback
+```
+
+Key flags:
+
+- `--set-xauthrequest` — emits `X-Auth-Request-User`, `X-Auth-Request-Email`, `X-Auth-Request-Preferred-Username`, and `X-Auth-Request-Groups` response headers on the internal `/oauth2/auth` check. This is exactly what nginx's `auth_request` reads.
+- `--upstream=http://chmonitor:8080` — oauth2-proxy can itself reverse-proxy to chmonitor, but in this setup nginx is the front door and only calls oauth2-proxy for the auth check (`/oauth2/auth`, `/oauth2/sign_in`, `/oauth2/callback`) — the `--upstream` value mainly matters if you ever hit oauth2-proxy directly.
+- `--email-domain=yourcompany.com` — restrict who can complete login; use `*` to allow any authenticated Google account (not recommended for anything but testing).
+- If your IdP supports groups (Okta, Keycloak, Dex, Authentik), also request the `groups` scope, e.g. `--scope="openid email profile groups"`, so `X-Auth-Request-Groups` is populated for `CHM_TRUSTED_ALLOWED_GROUPS` gating.
+</Step>
+<Step>
+### Configure nginx
+
+```nginx
+server {
+  listen 443 ssl;
+  server_name chmonitor.yourcompany.com;
+
+  # oauth2-proxy's own endpoints (login page, callback)
+  location /oauth2/ {
+    proxy_pass       http://oauth2-proxy:4180;
+    proxy_set_header Host             $host;
+    proxy_set_header X-Real-IP        $remote_addr;
+    proxy_set_header X-Scheme         $scheme;
+  }
+
+  # Internal auth-check endpoint nginx calls on every request
+  location = /oauth2/auth {
+    internal;
+    proxy_pass              http://oauth2-proxy:4180;
+    proxy_pass_request_body off;
+    proxy_set_header         Content-Length "";
+    proxy_set_header         X-Original-URI $request_uri;
+  }
+
+  location / {
+    auth_request /oauth2/auth;
+    error_page 401 = /oauth2/sign_in?rd=$scheme://$host$request_uri;
+
+    # Pull identity headers off the auth_request response
+    auth_request_set $user   $upstream_http_x_auth_request_user;
+    auth_request_set $email  $upstream_http_x_auth_request_email;
+    auth_request_set $name   $upstream_http_x_auth_request_preferred_username;
+    auth_request_set $groups $upstream_http_x_auth_request_groups;
+
+    proxy_set_header X-Forwarded-User               $user;
+    proxy_set_header X-Forwarded-Email              $email;
+    proxy_set_header X-Forwarded-Preferred-Username $name;
+    proxy_set_header X-Forwarded-Groups             $groups;
+
+    # Shared secret so chmonitor trusts these headers — never hardcode in
+    # source control; inject via envsubst / a secrets manager at deploy time.
+    proxy_set_header X-Chm-Proxy-Secret "your-shared-secret-here";
+
+    # Required for the AI agent chat's streaming (SSE-style) responses:
+    # buffering would hold the whole response until it completes.
+    proxy_http_version 1.1;
+    proxy_set_header   Connection "";
+    proxy_buffering    off;
+    proxy_read_timeout 3600s;
+
+    proxy_pass http://chmonitor:8080;
+  }
+}
+```
+
+<Callout type="warn" title="Don't hardcode the secret in source control">
+Load `X-Chm-Proxy-Secret`'s value at deploy time with `envsubst`, a secrets manager (Vault Agent, SOPS), or a templating step — never commit the literal secret in an nginx config file.
+</Callout>
+</Step>
+<Step>
+### Configure chmonitor
+
+<TypeTable
+  type={{
+    CHM_AUTH_PROVIDER: {
+      description: 'Set to trusted to read the forwarded identity headers into a full profile.',
+      type: 'string',
+      default: 'none',
+    },
+    CHM_TRUSTED_AUTH_SECRET: {
+      description: 'Shared secret — must equal the value nginx sends in X-Chm-Proxy-Secret. Constant-time compared.',
+      type: 'string',
+    },
+    CHM_TRUSTED_USER_HEADER: {
+      description: 'Identity header nginx forwards the username in.',
+      type: 'string',
+      default: 'X-Forwarded-User',
+    },
+    CHM_TRUSTED_EMAIL_HEADER: {
+      description: 'Email header.',
+      type: 'string',
+      default: 'X-Forwarded-Email',
+    },
+    CHM_TRUSTED_NAME_HEADER: {
+      description: 'Display name header.',
+      type: 'string',
+      default: 'X-Forwarded-Preferred-Username',
+    },
+    CHM_TRUSTED_GROUPS_HEADER: {
+      description: 'Comma/space-separated group list header.',
+      type: 'string',
+      default: 'X-Forwarded-Groups',
+    },
+  }}
+/>
+
+```bash
+CHM_AUTH_PROVIDER=trusted
+CHM_TRUSTED_AUTH_SECRET=your-shared-secret-here   # must match nginx's X-Chm-Proxy-Secret value
+
+# Only needed if you renamed the headers in the nginx config above — the
+# defaults already line up with X-Forwarded-User / X-Forwarded-Email / etc.
+# CHM_TRUSTED_USER_HEADER=X-Forwarded-User
+# CHM_TRUSTED_EMAIL_HEADER=X-Forwarded-Email
+# CHM_TRUSTED_NAME_HEADER=X-Forwarded-Preferred-Username
+# CHM_TRUSTED_GROUPS_HEADER=X-Forwarded-Groups
+
+# Optional: restrict access to specific oauth2-proxy/IdP groups
+# CHM_TRUSTED_ALLOWED_GROUPS=sre,ops,admin
+```
+
+Set the secret out-of-band, not in a plaintext `.env` committed to source control:
+
+```bash
+wrangler secret put CHM_TRUSTED_AUTH_SECRET
+# or, for Docker/K8s:
+kubectl create secret generic chm-trusted-secret --from-literal=value=<secret>
+```
+</Step>
+<Step>
+### Verify
+
+```bash
+# Hit chmonitor directly, bypassing nginx — must 401 (no secret header)
+curl -i http://chmonitor:8080/api/v1/auth/me
+
+# Through nginx without a session — redirected to oauth2-proxy's login
+curl -i https://chmonitor.yourcompany.com/
+
+# Through nginx with a valid session cookie — returns the authenticated principal
+curl -b "_oauth2_proxy=<cookie-value>" https://chmonitor.yourcompany.com/api/v1/auth/me | jq .
+```
+</Step>
+</Steps>
+
+## Troubleshooting
+
+<Accordions>
+<Accordion title="chmonitor returns 401 even though oauth2-proxy shows me as logged in">
+Confirm `CHM_TRUSTED_AUTH_SECRET` exactly matches the literal value in nginx's `proxy_set_header X-Chm-Proxy-Secret` line — a trailing newline or quoting difference will fail the constant-time comparison. Also confirm `--set-xauthrequest` is present on the oauth2-proxy command line; without it, `/oauth2/auth` returns `200` but with no `X-Auth-Request-*` headers, so `$user`/`$email` end up empty and nginx forwards empty `X-Forwarded-*` headers.
+</Accordion>
+<Accordion title="Wrong header name — chmonitor sees no identity">
+If your IdP or a different oauth2-proxy version emits headers under different names (some setups use `X-Auth-Request-Preferred-Username`, older ones may omit it), check the actual response with `curl -v` against `/oauth2/auth` directly, then point `CHM_TRUSTED_USER_HEADER` / `CHM_TRUSTED_NAME_HEADER` at whatever nginx variable you mapped it to — the header *name* chmonitor reads must match what nginx sets in `proxy_set_header`, not what oauth2-proxy originally called it.
+</Accordion>
+<Accordion title="Header spoofing risk">
+Without `CHM_TRUSTED_AUTH_SECRET` set, the `trusted` provider fails closed and rejects every request — it will not silently trust forwarded headers. The security guarantee depends entirely on nginx being the only path to chmonitor: if chmonitor's port is also reachable directly, a client can send its own `X-Forwarded-User` header, but it still needs the correct `X-Chm-Proxy-Secret` value to be trusted, which it won't have.
+</Accordion>
+<Accordion title="Websocket / streaming passthrough for the AI agent chat">
+The agent chat is a long-lived streaming HTTP response, not a websocket upgrade — but nginx's defaults (response buffering, a short `proxy_read_timeout`) can still truncate or stall it. Add `proxy_http_version 1.1;`, `proxy_set_header Connection "";`, `proxy_buffering off;`, and a generous `proxy_read_timeout` (as shown in the nginx config above) to the `location /` block so streamed tokens flush immediately instead of being buffered until the response completes.
+</Accordion>
+</Accordions>
+
+## Related
+
+<Cards>
+<Card title="Proxy auth overview" href="/guide/guides/proxy-auth-setup" description="Compare all three proxy patterns." />
+<Card title="Cloudflare Access + Tunnel" href="/guide/guides/proxy-auth-cloudflare-access" description="Zero Trust, signed JWT, no shared secret." />
+<Card title="Traefik ForwardAuth + OIDC" href="/guide/guides/proxy-auth-traefik-oidc" description="Traefik middleware forwarding an OIDC session." />
+<Card title="Trusted forwarded headers reference" href="/operate/authentication/trusted-proxy" description="Full env var reference for the trusted provider." />
+<Card title="Authentication overview" href="/operate/authentication" description="Compare all chmonitor auth providers." />
+</Cards>

--- a/docs/content/guide/guides/proxy-auth-setup.mdx
+++ b/docs/content/guide/guides/proxy-auth-setup.mdx
@@ -1,399 +1,50 @@
 ---
 title: Proxy & SSO auth setup
-description: Set up Cloudflare Access, nginx + oauth2-proxy, or Traefik ForwardAuth in front of chmonitor using the proxy or trusted auth provider.
+description: Overview of putting chmonitor behind a proxy that handles login — Cloudflare Access, nginx + oauth2-proxy, or Traefik ForwardAuth — using the proxy or trusted auth provider.
 icon: ShieldCheck
 ---
 
-Put chmonitor behind a proxy that handles login. Three patterns are covered — pick the one that matches your stack. All three use chmonitor's `trusted` or `proxy` auth provider; see [Authentication](/operate/authentication) for the full comparison.
+"Proxy auth" means chmonitor doesn't do the login itself — a reverse proxy in front of it authenticates the user and forwards their identity. chmonitor never sees a password or an OIDC handshake; it only ever sees either a cryptographically signed header (Cloudflare Access) or a plain identity header plus a shared secret (everything else). This is the model for self-hosted deployments that already have SSO infrastructure (Zero Trust, an internal IdP, Kubernetes ingress auth) and don't want chmonitor managing its own user database.
 
-- **Cloudflare Access + Tunnel** — Zero Trust, signed JWT, no shared secret needed.
-- **nginx + oauth2-proxy** — self-hosted OIDC login in front of nginx.
-- **Traefik ForwardAuth + OIDC** — Traefik middleware forwarding an OIDC session.
+## The security model
+
+<Callout type="danger" title="The proxy must be the only path to chmonitor">
+Every pattern below works by trusting a header the proxy sets. If chmonitor is reachable by any route that bypasses the proxy — a public LoadBalancer, a NodePort, a forwarded router port, a debug tunnel left open — that path can forge the same headers and impersonate any user. chmonitor's `trusted` provider fails closed (denies every request) unless you explicitly configure a trust gate (a shared secret, or an opt-in network-isolation flag); the `proxy` provider's Cloudflare Access mechanism is self-proving via JWT signature, but its optional shared-secret mechanism has the same bypass risk. **Treat "chmonitor's port is not independently reachable" as a hard requirement, not a nice-to-have.**
+</Callout>
+
+chmonitor has two auth providers for this:
+
+- **`proxy`** — verifies a signed `Cf-Access-Jwt-Assertion` JWT from Cloudflare Access (no secret needed), and/or a bare identity header gated by a shared secret. Extracts only a subject.
+- **`trusted`** — extracts a full principal (subject, name, email, avatar, groups) from multiple forwarded headers, gated by a shared secret or an explicit insecure/network-isolated opt-in. Supports group-based access gating (`CHM_TRUSTED_ALLOWED_GROUPS`).
+
+Pick the guide that matches your infrastructure — each is a complete, standalone walkthrough:
+
+<Cards>
+<Card title="Cloudflare Access + Tunnel" href="/guide/guides/proxy-auth-cloudflare-access" description="Zero Trust, signed JWT, no shared secret needed. Best if you're already on (or want) Cloudflare." />
+<Card title="nginx + oauth2-proxy" href="/guide/guides/proxy-auth-nginx-oauth2-proxy" description="Self-hosted OIDC login in front of nginx, using auth_request. Full identity profile via the trusted provider." />
+<Card title="Traefik ForwardAuth + OIDC" href="/guide/guides/proxy-auth-traefik-oidc" description="Traefik's forwardAuth middleware delegating to oauth2-proxy (or Authelia/Authentik) for OIDC login." />
+</Cards>
 
 ## Quick comparison
 
-| Setup | chmonitor provider | Trust mechanism |
-|---|---|---|
-| Cloudflare Access + Tunnel | `proxy` | Signed `Cf-Access-Jwt-Assertion` JWT — no shared secret needed |
-| nginx + oauth2-proxy | `trusted` | Shared secret header (`X-Chm-Proxy-Secret`) |
-| Traefik ForwardAuth + OIDC | `trusted` | Shared secret header or network isolation |
-
-## Set up your proxy
-
-<Tabs items={["Cloudflare Access + Tunnel", "nginx + oauth2-proxy", "Traefik ForwardAuth + OIDC"]}>
-<Tab value="Cloudflare Access + Tunnel">
-
-Cloudflare Access sits in front of chmonitor and issues a signed JWT on every authenticated request. chmonitor verifies the JWT cryptographically against Cloudflare's JWKS — no secret to share.
-
-<Mermaid chart={`flowchart LR
-  B["Browser"] -->|"1. Request"| CF["Cloudflare Access"]
-  CF -->|"2. Authenticate & issue JWT"| B
-  B -->|"3. Cf-Access-Jwt-Assertion"| CHM["chmonitor (proxy provider)"]
-  CHM -->|"4. Verify via JWKS"| CF`} />
-
-<Steps>
-<Step>
-### Create an Access application
-
-In the Cloudflare Zero Trust dashboard:
-
-1. **Access → Applications → Add application → Self-hosted**.
-2. Set the **Application domain** to `your-chmonitor.example.com`.
-3. Under **Session duration**, pick a reasonable window (e.g. 24 hours).
-4. Add an **Access policy** (e.g. allow users in your team's email domain).
-5. Note the **Application Audience (AUD) tag** from the application overview page — it looks like a 64-character hex string.
-</Step>
-<Step>
-### Create a Cloudflare Tunnel
-
-```bash
-cloudflared tunnel create chmonitor
-cloudflared tunnel route dns chmonitor your-chmonitor.example.com
-```
-
-Configure `~/.cloudflared/config.yml`:
-
-```yaml
-tunnel: chmonitor
-credentials-file: /root/.cloudflared/<tunnel-id>.json
-
-ingress:
-  - hostname: your-chmonitor.example.com
-    service: http://localhost:8080        # chmonitor container port
-  - service: http_status:404
-```
-
-Run the tunnel:
-
-```bash
-cloudflared tunnel run chmonitor
-```
-</Step>
-<Step>
-### Configure chmonitor
-
-```bash
-CHM_AUTH_PROVIDER=proxy
-
-CHM_CF_ACCESS_TEAM_DOMAIN=yourteam.cloudflareaccess.com
-CHM_CF_ACCESS_AUD=<64-char-aud-tag>
-```
-
-The `proxy` provider verifies the `Cf-Access-Jwt-Assertion` header against the team's JWKS automatically. No shared secret is needed — the JWT signature is the proof.
-</Step>
-<Step>
-### Verify
-
-```bash
-# Should return authenticated identity from Access
-curl -H "Cf-Access-Jwt-Assertion: <token>" \
-  https://your-chmonitor.example.com/api/v1/auth/me | jq .
-```
-
-Unauthenticated requests hit the Access login page (Cloudflare redirects them) before reaching chmonitor.
-</Step>
-</Steps>
-
-</Tab>
-<Tab value="nginx + oauth2-proxy">
-
-oauth2-proxy sits alongside nginx and handles the OIDC login flow. After login it sets forwarded-identity headers that chmonitor's `trusted` provider reads. nginx uses `auth_request` to check with oauth2-proxy on every request. If the session is valid, oauth2-proxy sets identity headers; nginx forwards them to chmonitor along with a shared secret.
-
-```
-Browser → nginx → oauth2-proxy (login) → nginx → chmonitor
-```
-
-<Steps>
-<Step>
-### Run oauth2-proxy
-
-Example with Google OIDC (replace with your provider):
-
-```bash
-docker run -d \
-  -p 4180:4180 \
-  quay.io/oauth2-proxy/oauth2-proxy \
-  --provider=google \
-  --client-id=YOUR_CLIENT_ID \
-  --client-secret=YOUR_CLIENT_SECRET \
-  --cookie-secret=$(openssl rand -base64 32) \
-  --email-domain=yourcompany.com \
-  --upstream=http://chmonitor:8080 \
-  --http-address=0.0.0.0:4180 \
-  --set-xauthrequest \          # emits X-Auth-Request-User, X-Auth-Request-Email
-  --pass-access-token=false
-```
-
-`--set-xauthrequest` makes oauth2-proxy emit `X-Auth-Request-User` and `X-Auth-Request-Email` on authenticated requests. Those map to chmonitor's default identity headers.
-</Step>
-<Step>
-### Configure nginx
-
-```nginx
-server {
-  listen 443 ssl;
-  server_name chmonitor.yourcompany.com;
-
-  location /oauth2/ {
-    proxy_pass http://oauth2-proxy:4180;
-    proxy_set_header Host $host;
-  }
-
-  location = /oauth2/auth {
-    proxy_pass http://oauth2-proxy:4180;
-    proxy_pass_request_body off;
-    proxy_set_header Content-Length "";
-    proxy_set_header X-Original-URI $request_uri;
-  }
-
-  location / {
-    auth_request /oauth2/auth;
-    error_page 401 = /oauth2/sign_in;
-
-    # Forward identity from oauth2-proxy
-    auth_request_set $user  $upstream_http_x_auth_request_user;
-    auth_request_set $email $upstream_http_x_auth_request_email;
-
-    proxy_set_header X-Forwarded-User  $user;
-    proxy_set_header X-Forwarded-Email $email;
-
-    # Shared secret so chmonitor trusts these headers
-    proxy_set_header X-Chm-Proxy-Secret "your-shared-secret-here";
-
-    proxy_pass http://chmonitor:8080;
-  }
-}
-```
-</Step>
-<Step>
-### Configure chmonitor
-
-```bash
-CHM_AUTH_PROVIDER=trusted
-
-# Shared secret — must match the value in nginx
-CHM_TRUSTED_AUTH_SECRET=your-shared-secret-here
-
-# Optional: override header names if oauth2-proxy emits different ones
-# CHM_TRUSTED_USER_HEADER=X-Auth-Request-User   # default: X-Forwarded-User
-# CHM_TRUSTED_EMAIL_HEADER=X-Auth-Request-Email  # default: X-Forwarded-Email
-```
-
-oauth2-proxy's `--set-xauthrequest` emits `X-Auth-Request-User` and `X-Auth-Request-Email`. The nginx `auth_request_set` block copies them to `X-Forwarded-User` / `X-Forwarded-Email`, which are chmonitor's defaults.
-</Step>
-<Step>
-### Verify
-
-```bash
-# Hit chmonitor directly (bypasses nginx) — should 401 (no shared secret)
-curl http://chmonitor:8080/api/v1/auth/me
-
-# Through nginx with a valid session cookie — should return authenticated principal
-curl -b "session=..." https://chmonitor.yourcompany.com/api/v1/auth/me | jq .
-```
-</Step>
-</Steps>
-
-</Tab>
-<Tab value="Traefik ForwardAuth + OIDC">
-
-Traefik's `forwardAuth` middleware sends every request to an external auth server (e.g. Authelia, Authentik, or a custom endpoint) before proxying it. On success the auth server adds identity headers.
-
-```
-Browser → Traefik → Authelia (forwardAuth) → Traefik → chmonitor
-```
-
-<Steps>
-<Step>
-### Configure Authelia (or Authentik)
-
-This example uses Authelia. Authelia adds `Remote-User`, `Remote-Name`, `Remote-Groups`, and `Remote-Email` headers on authenticated requests.
-
-`authelia/configuration.yml` (relevant section):
-
-```yaml
-access_control:
-  default_policy: deny
-  rules:
-    - domain: chmonitor.yourcompany.com
-      policy: one_factor
-```
-</Step>
-<Step>
-### Configure Traefik
-
-`docker-compose.yml` (extract):
-
-```yaml
-services:
-  traefik:
-    image: traefik:v3
-    command:
-      - --providers.docker=true
-      - --entrypoints.websecure.address=:443
-
-  chmonitor:
-    image: ghcr.io/chmonitor/chmonitor:latest
-    labels:
-      traefik.enable: "true"
-      traefik.http.routers.chmonitor.rule: "Host(`chmonitor.yourcompany.com`)"
-      traefik.http.routers.chmonitor.entrypoints: "websecure"
-      traefik.http.routers.chmonitor.middlewares: "authelia@docker"
-
-  authelia:
-    image: authelia/authelia:latest
-    labels:
-      traefik.enable: "true"
-      traefik.http.middlewares.authelia.forwardauth.address: "http://authelia:9091/api/authz/forward-auth"
-      traefik.http.middlewares.authelia.forwardauth.trustForwardHeader: "true"
-      traefik.http.middlewares.authelia.forwardauth.authResponseHeaders: >-
-        Remote-User,Remote-Groups,Remote-Name,Remote-Email
-```
-
-Authelia sets `Remote-User`, `Remote-Name`, `Remote-Groups`, `Remote-Email`. Tell chmonitor to read those.
-</Step>
-<Step>
-### Configure chmonitor
-
-```bash
-CHM_AUTH_PROVIDER=trusted
-
-# Authelia headers differ from chmonitor's defaults — override them
-CHM_TRUSTED_USER_HEADER=Remote-User
-CHM_TRUSTED_EMAIL_HEADER=Remote-Email
-CHM_TRUSTED_NAME_HEADER=Remote-Name
-CHM_TRUSTED_GROUPS_HEADER=Remote-Groups
-
-# Trust gate: either set a shared secret or enable network-isolation mode.
-# Network isolation (chmonitor only reachable via Traefik inside Docker):
-CHM_TRUSTED_ALLOW_INSECURE=true
-
-# Or: set a shared secret (more secure; configure Traefik to add it)
-# CHM_TRUSTED_AUTH_SECRET=your-secret
-# CHM_TRUSTED_SHARED_SECRET_HEADER=X-Chm-Proxy-Secret
-```
-
-<Callout type="warn" title="Network isolation requirement">
-If you use `CHM_TRUSTED_ALLOW_INSECURE=true`, make sure chmonitor's port (8080) is not exposed on the host — only reachable via Traefik inside the Docker network.
-</Callout>
-</Step>
-<Step>
-### Optional: group-based access control
-
-Restrict chmonitor to specific Authelia groups:
-
-```bash
-# Only users in the "ops" or "admin" group can access chmonitor
-CHM_TRUSTED_ALLOWED_GROUPS=ops,admin
-```
-
-Authelia forwards groups as a comma-separated list in `Remote-Groups`; chmonitor checks intersection (case-insensitive).
-</Step>
-<Step>
-### Verify
-
-```bash
-# Auth/me should show the identity forwarded by Authelia
-curl https://chmonitor.yourcompany.com/api/v1/auth/me | jq .
-```
-</Step>
-</Steps>
-
-</Tab>
-</Tabs>
-
-## Trusted provider — full reference
-
-All env vars for `CHM_AUTH_PROVIDER=trusted`.
-
-### Trust gate
-
-<TypeTable
-  type={{
-    CHM_TRUSTED_AUTH_SECRET: {
-      description: 'Shared secret the proxy sends in the secret header. Constant-time compared.',
-      type: 'string',
-      default: '—',
-    },
-    CHM_TRUSTED_ALLOW_INSECURE: {
-      description: 'Skip secret check when the worker is network-isolated behind the proxy.',
-      type: 'boolean',
-      default: 'false',
-    },
-    CHM_TRUSTED_SHARED_SECRET_HEADER: {
-      description: 'Header name the proxy sends the secret in.',
-      type: 'string',
-      default: 'X-Chm-Proxy-Secret',
-    },
-  }}
-/>
-
-### Identity headers
-
-<TypeTable
-  type={{
-    CHM_TRUSTED_USER_HEADER: {
-      description: 'Maps to: User subject / id.',
-      type: 'string',
-      default: 'X-Forwarded-User',
-    },
-    CHM_TRUSTED_EMAIL_HEADER: {
-      description: 'Maps to: Email address.',
-      type: 'string',
-      default: 'X-Forwarded-Email',
-    },
-    CHM_TRUSTED_NAME_HEADER: {
-      description: 'Maps to: Display name.',
-      type: 'string',
-      default: 'X-Forwarded-Preferred-Username',
-    },
-    CHM_TRUSTED_AVATAR_HEADER: {
-      description: 'Maps to: Avatar URL.',
-      type: 'string',
-      default: 'X-Forwarded-Avatar',
-    },
-    CHM_TRUSTED_GROUPS_HEADER: {
-      description: 'Maps to: Comma-separated group list.',
-      type: 'string',
-      default: 'X-Forwarded-Groups',
-    },
-    CHM_TRUSTED_ROLE_HEADER: {
-      description: 'Maps to: Single role (merged into groups).',
-      type: 'string',
-      default: 'X-Forwarded-Role',
-    },
-    CHM_TRUSTED_CUSTOM_HEADERS: {
-      description: 'Extra claims: field:Header-Name pairs.',
-      type: 'string',
-      default: '—',
-    },
-  }}
-/>
-
-### Access control
-
-<TypeTable
-  type={{
-    CHM_TRUSTED_ALLOWED_GROUPS: {
-      description: 'Comma-separated list of groups. If set, user must be in at least one.',
-      type: 'string',
-      default: '—',
-    },
-  }}
-/>
+| Setup | chmonitor provider | Trust mechanism | Full profile (name/email/avatar/groups)? |
+|---|---|---|---|
+| Cloudflare Access + Tunnel | `proxy` | Signed `Cf-Access-Jwt-Assertion` JWT — no shared secret needed | No — subject only (`email` claim) |
+| nginx + oauth2-proxy | `trusted` | Shared secret header (`X-Chm-Proxy-Secret`) | Yes |
+| Traefik ForwardAuth + OIDC | `trusted` | Shared secret header, or network isolation (`CHM_TRUSTED_ALLOW_INSECURE`) | Yes |
 
 ## Troubleshooting
 
 <Callout type="info" title="Every page returns 401">
-The `trusted` and `proxy` providers reject requests they can't verify. Confirm the trust gate: for `proxy`, `CHM_CF_ACCESS_TEAM_DOMAIN` and `CHM_CF_ACCESS_AUD`; for `trusted`, `CHM_TRUSTED_AUTH_SECRET` or `CHM_TRUSTED_ALLOW_INSECURE`. See [Troubleshooting → Auth failures](/guide/guides/troubleshooting).
+Both providers reject requests they can't verify — there is no open fallback. Confirm the trust gate: for `proxy`, `CHM_CF_ACCESS_TEAM_DOMAIN` and `CHM_CF_ACCESS_AUD` (Cloudflare Access) or `CHM_PROXY_AUTH_SECRET` (bare trusted-header); for `trusted`, `CHM_TRUSTED_AUTH_SECRET` or `CHM_TRUSTED_ALLOW_INSECURE`. Each per-platform guide above has a dedicated troubleshooting section covering wrong header names, header-spoofing risk, and websocket/streaming passthrough for the AI agent chat. See also [Troubleshooting → Auth failures](/guide/guides/troubleshooting).
 </Callout>
 
 ## Related
 
 <Cards>
 <Card title="Authentication overview" href="/operate/authentication" description="Compare all chmonitor auth providers side by side." />
-<Card title="Trusted proxy docs" href="/operate/authentication/trusted-proxy" description="Reference for the trusted forwarded-identity provider." />
-<Card title="Cloudflare Access docs" href="/operate/authentication/cloudflare-access" description="Reference for the proxy JWT provider." />
-<Card title="Trusted header docs" href="/operate/authentication/trusted-header" description="Header mapping for forwarded identity." />
+<Card title="Trusted forwarded headers reference" href="/operate/authentication/trusted-proxy" description="Full env var reference for the trusted provider (full profile)." />
+<Card title="Trusted header (proxy provider) reference" href="/operate/authentication/trusted-header" description="Bare identity subject via shared secret, no full profile." />
+<Card title="Cloudflare Access reference" href="/operate/authentication/cloudflare-access" description="Reference for the proxy JWT provider." />
 <Card title="API keys" href="/operate/authentication/api-keys" description="Issue and use chmonitor API tokens." />
 </Cards>

--- a/docs/content/guide/guides/proxy-auth-traefik-oidc.mdx
+++ b/docs/content/guide/guides/proxy-auth-traefik-oidc.mdx
@@ -1,0 +1,263 @@
+---
+title: Proxy auth — Traefik ForwardAuth + OIDC
+description: Use Traefik's forwardAuth middleware with oauth2-proxy (or Authelia/Authentik) to gate chmonitor behind an OIDC login, forwarding a full identity profile.
+icon: Waypoints
+---
+
+Traefik doesn't speak OIDC itself — it delegates the auth decision to an external service via the `forwardAuth` middleware, which calls that service on every request before proxying to chmonitor. Pair it with **oauth2-proxy** (or Authelia/Authentik) as the OIDC bridge: oauth2-proxy does the actual login against your IdP and exposes an internal check endpoint; Traefik calls it, copies the response headers it returns onto the real request, and chmonitor's `trusted` provider reads those into a full profile.
+
+<Callout type="info" title="When to pick this path">
+Use this when Traefik is already your ingress (bare Traefik, Traefik in Kubernetes/k3s via `IngressRoute`, or Docker with the Traefik provider) and you want OIDC login without switching to nginx or Cloudflare.
+</Callout>
+
+<Mermaid chart={`sequenceDiagram
+  participant B as Browser
+  participant T as Traefik
+  participant O as oauth2-proxy (OIDC)
+  participant A as chmonitor (trusted provider)
+  B->>T: request
+  T->>O: forwardAuth: GET /oauth2/auth
+  alt no valid session
+    O-->>T: 401
+    T-->>B: redirect to oauth2-proxy /oauth2/start
+  else valid session
+    O-->>T: 200 + X-Auth-Request-* headers
+    T->>A: forward + X-Auth-Request-* + X-Chm-Proxy-Secret
+    A->>A: verify secret, build principal
+    A-->>B: 200 data
+  end`} />
+
+## Prerequisites
+
+- Traefik v2 or v3 as your ingress (standalone, Docker provider, or Kubernetes CRD provider `IngressRoute`/`Middleware`).
+- oauth2-proxy (or Authelia/Authentik) reachable from Traefik, configured against an OIDC provider (Dex, Okta, Keycloak, Google Workspace, GitHub, etc.).
+- The ability to inject a static header (the shared secret) on requests forwarded to chmonitor — via a second Traefik `headers` middleware, or by running chmonitor network-isolated behind Traefik only.
+
+## Setup
+
+<Steps>
+<Step>
+### Run oauth2-proxy as the OIDC bridge
+
+```bash
+docker run -d \
+  --name oauth2-proxy \
+  -p 4180:4180 \
+  quay.io/oauth2-proxy/oauth2-proxy:latest \
+  --provider=oidc \
+  --oidc-issuer-url=https://dex.example.com \
+  --client-id=chmonitor \
+  --client-secret=YOUR_CLIENT_SECRET \
+  --cookie-secret=$(python3 -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())') \
+  --http-address=0.0.0.0:4180 \
+  --set-xauthrequest \
+  --scope="openid email profile groups" \
+  --redirect-url=https://chmonitor.example.com/oauth2/callback
+```
+
+`--scope="openid email profile groups"` requests the `groups` claim from your OIDC provider — needed if you plan to gate chmonitor access with `CHM_TRUSTED_ALLOWED_GROUPS`. Your IdP (Dex, Keycloak, Authentik) must be configured to actually populate `groups` for this to have any effect.
+</Step>
+<Step>
+### Define the forwardAuth middleware
+
+Traefik dynamic configuration (file provider) or a Kubernetes `Middleware` CRD:
+
+```yaml
+# Traefik file/dynamic config (traefik dynamic.yml)
+http:
+  middlewares:
+    oauth2-proxy-auth:
+      forwardAuth:
+        address: "http://oauth2-proxy:4180/oauth2/auth"
+        trustForwardHeader: true
+        authResponseHeaders:
+          - X-Auth-Request-User
+          - X-Auth-Request-Email
+          - X-Auth-Request-Preferred-Username
+          - X-Auth-Request-Groups
+
+    # Injects the shared secret chmonitor checks — chained after forwardAuth
+    chm-proxy-secret:
+      headers:
+        customRequestHeaders:
+          X-Chm-Proxy-Secret: "your-shared-secret-here"
+```
+
+Kubernetes CRD equivalent:
+
+```yaml
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: oauth2-proxy-auth
+  namespace: monitoring
+spec:
+  forwardAuth:
+    address: http://oauth2-proxy.monitoring.svc.cluster.local:4180/oauth2/auth
+    trustForwardHeader: true
+    authResponseHeaders:
+      - X-Auth-Request-User
+      - X-Auth-Request-Email
+      - X-Auth-Request-Preferred-Username
+      - X-Auth-Request-Groups
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: chm-proxy-secret
+  namespace: monitoring
+spec:
+  headers:
+    customRequestHeaders:
+      X-Chm-Proxy-Secret: "your-shared-secret-here"
+```
+
+`address` is the exact internal check endpoint oauth2-proxy exposes; `authResponseHeaders` is the allowlist of headers Traefik copies from oauth2-proxy's `200` response onto the request it forwards to chmonitor. `--set-xauthrequest` (step 1) is what makes oauth2-proxy actually populate those headers.
+
+<Callout type="warn" title="Don't hardcode the secret in a committed manifest">
+`customRequestHeaders` with a literal secret value works but shouldn't be committed to source control as-is. Template it from a Kubernetes Secret at apply time (Kustomize secretGenerator, SOPS, sealed-secrets) or a CI templating step, or skip the shared secret entirely and use `CHM_TRUSTED_ALLOW_INSECURE=true` if chmonitor is only reachable as a `ClusterIP` behind Traefik (see Troubleshooting below).
+</Callout>
+</Step>
+<Step>
+### Attach both middlewares to the chmonitor route
+
+Order matters: the auth check must run before the secret header is added.
+
+```yaml
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: chmonitor
+  namespace: monitoring
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`chmonitor.example.com`)
+      kind: Rule
+      middlewares:
+        - name: oauth2-proxy-auth
+        - name: chm-proxy-secret
+      services:
+        - name: chmonitor
+          port: 8080
+```
+
+Docker-provider label equivalent:
+
+```yaml
+labels:
+  traefik.enable: "true"
+  traefik.http.routers.chmonitor.rule: "Host(`chmonitor.example.com`)"
+  traefik.http.routers.chmonitor.middlewares: "oauth2-proxy-auth,chm-proxy-secret"
+  traefik.http.middlewares.oauth2-proxy-auth.forwardauth.address: "http://oauth2-proxy:4180/oauth2/auth"
+  traefik.http.middlewares.oauth2-proxy-auth.forwardauth.trustForwardHeader: "true"
+  traefik.http.middlewares.oauth2-proxy-auth.forwardauth.authResponseHeaders: "X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Preferred-Username,X-Auth-Request-Groups"
+  traefik.http.middlewares.chm-proxy-secret.headers.customrequestheaders.X-Chm-Proxy-Secret: "your-shared-secret-here"
+```
+
+You'll also need a route for oauth2-proxy's own `/oauth2/` paths (login page, callback) — route `PathPrefix(\`/oauth2/\`)` on the same host to the oauth2-proxy service directly, without the auth middlewares attached.
+</Step>
+<Step>
+### Configure chmonitor
+
+<TypeTable
+  type={{
+    CHM_AUTH_PROVIDER: {
+      description: 'Set to trusted.',
+      type: 'string',
+      default: 'none',
+    },
+    CHM_TRUSTED_AUTH_SECRET: {
+      description: 'Shared secret — must equal the value injected by the chm-proxy-secret middleware.',
+      type: 'string',
+    },
+    CHM_TRUSTED_USER_HEADER: {
+      description: "oauth2-proxy's response header is X-Auth-Request-User, not chmonitor's default X-Forwarded-User — override it.",
+      type: 'string',
+      default: 'X-Forwarded-User',
+    },
+    CHM_TRUSTED_EMAIL_HEADER: {
+      description: 'Override to match oauth2-proxy.',
+      type: 'string',
+      default: 'X-Forwarded-Email',
+    },
+    CHM_TRUSTED_NAME_HEADER: {
+      description: 'Override to match oauth2-proxy.',
+      type: 'string',
+      default: 'X-Forwarded-Preferred-Username',
+    },
+    CHM_TRUSTED_GROUPS_HEADER: {
+      description: 'Override to match oauth2-proxy.',
+      type: 'string',
+      default: 'X-Forwarded-Groups',
+    },
+  }}
+/>
+
+```bash
+CHM_AUTH_PROVIDER=trusted
+
+# oauth2-proxy's --set-xauthrequest headers are X-Auth-Request-*, not
+# chmonitor's X-Forwarded-* defaults — map them explicitly
+CHM_TRUSTED_USER_HEADER=X-Auth-Request-User
+CHM_TRUSTED_EMAIL_HEADER=X-Auth-Request-Email
+CHM_TRUSTED_NAME_HEADER=X-Auth-Request-Preferred-Username
+CHM_TRUSTED_GROUPS_HEADER=X-Auth-Request-Groups
+
+CHM_TRUSTED_AUTH_SECRET=your-shared-secret-here
+
+# Optional: restrict to specific IdP groups
+# CHM_TRUSTED_ALLOWED_GROUPS=sre,admin
+```
+
+<Callout type="warn" title="Network isolation is an alternative to the shared secret">
+If chmonitor runs as a Kubernetes `ClusterIP` Service with no other route to it besides this Traefik `IngressRoute`, you can skip the `chm-proxy-secret` middleware and set `CHM_TRUSTED_ALLOW_INSECURE=true` instead. Only do this when you're certain nothing else (a NodePort, a debug port-forward left open, a second Ingress) can reach chmonitor directly.
+</Callout>
+</Step>
+<Step>
+### Verify
+
+```bash
+# No session — Traefik's forwardAuth call gets a 401 from oauth2-proxy,
+# which should surface as a redirect to the login flow
+curl -i https://chmonitor.example.com/
+
+# Direct to the chmonitor Service, bypassing Traefik entirely — must 401
+kubectl -n monitoring exec -it deploy/debug -- curl -i http://chmonitor:8080/api/v1/auth/me
+
+# Through Traefik with a valid oauth2-proxy session cookie
+curl -b "_oauth2_proxy=<cookie-value>" https://chmonitor.example.com/api/v1/auth/me | jq .
+```
+</Step>
+</Steps>
+
+## Troubleshooting
+
+<Accordions>
+<Accordion title="forwardAuth returns 401 but chmonitor never even sees a request">
+That's Traefik correctly enforcing the middleware — check oauth2-proxy's own logs, not chmonitor's. A 401 from `/oauth2/auth` means no valid session cookie was presented; Traefik should be configured to redirect to oauth2-proxy's sign-in flow (via an `errors` middleware or oauth2-proxy's own redirect behavior) rather than surfacing a bare 401 to the user.
+</Accordion>
+<Accordion title="chmonitor 401s even though Traefik and oauth2-proxy both say the user is authenticated">
+Two likely causes: (1) `authResponseHeaders` in the `forwardAuth` middleware doesn't list a header oauth2-proxy actually returns — Traefik only copies headers on that allowlist, silently dropping anything not listed; (2) `CHM_TRUSTED_AUTH_SECRET` doesn't match the literal value in the `chm-proxy-secret` middleware's `customRequestHeaders` — this is a constant-time comparison, so even a trailing-whitespace difference fails it.
+</Accordion>
+<Accordion title="Wrong header name — chmonitor builds an empty or partial profile">
+oauth2-proxy's `--set-xauthrequest` headers are `X-Auth-Request-User` / `X-Auth-Request-Email` / `X-Auth-Request-Preferred-Username` / `X-Auth-Request-Groups` — these do **not** match chmonitor's `X-Forwarded-*` defaults. You must explicitly set `CHM_TRUSTED_USER_HEADER`, `CHM_TRUSTED_EMAIL_HEADER`, `CHM_TRUSTED_NAME_HEADER`, and `CHM_TRUSTED_GROUPS_HEADER` as shown above (unlike nginx, where you typically rename headers in the proxy config itself, here it's usually simpler to keep Traefik's `authResponseHeaders` names as-is and point chmonitor's env vars at them).
+</Accordion>
+<Accordion title="Header spoofing risk">
+`trustForwardHeader: true` only affects how Traefik reads *its own* `X-Forwarded-*` routing headers from an upstream load balancer — it has no bearing on whether chmonitor trusts the identity headers. That trust is entirely gated by `CHM_TRUSTED_AUTH_SECRET` (or `CHM_TRUSTED_ALLOW_INSECURE` + genuine network isolation). Without one of those two, the `trusted` provider fails closed and denies all requests, so a forged `X-Auth-Request-User` from a client that bypasses Traefik still won't authenticate.
+</Accordion>
+<Accordion title="Websocket / streaming passthrough for the AI agent chat">
+Traefik proxies streaming HTTP responses (including SSE-style output like the agent chat) without extra configuration by default — there's no buffering step to disable like nginx. `forwardAuth` only intercepts the initial request to decide whether to forward it at all; it does not re-check per chunk once the streamed response has started. If a long chat response gets cut off, check `forwardAuth`'s implicit timeout (Traefik times out the auth call itself, not the upstream response) and any `readTimeout`/`idleTimeout` configured on the Traefik entrypoint.
+</Accordion>
+</Accordions>
+
+## Related
+
+<Cards>
+<Card title="Proxy auth overview" href="/guide/guides/proxy-auth-setup" description="Compare all three proxy patterns." />
+<Card title="Cloudflare Access + Tunnel" href="/guide/guides/proxy-auth-cloudflare-access" description="Zero Trust, signed JWT, no shared secret." />
+<Card title="nginx + oauth2-proxy" href="/guide/guides/proxy-auth-nginx-oauth2-proxy" description="Self-hosted OIDC login in front of nginx." />
+<Card title="Trusted forwarded headers reference" href="/operate/authentication/trusted-proxy" description="Full env var reference for the trusted provider, incl. a k3s + Traefik + oauth2-proxy + Dex example." />
+<Card title="Authentication overview" href="/operate/authentication" description="Compare all chmonitor auth providers." />
+</Cards>


### PR DESCRIPTION
## Summary
- Split `docs/content/guide/guides/proxy-auth-setup.mdx` into three detailed per-platform guides: Cloudflare Access + Tunnel, nginx + oauth2-proxy, and Traefik ForwardAuth + OIDC.
- Each new page covers prerequisites, full config files (cloudflared/nginx/Traefik + oauth2-proxy), the exact chmonitor env vars (`CHM_AUTH_PROVIDER=proxy|trusted`, `CHM_CF_ACCESS_*`, `CHM_TRUSTED_*`), verification steps, and troubleshooting (wrong header names, header-spoofing risk, websocket/streaming passthrough for the AI agent chat).
- `proxy-auth-setup.mdx` is now a short overview/landing page: security model, provider comparison table, and Cards linking to the three new pages. The existing inbound link from `connect-firewalled-clickhouse.mdx` still resolves.
- Header names, env vars, and defaults were verified against the actual auth provider source (`apps/dashboard/src/lib/auth/providers/{trusted,proxy}.ts`) and cross-checked against the existing `/operate/authentication/{trusted-proxy,trusted-header,cloudflare-access}` reference pages — no discrepancies found. Cloudflare/oauth2-proxy/Traefik config syntax was verified against official docs via WebFetch.

## Test plan
- [x] `cd apps/docs && pnpm run build` (sync-docs → prerender) succeeds; all 4 proxy-auth pages prerender cleanly.
- [x] Verified env vars/headers against source (`trusted.ts`, `proxy.ts`) and existing reference docs.
- [ ] CI green

https://claude.ai/code/session_011a1CRbruQCZCPdjj2ntKjZ