### PR TITLE
fix: only bump helm chart version when chart code changes, use latest image tag

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -14,16 +14,6 @@
       "prerelease": false,
       "extra-files": [
         {
-          "type": "yaml",
-          "path": "deploy/helm/chmonitor/Chart.yaml",
-          "jsonpath": "$.version"
-        },
-        {
-          "type": "yaml",
-          "path": "deploy/helm/chmonitor/Chart.yaml",
-          "jsonpath": "$.appVersion"
-        },
-        {
           "type": "json",
           "path": "apps/dashboard/src/package.json",
           "jsonpath": "$.version"

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -4,10 +4,9 @@ name: Helm Chart Release
 # packages to the gh-pages branch; a follow-up job mirrors that branch to the
 # chmonitor-charts Cloudflare Pages project, served at charts.chmonitor.dev.
 # chart-releaser detects Chart.yaml version bumps and only re-packages charts
-# that changed since the last published release. Chart.yaml version + appVersion
-# are auto-bumped by release-please on each app release (see
-# .github/release-please-config.json extra-files), so the shipped image tag
-# (defaults to appVersion) tracks the release.
+# that changed since the last published release. The chart version is bumped
+# manually when chart code changes (templates, values). The image tag always
+# defaults to "latest" (set in Chart.yaml appVersion) — no per-release sync.
 #
 # The gh-pages branch is auto-created on first run (see "Bootstrap gh-pages
 # branch" step). charts.chmonitor.dev is bound to the chmonitor-charts Pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,51 +233,6 @@ jobs:
             docker buildx imagetools create -t "$TAG" "$AMD64" "$ARM64"
           done
 
-  helm-publish:
-    name: helm-publish
-    needs: docker-manifest
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.release.tag_name || inputs.tag || github.ref }}
-
-      - name: Extract version
-        id: ver
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag || github.ref_name }}
-        run: |
-          TAG="$RELEASE_TAG"
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-            echo "Invalid release tag: $TAG" >&2
-            exit 1
-          fi
-          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
-
-      - name: Install Helm
-        uses: azure/setup-helm@v5
-
-      - name: Sync Chart.yaml to release version
-        run: |
-          VERSION="${{ steps.ver.outputs.version }}"
-          sed -i "s/^version:.*/version: $VERSION/" deploy/helm/chmonitor/Chart.yaml
-          sed -i "s/^appVersion:.*/appVersion: \"$VERSION\"/" deploy/helm/chmonitor/Chart.yaml
-
-      - name: Package chart
-        run: helm package deploy/helm/chmonitor --destination /tmp/helm-pkg
-
-      - name: Login to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
-
-      # Push to OCI registry: oci://ghcr.io/chmonitor/chmonitor
-      # Pull with: helm install my-chm oci://ghcr.io/chmonitor/chmonitor --version X.Y.Z
-      - name: Push chart to OCI (GHCR)
-        run: |
-          VERSION="${{ steps.ver.outputs.version }}"
-          helm push /tmp/helm-pkg/chmonitor-${VERSION}.tgz oci://ghcr.io/${{ github.repository_owner }}
-
   assets:
     name: assets
     needs: docker-manifest

--- a/deploy/helm/chmonitor/Chart.yaml
+++ b/deploy/helm/chmonitor/Chart.yaml
@@ -3,7 +3,7 @@ name: chmonitor
 description: A Helm chart for the chmonitor dashboard
 type: application
 version: 0.2.15
-appVersion: 0.2.15
+appVersion: latest
 home: https://github.com/chmonitor/chmonitor
 sources:
   - https://github.com/chmonitor/chmonitor


### PR DESCRIPTION
## Summary

Stop the Helm chart version from auto-bumping on every app release. Chart version should only increment when chart code (templates, values, helpers) actually changes. The image tag always defaults to `latest`.

## Changes

### `release-please-config.json`
- Removed `Chart.yaml` (both `$.version` and `$.appVersion`) from `extra-files` — release-please no longer bumps the chart version/appVersion on every app release

### `deploy/helm/chmonitor/Chart.yaml`
- Set `appVersion: latest` — the deployed image always defaults to `latest` tag (via the `chmonitor.image` helper), not a pinned release version

### `release.yml`
- Removed the `helm-publish` job — stops publishing a new OCI chart on every app release. Chart releases now only happen via `helm-release.yml` when chart code changes

### `helm-release.yml`
- Updated comment to reflect the new policy (no more auto-bump by release-please)

## Motivation

Before: every release-please bump updated `Chart.yaml` (version + appVersion), which triggered `helm-release.yml` (watches `deploy/helm/**`) and published a new chart even when only docs/blog/chore commits were in the release — no chart code changed.

After: chart releases are decoupled from app releases. Only edits to templates, values, or helpers produce a new chart version.