### PR TITLE
fix(brand): generate logo SVGs for blog and docs apps

### DIFF
--- a/apps/blog/public/brand/logo-chmonitor-mono.svg
+++ b/apps/blog/public/brand/logo-chmonitor-mono.svg
@@ -1,0 +1,10 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="chmonitor">
+  <g fill="currentColor">
+    <rect x="3.3" y="9.75" width="3.8" height="3.3"/>
+    <rect x="3.3" y="13.95" width="3.8" height="14.55"/>
+    <rect x="8.7" y="3.5" width="3.8" height="25"/>
+    <rect x="14.1" y="13.25" width="3.8" height="15.25"/>
+    <rect x="19.5" y="6.25" width="3.8" height="22.25"/>
+    <rect x="24.9" y="16.8" width="3.8" height="11.7"/>
+  </g>
+</svg>

--- a/apps/blog/public/brand/logo-chmonitor.svg
+++ b/apps/blog/public/brand/logo-chmonitor.svg
@@ -1,0 +1,3 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="chmonitor">
+<rect x="3.3" y="13.05" width="3.8" height="15.45" fill="#f97316"/><rect x="8.7" y="3.5" width="3.8" height="25" fill="#f97316"/><rect x="14.1" y="13.25" width="3.8" height="15.25" fill="#f97316"/><rect x="19.5" y="6.25" width="3.8" height="22.25" fill="#f97316"/><rect x="24.9" y="16.8" width="3.8" height="11.7" fill="#f97316"/><rect x="3.3" y="9.75" width="3.8" height="3.3" fill="#10b981"/>
+</svg>

--- a/apps/blog/public/brand/logo-dark.svg
+++ b/apps/blog/public/brand/logo-dark.svg
@@ -1,0 +1,7 @@
+<svg width="208" height="44" viewBox="0 0 208 44" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="chmonitor">
+  <title>chmonitor</title>
+  <g transform="translate(6 6)">
+    <rect x="3.3" y="13.05" width="3.8" height="15.45" fill="#f97316"/><rect x="8.7" y="3.5" width="3.8" height="25" fill="#f97316"/><rect x="14.1" y="13.25" width="3.8" height="15.25" fill="#f97316"/><rect x="19.5" y="6.25" width="3.8" height="22.25" fill="#f97316"/><rect x="24.9" y="16.8" width="3.8" height="11.7" fill="#f97316"/><rect x="3.3" y="9.75" width="3.8" height="3.3" fill="#10b981"/>
+  </g>
+  <text x="48" y="29" font-family="Inter, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="24" font-weight="650" letter-spacing="-.6" fill="#fafafa">chmonitor</text>
+</svg>

--- a/apps/blog/public/brand/logo.svg
+++ b/apps/blog/public/brand/logo.svg
@@ -1,0 +1,7 @@
+<svg width="208" height="44" viewBox="0 0 208 44" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="chmonitor">
+  <title>chmonitor</title>
+  <g transform="translate(6 6)">
+    <rect x="3.3" y="13.05" width="3.8" height="15.45" fill="#f97316"/><rect x="8.7" y="3.5" width="3.8" height="25" fill="#f97316"/><rect x="14.1" y="13.25" width="3.8" height="15.25" fill="#f97316"/><rect x="19.5" y="6.25" width="3.8" height="22.25" fill="#f97316"/><rect x="24.9" y="16.8" width="3.8" height="11.7" fill="#f97316"/><rect x="3.3" y="9.75" width="3.8" height="3.3" fill="#10b981"/>
+  </g>
+  <text x="48" y="29" font-family="Inter, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="24" font-weight="650" letter-spacing="-.6" fill="#09090b">chmonitor</text>
+</svg>

--- a/apps/docs/public/brand/logo-chmonitor-mono.svg
+++ b/apps/docs/public/brand/logo-chmonitor-mono.svg
@@ -1,0 +1,10 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="chmonitor">
+  <g fill="currentColor">
+    <rect x="3.3" y="9.75" width="3.8" height="3.3"/>
+    <rect x="3.3" y="13.95" width="3.8" height="14.55"/>
+    <rect x="8.7" y="3.5" width="3.8" height="25"/>
+    <rect x="14.1" y="13.25" width="3.8" height="15.25"/>
+    <rect x="19.5" y="6.25" width="3.8" height="22.25"/>
+    <rect x="24.9" y="16.8" width="3.8" height="11.7"/>
+  </g>
+</svg>

--- a/apps/docs/public/brand/logo-dark.svg
+++ b/apps/docs/public/brand/logo-dark.svg
@@ -1,0 +1,7 @@
+<svg width="208" height="44" viewBox="0 0 208 44" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="chmonitor">
+  <title>chmonitor</title>
+  <g transform="translate(6 6)">
+    <rect x="3.3" y="13.05" width="3.8" height="15.45" fill="#f97316"/><rect x="8.7" y="3.5" width="3.8" height="25" fill="#f97316"/><rect x="14.1" y="13.25" width="3.8" height="15.25" fill="#f97316"/><rect x="19.5" y="6.25" width="3.8" height="22.25" fill="#f97316"/><rect x="24.9" y="16.8" width="3.8" height="11.7" fill="#f97316"/><rect x="3.3" y="9.75" width="3.8" height="3.3" fill="#10b981"/>
+  </g>
+  <text x="48" y="29" font-family="Inter, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="24" font-weight="650" letter-spacing="-.6" fill="#fafafa">chmonitor</text>
+</svg>

--- a/apps/docs/public/brand/logo.svg
+++ b/apps/docs/public/brand/logo.svg
@@ -1,0 +1,7 @@
+<svg width="208" height="44" viewBox="0 0 208 44" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="chmonitor">
+  <title>chmonitor</title>
+  <g transform="translate(6 6)">
+    <rect x="3.3" y="13.05" width="3.8" height="15.45" fill="#f97316"/><rect x="8.7" y="3.5" width="3.8" height="25" fill="#f97316"/><rect x="14.1" y="13.25" width="3.8" height="15.25" fill="#f97316"/><rect x="19.5" y="6.25" width="3.8" height="22.25" fill="#f97316"/><rect x="24.9" y="16.8" width="3.8" height="11.7" fill="#f97316"/><rect x="3.3" y="9.75" width="3.8" height="3.3" fill="#10b981"/>
+  </g>
+  <text x="48" y="29" font-family="Inter, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="24" font-weight="650" letter-spacing="-.6" fill="#09090b">chmonitor</text>
+</svg>

--- a/apps/landing/scripts/build-brand-assets.ts
+++ b/apps/landing/scripts/build-brand-assets.ts
@@ -221,21 +221,26 @@ async function buildOg() {
 async function run() {
   await mkdir(join(landing, 'brand'), { recursive: true })
   await mkdir(dashboard, { recursive: true })
-  await mkdir(docs, { recursive: true })
+  await mkdir(join(docs, 'brand'), { recursive: true })
   await mkdir(join(blog, 'brand'), { recursive: true })
 
   // Mark SVGs (filenames the site already references).
   await writeFile(join(landing, 'favicon.svg'), markColor)
-  await writeFile(
-    join(landing, 'brand', 'logo-chmonitor.svg'),
-    markColor.replace('<svg ', '<svg width="32" height="32" ')
+
+  const logoColorSvg = markColor.replace(
+    '<svg ',
+    '<svg width="32" height="32" '
   )
-  await writeFile(
-    join(landing, 'brand', 'logo-chmonitor-mono.svg'),
-    markMono.replace('<svg ', '<svg width="32" height="32" ')
-  )
-  await writeFile(join(landing, 'brand', 'logo.svg'), lockup(INK))
-  await writeFile(join(landing, 'brand', 'logo-dark.svg'), lockup(PAPER))
+  const logoMonoSvg = markMono.replace('<svg ', '<svg width="32" height="32" ')
+  const logoLockupLight = lockup(INK)
+  const logoLockupDark = lockup(PAPER)
+
+  for (const dir of [landing, blog, docs]) {
+    await writeFile(join(dir, 'brand', 'logo-chmonitor.svg'), logoColorSvg)
+    await writeFile(join(dir, 'brand', 'logo-chmonitor-mono.svg'), logoMonoSvg)
+    await writeFile(join(dir, 'brand', 'logo.svg'), logoLockupLight)
+    await writeFile(join(dir, 'brand', 'logo-dark.svg'), logoLockupDark)
+  }
 
   // Landing rasters.
   await sharp(await rasterTransparent(16)).toFile(
@@ -330,8 +335,8 @@ async function run() {
     `✓ avatars (${avatars.map((a) => a.name).join(', ')}) → landing + blog`
   )
 
-  // Dashboard + docs favicons (own public dirs, separate deploys).
-  for (const dir of [dashboard, docs]) {
+  // Dashboard, docs + blog favicons (own public dirs, separate deploys).
+  for (const dir of [dashboard, docs, blog]) {
     await writeFile(join(dir, 'favicon.svg'), markColor)
     await sharp(await rasterTransparent(16)).toFile(join(dir, 'favicon-16.png'))
     await sharp(await rasterTransparent(32)).toFile(join(dir, 'favicon-32.png'))


### PR DESCRIPTION
This PR updates the brand asset builder script to output core logo SVGs into the blog and docs public brand directories, and updates the favicons generator to include the blog. This resolves missing/broken logo images on the blog and docs layouts.

Co-Authored-By: duyetbot <bot@duyet.net>