### PR TITLE
fix(landing): footer changelog link to real release anchor

### DIFF
--- a/apps/landing/src/components/ChangelogBand.astro
+++ b/apps/landing/src/components/ChangelogBand.astro
@@ -14,7 +14,7 @@ const latest = features.slice(0, 4)
       {
         latest.map((f) => (
           <a
-            href="/changelog#ship-log"
+            href="/changelog#features"
             class="group flex flex-col gap-2 rounded-xl border border-border bg-transparent p-5 transition-colors hover:border-[var(--hairline-strong)]"
           >
             <span class="font-mono text-xs tabular-nums text-muted-foreground">

--- a/apps/landing/src/components/FeaturesCatalog.astro
+++ b/apps/landing/src/components/FeaturesCatalog.astro
@@ -12,7 +12,7 @@ const scopes = groups.map((g) => g.scope)
 ---
 
 <section
-  id="ship-log"
+  id="features"
   class="py-12 sm:py-16"
   data-feature-count={totalCount}
   data-features-catalog

--- a/apps/landing/src/components/Footer.astro
+++ b/apps/landing/src/components/Footer.astro
@@ -1,5 +1,8 @@
 ---
+import { loadLatestChangelogVersion } from '../data/changelog-features'
 import { useCases } from '../data/use-cases'
+
+const latestVersion = loadLatestChangelogVersion()
 ---
   <footer class="border-t border-border">
     <div class="mx-auto max-w-6xl px-4 sm:px-6 py-12 sm:py-16">
@@ -24,8 +27,10 @@ import { useCases } from '../data/use-cases'
               <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="/pricing">Pricing</a>
               <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="https://dash.chmonitor.dev" target="_blank" rel="noopener">Dashboard</a>
               <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="https://blog.chmonitor.dev" target="_blank" rel="noopener">Blog</a>
-              <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="/changelog">Changelog</a>
-              <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="/changelog#ship-log">Feature index</a>
+              <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href={latestVersion ? `/changelog#v${latestVersion}` : '/changelog'}>
+                Changelog{latestVersion && <span class="font-mono text-xs"> · v{latestVersion}</span>}
+              </a>
+              <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="/changelog#features">Feature index</a>
             </div>
           </div>
           <div class="min-w-0 sm:min-w-36">

--- a/apps/landing/src/components/Nav.astro
+++ b/apps/landing/src/components/Nav.astro
@@ -18,7 +18,7 @@ import { btnOutline, btnOutlineBlock, btnPrimary, btnPrimaryBlock } from '../lib
           <div class="nav-menu">
             <a href="/#top">Overview<small>Product positioning and capabilities</small></a>
             <a href="/#features">Features<small>Agent, queries, topology and more</small></a>
-            <a href="/changelog#ship-log">Feature index<small>Shipped features by scope</small></a>
+            <a href="/changelog#features">Feature index<small>Shipped features by scope</small></a>
             <a href="/#feature-ai-agent">AI Agent<small>Schema-aware recommendations</small></a>
             <a href="/#feature-queries">Queries<small>Running, slow and expensive</small></a>
             <a href="/monitor-queries">Query monitoring<small>Running, slow, failed &amp; expensive</small></a>
@@ -36,7 +36,7 @@ import { btnOutline, btnOutlineBlock, btnPrimary, btnPrimaryBlock } from '../lib
           <div class="nav-menu">
             <a href="https://blog.chmonitor.dev" target="_blank" rel="noopener">Blog<small>Release notes and product updates</small></a>
             <a href="/changelog">Changelog<small>Release notes and full ship log</small></a>
-            <a href="/changelog#ship-log">Feature index<small>Every CHANGELOG.md feature, searchable</small></a>
+            <a href="/changelog#features">Feature index<small>Every CHANGELOG.md feature, searchable</small></a>
             <a href="https://docs.chmonitor.dev" target="_blank" rel="noopener">Docs<small>Setup, deploy and API guides</small></a>
             <a href="/brand">Brand<small>Logos and brand assets</small></a>
           </div>
@@ -78,7 +78,7 @@ import { btnOutline, btnOutlineBlock, btnPrimary, btnPrimaryBlock } from '../lib
         <span class="nav-drawer-label">Features</span>
         <a href="/#top">Overview</a>
         <a href="/#features">Features</a>
-        <a href="/changelog#ship-log">Feature index</a>
+        <a href="/changelog#features">Feature index</a>
         <a href="/#feature-ai-agent">AI Agent</a>
         <a href="/#feature-queries">Queries</a>
         <a href="/monitor-queries">Query monitoring</a>
@@ -90,7 +90,7 @@ import { btnOutline, btnOutlineBlock, btnPrimary, btnPrimaryBlock } from '../lib
         <span class="nav-drawer-label">Resources</span>
         <a href="https://blog.chmonitor.dev" target="_blank" rel="noopener">Blog</a>
         <a href="/changelog">Changelog</a>
-        <a href="/changelog#ship-log">Feature index</a>
+        <a href="/changelog#features">Feature index</a>
         <a href="/brand">Brand</a>
       </div>
       <div class="nav-drawer-foot">

--- a/apps/landing/src/data/changelog-features.ts
+++ b/apps/landing/src/data/changelog-features.ts
@@ -40,3 +40,18 @@ export function loadChangelogFeatures() {
 
   return cached
 }
+
+let cachedLatestVersion: string | null | undefined
+
+/**
+ * Latest released version from CHANGELOG.md (first `## [x.y.z]` heading),
+ * e.g. `0.2.14`. Returns null when no versioned heading exists.
+ */
+export function loadLatestChangelogVersion(): string | null {
+  if (cachedLatestVersion !== undefined) return cachedLatestVersion
+
+  const markdown = readFileSync(resolveChangelogPath(), 'utf8')
+  const match = markdown.match(/^## \[(\d+\.\d+\.\d+)\]/m)
+  cachedLatestVersion = match ? match[1] : null
+  return cachedLatestVersion
+}

--- a/apps/landing/src/pages/changelog.astro
+++ b/apps/landing/src/pages/changelog.astro
@@ -88,7 +88,7 @@ const breadcrumbJsonLd = {
         {releases.length > 0 ? (
           <div class="cl-list">
             {releases.map((r) => (
-              <div class="cl-entry">
+              <div class="cl-entry" id={r.tag_name}>
                 <div class="cl-meta">
                   <a class="cl-tag" href={r.html_url} target="_blank" rel="noopener">{r.tag_name}</a>
                   <span class="cl-date">{fmtDate(r.published_at)}</span>


### PR DESCRIPTION
Footer "Changelog" on chmonitor.dev pointed users at `/changelog#ship-log` (feature-index anchor), not the actual release notes.

- Footer Changelog now links to `/changelog#v0.2.14` — the latest version parsed at build time from the committed `CHANGELOG.md` (real content, no hardcoding), with a `· v0.2.14` label; falls back to `/changelog` if no versioned heading exists.
- Each release entry on `/changelog` gets a real `id="vX.Y.Z"` anchor (tags from GitHub releases).
- Renamed the feature-index anchor `#ship-log` → `#features`; updated all references (Nav ×4, ChangelogBand, Footer) — the "Feature index" link stays.

Verified: landing build clean (15 pages), `bun test` 25 pass, built HTML contains `href="/changelog#v0.2.14"`, per-release anchors, and zero `ship-log` references.

https://claude.ai/code/session_011a1CRbruQCZCPdjj2ntKjZ