### PR TITLE
feat(cloud-hooks): GitHub App auth for exception issues

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -1062,6 +1062,9 @@ jobs:
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           GITHUB_TOKEN: ${{ secrets.CLOUD_HOOKS_GITHUB_TOKEN }}
           CF_OBSERVABILITY_API_TOKEN: ${{ secrets.CF_OBSERVABILITY_API_TOKEN }}
+          # GitHub App auth for exception issues (preferred over the PAT above).
+          GH_APP_ID: ${{ secrets.CLOUD_HOOKS_GH_APP_ID }}
+          GH_APP_PRIVATE_KEY: ${{ secrets.CLOUD_HOOKS_GH_APP_PRIVATE_KEY }}
         run: |
           set -euo pipefail
           put() {
@@ -1079,3 +1082,5 @@ jobs:
           put TELEGRAM_CHAT_ID "${TELEGRAM_CHAT_ID:-}"
           put GITHUB_TOKEN "${GITHUB_TOKEN:-}"
           put CF_OBSERVABILITY_API_TOKEN "${CF_OBSERVABILITY_API_TOKEN:-}"
+          put GH_APP_ID "${GH_APP_ID:-}"
+          put GH_APP_PRIVATE_KEY "${GH_APP_PRIVATE_KEY:-}"

--- a/apps/cloud-hooks/deploy.config.ts
+++ b/apps/cloud-hooks/deploy.config.ts
@@ -14,6 +14,9 @@ export default {
     'CHM_EXCEPTION_ISSUE_LABELS',
     'CHM_EXCEPTION_MAX_ISSUES_PER_RUN',
     'CHM_EXCEPTION_SCRIPTS',
+    // Optional GitHub App installation id (non-secret); unset → resolved from
+    // the repo and cached in KV.
+    'GH_APP_INSTALLATION_ID',
   ],
   secrets: [
     'POLAR_WEBHOOK_SECRET',
@@ -26,5 +29,9 @@ export default {
     // values are skipped with a warning, not a hard failure.
     'GITHUB_TOKEN',
     'CF_OBSERVABILITY_API_TOKEN',
+    // GitHub App auth (the `duyetbot` app) — takes precedence over GITHUB_TOKEN
+    // when both are set. GH_APP_PRIVATE_KEY must be a PKCS#8 PEM.
+    'GH_APP_ID',
+    'GH_APP_PRIVATE_KEY',
   ],
 }

--- a/apps/cloud-hooks/src/env.ts
+++ b/apps/cloud-hooks/src/env.ts
@@ -17,11 +17,31 @@ export interface Env {
   TELEGRAM_BOT_TOKEN?: string
   TELEGRAM_CHAT_ID?: string
   /**
-   * GitHub token (PAT/App token with `issues:write` on the target repo) used to
-   * file a GitHub issue per NEW Cloudflare Worker exception fingerprint. Unset →
-   * the exception-scan capability is disabled (no crash).
+   * GitHub PAT with `issues:write` on the target repo, used to file a GitHub
+   * issue per NEW Cloudflare Worker exception fingerprint. Fallback when the
+   * GitHub App creds below are unset. No auth at all → the exception-scan
+   * capability is disabled (no crash).
    */
   GITHUB_TOKEN?: string
+  /**
+   * GitHub App id (the `duyetbot` app). With `GH_APP_PRIVATE_KEY`, exception
+   * issues are filed as the App (installation token) instead of a PAT — App
+   * creds take precedence over `GITHUB_TOKEN`. The App needs **Issues: Read &
+   * write** and must be installed on the target repo.
+   */
+  GH_APP_ID?: string
+  /**
+   * GitHub App private key as a **PKCS#8** PEM (`-----BEGIN PRIVATE KEY-----`).
+   * Escaped `\n` newlines are handled. A PKCS#1 key (`BEGIN RSA PRIVATE KEY`,
+   * GitHub's default download) fails with a clear "convert with
+   * `openssl pkcs8 -topk8`" message — convert it once before setting.
+   */
+  GH_APP_PRIVATE_KEY?: string
+  /**
+   * Optional GitHub App installation id. Unset → resolved once from the repo
+   * (`GET /repos/{owner}/{repo}/installation`) and cached in `CHM_HOOKS_KV`.
+   */
+  GH_APP_INSTALLATION_ID?: string
   /**
    * Cloudflare API token with **Account → Workers Observability → Read** (the
    * Telemetry query API). Used to pull recent Worker exceptions. Unset → the

--- a/apps/cloud-hooks/src/exceptions.ts
+++ b/apps/cloud-hooks/src/exceptions.ts
@@ -14,8 +14,11 @@
  * logged and skipped rather than crashing the cron.
  */
 
+import type { GitHubAppAuth } from './github-app'
 import type { WorkerException } from './observability'
 import type { NotifyKind } from './telegram'
+
+import { withTokenRefresh } from './github-app'
 
 export const EXCEPTION_NOTIFY_KIND: NotifyKind = 'error'
 const KV_PREFIX = 'exc-fp:v1:'
@@ -195,7 +198,13 @@ export interface KVLike {
 
 export interface RunExceptionScanDeps {
   repo: GitHubRepo
+  /** A ready-to-use GitHub token (App installation token or PAT). */
   githubToken: string
+  /**
+   * When issues are authed as a GitHub App, the token provider used to refresh
+   * once on a 401 (installation token revoked/expired early). Omit for PAT auth.
+   */
+  auth?: GitHubAppAuth | null
   /** Fetch aggregated exception fingerprints (from observability.ts). */
   fetchExceptions: () => Promise<WorkerException[]>
   kv?: KVLike | null
@@ -281,14 +290,12 @@ export async function runExceptionScan(
       continue
     }
 
-    // 3. File the issue.
+    // 3. File the issue (refreshing App auth once on a 401).
     const issue = buildExceptionIssue(exc, labels)
-    const result = await createGitHubIssue(
-      deps.repo,
-      deps.githubToken,
-      issue,
-      fetchImpl,
-      apiBase
+    const result = await withTokenRefresh(
+      deps.auth ?? null,
+      (token) => createGitHubIssue(deps.repo, token, issue, fetchImpl, apiBase),
+      deps.githubToken
     )
     if (!result.ok) {
       logError('[cloud-hooks] createGitHubIssue failed', {

--- a/apps/cloud-hooks/src/github-app.test.ts
+++ b/apps/cloud-hooks/src/github-app.test.ts
@@ -1,0 +1,343 @@
+/**
+ * GitHub App auth: JWT claim shape, PEM normalization, RS256 signing (verified
+ * against the public key), installation-token cache + expiry, 401-refresh-once,
+ * and the App→PAT→disabled resolution order. No network — fetch/KV are mocked.
+ */
+
+import type { KVLike } from './exceptions'
+
+import {
+  buildJwtClaims,
+  createAppJwt,
+  GitHubAppAuth,
+  isTokenFresh,
+  normalizePrivateKey,
+  resolveGitHubAuth,
+  resolveInstallationId,
+  TOKEN_EXPIRY_MARGIN_MS,
+  withTokenRefresh,
+} from './github-app'
+import { beforeAll, describe, expect, mock, test } from 'bun:test'
+
+// A real RSA key pair generated once, exported to a PKCS#8 PEM, so signing
+// exercises WebCrypto for real (and we can verify the signature).
+let pkcs8Pem = ''
+let publicKey: CryptoKey
+
+function derToPem(der: ArrayBuffer, label: string): string {
+  const b64 = btoa(String.fromCharCode(...new Uint8Array(der)))
+  const lines = b64.match(/.{1,64}/g)?.join('\n') ?? b64
+  return `-----BEGIN ${label}-----\n${lines}\n-----END ${label}-----\n`
+}
+
+beforeAll(async () => {
+  const pair = await crypto.subtle.generateKey(
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: 'SHA-256',
+    },
+    true,
+    ['sign', 'verify']
+  )
+  publicKey = pair.publicKey
+  const pkcs8 = await crypto.subtle.exportKey('pkcs8', pair.privateKey)
+  pkcs8Pem = derToPem(pkcs8, 'PRIVATE KEY')
+})
+
+function makeKV(initial?: Record<string, string>): KVLike & {
+  store: Map<string, string>
+} {
+  const store = new Map(Object.entries(initial ?? {}))
+  return {
+    store,
+    async get(k) {
+      return store.get(k) ?? null
+    },
+    async put(k, v) {
+      store.set(k, v)
+    },
+  }
+}
+
+function b64urlToBytes(s: string): Uint8Array {
+  const b64 = s.replace(/-/g, '+').replace(/_/g, '/')
+  const pad = b64.length % 4 ? '='.repeat(4 - (b64.length % 4)) : ''
+  const bin = atob(b64 + pad)
+  const out = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i)
+  return out
+}
+
+function decodeJwtPart(part: string): Record<string, unknown> {
+  return JSON.parse(new TextDecoder().decode(b64urlToBytes(part)))
+}
+
+describe('buildJwtClaims', () => {
+  test('iat backdated 60s, exp +9min, iss = appId', () => {
+    const now = 1_700_000_000_000 // fixed ms
+    const claims = buildJwtClaims('123456', now)
+    const nowSec = Math.floor(now / 1000)
+    expect(claims.iat).toBe(nowSec - 60)
+    expect(claims.exp).toBe(nowSec + 9 * 60)
+    expect(claims.iss).toBe('123456')
+    // GitHub rejects >10min lifetime; ours is 10min total (−60s..+540s).
+    expect(claims.exp - claims.iat).toBeLessThanOrEqual(600)
+  })
+})
+
+describe('normalizePrivateKey', () => {
+  test('escaped \\n newlines normalize to the same DER as real newlines', () => {
+    const real = normalizePrivateKey(pkcs8Pem)
+    const escaped = normalizePrivateKey(pkcs8Pem.replace(/\n/g, '\\n'))
+    expect(Array.from(escaped)).toEqual(Array.from(real))
+  })
+
+  test('PKCS#1 key throws with an openssl-conversion hint', () => {
+    const pkcs1 =
+      '-----BEGIN RSA PRIVATE KEY-----\nMIIfake\n-----END RSA PRIVATE KEY-----'
+    expect(() => normalizePrivateKey(pkcs1)).toThrow(/pkcs8 -topk8/)
+  })
+
+  test('non-PEM input throws', () => {
+    expect(() => normalizePrivateKey('not a key')).toThrow(/PKCS#8 PEM/)
+  })
+})
+
+describe('createAppJwt', () => {
+  test('produces a 3-part RS256 JWT that verifies against the public key', async () => {
+    const now = 1_700_000_000_000
+    const jwt = await createAppJwt('42', pkcs8Pem, now)
+    const [h, p, s] = jwt.split('.')
+    expect(h && p && s).toBeTruthy()
+
+    const header = decodeJwtPart(h)
+    expect(header.alg).toBe('RS256')
+    expect(header.typ).toBe('JWT')
+
+    const payload = decodeJwtPart(p)
+    expect(payload.iss).toBe('42')
+    expect(payload.iat).toBe(Math.floor(now / 1000) - 60)
+
+    const ok = await crypto.subtle.verify(
+      'RSASSA-PKCS1-v1_5',
+      publicKey,
+      b64urlToBytes(s),
+      new TextEncoder().encode(`${h}.${p}`)
+    )
+    expect(ok).toBe(true)
+  })
+})
+
+describe('isTokenFresh', () => {
+  const now = 1_700_000_000_000
+  test('fresh when now is before expiry minus margin', () => {
+    expect(
+      isTokenFresh(
+        { token: 't', expiresAt: now + TOKEN_EXPIRY_MARGIN_MS + 1 },
+        now
+      )
+    ).toBe(true)
+  })
+  test('stale within the margin', () => {
+    expect(
+      isTokenFresh(
+        { token: 't', expiresAt: now + TOKEN_EXPIRY_MARGIN_MS - 1 },
+        now
+      )
+    ).toBe(false)
+  })
+})
+
+const appCfg = {
+  appId: '1',
+  owner: 'chmonitor',
+  repo: 'chmonitor',
+  installationId: '999',
+}
+
+describe('resolveInstallationId', () => {
+  test('returns explicit id without a network call', async () => {
+    const fetchImpl = mock(async () => new Response('{}'))
+    const id = await resolveInstallationId(
+      { ...appCfg, privateKeyPem: pkcs8Pem },
+      'jwt',
+      null,
+      fetchImpl as unknown as typeof fetch
+    )
+    expect(id).toBe('999')
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  test('resolves from repo + caches in KV when id is unset', async () => {
+    const kv = makeKV()
+    const fetchImpl = mock(
+      async () => new Response(JSON.stringify({ id: 555 }), { status: 200 })
+    )
+    const cfg = { appId: '1', owner: 'o', repo: 'r', privateKeyPem: pkcs8Pem }
+    const id = await resolveInstallationId(
+      cfg,
+      'jwt',
+      kv,
+      fetchImpl as unknown as typeof fetch
+    )
+    expect(id).toBe('555')
+    expect(kv.store.get('gh-app:install-id:v1:o/r')).toBe('555')
+    // Second call hits KV, not the network.
+    const fetch2 = mock(async () => new Response('{}'))
+    const id2 = await resolveInstallationId(
+      cfg,
+      'jwt',
+      kv,
+      fetch2 as unknown as typeof fetch
+    )
+    expect(id2).toBe('555')
+    expect(fetch2).not.toHaveBeenCalled()
+  })
+})
+
+describe('GitHubAppAuth token cache', () => {
+  test('mints + caches an installation token, reuses a fresh cache', async () => {
+    const kv = makeKV()
+    let mintCount = 0
+    const fetchImpl = mock(async (url: string) => {
+      if (url.includes('/access_tokens')) {
+        mintCount++
+        return new Response(
+          JSON.stringify({
+            token: `ghs_minted_${mintCount}`,
+            expires_at: new Date(Date.now() + 60 * 60_000).toISOString(),
+          }),
+          { status: 201 }
+        )
+      }
+      return new Response('{}', { status: 200 })
+    })
+    const auth = new GitHubAppAuth({
+      cfg: { ...appCfg, privateKeyPem: pkcs8Pem },
+      kv,
+      fetch: fetchImpl as unknown as typeof fetch,
+    })
+    const t1 = await auth.getToken()
+    expect(t1).toBe('ghs_minted_1')
+    expect(kv.store.has('gh-app:token:v1:chmonitor/chmonitor')).toBe(true)
+    // Cached + fresh → no second mint.
+    const t2 = await auth.getToken()
+    expect(t2).toBe('ghs_minted_1')
+    expect(mintCount).toBe(1)
+  })
+
+  test('near-expiry cache is refreshed', async () => {
+    const kv = makeKV({
+      'gh-app:token:v1:chmonitor/chmonitor': JSON.stringify({
+        token: 'ghs_old',
+        expiresAt: Date.now() + TOKEN_EXPIRY_MARGIN_MS - 1_000, // within margin
+      }),
+    })
+    const fetchImpl = mock(
+      async () =>
+        new Response(
+          JSON.stringify({
+            token: 'ghs_fresh',
+            expires_at: new Date(Date.now() + 60 * 60_000).toISOString(),
+          }),
+          { status: 201 }
+        )
+    )
+    const auth = new GitHubAppAuth({
+      cfg: { ...appCfg, privateKeyPem: pkcs8Pem },
+      kv,
+      fetch: fetchImpl as unknown as typeof fetch,
+    })
+    expect(await auth.getToken()).toBe('ghs_fresh')
+  })
+})
+
+describe('withTokenRefresh', () => {
+  test('refreshes once on 401 then retries with the new token', async () => {
+    const fetchImpl = mock(
+      async () =>
+        new Response(
+          JSON.stringify({
+            token: 'ghs_refreshed',
+            expires_at: new Date(Date.now() + 60 * 60_000).toISOString(),
+          }),
+          { status: 201 }
+        )
+    )
+    const auth = new GitHubAppAuth({
+      cfg: { ...appCfg, privateKeyPem: pkcs8Pem },
+      kv: null,
+      fetch: fetchImpl as unknown as typeof fetch,
+    })
+    const seen: string[] = []
+    const op = async (token: string) => {
+      seen.push(token)
+      return { status: seen.length === 1 ? 401 : 201 }
+    }
+    const res = await withTokenRefresh(auth, op, 'stale-token')
+    expect(res.status).toBe(201)
+    expect(seen).toEqual(['stale-token', 'ghs_refreshed'])
+  })
+
+  test('non-401 result is returned without a refresh', async () => {
+    const auth = new GitHubAppAuth({
+      cfg: { ...appCfg, privateKeyPem: pkcs8Pem },
+      kv: null,
+      fetch: mock(async () => new Response('{}')) as unknown as typeof fetch,
+    })
+    let calls = 0
+    const op = async () => {
+      calls++
+      return { status: 201 }
+    }
+    const res = await withTokenRefresh(auth, op, 'tok')
+    expect(res.status).toBe(201)
+    expect(calls).toBe(1)
+  })
+
+  test('PAT (null auth) never refreshes even on 401', async () => {
+    let calls = 0
+    const op = async () => {
+      calls++
+      return { status: 401 }
+    }
+    const res = await withTokenRefresh(null, op, 'pat')
+    expect(res.status).toBe(401)
+    expect(calls).toBe(1)
+  })
+})
+
+describe('resolveGitHubAuth — order', () => {
+  test('App creds → app mode (precedence over PAT)', () => {
+    const r = resolveGitHubAuth(
+      { GH_APP_ID: '1', GH_APP_PRIVATE_KEY: pkcs8Pem, GITHUB_TOKEN: 'pat' },
+      'o',
+      'r',
+      null
+    )
+    expect(r.mode).toBe('app')
+    expect(r.app).toBeInstanceOf(GitHubAppAuth)
+  })
+
+  test('only PAT → pat mode', () => {
+    const r = resolveGitHubAuth({ GITHUB_TOKEN: 'pat' }, 'o', 'r', null)
+    expect(r.mode).toBe('pat')
+    expect(r.token).toBe('pat')
+  })
+
+  test('no creds → disabled', () => {
+    expect(resolveGitHubAuth({}, 'o', 'r', null).mode).toBe('disabled')
+  })
+
+  test('App id without a key falls back to PAT', () => {
+    const r = resolveGitHubAuth(
+      { GH_APP_ID: '1', GITHUB_TOKEN: 'pat' },
+      'o',
+      'r',
+      null
+    )
+    expect(r.mode).toBe('pat')
+  })
+})

--- a/apps/cloud-hooks/src/github-app.ts
+++ b/apps/cloud-hooks/src/github-app.ts
@@ -1,0 +1,405 @@
+/**
+ * GitHub App authentication (the `duyetbot` app) for cloud-hooks.
+ *
+ * The exception scan files GitHub issues. It can authenticate as a **GitHub
+ * App installation** instead of / in addition to a personal access token (PAT):
+ *
+ *   1. Mint a short-lived **app JWT** (RS256) signed with WebCrypto from the
+ *      app's PEM private key — no npm `jsonwebtoken` dependency.
+ *   2. Exchange it for an **installation access token**
+ *      (`POST /app/installations/{installation_id}/access_tokens`), resolving
+ *      the installation id once (`GET /repos/{owner}/{repo}/installation`) when
+ *      `GH_APP_INSTALLATION_ID` is unset and caching it in KV.
+ *   3. Cache the installation token in KV until ~5 min before its 1h expiry.
+ *
+ * Everything is injected (fetch / KV / clock) and unit-tested without the
+ * network. Auth resolution order lives in `resolveGitHubAuth`: App creds win,
+ * then a PAT, else disabled.
+ */
+
+import type { KVLike } from './exceptions'
+
+/** Cache keys (versioned so a format change is a clean cutover). */
+const KV_INSTALL_ID_PREFIX = 'gh-app:install-id:v1:'
+const KV_TOKEN_PREFIX = 'gh-app:token:v1:'
+
+/** Refresh an installation token this many ms before its stated expiry. */
+export const TOKEN_EXPIRY_MARGIN_MS = 5 * 60_000
+
+const DEFAULT_API_BASE = 'https://api.github.com'
+const UA = 'chmonitor-hooks'
+
+// ── base64 / base64url helpers ──────────────────────────────────────────────
+
+function base64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64)
+  const bytes = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i)
+  return bytes
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let bin = ''
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i])
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function stringToBase64Url(input: string): string {
+  return bytesToBase64Url(new TextEncoder().encode(input))
+}
+
+// ── private key handling ────────────────────────────────────────────────────
+
+/**
+ * Normalize a PEM private-key secret into raw PKCS#8 DER bytes.
+ *
+ * - Handles escaped newlines (`\n`) — env secrets are often single-line.
+ * - Accepts PKCS#8 (`BEGIN PRIVATE KEY`), which WebCrypto imports directly.
+ * - Rejects PKCS#1 (`BEGIN RSA PRIVATE KEY`) with a clear, actionable message
+ *   instead of a cryptic WebCrypto `importKey` throw.
+ */
+export function normalizePrivateKey(pem: string): Uint8Array {
+  const normalized = pem.replace(/\\n/g, '\n').trim()
+
+  if (/BEGIN RSA PRIVATE KEY/.test(normalized)) {
+    throw new Error(
+      'GH_APP_PRIVATE_KEY is in PKCS#1 format (BEGIN RSA PRIVATE KEY), which ' +
+        'WebCrypto cannot import. Convert it to PKCS#8 once with:\n' +
+        '  openssl pkcs8 -topk8 -nocrypt -in app.private-key.pem -out app.pkcs8.pem\n' +
+        'then set the PKCS#8 result (BEGIN PRIVATE KEY) as the secret.'
+    )
+  }
+
+  const match = normalized.match(
+    /-----BEGIN PRIVATE KEY-----([\s\S]*?)-----END PRIVATE KEY-----/
+  )
+  if (!match) {
+    throw new Error(
+      'GH_APP_PRIVATE_KEY is not a PKCS#8 PEM (expected a ' +
+        '"-----BEGIN PRIVATE KEY-----" block).'
+    )
+  }
+
+  const body = match[1].replace(/\s+/g, '')
+  if (!body) throw new Error('GH_APP_PRIVATE_KEY PEM body is empty.')
+  return base64ToBytes(body)
+}
+
+async function importSigningKey(pem: string): Promise<CryptoKey> {
+  const der = normalizePrivateKey(pem)
+  return crypto.subtle.importKey(
+    'pkcs8',
+    der as unknown as ArrayBuffer,
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+    false,
+    ['sign']
+  )
+}
+
+// ── app JWT ─────────────────────────────────────────────────────────────────
+
+export interface JwtClaims {
+  /** issued-at, backdated 60s to tolerate minor clock skew (GitHub guidance). */
+  iat: number
+  /** expiry, +9 min (GitHub rejects app JWTs with >10 min lifetime). */
+  exp: number
+  /** the GitHub App id. */
+  iss: string
+}
+
+/** Build the RS256 JWT claim set for a GitHub App (pure — unit-tested). */
+export function buildJwtClaims(appId: string, nowMs: number): JwtClaims {
+  const nowSec = Math.floor(nowMs / 1000)
+  return {
+    iat: nowSec - 60,
+    exp: nowSec + 9 * 60,
+    iss: appId,
+  }
+}
+
+/** Mint a signed RS256 app JWT via WebCrypto. */
+export async function createAppJwt(
+  appId: string,
+  privateKeyPem: string,
+  nowMs: number = Date.now()
+): Promise<string> {
+  const header = { alg: 'RS256', typ: 'JWT' }
+  const claims = buildJwtClaims(appId, nowMs)
+  const signingInput = `${stringToBase64Url(
+    JSON.stringify(header)
+  )}.${stringToBase64Url(JSON.stringify(claims))}`
+
+  const key = await importSigningKey(privateKeyPem)
+  const signature = await crypto.subtle.sign(
+    'RSASSA-PKCS1-v1_5',
+    key,
+    new TextEncoder().encode(signingInput)
+  )
+  return `${signingInput}.${bytesToBase64Url(new Uint8Array(signature))}`
+}
+
+// ── installation id + token ─────────────────────────────────────────────────
+
+export interface GitHubAppConfig {
+  appId: string
+  privateKeyPem: string
+  /** Explicit installation id; when unset it is resolved from the repo + cached. */
+  installationId?: string
+  owner: string
+  repo: string
+}
+
+interface CachedToken {
+  token: string
+  /** unix ms — GitHub's `expires_at` parsed. */
+  expiresAt: number
+}
+
+/**
+ * Resolve the installation id for the app on `owner/repo`, caching it in KV.
+ * Uses the app JWT (`GET /repos/{owner}/{repo}/installation`).
+ */
+export async function resolveInstallationId(
+  cfg: GitHubAppConfig,
+  jwt: string,
+  kv: KVLike | null | undefined,
+  fetchImpl: typeof fetch = fetch,
+  apiBase = DEFAULT_API_BASE
+): Promise<string> {
+  if (cfg.installationId) return cfg.installationId
+
+  const cacheKey = `${KV_INSTALL_ID_PREFIX}${cfg.owner}/${cfg.repo}`
+  if (kv) {
+    try {
+      const cached = await kv.get(cacheKey)
+      if (cached) return cached
+    } catch {
+      /* ignore — fall through to a live lookup */
+    }
+  }
+
+  const url = `${apiBase}/repos/${cfg.owner}/${cfg.repo}/installation`
+  const res = await fetchImpl(url, {
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      Accept: 'application/vnd.github+json',
+      'User-Agent': UA,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  })
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(
+      `GitHub App installation lookup failed (${res.status}) for ${cfg.owner}/${cfg.repo}: ${text}`
+    )
+  }
+  const data = (await res.json()) as { id?: number }
+  if (!data.id) {
+    throw new Error(
+      `GitHub App installation lookup returned no id for ${cfg.owner}/${cfg.repo}.`
+    )
+  }
+  const id = String(data.id)
+  if (kv) {
+    try {
+      await kv.put(cacheKey, id)
+    } catch {
+      /* ignore */
+    }
+  }
+  return id
+}
+
+/** Mint a fresh installation access token from the app JWT + installation id. */
+export async function mintInstallationToken(
+  installationId: string,
+  jwt: string,
+  fetchImpl: typeof fetch = fetch,
+  apiBase = DEFAULT_API_BASE
+): Promise<CachedToken> {
+  const url = `${apiBase}/app/installations/${installationId}/access_tokens`
+  const res = await fetchImpl(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      Accept: 'application/vnd.github+json',
+      'User-Agent': UA,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  })
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(
+      `GitHub App token exchange failed (${res.status}) for installation ${installationId}: ${text}`
+    )
+  }
+  const data = (await res.json()) as { token?: string; expires_at?: string }
+  if (!data.token) {
+    throw new Error('GitHub App token exchange returned no token.')
+  }
+  const expiresAt = data.expires_at ? Date.parse(data.expires_at) : NaN
+  return {
+    token: data.token,
+    // Fall back to a conservative 55-min lifetime if expires_at is unparseable.
+    expiresAt: Number.isNaN(expiresAt) ? Date.now() + 55 * 60_000 : expiresAt,
+  }
+}
+
+/** True when a cached token is still safely within its validity margin. */
+export function isTokenFresh(cached: CachedToken, nowMs: number): boolean {
+  return nowMs < cached.expiresAt - TOKEN_EXPIRY_MARGIN_MS
+}
+
+export interface GitHubAppAuthDeps {
+  cfg: GitHubAppConfig
+  kv?: KVLike | null
+  fetch?: typeof fetch
+  apiBase?: string
+  now?: () => number
+}
+
+/**
+ * A GitHub App token provider with a KV-backed installation-token cache.
+ * `getToken()` returns a valid installation token, minting a new one (and a
+ * fresh app JWT + installation id) only when the cache is empty or near expiry.
+ * `getToken(true)` forces a refresh — used to recover from a mid-flight 401.
+ */
+export class GitHubAppAuth {
+  private readonly cfg: GitHubAppConfig
+  private readonly kv: KVLike | null
+  private readonly fetchImpl: typeof fetch
+  private readonly apiBase: string
+  private readonly now: () => number
+  private readonly tokenKey: string
+
+  constructor(deps: GitHubAppAuthDeps) {
+    this.cfg = deps.cfg
+    this.kv = deps.kv ?? null
+    this.fetchImpl = deps.fetch ?? fetch
+    this.apiBase = deps.apiBase ?? DEFAULT_API_BASE
+    this.now = deps.now ?? Date.now
+    this.tokenKey = `${KV_TOKEN_PREFIX}${this.cfg.owner}/${this.cfg.repo}`
+  }
+
+  private async readCache(): Promise<CachedToken | null> {
+    if (!this.kv) return null
+    try {
+      const raw = await this.kv.get(this.tokenKey)
+      if (!raw) return null
+      const parsed = JSON.parse(raw) as CachedToken
+      if (
+        typeof parsed.token === 'string' &&
+        typeof parsed.expiresAt === 'number'
+      )
+        return parsed
+    } catch {
+      /* ignore — treat as a cache miss */
+    }
+    return null
+  }
+
+  private async writeCache(token: CachedToken): Promise<void> {
+    if (!this.kv) return
+    try {
+      await this.kv.put(this.tokenKey, JSON.stringify(token))
+    } catch {
+      /* ignore */
+    }
+  }
+
+  async getToken(forceRefresh = false): Promise<string> {
+    if (!forceRefresh) {
+      const cached = await this.readCache()
+      if (cached && isTokenFresh(cached, this.now())) return cached.token
+    }
+
+    const jwt = await createAppJwt(
+      this.cfg.appId,
+      this.cfg.privateKeyPem,
+      this.now()
+    )
+    const installationId = await resolveInstallationId(
+      this.cfg,
+      jwt,
+      this.kv,
+      this.fetchImpl,
+      this.apiBase
+    )
+    const minted = await mintInstallationToken(
+      installationId,
+      jwt,
+      this.fetchImpl,
+      this.apiBase
+    )
+    await this.writeCache(minted)
+    return minted.token
+  }
+}
+
+/**
+ * Run a token-consuming GitHub operation, refreshing the App token once if it
+ * comes back 401 (a token revoked/expired earlier than its stated `expires_at`).
+ * PAT auth (no provider) never refreshes — a 401 is returned as-is.
+ */
+export async function withTokenRefresh<T extends { status: number }>(
+  auth: GitHubAppAuth | null,
+  op: (token: string) => Promise<T>,
+  initialToken: string
+): Promise<T> {
+  const first = await op(initialToken)
+  if (first.status !== 401 || !auth) return first
+  const refreshed = await auth.getToken(true)
+  return op(refreshed)
+}
+
+// ── auth resolution ─────────────────────────────────────────────────────────
+
+export type GitHubAuthMode = 'app' | 'pat' | 'disabled'
+
+export interface ResolvedGitHubAuth {
+  mode: GitHubAuthMode
+  /** Present for `app` mode — mints/caches installation tokens. */
+  app?: GitHubAppAuth
+  /** Present for `pat` mode — the static PAT. */
+  token?: string
+}
+
+export interface GitHubAuthEnv {
+  GH_APP_ID?: string
+  GH_APP_PRIVATE_KEY?: string
+  GH_APP_INSTALLATION_ID?: string
+  GITHUB_TOKEN?: string
+}
+
+/**
+ * Resolve GitHub auth for issue creation. Order: App creds (`GH_APP_ID` +
+ * `GH_APP_PRIVATE_KEY`) → PAT (`GITHUB_TOKEN`) → disabled.
+ */
+export function resolveGitHubAuth(
+  env: GitHubAuthEnv,
+  owner: string,
+  repo: string,
+  kv: KVLike | null | undefined,
+  fetchImpl?: typeof fetch,
+  apiBase?: string
+): ResolvedGitHubAuth {
+  if (env.GH_APP_ID && env.GH_APP_PRIVATE_KEY) {
+    const app = new GitHubAppAuth({
+      cfg: {
+        appId: env.GH_APP_ID,
+        privateKeyPem: env.GH_APP_PRIVATE_KEY,
+        installationId: env.GH_APP_INSTALLATION_ID,
+        owner,
+        repo,
+      },
+      kv,
+      fetch: fetchImpl,
+      apiBase,
+    })
+    return { mode: 'app', app }
+  }
+  if (env.GITHUB_TOKEN) {
+    return { mode: 'pat', token: env.GITHUB_TOKEN }
+  }
+  return { mode: 'disabled' }
+}

--- a/apps/cloud-hooks/src/index.ts
+++ b/apps/cloud-hooks/src/index.ts
@@ -15,6 +15,7 @@
 import type { Env } from './env'
 
 import { parseRepo, runExceptionScan } from './exceptions'
+import { resolveGitHubAuth } from './github-app'
 import { fetchWorkerExceptions } from './observability'
 import { runProbes } from './probes'
 import { collectSummary, formatSummary } from './summary'
@@ -48,7 +49,10 @@ async function runDailySummary(env: Env, notifier: Notifier): Promise<void> {
  */
 async function runExceptions(env: Env, notifier: Notifier): Promise<void> {
   const missing: string[] = []
-  if (!env.GITHUB_TOKEN) missing.push('GITHUB_TOKEN')
+  const hasGitHubAuth =
+    (env.GH_APP_ID && env.GH_APP_PRIVATE_KEY) || env.GITHUB_TOKEN
+  if (!hasGitHubAuth)
+    missing.push('GH_APP_ID+GH_APP_PRIVATE_KEY or GITHUB_TOKEN')
   if (!env.CF_OBSERVABILITY_API_TOKEN)
     missing.push('CF_OBSERVABILITY_API_TOKEN')
   if (!env.CF_ACCOUNT_ID) missing.push('CF_ACCOUNT_ID')
@@ -62,6 +66,17 @@ async function runExceptions(env: Env, notifier: Notifier): Promise<void> {
   const repo = parseRepo(env.GITHUB_REPOSITORY || 'chmonitor/chmonitor')
   if (!repo) {
     console.log('[cloud-hooks] exception scan disabled (bad GITHUB_REPOSITORY)')
+    return
+  }
+
+  const auth = resolveGitHubAuth(
+    env,
+    repo.owner,
+    repo.repo,
+    env.CHM_HOOKS_KV ?? null
+  )
+  if (auth.mode === 'disabled') {
+    console.log('[cloud-hooks] exception scan disabled (no GitHub credentials)')
     return
   }
 
@@ -80,10 +95,20 @@ async function runExceptions(env: Env, notifier: Notifier): Promise<void> {
     10
   )
 
+  let githubToken: string
+  try {
+    githubToken =
+      auth.mode === 'app' ? await auth.app!.getToken() : (auth.token as string)
+  } catch (err) {
+    console.error('[cloud-hooks] GitHub App token acquisition failed', err)
+    return
+  }
+
   try {
     await runExceptionScan({
       repo,
-      githubToken: env.GITHUB_TOKEN as string,
+      githubToken,
+      auth: auth.mode === 'app' ? auth.app : null,
       fetchExceptions: () =>
         fetchWorkerExceptions({
           accountId: env.CF_ACCOUNT_ID as string,

--- a/apps/cloud-hooks/wrangler.toml
+++ b/apps/cloud-hooks/wrangler.toml
@@ -11,11 +11,25 @@
 #   CLERK_SECRET_KEY            lazy Clerk org creation on first paid event
 #   TELEGRAM_BOT_TOKEN          operator notifications
 #   TELEGRAM_CHAT_ID            operator notifications target chat
-#   GITHUB_TOKEN                file a GitHub issue per NEW Worker exception
-#                               (PAT/App token with `issues:write` on the repo)
+#   GITHUB_TOKEN                file a GitHub issue per NEW Worker exception —
+#                               PAT with `issues:write` on the repo (fallback
+#                               when the GitHub App creds below are unset)
+#   GH_APP_ID                   GitHub App id (the `duyetbot` app). With
+#                               GH_APP_PRIVATE_KEY, issues are filed as the App
+#                               (installation token) — takes precedence over
+#                               GITHUB_TOKEN. App needs Issues: Read & write and
+#                               must be installed on the repo.
+#   GH_APP_PRIVATE_KEY          App private key as a PKCS#8 PEM (BEGIN PRIVATE
+#                               KEY). Escaped \n newlines OK. Convert GitHub's
+#                               PKCS#1 download once:
+#                               openssl pkcs8 -topk8 -nocrypt -in key.pem -out pkcs8.pem
 #   CF_OBSERVABILITY_API_TOKEN  read Worker exceptions via the Telemetry query
 #                               API. Token scope: Account → Workers
 #                               Observability → Read.
+#
+# GitHub App config (optional):
+#   GH_APP_INSTALLATION_ID      installation id; unset → resolved from the repo
+#                               and cached in CHM_HOOKS_KV.
 #
 # Exception-scan config (non-secret, optional — set via CI `--var`; sensible
 # defaults baked in):
@@ -25,8 +39,9 @@
 #   CHM_EXCEPTION_MAX_ISSUES_PER_RUN  rate cap, default 5
 #   CHM_EXCEPTION_SCRIPTS             default `chmonitor-dash,chmonitor-hooks`
 #
-# Any of GITHUB_TOKEN / CF_OBSERVABILITY_API_TOKEN / CF_ACCOUNT_ID unset →
-# the exception-scan capability logs one line and no-ops (never crashes).
+# No GitHub auth (neither App creds nor GITHUB_TOKEN), or CF_OBSERVABILITY_API_TOKEN
+# / CF_ACCOUNT_ID unset → the exception-scan capability logs one line and no-ops
+# (never crashes).
 #
 # Product→plan mapping (non-secret, set via CI `--var` or the dashboard, mirror
 # apps/dashboard/.env.production so both Workers map products IDENTICALLY):

--- a/docs/knowledge/cloud-hooks-worker.md
+++ b/docs/knowledge/cloud-hooks-worker.md
@@ -3,7 +3,7 @@ id: cloud-hooks-worker
 type: spec
 related: [billing-checkout-flow, cloud-saas-mode, bug-handler-email-worker, deployment]
 tags: [cloud-hooks, polar, webhook, telegram, cron, cloudflare, billing, d1]
-updated: 2026-07-11
+updated: 2026-07-12
 ---
 
 # Cloud-hooks worker (Polar webhooks + ops notifications)
@@ -71,6 +71,26 @@ The same `chm-cloud` D1 is bound into both Workers; the monotonic
   GitHub search fallback (`in:body "<fp>"`) so a KV miss/eviction never re-files;
   the fallback backfills KV. **Rate cap**: `maxIssuesPerRun` (default 5). Labels
   default `bug,cloudflare-exception`. Every step is injected + never throws.
+  **Auth** is resolved by `github-app.ts`'s `resolveGitHubAuth`, order:
+  GitHub App creds (`GH_APP_ID` + `GH_APP_PRIVATE_KEY`) → PAT (`GITHUB_TOKEN`) →
+  disabled (one log line). App mode passes the installation token as
+  `githubToken` and the provider as `auth` so a `401` refreshes once.
+- `github-app.ts` — **GitHub App auth** (the `duyetbot` app) for the exception
+  scan's issue creation. Mints an RS256 **app JWT** with WebCrypto
+  (`crypto.subtle.importKey('pkcs8', …)` + `sign` — no npm `jsonwebtoken` dep;
+  claims `iat=now-60`, `exp=now+9min`, `iss=appId`), exchanges it for an
+  **installation access token** (`POST /app/installations/{id}/access_tokens`),
+  resolving the installation id once (`GET /repos/{owner}/{repo}/installation`)
+  when `GH_APP_INSTALLATION_ID` is unset and caching it in `CHM_HOOKS_KV`
+  (`gh-app:install-id:v1:<owner>/<repo>`). The installation token is cached in KV
+  (`gh-app:token:v1:<owner>/<repo>`) until ~5 min before its 1h expiry
+  (`TOKEN_EXPIRY_MARGIN_MS`); `withTokenRefresh` refreshes once on a mid-flight
+  `401`. `normalizePrivateKey` handles escaped `\n` newlines and accepts only
+  **PKCS#8** (`BEGIN PRIVATE KEY`) — a PKCS#1 key (`BEGIN RSA PRIVATE KEY`,
+  GitHub's default download) throws a clear "convert with `openssl pkcs8 -topk8`"
+  message rather than a cryptic WebCrypto error. `resolveGitHubAuth` decides the
+  auth mode (see below). Everything is injected (fetch/KV/clock) and unit-tested
+  without the network.
 - `summary.ts` — `collectSummary` queries the subscription store (active subs by
   plan, new signups in 24h) and computes an MRR estimate from `BILLING_PLANS`
   (`@chm/pricing`) — yearly normalized to price/12. Pure `reduceSummary`/
@@ -103,8 +123,10 @@ The same `chm-cloud` D1 is bound into both Workers; the monotonic
 - **No secrets, no product-id vars committed.** Secrets set via
   `wrangler secret put` (CI does this, skipping any that are unset):
   `POLAR_WEBHOOK_SECRET`, `POLAR_ACCESS_TOKEN`, `CLERK_SECRET_KEY`,
-  `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, plus `GITHUB_TOKEN` (repo secret
-  `CLOUD_HOOKS_GITHUB_TOKEN`, `issues:write`) and `CF_OBSERVABILITY_API_TOKEN`
+  `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, plus GitHub issue-creation auth
+  (**either** `GH_APP_ID` + `GH_APP_PRIVATE_KEY` for GitHub App auth — preferred —
+  **or** `GITHUB_TOKEN`, a PAT with `issues:write`, repo secret
+  `CLOUD_HOOKS_GITHUB_TOKEN`) and `CF_OBSERVABILITY_API_TOKEN`
   (token scope **Account → Workers Observability → Read**). The `CHM_POLAR_PRODUCT_*`
   map + `CHM_POLAR_SERVER` must be set (mirroring `apps/dashboard/.env.production`)
   before the Polar endpoint is cut over, or products won't map.
@@ -114,6 +136,30 @@ The same `chm-cloud` D1 is bound into both Workers; the monotonic
   `CHM_EXCEPTION_ISSUE_LABELS` (`bug,cloudflare-exception`),
   `CHM_EXCEPTION_MAX_ISSUES_PER_RUN` (`5`), `CHM_EXCEPTION_SCRIPTS`
   (`chmonitor-dash,chmonitor-hooks`).
+
+## GitHub App auth setup (issue creation)
+
+The exception scan can file issues as the **`duyetbot` GitHub App** (preferred
+over a PAT — no personal token, scoped, shows as the app). Operator steps:
+
+1. **App permissions** — in the GitHub App settings, set **Repository →
+   Issues: Read & write** (the only permission the scan needs).
+2. **Install on the repo** — install the app on `chmonitor/chmonitor` (or the
+   `GITHUB_REPOSITORY` you target).
+3. **Generate a private key** — App settings → "Generate a private key". GitHub
+   hands you a **PKCS#1** PEM (`BEGIN RSA PRIVATE KEY`). WebCrypto only imports
+   **PKCS#8**, so convert it once:
+   ```bash
+   openssl pkcs8 -topk8 -nocrypt -in duyetbot.private-key.pem -out duyetbot.pkcs8.pem
+   ```
+   (Setting the PKCS#1 key directly fails fast with this exact hint.)
+4. **Set the secrets** — `GH_APP_ID` = the app's numeric id, `GH_APP_PRIVATE_KEY`
+   = the PKCS#8 PEM contents (escaped `\n` newlines are fine). Optionally set
+   `GH_APP_INSTALLATION_ID` to skip the one-time installation lookup (otherwise
+   it is resolved from the repo and cached in `CHM_HOOKS_KV`).
+
+With App creds present, `GITHUB_TOKEN` is ignored. Remove both → the scan
+falls back to the PAT; remove all GitHub creds → the scan no-ops.
 
 ## CI
 


### PR DESCRIPTION
## What

Let `apps/cloud-hooks` authenticate GitHub issue creation (the Cloudflare Worker exception scan from #2613) as the **`duyetbot` GitHub App** instead of / in addition to a PAT.

## How

New `src/github-app.ts`:
- Mints an **RS256 app JWT** with WebCrypto (`importKey('pkcs8')` + `sign`) — no npm jwt dependency. Claims: `iat=now-60`, `exp=now+9min`, `iss=appId`.
- Exchanges the JWT for an **installation access token** (`POST /app/installations/{id}/access_tokens`), resolving the installation id once (`GET /repos/{owner}/{repo}/installation`) when `GH_APP_INSTALLATION_ID` is unset and caching it in `CHM_HOOKS_KV`.
- Caches the installation token in KV until ~5 min before its 1h expiry; `withTokenRefresh` refreshes once on a mid-flight 401.
- `normalizePrivateKey` handles escaped `\n` newlines and accepts only **PKCS#8**; a PKCS#1 key (GitHub's default download) throws a clear "convert with `openssl pkcs8 -topk8`" message.

Auth resolution order in the issue path (`resolveGitHubAuth`): **App creds (`GH_APP_ID` + `GH_APP_PRIVATE_KEY`) → PAT (`GITHUB_TOKEN`) → disabled** (one log line). Wired through `runExceptionScan` + `index.ts`; graceful degradation preserved.

## Secrets / operator setup

New: `GH_APP_ID`, `GH_APP_PRIVATE_KEY` (secrets), `GH_APP_INSTALLATION_ID` (optional var). CI repo secrets: `CLOUD_HOOKS_GH_APP_ID`, `CLOUD_HOOKS_GH_APP_PRIVATE_KEY`.

Setup: App permission **Issues: Read & write** → install on repo → generate key and convert PKCS#1→PKCS#8 → set secrets. Full steps in `docs/knowledge/cloud-hooks-worker.md`.

## Tests

18 new bun tests (mocked fetch/KV, no real GitHub): JWT claim shape, PEM normalization (escaped newlines + PKCS#1 rejection), RS256 sign+verify against the public key, install-id + token cache/expiry, 401-refresh-once, App→PAT→disabled order. Full suite green (73 pass), `tsc --noEmit` clean, biome clean.

https://claude.ai/code/session_011a1CRbruQCZCPdjj2ntKjZ