### PR TITLE
fix(insights): restore severity accent left border on insight cards

### DIFF
--- a/apps/dashboard/src/components/insights/insight-card.tsx
+++ b/apps/dashboard/src/components/insights/insight-card.tsx
@@ -63,7 +63,7 @@ export function InsightCard({
         }
       }}
       className={cn(
-        'h-full cursor-pointer gap-0 border-l-0 p-4 transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        'h-full cursor-pointer gap-0 p-4 transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
         style.accent,
         className
       )}


### PR DESCRIPTION
border-l-0 was stripping the left border, hiding the colored severity accent (e.g. the rose border on the first/critical card). Remove it so the full-border accent from SEVERITY_META renders on all four sides.

## Summary

<!-- One or two sentences describing what this PR does and why. -->

## Changes

<!-- Bullet list of the key changes. Be specific about files or components changed. -->

-
-

## Test plan

<!-- How did you verify this works? Tick the boxes that apply. -->

- [ ] `pnpm run lint` passes with no errors
- [ ] `pnpm run build` passes (includes `tsc --noEmit`)
- [ ] `pnpm run type-check:test` passes (catches test-file type errors not covered by the build — see CONTRIBUTING.md §Type-check gap)
- [ ] `pnpm run test:unit` passes
- [ ] Tested manually in local dev (`pnpm run dev`)
- [ ] Docs updated in `docs/content/` if behaviour or config changed
- [ ] `docs/content/ai-agent.mdx` updated if agent tools/skills/env vars changed

## Notes for reviewer

<!-- Optional: anything non-obvious, design decisions, or things to look out for. -->

---

Co-Authored-By: duyetbot <bot@duyet.net>
