### PR TITLE
fix(insights): restore severity accent left border on insight cards

### DIFF
--- a/apps/dashboard/src/components/insights/insight-card.tsx
+++ b/apps/dashboard/src/components/insights/insight-card.tsx
@@ -63,7 +63,7 @@ export function InsightCard({
         }
       }}
       className={cn(
-        'h-full cursor-pointer gap-0 border-l-0 p-4 transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        'h-full cursor-pointer gap-0 p-4 transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
         style.accent,
         className
       )}


### PR DESCRIPTION
## Summary
- Remove `border-l-0` from the `InsightCard` root `Card` className.
- The severity `accent` token from `SEVERITY_META` colors all four borders (e.g. rose on critical), but `border-l-0` was stripping the left border — the "missing border left of first card" bug reported on `/overview?host=0`.

## Test plan
- [x] Visual: critical/warning insight cards now show the full colored border on all sides.
- Note: pre-push `bun test` has 2 pre-existing, unrelated failures in `apps/dashboard/src/components/dashboard/time-range-context.test.tsx` (`act is not a function`) that also fail on `main` and are untouched by this change.

🤖 Generated with [CommandCode](https://commandcode.ai)