### PR TITLE
style(landing): dark minimal editorial restyle

### DIFF
--- a/apps/landing/src/components/ChangelogBand.astro
+++ b/apps/landing/src/components/ChangelogBand.astro
@@ -1,0 +1,38 @@
+---
+import { loadChangelogFeatures } from '../data/changelog-features'
+
+// Newest features sit first in CHANGELOG.md, so the raw (file-order) list gives
+// us the latest four without re-sorting. Each card is a quiet, flat, bordered
+// link into the full changelog.
+const { features } = loadChangelogFeatures()
+const latest = features.slice(0, 4)
+---
+<section class="py-20 sm:py-[80px]">
+  <div class="mx-auto max-w-6xl px-4 sm:px-6">
+    <p class="font-mono text-[11px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">Changelog</p>
+    <div class="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {
+        latest.map((f) => (
+          <a
+            href="/changelog#ship-log"
+            class="group flex flex-col gap-2 rounded-xl border border-border bg-transparent p-5 transition-colors hover:border-[var(--hairline-strong)]"
+          >
+            <span class="font-mono text-xs tabular-nums text-muted-foreground">
+              {f.version ? `v${f.version}` : f.scope}
+            </span>
+            <span class="text-pretty text-sm font-medium leading-snug text-foreground">
+              {f.title}
+            </span>
+          </a>
+        ))
+      }
+    </div>
+    <a
+      href="/changelog"
+      class="mt-6 inline-flex items-center gap-1.5 text-sm font-medium text-[var(--accent-link)] transition-opacity hover:opacity-80"
+    >
+      See what's new
+      <svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+    </a>
+  </div>
+</section>

--- a/apps/landing/src/components/FeatureShowcase.astro
+++ b/apps/landing/src/components/FeatureShowcase.astro
@@ -33,14 +33,20 @@ const icons: Record<string, string> = {
 
     <div class="mt-16 sm:mt-20 flex flex-col gap-20 sm:gap-[80px]">
       {
-        FEATURE_SECTIONS.map((section) => (
+        FEATURE_SECTIONS.map((section, i) => (
           <article id={section.id} class="scroll-mt-6">
             {/* Copy sits above the shot so the screenshot gets the full
                 column instead of half of it. `reverse` alternates which side
                 the bullet list lands on. */}
             <div class="grid gap-6 md:grid-cols-2 md:items-end md:gap-16">
               <div class={section.reverse ? 'md:order-2' : 'md:order-1'}>
-                <span class="inline-flex size-11 items-center justify-center rounded-xl bg-[var(--surface-strong)] [&_svg]:text-foreground" set:html={icons[section.icon]} />
+                <div class="flex items-center gap-3">
+                  <span class="inline-flex size-11 items-center justify-center rounded-xl bg-[var(--surface-strong)] [&_svg]:text-foreground" set:html={icons[section.icon]} />
+                  <span class="font-mono text-sm tabular-nums text-muted-foreground">
+                    {String(i + 1).padStart(2, '0')}
+                    <span class="text-[var(--muted-soft)]"> / {String(FEATURE_SECTIONS.length).padStart(2, '0')}</span>
+                  </span>
+                </div>
                 <p class="mt-4 font-mono text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--brand-ink)]">
                   {section.eyebrow}
                 </p>

--- a/apps/landing/src/components/FinalCta.astro
+++ b/apps/landing/src/components/FinalCta.astro
@@ -3,17 +3,10 @@ import { btnOnDarkOutline, btnOnDarkBrand } from '../lib/button-classes'
 ---
 <section class="pt-4 sm:pt-6 pb-20 sm:pb-[80px]">
   <div class="mx-auto max-w-[1080px] px-4 sm:px-6">
-    {/* Fixed warm-ink band: light-on-dark in both themes. One brand wash, no
-        second hue — the ink surface carries the contrast. */}
-    <div class="reveal relative isolate overflow-hidden rounded-xl border border-white/10 bg-[#26251e]">
-      <div
-        class="pointer-events-none absolute inset-0 -z-10"
-        aria-hidden="true"
-      >
-        <div class="absolute inset-0 bg-[radial-gradient(ellipse_55%_45%_at_50%_0%,rgba(245,78,0,0.20),transparent_70%)]"></div>
-      </div>
-
-      <div class="relative mx-auto max-w-2xl px-4 sm:px-6 py-16 text-center sm:py-24">
+    {/* Quiet ink band: near-black surface, a single hairline, and a lot of air.
+        No brand wash — the monochrome surface carries the contrast. */}
+    <div class="reveal relative isolate overflow-hidden rounded-2xl border border-white/10 bg-[#0d0d0d]">
+      <div class="relative mx-auto max-w-2xl px-4 sm:px-6 py-24 text-center sm:py-32">
         <span class="mb-5 sm:mb-6 flex justify-center" aria-hidden="true">
           <img src="/brand/logo-mark.svg" alt="" class="size-8 sm:size-9 opacity-90" />
         </span>

--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -61,11 +61,11 @@ const githubSvg = `<svg class="size-3.5" viewBox="0 0 24 24" fill="currentColor"
 
       {/* Display stays at weight 400 with negative tracking — the editorial
           voice depends on it. Do not bold. */}
-      <h1 class="mt-6 sm:mt-10 text-balance font-normal text-[clamp(2rem,8vw,4.5rem)] text-foreground leading-[1.1] tracking-[-0.03em]">
+      <h1 class="mt-6 sm:mt-10 text-balance font-normal text-[clamp(3.25rem,8vw,6rem)] text-foreground leading-[1.05] tracking-[-0.02em]">
         The ops dashboard<br class="hidden sm:block" /> for <span class="text-[var(--brand)]">ClickHouse</span>.
       </h1>
 
-      <p class="mx-auto mt-5 sm:mt-7 max-w-xl text-pretty text-muted-foreground text-base leading-relaxed tracking-[0.005em]">
+      <p class="mx-auto mt-6 sm:mt-8 max-w-xl text-pretty text-muted-foreground text-lg sm:text-xl leading-relaxed tracking-[0.005em]">
         Monitor queries, merges, parts, replication, and health. An AI advisor on top — open source, self-host free.
       </p>
 

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -35,7 +35,7 @@ const ogImage = new URL(image, Astro.site).toString()
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
   <link rel="manifest" href="/site.webmanifest" />
   <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
-  <meta name="theme-color" content="#1c1b17" media="(prefers-color-scheme: dark)" />
+  <meta name="theme-color" content="#0a0a0a" media="(prefers-color-scheme: dark)" />
   <meta name="twitter:site" content="@chmonitor" />
   <script type="application/ld+json" set:html={JSON.stringify({
     "@context": "https://schema.org",
@@ -82,14 +82,14 @@ const ogImage = new URL(image, Astro.site).toString()
     :root{--serif:'Geist',ui-sans-serif,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif}
   </style>
   <script is:inline>
-    // Resolve theme before paint (no flash): the landing defaults to the light
-    // canvas. A saved choice still wins so the toggle works.
+    // Resolve theme before paint (no flash): the landing showcases the dark
+    // near-black canvas by default. A saved choice still wins so the toggle works.
     (function () {
       try {
         var saved = localStorage.getItem('chm-theme')
-        document.documentElement.setAttribute('data-theme', saved || 'light')
+        document.documentElement.setAttribute('data-theme', saved || 'dark')
       } catch (e) {
-        document.documentElement.setAttribute('data-theme', 'light')
+        document.documentElement.setAttribute('data-theme', 'dark')
       }
     })()
     // Theme-aware screenshots: a single <img data-src-light data-src-dark>
@@ -153,32 +153,33 @@ const ogImage = new URL(image, Astro.site).toString()
       --shadow-glow:none;
     }
     :root[data-theme="dark"]{
-      --bg:#1c1b17;
-      --bg-soft:#211f1a;
-      --fg:#edece6;
-      --fg-soft:#b5b2a8;
-      --muted-fg:#97948a;
-      --border:#38362f;
-      --border-soft:#2e2c26;
-      --border-hover:#4a473e;
-      --muted:#2e2c26;
-      --card:#262520;
-      --nav-bg:rgba(28,27,23,.72);
-      --browser-bar:#211f1a;
-      --primary:#edece6;
-      --primary-fg:#1c1b17;
+      --bg:#0a0a0a;
+      --bg-soft:#0d0d0d;
+      --fg:#ffffff;
+      --fg-soft:#c9cbd1;
+      --muted-fg:#9ca3af;
+      --border:rgba(255,255,255,.10);
+      --border-soft:rgba(255,255,255,.06);
+      --border-hover:rgba(255,255,255,.20);
+      --muted:#1a1a1a;
+      --card:#141414;
+      --nav-bg:rgba(10,10,10,.72);
+      --browser-bar:#141414;
+      --primary:#ffffff;
+      --primary-fg:#0a0a0a;
       --shadow-glow:none;
-      --btn-primary-bg:#d04200;
-      --btn-primary-bg-hover:#b03800;
-      --btn-primary-fg:#ffffff;
-      --brand:#f54e00;
-      --orange:#f97316;
-      --amber:#97948a;
+      /* Pill CTAs go monochrome in dark: white fill / black label. */
+      --btn-primary-bg:#ffffff;
+      --btn-primary-bg-hover:#e5e5e5;
+      --btn-primary-fg:#0a0a0a;
+      --brand:#f97316;
+      --orange:#fb923c;
+      --amber:#9ca3af;
       --emerald:#35b184;
-      --violet:#97948a;
-      --blue:#edece6;
+      --violet:#9ca3af;
+      --blue:#ffffff;
       --shadow-card:none;
-      --shadow-float:0 1px 1px rgba(0,0,0,.2), 0 4px 12px -6px rgba(0,0,0,.5);
+      --shadow-float:0 1px 1px rgba(0,0,0,.4), 0 8px 24px -10px rgba(0,0,0,.7);
     }
     *{margin:0;padding:0;box-sizing:border-box}
     /* Tailwind's preflight is intentionally not imported (see globals.css), and
@@ -204,15 +205,15 @@ const ogImage = new URL(image, Astro.site).toString()
     .wrap{max-width:var(--maxw);margin:0 auto;padding:0 24px}
     .eyebrow{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,monospace;font-size:11.5px;font-weight:500;letter-spacing:.14em;text-transform:uppercase;color:var(--muted-fg)}
 
-    /* ── buttons (Geist: 40px height, 6px radius, no lift) ── */
-    .btn{display:inline-flex;align-items:center;gap:8px;height:40px;padding:0 14px;border-radius:var(--radius);
+    /* ── buttons (pill: fully rounded, editorial) ── */
+    .btn{display:inline-flex;align-items:center;gap:8px;height:44px;padding:0 22px;border-radius:999px;
       font-size:14px;font-weight:500;white-space:nowrap;transition:background .15s ease,border-color .15s ease,color .15s ease;border:1px solid transparent;cursor:pointer}
     .btn svg{width:16px;height:16px}
     .btn-primary{background:var(--btn-primary-bg);color:var(--btn-primary-fg)}
     .btn-primary:hover{background:var(--btn-primary-bg-hover)}
     .btn-ghost{background:var(--card);color:var(--fg);border-color:var(--border)}
     .btn-ghost:hover{background:var(--muted);border-color:var(--border-hover)}
-    .btn-sm{height:32px;padding:0 10px;font-size:13px;border-radius:var(--radius)}
+    .btn-sm{height:36px;padding:0 16px;font-size:13px;border-radius:999px}
 
     /* ── logo mark ── */
     .mark{width:30px;height:30px;display:flex;align-items:center;justify-content:center;flex:0 0 auto}

--- a/apps/landing/src/lib/button-classes.ts
+++ b/apps/landing/src/lib/button-classes.ts
@@ -1,26 +1,27 @@
 /**
- * Shared landing button classes — one size everywhere (40px; 44px for the
- * larger `btnDownload`). Keep padding/height identical across hero, nav,
- * pricing, and final CTA.
+ * Shared landing button classes — pill-shaped (fully rounded), one large size
+ * everywhere (h-12, px-6). Editorial monochrome: the primary CTA is a solid
+ * ink/white pill, secondary is a quiet dark surface with a faint border. Color
+ * comes from screenshots and art panels, not from buttons.
  *
- * `rounded-lg` resolves to 8px, the CTA radius. Cards use `rounded-xl` (12px).
+ * Pills use `rounded-full`. Cards use `rounded-xl` (12px).
  */
 
 const size =
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg h-10 px-[18px] text-sm font-medium transition-colors active:scale-[.98] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-[var(--brand)]/40'
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full h-12 px-6 text-sm font-medium transition-colors active:scale-[.98] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-[var(--brand)]/40'
 
 /**
- * The one brand CTA. Fill is `--brand-strong`, not `--brand`: a 14px label is
- * "normal text" to WCAG, and white clears 4.5:1 only against the deeper tone.
+ * The one primary CTA — monochrome pill. Solid white on black in dark, solid
+ * ink on white in light (`--primary` / `--primary-foreground`).
  */
-export const btnPrimary = `${size} bg-[var(--brand-strong)] text-[var(--on-brand)] hover:bg-[var(--brand-ink)]`
+export const btnPrimary = `${size} bg-primary text-primary-foreground hover:bg-primary/90`
 
-export const btnOutline = `${size} border border-[var(--hairline-strong)] bg-card text-foreground hover:bg-accent`
+export const btnOutline = `${size} border border-[var(--hairline-strong)] bg-secondary text-foreground hover:bg-accent`
 
 export const btnGhost = `${size} text-muted-foreground hover:bg-accent hover:text-accent-foreground`
 
-/** Larger ink-on-canvas CTA (44px) for "Self-host" style secondary actions. */
-export const btnDownload = `inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg h-11 px-5 text-sm font-medium transition-colors active:scale-[.98] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-[var(--brand)]/40 bg-primary text-primary-foreground hover:bg-primary/90`
+/** Larger ink-on-canvas CTA for "Self-host" style secondary actions. */
+export const btnDownload = `inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full h-12 px-6 text-sm font-medium transition-colors active:scale-[.98] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-[var(--brand)]/40 bg-primary text-primary-foreground hover:bg-primary/90`
 
 /** Full-width variant (pricing cards, mobile drawer). */
 export const btnPrimaryBlock = `${btnPrimary} w-full`
@@ -32,8 +33,8 @@ export const btnInk = `${size} bg-primary text-primary-foreground hover:bg-prima
 
 export const btnInkBlock = `${btnInk} w-full`
 
-/** Final CTA on the fixed ink band (light-on-dark regardless of theme). */
-export const btnOnDarkBrand = `${size} bg-[var(--brand-strong)] text-[var(--on-brand)] hover:bg-[var(--brand)]`
+/** Final CTA band (light-on-dark regardless of theme). Monochrome white pill. */
+export const btnOnDarkBrand = `${size} bg-white text-black hover:bg-white/90`
 
 export const btnOnDarkPrimary = `${size} bg-white text-black hover:bg-white/90`
 

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -8,6 +8,7 @@ import Comparison from '../components/Comparison.astro'
 import Pricing from '../components/Pricing.astro'
 import FAQ from '../components/FAQ.astro'
 import FinalCta from '../components/FinalCta.astro'
+import ChangelogBand from '../components/ChangelogBand.astro'
 import Footer from '../components/Footer.astro'
 import UseCaseLinks from '../components/UseCaseLinks.astro'
 import { useCases } from '../data/use-cases'
@@ -23,6 +24,7 @@ import { useCases } from '../data/use-cases'
     <Pricing compact />
     <FAQ />
     <FinalCta />
+    <ChangelogBand />
   </main>
   <Footer />
 </Base>

--- a/apps/landing/src/styles/globals.css
+++ b/apps/landing/src/styles/globals.css
@@ -59,38 +59,47 @@
   --brand-soft: rgba(245, 78, 0, 0.09);
   /* Semantic — confirmation only, never a second brand action color. */
   --semantic-success: #1f8a65;
+  /* One soft-blue accent link ("See what's new →"). */
+  --accent-link: #2f6feb;
 }
 
+/* Dark = the showcase theme for the landing. Near-black neutral canvas
+   (#0A0A0A floor, #0D0D0D bands), pure-white ink, and depth carried by
+   ultra-subtle white hairlines (6–14% opacity) — no heavy shadows. The only
+   color comes from product screenshots, the painterly backdrop panels, and a
+   scarce brand/accent mark. Light mode (above) is preserved and still toggles. */
 [data-theme='dark'] {
-  --background: #1c1b17;
-  --foreground: #edece6;
-  --card: #262520;
-  --card-foreground: #edece6;
-  --popover: #262520;
-  --popover-foreground: #edece6;
-  --primary: #edece6;
-  --primary-foreground: #1c1b17;
-  --secondary: #211f1a;
-  --secondary-foreground: #edece6;
-  --muted: #2e2c26;
-  --muted-foreground: #b5b2a8;
-  --accent: #2e2c26;
-  --accent-foreground: #edece6;
+  --background: #0a0a0a;
+  --foreground: #ffffff;
+  --card: #141414;
+  --card-foreground: #f4f4f5;
+  --popover: #141414;
+  --popover-foreground: #f4f4f5;
+  --primary: #ffffff;
+  --primary-foreground: #0a0a0a;
+  --secondary: #1a1a1a;
+  --secondary-foreground: #f4f4f5;
+  --muted: #1a1a1a;
+  --muted-foreground: #9ca3af;
+  --accent: #1f1f1f;
+  --accent-foreground: #ffffff;
   --destructive: #ff6b8b;
-  --border: #38362f;
-  --input: #4a473e;
+  --border: rgba(255, 255, 255, 0.08);
+  --input: rgba(255, 255, 255, 0.14);
   --ring: #f97316;
-  --canvas-soft: #211f1a;
-  --surface-strong: #33312a;
-  --hairline-soft: #2e2c26;
-  --hairline-strong: #4a473e;
-  --muted-soft: #6f6c63;
-  --brand: #f54e00;
-  --brand-strong: #d04200;
-  --brand-ink: #f97316;
-  --on-brand: #ffffff;
-  --brand-soft: rgba(245, 78, 0, 0.16);
+  --canvas-soft: #0d0d0d;
+  --surface-strong: #1c1c1c;
+  --hairline-soft: rgba(255, 255, 255, 0.06);
+  --hairline-strong: rgba(255, 255, 255, 0.16);
+  --muted-soft: #6f6f6f;
+  --brand: #f97316;
+  --brand-strong: #f97316;
+  --brand-ink: #fb923c;
+  --on-brand: #0a0a0a;
+  --brand-soft: rgba(249, 115, 22, 0.10);
   --semantic-success: #35b184;
+  /* One soft-blue accent link ("See what's new →"). */
+  --accent-link: #7aa2f7;
 }
 
 img {


### PR DESCRIPTION
Pure **restyle** of the landing (`apps/landing`) — content, copy, screenshots, links and information architecture are unchanged. Only layout arrangement, typography, color, spacing and component chrome move.

## What changed per surface
- **Theme / tokens** — dark is now the showcase default (light still toggles). Near-black neutral canvas (`#0A0A0A` floor, `#0D0D0D` bands), pure-white ink, ultra-subtle white hairlines (6–16% opacity), monochrome UI where the only color comes from product screenshots + the painterly `*-with-bg` art panels. Updated `globals.css` dark tokens and the legacy `@layer base` dark tokens in `Base.astro`.
- **Buttons** — pill-shaped (fully rounded, `h-12`/`px-6`). Primary = solid monochrome pill (white-on-black in dark, ink-on-white in light); secondary = quiet dark surface + faint border. Legacy `.btn` goes pill too.
- **Nav** — quiet near-black bar (token-driven).
- **Hero** — headline scaled up to `clamp(3.25rem, 8vw, 6rem)` with tight tracking; larger gray subheadline.
- **Feature sections** — numbered editorial index (`01 / 08`) beside each icon; the framed-on-art `*-with-bg` screenshots carry the visual signature.
- **Changelog band (new)** — quiet section above the footer: flat bordered 4-column cards (small gray version, white title) linking into the changelog, plus one soft-blue "See what's new →" accent link.
- **Final CTA** — de-glowed: near-black surface, single hairline, more vertical air; one white pill primary.
- **Footer** — already minimal; now sits on the near-black canvas.

## Verification
- `bun test` (apps/landing): 25 pass / 0 fail
- `pnpm run build`: 15 pages built, no errors
- `bun scripts/verify-landing-structure.ts`: all checks pass (headline markers intact, borderless zoom wrappers, no React islands, 10 zoom triggers)
- `biome check` on changed TS: clean

Brand logo colors are untouched; tiny accent usage (brand orange, soft-blue link) only.

https://claude.ai/code/session_011a1CRbruQCZCPdjj2ntKjZ