### PR TITLE
feat(billing): count replicas as 0.5 billable host (#2379)

### DIFF
--- a/apps/dashboard/src/components/billing/usage-summary.tsx
+++ b/apps/dashboard/src/components/billing/usage-summary.tsx
@@ -151,7 +151,7 @@ export function UsageSummary({
         <UsageMeterBar
           label="Hosts"
           meter={hosts}
-          note={deferredNote('hosts')}
+          note={deferredNote('hosts') ?? 'detected replicas count as 0.5 host'}
         />
         <UsageMeterBar
           label="Team seats"

--- a/apps/dashboard/src/lib/billing/org-host-count.test.ts
+++ b/apps/dashboard/src/lib/billing/org-host-count.test.ts
@@ -14,13 +14,41 @@ mock.module('@clerk/tanstack-react-start/server', () => ({
   }),
 }))
 
+// Mock the live ClickHouse query used by replica-detection's probe. Tests that
+// don't care about replica weighting never populate credentials, so this is
+// only exercised by the weighting-specific tests below.
+let queryConnectionImpl: (...args: unknown[]) => Promise<unknown> =
+  async () => ({
+    data: [],
+  })
+mock.module('@/lib/connection-query/connection-client', () => ({
+  queryConnection: (...args: unknown[]) => queryConnectionImpl(...args),
+}))
+
 const { countOwnerHosts } = await import('./org-host-count')
 
 // A fake store whose list() returns N placeholder rows per user, from a map.
+// No `id`/credentials — weighting falls back to a full host per connection.
 function fakeStore(counts: Record<string, number>): ConnectionStore {
   return {
     list: async (userId: string) =>
       Array.from({ length: counts[userId] ?? 0 }, () => ({}) as never),
+  } as unknown as ConnectionStore
+}
+
+// A fake store that additionally serves credentials, so replica weighting via
+// probeHostTopology (mocked above) actually runs.
+function fakeStoreWithCredentials(
+  connectionsByUser: Record<string, string[]>
+): ConnectionStore {
+  return {
+    list: async (userId: string) =>
+      (connectionsByUser[userId] ?? []).map((id) => ({ id }) as never),
+    getCredentials: async (_userId: string, id: string) => ({
+      host: `https://${id}.example.com`,
+      user: 'x',
+      password: 'y',
+    }),
   } as unknown as ConnectionStore
 }
 
@@ -80,5 +108,45 @@ describe('countOwnerHosts', () => {
     )
     expect(usage.count).toBe(3)
     expect(usage.memberUserIds).toEqual(['user_a'])
+  })
+
+  test('a detected replica in the same cluster shard bills at 0.5 host', async () => {
+    const topologyByHost: Record<
+      string,
+      { cluster: string; shard_num: number }
+    > = {
+      conn_primary: { cluster: 'prod', shard_num: 1 },
+      conn_replica: { cluster: 'prod', shard_num: 1 },
+    }
+    // queryConnection(credentials, sql) — id is embedded in the host, extract it.
+    queryConnectionImpl = async (...args: unknown[]) => {
+      const credentials = args[0] as { host: string }
+      const id = credentials.host.replace('https://', '').split('.')[0]
+      const row = topologyByHost[id]
+      return { data: row ? [row] : [] }
+    }
+
+    const store = fakeStoreWithCredentials({
+      user_a: ['conn_primary', 'conn_replica'],
+    })
+    const usage = await countOwnerHosts(
+      { type: 'user', id: 'user_a' },
+      store,
+      'user_a'
+    )
+    expect(usage.count).toBe(1.5)
+  })
+
+  test('standalone hosts (no cluster) each bill as a full host', async () => {
+    queryConnectionImpl = async () => ({ data: [] })
+    const store = fakeStoreWithCredentials({
+      user_a: ['conn_1', 'conn_2'],
+    })
+    const usage = await countOwnerHosts(
+      { type: 'user', id: 'user_a' },
+      store,
+      'user_a'
+    )
+    expect(usage.count).toBe(2)
   })
 })

--- a/apps/dashboard/src/lib/billing/org-host-count.ts
+++ b/apps/dashboard/src/lib/billing/org-host-count.ts
@@ -1,9 +1,16 @@
 import type { ConnectionStore } from '@/lib/connection-store/types'
 import type { BillingOwner } from './billing-owner'
 
+import { computeHostWeights, probeHostTopology } from './replica-detection'
+
 /** Pooled host usage for a billing owner: the count plus the member id set it was computed from. */
 export interface OwnerHostUsage {
-  /** Hosts counted so far — the value fed to `checkHostLimit`. */
+  /**
+   * Weighted host count — the value fed to `checkHostLimit`. A detected
+   * replica (same cluster shard as an already-counted host, see
+   * `replica-detection.ts`) counts as 0.5; every other host counts as 1, so
+   * this can be fractional.
+   */
   count: number
   /**
    * The user_ids whose connections were counted. `[actingUserId]` for a user
@@ -37,7 +44,7 @@ export async function countOwnerHosts(
   actingUserId: string
 ): Promise<OwnerHostUsage> {
   if (owner.type !== 'org') {
-    const count = (await store.list(actingUserId)).length
+    const count = await weightedHostCount([actingUserId], store)
     return { count, memberUserIds: [actingUserId] }
   }
 
@@ -55,18 +62,50 @@ export async function countOwnerHosts(
     // Count the acting user even if their membership row hasn't propagated yet.
     if (!memberIds.includes(actingUserId)) memberIds.push(actingUserId)
 
-    const counts = await Promise.all(
-      memberIds.map((id) =>
-        store.list(id).then((connections) => connections.length)
-      )
-    )
-    return {
-      count: counts.reduce((sum, n) => sum + n, 0),
-      memberUserIds: memberIds,
-    }
+    const count = await weightedHostCount(memberIds, store)
+    return { count, memberUserIds: memberIds }
   } catch {
     // Permissive fallback — never block a paying org on an enumeration failure.
-    const count = (await store.list(actingUserId)).length
+    const count = await weightedHostCount([actingUserId], store)
     return { count, memberUserIds: [actingUserId] }
+  }
+}
+
+/**
+ * Sum the billable host weight across every connection owned by
+ * `memberUserIds` (see `replica-detection.ts`: a detected replica of an
+ * already-counted host bills at 0.5). Fails safe to the plain connection
+ * count — untouched by weighting — if anything in the weighting step throws,
+ * so a probe/credentials hiccup can only forfeit the discount, never break
+ * host counting itself.
+ */
+async function weightedHostCount(
+  memberUserIds: string[],
+  store: ConnectionStore
+): Promise<number> {
+  const perUserConnections = await Promise.all(
+    memberUserIds.map((id) => store.list(id))
+  )
+  const flatConnections = memberUserIds.flatMap((userId, i) =>
+    perUserConnections[i].map((meta) => ({ userId, id: meta.id }))
+  )
+  if (flatConnections.length === 0) return 0
+
+  try {
+    const topologies = await Promise.all(
+      flatConnections.map(async ({ userId, id }) => {
+        try {
+          const credentials = await store.getCredentials(userId, id)
+          if (!credentials) return { cluster: null, shardNum: null }
+          return await probeHostTopology(credentials)
+        } catch {
+          // One host's probe failing must not affect the others' discount.
+          return { cluster: null, shardNum: null }
+        }
+      })
+    )
+    return computeHostWeights(topologies).reduce((sum, w) => sum + w, 0)
+  } catch {
+    return flatConnections.length
   }
 }

--- a/apps/dashboard/src/lib/billing/replica-detection.test.ts
+++ b/apps/dashboard/src/lib/billing/replica-detection.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, mock, test } from 'bun:test'
+
+// Mock the live ClickHouse query used by probeHostTopology.
+let queryConnectionImpl: (...args: unknown[]) => Promise<unknown> =
+  async () => ({
+    data: [],
+  })
+mock.module('@/lib/connection-query/connection-client', () => ({
+  queryConnection: (...args: unknown[]) => queryConnectionImpl(...args),
+}))
+
+const {
+  computeHostWeights,
+  probeHostTopology,
+  PRIMARY_HOST_WEIGHT,
+  REPLICA_HOST_WEIGHT,
+  STANDALONE_TOPOLOGY,
+} = await import('./replica-detection')
+
+describe('computeHostWeights', () => {
+  test('standalone hosts (no cluster) are always a full host', () => {
+    const weights = computeHostWeights([
+      STANDALONE_TOPOLOGY,
+      STANDALONE_TOPOLOGY,
+      STANDALONE_TOPOLOGY,
+    ])
+    expect(weights).toEqual([1, 1, 1])
+  })
+
+  test('the first host in a shard is full, later ones in the same shard are replicas', () => {
+    const weights = computeHostWeights([
+      { cluster: 'prod', shardNum: 1 },
+      { cluster: 'prod', shardNum: 1 },
+      { cluster: 'prod', shardNum: 1 },
+    ])
+    expect(weights).toEqual([
+      PRIMARY_HOST_WEIGHT,
+      REPLICA_HOST_WEIGHT,
+      REPLICA_HOST_WEIGHT,
+    ])
+  })
+
+  test('different shards of the same cluster are each a full host', () => {
+    const weights = computeHostWeights([
+      { cluster: 'prod', shardNum: 1 },
+      { cluster: 'prod', shardNum: 2 },
+    ])
+    expect(weights).toEqual([1, 1])
+  })
+
+  test('different clusters never count as replicas of each other', () => {
+    const weights = computeHostWeights([
+      { cluster: 'prod', shardNum: 1 },
+      { cluster: 'staging', shardNum: 1 },
+    ])
+    expect(weights).toEqual([1, 1])
+  })
+
+  test('mixed standalone + replicated hosts', () => {
+    const weights = computeHostWeights([
+      STANDALONE_TOPOLOGY,
+      { cluster: 'prod', shardNum: 1 },
+      { cluster: 'prod', shardNum: 1 },
+    ])
+    expect(weights).toEqual([1, 1, REPLICA_HOST_WEIGHT])
+  })
+})
+
+describe('probeHostTopology', () => {
+  const credentials = {
+    host: 'https://ch.example.com',
+    user: 'x',
+    password: 'y',
+  }
+
+  test('reads cluster + shard_num from system.clusters', async () => {
+    queryConnectionImpl = async () => ({
+      data: [{ cluster: 'prod', shard_num: 2 }],
+    })
+    const topology = await probeHostTopology(credentials)
+    expect(topology).toEqual({ cluster: 'prod', shardNum: 2 })
+  })
+
+  test('returns standalone when the host has no cluster rows', async () => {
+    queryConnectionImpl = async () => ({ data: [] })
+    const topology = await probeHostTopology(credentials)
+    expect(topology).toEqual(STANDALONE_TOPOLOGY)
+  })
+
+  test('fails safe to standalone when the probe throws', async () => {
+    queryConnectionImpl = async () => {
+      throw new Error('connection refused')
+    }
+    const topology = await probeHostTopology(credentials)
+    expect(topology).toEqual(STANDALONE_TOPOLOGY)
+  })
+})

--- a/apps/dashboard/src/lib/billing/replica-detection.ts
+++ b/apps/dashboard/src/lib/billing/replica-detection.ts
@@ -1,0 +1,92 @@
+/**
+ * Replica detection — bills a detected ClickHouse replica host at 0.5 of a
+ * full host, mirroring pganalyze's standby-replica discount (issue #2379).
+ *
+ * A host's role is read from its own cluster topology (`system.clusters`):
+ * hosts that share the same `(cluster, shard_num)` pair are replicas of each
+ * other — redundant copies of the same shard's data. The first host counted
+ * for a given shard is billed as a full host; every additional host in that
+ * same shard is a replica, billed at {@link REPLICA_HOST_WEIGHT}. Hosts with
+ * no cluster (standalone) or a different shard are always full hosts.
+ *
+ * Detection is best-effort and fails safe: any error probing a host (network,
+ * auth, older ClickHouse versions without `system.clusters`, timeout) resolves
+ * to {@link STANDALONE_TOPOLOGY} — a probe failure can only forfeit the
+ * discount for that one host, never over-discount revenue or block a request.
+ */
+
+import type { ConnectionCredentials } from '@/lib/connection-store/types'
+
+import { queryConnection } from '@/lib/connection-query/connection-client'
+
+/** Billing weight of a host confirmed to be a replica of an already-counted host. */
+export const REPLICA_HOST_WEIGHT = 0.5
+/** Billing weight of a standalone host, or the first host counted in a shard. */
+export const PRIMARY_HOST_WEIGHT = 1
+
+/** A host's cluster/shard membership, or both null when standalone/unknown. */
+export interface HostTopology {
+  cluster: string | null
+  shardNum: number | null
+}
+
+export const STANDALONE_TOPOLOGY: HostTopology = {
+  cluster: null,
+  shardNum: null,
+}
+
+const PROBE_TIMEOUT_MS = 2000
+
+/**
+ * Probe a host's cluster/shard membership. Reads `system.clusters` for the
+ * cluster this host's own instance belongs to (`is_local = 1`) — if the host
+ * is a member of more than one cluster, the first row (arbitrary but stable
+ * per host) is used. Fails safe to {@link STANDALONE_TOPOLOGY} on any error or
+ * if the probe exceeds {@link PROBE_TIMEOUT_MS}.
+ */
+export async function probeHostTopology(
+  credentials: ConnectionCredentials
+): Promise<HostTopology> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(
+        () => reject(new Error('replica-topology-probe-timeout')),
+        PROBE_TIMEOUT_MS
+      )
+    })
+    const result = await Promise.race([
+      queryConnection<{ cluster: string; shard_num: number }>(
+        credentials,
+        'SELECT cluster, shard_num FROM system.clusters WHERE is_local = 1 ORDER BY cluster LIMIT 1'
+      ),
+      timeout,
+    ])
+    const row = result.data[0]
+    if (!row) return STANDALONE_TOPOLOGY
+    return { cluster: row.cluster, shardNum: row.shard_num }
+  } catch {
+    return STANDALONE_TOPOLOGY
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+/**
+ * Weight each host in `topologies` (same order as the input connections).
+ * Standalone hosts (null cluster/shard) are always {@link PRIMARY_HOST_WEIGHT}.
+ * Among hosts sharing the same `cluster:shardNum` key, the first occurrence in
+ * input order is {@link PRIMARY_HOST_WEIGHT} and every later one is
+ * {@link REPLICA_HOST_WEIGHT}. Pure — no I/O, easy to unit test independent of
+ * the live probe.
+ */
+export function computeHostWeights(topologies: HostTopology[]): number[] {
+  const seenShards = new Set<string>()
+  return topologies.map(({ cluster, shardNum }) => {
+    if (cluster == null || shardNum == null) return PRIMARY_HOST_WEIGHT
+    const key = `${cluster}:${shardNum}`
+    if (seenShards.has(key)) return REPLICA_HOST_WEIGHT
+    seenShards.add(key)
+    return PRIMARY_HOST_WEIGHT
+  })
+}

--- a/apps/landing/src/data/pricing.ts
+++ b/apps/landing/src/data/pricing.ts
@@ -191,7 +191,7 @@ export const pricingFaqs: PricingFaq[] = [
   },
   {
     q: "What's a “host”?",
-    a: 'A host is a single monitored connection — one ClickHouse cluster endpoint, or (beta) one Postgres database. Your plan caps how many hosts you can connect to the hosted dashboard at once. Self-hosting has no host limit.',
+    a: 'A host is a single monitored connection — one ClickHouse cluster endpoint, or (beta) one Postgres database. Your plan caps how many hosts you can connect to the hosted dashboard at once. Self-hosting has no host limit. A detected replica (a redundant copy in the same cluster shard) counts as 0.5 host.',
   },
   {
     q: 'How does AI usage metering work?',


### PR DESCRIPTION
## Summary
- Detect a host's ClickHouse cluster/shard topology (`system.clusters`) and bill it as a full host (1.0) or, when it shares a shard with an already-counted host, as a replica (0.5) — mirrors pganalyze's standby-replica discount.
- Wired into `countOwnerHosts` (`lib/billing/org-host-count.ts`), which already feeds `checkHostLimit`/`checkHostSoftCap` — those accept fractional counts unchanged.
- Detection is best-effort and fails safe: any probe error (network, auth, old ClickHouse without `system.clusters`, timeout) forfeits the discount for that host only, never blocks host counting or over-discounts revenue.
- Synced the "what's a host" copy in `apps/landing` pricing FAQ and the in-app billing usage card note.

## Test plan
- [x] `pnpm run type-check` — no new errors (pre-existing `routeTree.gen.ts` baseline errors unrelated, confirmed present on `main` too)
- [x] `pnpm run lint` — clean
- [x] `bun test apps/dashboard/src/lib/billing --isolate` — 202 pass
- [x] `bun test apps/dashboard/src/lib/billing/replica-detection.test.ts apps/dashboard/src/lib/billing/org-host-count.test.ts --isolate` — 14 pass

Closes #2379