### PR TITLE
fix(oss): agent stream errors, tables 500, billing 401 spam on self-hosted

### DIFF
--- a/apps/dashboard/src/components/assistant-ui/thread.tsx
+++ b/apps/dashboard/src/components/assistant-ui/thread.tsx
@@ -33,6 +33,7 @@
  */
 
 import {
+  AlertTriangleIcon,
   CheckIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
@@ -78,6 +79,10 @@ import {
   MessageScrollerProvider,
   MessageScrollerViewport,
 } from '@/components/ui/message-scroller'
+import {
+  type AgentError,
+  extractAgentErrorFromParts,
+} from '@/lib/ai/agent/errors'
 import { getFollowUpPrompts } from '@/lib/ai/agent/follow-up-prompts'
 import { resolveConversationBackend } from '@/lib/conversation-store/adapter/resolve-thread-list-adapter'
 import { useAgentSkills } from '@/lib/hooks/use-agent-skills'
@@ -331,6 +336,39 @@ function MessageError() {
   )
 }
 
+/**
+ * Renders a `data-error` part the agent route streamed for a failure that
+ * happened INSIDE the UI-message stream (provider/tool/upstream error surfacing
+ * after the HTTP 200 headers were sent). assistant-ui's `MessagePrimitive.Error`
+ * only covers the runtime's own error status, so without this these classified
+ * errors were dropped and the message looked dead ("An error occurred" / an
+ * empty bubble). This makes the real cause + actionable suggestion visible.
+ */
+function AgentDataError() {
+  const content = useMessage((m) => m.content) as readonly unknown[]
+  const agentError: AgentError | null = extractAgentErrorFromParts(content)
+  if (!agentError) return null
+
+  return (
+    <div
+      role="alert"
+      className="border-destructive/40 bg-destructive/10 text-destructive mt-1 rounded-lg border px-3 py-2 text-sm"
+    >
+      <div className="flex items-start gap-2">
+        <AlertTriangleIcon className="mt-0.5 size-4 shrink-0" />
+        <div className="min-w-0 space-y-1">
+          <p className="font-medium break-words">{agentError.message}</p>
+          {agentError.suggestion && (
+            <p className="text-destructive/80 text-xs break-words">
+              {agentError.suggestion}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
 // ---------------------------------------------------------------------------
 // AssistantMessage — wires all tasks together
 // ---------------------------------------------------------------------------
@@ -367,6 +405,11 @@ const AssistantMessage: FC = () => {
 
             {/* Task #5: error display */}
             <MessageError />
+
+            {/* Surface errors the route streamed as a `data-error` part (a
+                failure inside the stream, after HTTP 200) — otherwise the
+                message looks dead. */}
+            <AgentDataError />
 
             <div className="flex items-center gap-1">
               <BranchPicker />

--- a/apps/dashboard/src/components/billing/usage-summary.tsx
+++ b/apps/dashboard/src/components/billing/usage-summary.tsx
@@ -13,6 +13,7 @@ import {
 } from './usage-meter-utils'
 import { Progress } from '@/components/ui/progress'
 import { Skeleton } from '@/components/ui/skeleton'
+import { retryBillingUnlessAuthError } from '@/lib/billing/retry'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { cn } from '@/lib/utils'
 
@@ -55,13 +56,26 @@ interface Envelope<T> {
   error?: { message?: string }
 }
 
+/** Error carrying the HTTP status so the retry predicate can skip 401/403. */
+class UsageRequestError extends Error {
+  readonly status: number
+  constructor(message: string, status: number) {
+    super(message)
+    this.name = 'UsageRequestError'
+    this.status = status
+  }
+}
+
 async function fetchUsage(): Promise<BillingUsage> {
   const res = await apiFetch('/api/v1/billing/usage')
   const json = (await res
     .json()
     .catch(() => null)) as Envelope<BillingUsage> | null
   if (!res.ok || !json?.success || json.data === undefined) {
-    throw new Error(json?.error?.message || `Request failed (${res.status})`)
+    throw new UsageRequestError(
+      json?.error?.message || `Request failed (${res.status})`,
+      res.status
+    )
   }
   return json.data
 }
@@ -74,7 +88,9 @@ function useBillingUsage() {
     // Match useBillingSubscription: the Clerk __session cookie is refreshed a few
     // seconds after a cold load, so retry until the fresh cookie lands.
     refetchOnMount: 'always',
-    retry: 5,
+    // A deterministic 401/403 (OSS / no billing owner) is not retried — it can
+    // never succeed and would only flood the console/Sentry.
+    retry: retryBillingUnlessAuthError,
     retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 4000),
   })
 }

--- a/apps/dashboard/src/lib/ai/agent/__tests__/errors.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/__tests__/errors.test.ts
@@ -1,5 +1,42 @@
-import { classifyError, parseAgentError } from '../errors'
+import {
+  classifyError,
+  extractAgentErrorFromParts,
+  parseAgentError,
+} from '../errors'
 import { describe, expect, test } from 'bun:test'
+
+describe('extractAgentErrorFromParts', () => {
+  const agentError = classifyError(
+    { statusCode: 401, error: { message: 'Invalid API key' } },
+    { model: 'openrouter:x', provider: 'openrouter' }
+  )
+
+  test('reads the AgentError out of a data-error part (array data)', () => {
+    const parts = [
+      { type: 'text', text: 'hi' },
+      { type: 'data-error', data: [agentError] },
+    ]
+    expect(extractAgentErrorFromParts(parts)).toEqual(agentError)
+  })
+
+  test('reads the AgentError out of a data-error part (object data)', () => {
+    const parts = [{ type: 'data-error', data: agentError }]
+    expect(extractAgentErrorFromParts(parts)).toEqual(agentError)
+  })
+
+  test('returns null when there is no data-error part', () => {
+    expect(
+      extractAgentErrorFromParts([{ type: 'text', text: 'ok' }])
+    ).toBeNull()
+    expect(extractAgentErrorFromParts([])).toBeNull()
+    expect(extractAgentErrorFromParts(undefined)).toBeNull()
+  })
+
+  test('ignores a malformed data-error payload', () => {
+    const parts = [{ type: 'data-error', data: [{ nope: true }] }]
+    expect(extractAgentErrorFromParts(parts)).toBeNull()
+  })
+})
 
 describe('agent error classification', () => {
   test('extracts AnyRouter upstream envelope details', () => {

--- a/apps/dashboard/src/lib/ai/agent/errors.ts
+++ b/apps/dashboard/src/lib/ai/agent/errors.ts
@@ -426,6 +426,35 @@ export function parseAgentError(error: Error): AgentError | null {
   return candidate
 }
 
+/**
+ * Extract the classified {@link AgentError} from a streamed `data-error` part,
+ * if the assistant message carries one.
+ *
+ * The agent route catches failures that happen *inside* the UI-message stream
+ * (provider/tool/upstream errors that surface after the HTTP 200 headers are
+ * sent) and writes them as a `data-error` data part — `{ type: 'data-error',
+ * data: [AgentError] }` — rather than aborting the stream. assistant-ui's
+ * built-in `MessagePrimitive.Error` only renders the runtime's own error status,
+ * so without an explicit renderer these parts were silently dropped: the user
+ * saw a dead, empty assistant bubble ("An error occurred" / nothing) even though
+ * the server had classified the failure. This reads the part back out so the UI
+ * can surface the real cause + suggestion. Scans newest→oldest and returns the
+ * first valid AgentError, or null when there is none.
+ */
+export function extractAgentErrorFromParts(
+  parts: readonly unknown[] | undefined | null
+): AgentError | null {
+  if (!Array.isArray(parts)) return null
+  for (let index = parts.length - 1; index >= 0; index--) {
+    const part = parts[index]
+    if (!isObject(part) || part.type !== 'data-error') continue
+    const data = part.data
+    const candidate = Array.isArray(data) ? data[0] : data
+    if (isAgentError(candidate)) return candidate
+  }
+  return null
+}
+
 export function isAgentError(value: unknown): value is AgentError {
   return (
     isObject(value) &&

--- a/apps/dashboard/src/lib/billing/__tests__/retry.test.ts
+++ b/apps/dashboard/src/lib/billing/__tests__/retry.test.ts
@@ -1,0 +1,52 @@
+import {
+  billingErrorStatus,
+  isBillingAuthError,
+  retryBillingUnlessAuthError,
+} from '../retry'
+import { describe, expect, test } from 'bun:test'
+
+describe('billingErrorStatus', () => {
+  test('reads a numeric status property', () => {
+    expect(billingErrorStatus({ status: 401 })).toBe(401)
+  })
+
+  test('parses a status embedded in the message', () => {
+    expect(billingErrorStatus(new Error('Request failed (403)'))).toBe(403)
+  })
+
+  test('returns null when no status is present', () => {
+    expect(billingErrorStatus(new Error('boom'))).toBeNull()
+    expect(billingErrorStatus(null)).toBeNull()
+    expect(billingErrorStatus('nope')).toBeNull()
+  })
+})
+
+describe('isBillingAuthError', () => {
+  test('true for 401/403', () => {
+    expect(isBillingAuthError({ status: 401 })).toBe(true)
+    expect(isBillingAuthError({ status: 403 })).toBe(true)
+    expect(isBillingAuthError(new Error('Usage request failed (401)'))).toBe(
+      true
+    )
+  })
+
+  test('false for other statuses / no status', () => {
+    expect(isBillingAuthError({ status: 500 })).toBe(false)
+    expect(isBillingAuthError(new Error('network error'))).toBe(false)
+  })
+})
+
+describe('retryBillingUnlessAuthError', () => {
+  test('never retries a deterministic auth failure (the OSS 401 spam case)', () => {
+    const err = { status: 401 }
+    expect(retryBillingUnlessAuthError(0, err)).toBe(false)
+    expect(retryBillingUnlessAuthError(3, err)).toBe(false)
+  })
+
+  test('retries a transient failure up to 5 times', () => {
+    const err = new Error('network error')
+    expect(retryBillingUnlessAuthError(0, err)).toBe(true)
+    expect(retryBillingUnlessAuthError(4, err)).toBe(true)
+    expect(retryBillingUnlessAuthError(5, err)).toBe(false)
+  })
+})

--- a/apps/dashboard/src/lib/billing/retry.ts
+++ b/apps/dashboard/src/lib/billing/retry.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared retry policy for the client-side billing queries.
+ *
+ * Billing calls (`/api/v1/billing/subscription`, `/api/v1/billing/usage`) can
+ * legitimately fail transiently right after a cold load, while the short-lived
+ * Clerk `__session` cookie is still being refreshed — so a bounded retry is
+ * worth it. But a `401`/`403` is DETERMINISTIC: on self-hosted / OSS (no Clerk
+ * owner) the route can never resolve a billing owner, so every retry returns the
+ * same 401. Retrying then only floods the console and Sentry. This predicate
+ * keeps the bounded retry for everything EXCEPT an auth failure, which it gives
+ * up on immediately.
+ */
+
+const MAX_BILLING_RETRIES = 5
+
+/** Extract an HTTP status from a thrown billing error, if one is present. */
+export function billingErrorStatus(error: unknown): number | null {
+  if (typeof error !== 'object' || error === null) return null
+
+  const status = (error as { status?: unknown }).status
+  if (typeof status === 'number' && Number.isFinite(status)) return status
+
+  // Fallback for errors that only carry the status inside their message
+  // (e.g. `new Error('Usage request failed (401)')`).
+  const message = (error as { message?: unknown }).message
+  if (typeof message === 'string') {
+    const match = message.match(/\((\d{3})\)/)
+    if (match) return Number(match[1])
+  }
+
+  return null
+}
+
+/** True for a deterministic auth failure that retrying can never fix. */
+export function isBillingAuthError(error: unknown): boolean {
+  const status = billingErrorStatus(error)
+  return status === 401 || status === 403
+}
+
+/**
+ * TanStack Query `retry` predicate: retry up to {@link MAX_BILLING_RETRIES}
+ * times, but never on a `401`/`403`.
+ */
+export function retryBillingUnlessAuthError(
+  failureCount: number,
+  error: unknown
+): boolean {
+  if (isBillingAuthError(error)) return false
+  return failureCount < MAX_BILLING_RETRIES
+}

--- a/apps/dashboard/src/lib/billing/use-billing.ts
+++ b/apps/dashboard/src/lib/billing/use-billing.ts
@@ -9,6 +9,8 @@ import { useQuery } from '@tanstack/react-query'
 import type { PlanId } from '@/lib/billing/plans'
 
 import { getDistinctId, trackEvent } from '@/lib/analytics/analytics'
+import { retryBillingUnlessAuthError } from '@/lib/billing/retry'
+import { isCloudModeClient } from '@/lib/cloud/cloud-mode'
 import { apiFetch } from '@/lib/swr/api-fetch'
 
 export interface BillingSubscription {
@@ -35,14 +37,34 @@ interface Envelope<T> {
 async function readEnvelope<T>(res: Response): Promise<T> {
   const json = (await res.json().catch(() => null)) as Envelope<T> | null
   if (!res.ok || !json?.success || json.data === undefined) {
-    throw new Error(json?.error?.message || `Request failed (${res.status})`)
+    throw new BillingRequestError(
+      json?.error?.message || `Request failed (${res.status})`,
+      res.status
+    )
   }
   return json.data
 }
 
+/** Error carrying the HTTP status so the retry predicate can skip 401/403. */
+export class BillingRequestError extends Error {
+  readonly status: number
+  constructor(message: string, status: number) {
+    super(message)
+    this.name = 'BillingRequestError'
+    this.status = status
+  }
+}
+
 export function useBillingSubscription() {
+  // Billing is a Cloud-only surface. On self-hosted / OSS (no Clerk) the route
+  // resolves no billing owner and returns 401 on every call — with `retry: 5`
+  // + `refetchOnMount: 'always'` that floods the console/Sentry on every focus.
+  // Gate the query off entirely when not in cloud mode (mirrors how the nav
+  // already hides the plan label off cloud), so OSS never hits the endpoint.
+  const cloud = isCloudModeClient()
   return useQuery({
     queryKey: ['billing', 'subscription'],
+    enabled: cloud,
     queryFn: async (): Promise<BillingSubscription> => {
       const res = await apiFetch('/api/v1/billing/subscription')
       return readEnvelope<BillingSubscription>(res)
@@ -53,9 +75,10 @@ export function useBillingSubscription() {
     // would otherwise cache "free" for the whole session. Always refetch on
     // mount and keep retrying (capped ~4s delay, ~15s total) so the request
     // lands once the fresh cookie is in place and the real plan replaces the
-    // stale value.
+    // stale value. A deterministic 401/403 (auth genuinely unavailable) is NOT
+    // retried — retrying can never make it succeed, it only spams.
     refetchOnMount: 'always',
-    retry: 5,
+    retry: retryBillingUnlessAuthError,
     retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 4000),
   })
 }

--- a/apps/dashboard/src/routes/api/v1/tables/index.ts
+++ b/apps/dashboard/src/routes/api/v1/tables/index.ts
@@ -9,21 +9,47 @@
 import { createFileRoute } from '@tanstack/react-router'
 
 import type { ApiErrorType } from '@/lib/api/types'
+import type { QueryConfig } from '@/lib/query-config'
 
 import { env } from 'cloudflare:workers'
-import { fetchData } from '@chm/clickhouse-client'
 import { debug, error } from '@chm/logger'
+import { executeTableConfig } from '@/lib/api/query-executor'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import { isDemoHostBlockedForRequest } from '@/lib/cloud/reject-demo-host'
 
 const DEFAULT_LIMIT = 500
 const MAX_LIMIT = 1000
 
-interface TableRow {
-  database: string
-  name: string
-  engine: string
-  total_rows: string
+/**
+ * Autocomplete table-list query. Routed through {@link executeTableConfig} (the
+ * same read-only GET path the `/api/v1/tables/$name` and chart routes use) so it
+ * resolves the host's ClickHouse version and opts into the query cache via the
+ * shared `buildQueryCacheSettings` helper. That matters for correctness, not
+ * just caching: on ClickHouse 24.4+ (#2610) a query that touches a `system.*`
+ * table fails outright with error 719 the moment `use_query_cache=1` is set
+ * unless `query_cache_system_table_handling='save'` is sent — which the shared
+ * helper version-gates. This route previously issued a raw `fetchData` call that
+ * bypassed that handling, so a host whose default profile enables the query
+ * cache 500'd every autocomplete fetch. `refreshInterval` doubles as the cache
+ * TTL (see `tableCacheTtlSeconds`).
+ */
+const TABLES_AUTOCOMPLETE_CONFIG: QueryConfig = {
+  name: 'tables-autocomplete',
+  refreshInterval: 60_000,
+  disableSqlValidation: true,
+  sql: `
+    SELECT
+      database,
+      name,
+      engine,
+      toString(total_rows) AS total_rows
+    FROM system.tables
+    WHERE database NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema')
+      AND NOT is_temporary
+    ORDER BY total_bytes DESC NULLS LAST
+    LIMIT {limit: UInt32}
+  `,
+  columns: ['database', 'name', 'engine', 'total_rows'],
 }
 
 export const Route = createFileRoute('/api/v1/tables/')({
@@ -73,23 +99,12 @@ export const Route = createFileRoute('/api/v1/tables/')({
           })
         }
 
-        const result = await fetchData<TableRow[]>({
-          query: `
-            SELECT
-              database,
-              name,
-              engine,
-              toString(total_rows) AS total_rows
-            FROM system.tables
-            WHERE database NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema')
-              AND NOT is_temporary
-            ORDER BY total_bytes DESC NULLS LAST
-            LIMIT {limit: UInt32}
-          `,
-          query_params: { limit },
-          hostId,
-          format: 'JSONEachRow',
-        })
+        const { result } = await executeTableConfig(
+          TABLES_AUTOCOMPLETE_CONFIG,
+          Number.isFinite(hostId) ? hostId : 0,
+          { limit },
+          { bindings: env as Record<string, string | undefined> }
+        )
 
         if (result.error) {
           error('[GET /api/v1/tables] Query error:', result.error)


### PR DESCRIPTION
Three bugs reported on a **self-hosted OSS** deployment (Docker/K8s, no Clerk, no cloud mode), all observed on the `/agents` chat page.

## 1. Agent chat dead — HTTP 200 but "An error occurred", nothing streams
**Root cause:** the agent route catches failures that happen *inside* the UI-message stream (provider/tool/upstream errors surfacing after the 200 headers) and writes them as a `data-error` data part instead of aborting the stream. assistant-ui's built-in `MessagePrimitive.Error` only renders the runtime's own error status, so these parts were **silently dropped** — the message looked dead.
**Fix:** `extractAgentErrorFromParts()` + an `AgentDataError` renderer in the thread that reads the classified error back out and shows its message + actionable suggestion.
Files: `lib/ai/agent/errors.ts`, `components/assistant-ui/thread.tsx`.

## 2. `GET /api/v1/tables?hostId=0&limit=500` → 500 repeatedly
**Root cause:** the autocomplete table-list route issued a **raw `fetchData`** call that bypassed `buildQueryCacheSettings`. On ClickHouse 24.4+ a host whose default profile enables the query cache then fails every request with error **719 `QUERY_CACHE_USED_WITH_SYSTEM_TABLE`** (`system.tables` is a system table; `query_cache_system_table_handling` defaults to `throw`) — the exact class of bug fixed for other routes in #2610.
**Fix:** route the query through the shared `executeTableConfig`, so it gets the same version-gated system-table handling, optional-table checks and otel span as the other read-only GET paths. The thread's autocomplete hook already degrades gracefully (empty list) when this fetch fails, so chat keeps working.
Files: `routes/api/v1/tables/index.ts`.

## 3. `GET /api/v1/billing/usage` / `subscription` → 401 spam on OSS
**Root cause:** `useBillingSubscription()` (mounted in the sidebar nav on every page, incl. `/agents`) fired **unconditionally** with `retry: 5` + `refetchOnMount: 'always'`. Billing is a cloud-only surface, so on OSS the route 401s every call and it flooded the console/Sentry on every window focus.
**Fix:** gate the query with `enabled: isCloudModeClient()` and add a shared `retryBillingUnlessAuthError` predicate — a deterministic 401/403 is never retried. Same no-retry-on-auth policy applied to the billing usage-summary query. Fails open silently per the OSS invariant.
Files: `lib/billing/retry.ts`, `lib/billing/use-billing.ts`, `components/billing/usage-summary.tsx`.

### Also seen: `/api/v1/menu-counts` 504
Not addressed here — no obvious code cause (that route already uses `buildQueryCacheSettings`); the 504 points at a slow ClickHouse rather than a code bug. Noted for follow-up.

## Tests
- `lib/ai/agent/__tests__/errors.test.ts` — `extractAgentErrorFromParts` (array/object/absent/malformed).
- `lib/billing/__tests__/retry.test.ts` — status extraction + no-retry-on-401 predicate.
- `bun test` green (15 pass); `pnpm run type-check` clean.

https://claude.ai/code/session_011a1CRbruQCZCPdjj2ntKjZ