### PR TITLE
fix(dashboard): resolve running queries alignment and responsiveness

### DIFF
--- a/apps/dashboard/src/components/running-queries/running-queries-table.tsx
+++ b/apps/dashboard/src/components/running-queries/running-queries-table.tsx
@@ -363,10 +363,10 @@ export const RunningQueriesTable = memo(function RunningQueriesTable({
           phones: below it the wrapper scrolls horizontally rather than letting
           table-fixed crush the Query column to a few pixels. */
         <div className="overflow-x-auto">
-          <table className="w-full min-w-[640px] table-fixed border-collapse">
+          <table className="w-full min-w-[768px] table-fixed border-collapse">
             <thead className="border-b border-border bg-muted/40">
               <tr>
-                <SortableHeader width="108px">Type</SortableHeader>
+                <SortableHeader width="140px">Type</SortableHeader>
                 <SortableHeader>Query</SortableHeader>
                 <SortableHeader
                   width="140px"

--- a/apps/dashboard/src/components/running-queries/table/query-row.tsx
+++ b/apps/dashboard/src/components/running-queries/table/query-row.tsx
@@ -83,7 +83,7 @@ export const QueryRow = memo(function QueryRow({
     <>
       <tr
         className={cn(
-          'group animate-in cursor-pointer border-b border-border align-middle fade-in-0 slide-in-from-top-1 duration-300 hover:bg-muted/60',
+          'group animate-in cursor-pointer border-b border-border align-top fade-in-0 slide-in-from-top-1 duration-300 hover:bg-muted/60',
           done &&
             'bg-emerald-50/60 hover:bg-emerald-50 dark:bg-emerald-950/20 dark:hover:bg-emerald-950/30'
         )}
@@ -91,7 +91,7 @@ export const QueryRow = memo(function QueryRow({
       >
         {/* Type + expand chevron */}
         <td className="px-2 py-2.5 sm:px-3">
-          <div className="flex items-center gap-1.5 sm:gap-2">
+          <div className="flex items-center gap-1.5 sm:gap-2 whitespace-nowrap">
             <ChevronRight
               className={cn(
                 'size-3 shrink-0 text-muted-foreground transition-transform',


### PR DESCRIPTION
This PR fixes query badge overlaps, table responsive issues, and row alignment on the running queries page.

### Changes
- Adjust Type column width to `140px` to prevent horizontal overflow and badge overlap (especially when a query is retained as `done` and has both DONE and kind badges visible).
- Use `align-top` on table rows in `QueryRow` so that expand/status badges and actions align properly with the start of wrapped query text.
- Add `whitespace-nowrap` to the badge flex container in `QueryRow` first cell to prevent internal wrapping of badges.
- Increase the table minimum width to `768px` to ensure the Query column is not crushed too much on smaller viewports.

Co-Authored-By: duyetbot <bot@duyet.net>