### PR TITLE
fix(cloud-hooks): break exceptions↔github-app import cycle

### DIFF
--- a/apps/cloud-hooks/src/exceptions.ts
+++ b/apps/cloud-hooks/src/exceptions.ts
@@ -14,7 +14,7 @@
  * logged and skipped rather than crashing the cron.
  */
 
-import type { GitHubAppAuth } from './github-app'
+import type { GitHubAppAuth, KVLike } from './github-app'
 import type { WorkerException } from './observability'
 import type { NotifyKind } from './telegram'
 
@@ -190,11 +190,7 @@ export async function issueExistsForFingerprint(
   }
 }
 
-/** Minimal KV subset (matches probes' `KVLike`). */
-export interface KVLike {
-  get(key: string): Promise<string | null>
-  put(key: string, value: string): Promise<void>
-}
+export type { KVLike } from './github-app'
 
 export interface RunExceptionScanDeps {
   repo: GitHubRepo

--- a/apps/cloud-hooks/src/github-app.ts
+++ b/apps/cloud-hooks/src/github-app.ts
@@ -17,7 +17,11 @@
  * then a PAT, else disabled.
  */
 
-import type { KVLike } from './exceptions'
+/** Minimal KV subset (matches probes' `KVLike`). */
+export interface KVLike {
+  get(key: string): Promise<string | null>
+  put(key: string, value: string): Promise<void>
+}
 
 /** Cache keys (versioned so a format change is a clean cutover). */
 const KV_INSTALL_ID_PREFIX = 'gh-app:install-id:v1:'


### PR DESCRIPTION
Depcruise on main fails since #2613 with:

```
error no-circular: apps/cloud-hooks/src/exceptions.ts → github-app.ts → exceptions.ts
```

Fix: move `KVLike` into `github-app.ts` (its heaviest consumer) and re-export it type-only from `exceptions.ts`, keeping existing importers working. Verified locally: depcruise clean, `bun test` 103 pass, `tsc --noEmit` clean.

https://claude.ai/code/session_011a1CRbruQCZCPdjj2ntKjZ