### PR TITLE
feat(billing): $199 Fleet mid-anchor tier behind experiment flag (#2381)

### DIFF
--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -101,6 +101,10 @@ CHM_FEATURE_AGENT_ACCESS=public
 # both cloud and self-hosted; a pure env gate (no Clerk requirement) so OSS has
 # equal Postgres support. Everything Postgres stays inert until this is on.
 # CHM_FEATURE_POSTGRES_SOURCE=false
+# $199 "Fleet" mid-anchor tier experiment (#2381): 5 hosts included, between
+# Pro and Max, to A/B against Max + overage. Fail-closed, default off — a pure
+# env gate (no Clerk requirement), presentation-only until wired to checkout.
+# CHM_FEATURE_FLEET_TIER=false
 # Postgres sources the AI agent can query (read-only) when the flag above is on.
 # Comma-separated, index-aligned lists (the id space is a flat pgHostId index,
 # like CLICKHOUSE_* → hostId). A single POSTGRES_USER/POSTGRES_PASSWORD applies

--- a/apps/dashboard/src/lib/billing/plans.test.ts
+++ b/apps/dashboard/src/lib/billing/plans.test.ts
@@ -1,6 +1,7 @@
 import {
   BILLING_PLAN_LIST,
   BILLING_PLANS,
+  getVisiblePlans,
   monthlyEquivalentUsd,
   planHasCapability,
   yearlyMonthsFree,
@@ -90,5 +91,42 @@ describe('billing plans', () => {
     expect(planHasCapability('pro', 'custom_dashboards')).toBe(false)
     expect(planHasCapability('max', 'custom_dashboards')).toBe(true)
     expect(planHasCapability('max', 'webhook_integrations')).toBe(true)
+  })
+})
+
+describe('Fleet tier experiment (#2381, B4)', () => {
+  test('Fleet is NOT part of the canonical plan list/ids (not a real checkout target yet)', () => {
+    expect(BILLING_PLAN_LIST.map((p) => p.id)).toEqual([
+      'free',
+      'pro',
+      'max',
+      'enterprise',
+    ])
+    expect('fleet' in BILLING_PLANS).toBe(true)
+  })
+
+  test('Fleet is priced/scoped as the mid-anchor between Pro and Max', () => {
+    const fleet = BILLING_PLANS.fleet
+    expect(fleet.priceMonthlyUsd).toBe(199)
+    expect(fleet.priceYearlyUsd).toBe(1990)
+    expect(fleet.hosts).toBe(5)
+    expect(fleet.hostOverage).toEqual({ usdPer: 19 })
+    expect(planHasCapability('fleet', 'fleet_view')).toBe(true)
+  })
+
+  test('getVisiblePlans(false) is identical to BILLING_PLAN_LIST — flag off changes nothing', () => {
+    expect(getVisiblePlans(false)).toEqual(BILLING_PLAN_LIST)
+    expect(getVisiblePlans(false).some((p) => p.id === 'fleet')).toBe(false)
+  })
+
+  test('getVisiblePlans(true) inserts Fleet between Pro and Max', () => {
+    const withFleet = getVisiblePlans(true)
+    expect(withFleet.map((p) => p.id)).toEqual([
+      'free',
+      'pro',
+      'fleet',
+      'max',
+      'enterprise',
+    ])
   })
 })

--- a/apps/dashboard/src/lib/feature-flags.test.ts
+++ b/apps/dashboard/src/lib/feature-flags.test.ts
@@ -48,6 +48,7 @@ const FEATURE_KEYS = [
   'VITE_FEATURE_USER_CONNECTIONS_DB',
   'VITE_FEATURE_WEBHOOK_SUBSCRIPTIONS',
   'VITE_FEATURE_POSTGRES_SOURCE',
+  'VITE_FEATURE_FLEET_TIER',
 ] as const
 
 type FeatureEnvKey = (typeof FEATURE_KEYS)[number]
@@ -239,6 +240,32 @@ describe('featureFlags.postgresSource — pure env gate (NOT Clerk-gated)', () =
   })
 })
 
+describe('featureFlags.fleetTierExperiment — pure env gate (NOT Clerk-gated)', () => {
+  // Fleet ($199 mid-anchor tier, #2381) is a presentation-only pricing A/B —
+  // it must render the same regardless of auth mode, so no Clerk requirement.
+
+  test('returns false when env var is unset (safe default)', () => {
+    mockIsClerkEnabled.mockReturnValue(true)
+    expect(featureFlags.fleetTierExperiment()).toBe(false)
+  })
+
+  test('returns false when env var is "false"', () => {
+    setEnv('VITE_FEATURE_FLEET_TIER', 'false')
+    expect(featureFlags.fleetTierExperiment()).toBe(false)
+  })
+
+  test('returns false when env var is "1" (not strictly "true")', () => {
+    setEnv('VITE_FEATURE_FLEET_TIER', '1')
+    expect(featureFlags.fleetTierExperiment()).toBe(false)
+  })
+
+  test('returns true when env var is "true" EVEN IF Clerk is disabled', () => {
+    mockIsClerkEnabled.mockReturnValue(false)
+    setEnv('VITE_FEATURE_FLEET_TIER', 'true')
+    expect(featureFlags.fleetTierExperiment()).toBe(true)
+  })
+})
+
 describe('featureFlags — both flags disabled simultaneously', () => {
   test('neither flag leaks into the other: conversationDb false does not affect userConnectionsDb', () => {
     // Only userConnectionsDb enabled.
@@ -301,6 +328,7 @@ describe('featureFlags — shape invariants', () => {
   test('has exactly the expected keys', () => {
     expect(Object.keys(featureFlags).sort()).toEqual([
       'conversationDb',
+      'fleetTierExperiment',
       'postgresSource',
       'userConnectionsDb',
       'webhookSubscriptions',

--- a/apps/dashboard/src/lib/feature-flags.ts
+++ b/apps/dashboard/src/lib/feature-flags.ts
@@ -104,6 +104,23 @@ export const featureFlags = {
   postgresSource: (): boolean => {
     return import.meta.env.VITE_FEATURE_POSTGRES_SOURCE === 'true'
   },
+
+  /**
+   * Enable the $199/mo "Fleet" mid-anchor tier experiment (B4, #2381) — a
+   * 5-host-included plan between Pro and Max, A/B tested vs Max + overage.
+   *
+   * Fail-closed: PURE env gate, like `postgresSource`. It only controls
+   * whether the Fleet tier is rendered on the landing pricing page and the
+   * in-app billing card (`getVisiblePlans` in `@chm/pricing`) — it is not
+   * (yet) wired to checkout/entitlements, so it never degrades a real
+   * subscription and needs no Clerk check.
+   *
+   * @default false (unset)
+   * @env VITE_FEATURE_FLEET_TIER (canonical CHM_FEATURE_FLEET_TIER)
+   */
+  fleetTierExperiment: (): boolean => {
+    return import.meta.env.VITE_FEATURE_FLEET_TIER === 'true'
+  },
 } as const
 
 /**

--- a/apps/dashboard/src/routes/(dashboard)/billing.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/billing.tsx
@@ -32,7 +32,8 @@ import {
   CardTitle,
 } from '@/components/ui/card'
 import { trackEvent } from '@/lib/analytics/analytics'
-import { BILLING_PLAN_LIST, getPlan } from '@/lib/billing/plans'
+import { getPlan, getVisiblePlans } from '@/lib/billing/plans'
+import { isFeatureEnabled } from '@/lib/feature-flags'
 import {
   checkCanDowngrade,
   openBillingPortal,
@@ -73,6 +74,9 @@ function BillingPage() {
   // usage onto that plan's limits inside the current-plan card. Click again
   // (or the ✕) to clear.
   const [comparePlanId, setComparePlanId] = useState<PlanId | null>(null)
+  // B4 experiment (#2381): Fleet tier only renders when the flag is on, kept
+  // in sync with the landing pricing cards via the same @chm/pricing helper.
+  const visiblePlans = getVisiblePlans(isFeatureEnabled('fleetTierExperiment'))
 
   // Cloud visitors who aren't signed in get a sign-in prompt instead of a
   // billing UI they can't act on. (Always signed-in in OSS, so never shown.)
@@ -220,8 +224,12 @@ function BillingPage() {
       <BillingPeriodToggle value={period} onChange={setPeriod} />
 
       {/* Plan grid */}
-      <div className="grid items-stretch gap-4 md:grid-cols-2 lg:grid-cols-4">
-        {BILLING_PLAN_LIST.map((plan) => {
+      <div
+        className={`grid items-stretch gap-4 md:grid-cols-2 ${
+          visiblePlans.length > 4 ? 'lg:grid-cols-5' : 'lg:grid-cols-4'
+        }`}
+      >
+        {visiblePlans.map((plan) => {
           const isCurrent = plan.id === currentPlanId
           const paid = plan.id === 'pro' || plan.id === 'max'
           return (
@@ -304,6 +312,24 @@ function BillingPage() {
                         hi@anyrouter.dev
                       </a>{' '}
                       for details on a dedicated instance.
+                    </p>
+                  </div>
+                ) : plan.id === 'fleet' ? (
+                  // Experiment tier (#2381) — not wired to self-serve checkout
+                  // yet, so keep the paywall honest: sales-assisted only.
+                  <div className="w-full space-y-1.5">
+                    <Button variant="outline" className="w-full" disabled>
+                      Coming soon
+                    </Button>
+                    <p className="text-muted-foreground text-center text-[11px] leading-snug">
+                      Contact{' '}
+                      <a
+                        href="mailto:hi@anyrouter.dev?subject=chmonitor%20Fleet%20tier"
+                        className="text-foreground underline underline-offset-2"
+                      >
+                        hi@anyrouter.dev
+                      </a>{' '}
+                      to get set up on Fleet.
                     </p>
                   </div>
                 ) : (

--- a/apps/dashboard/src/vite-env.d.ts
+++ b/apps/dashboard/src/vite-env.d.ts
@@ -12,6 +12,9 @@ interface ImportMetaEnv {
   readonly VITE_FEATURE_WEBHOOK_SUBSCRIPTIONS?: string
   // Postgres source engine (RFC #2264, phase 1 #2448). Fail-closed, default off.
   readonly VITE_FEATURE_POSTGRES_SOURCE?: string
+  // $199 "Fleet" mid-anchor tier experiment (#2381). Fail-closed, default off —
+  // presentation-only A/B variant, see lib/feature-flags.ts + @chm/pricing.
+  readonly VITE_FEATURE_FLEET_TIER?: string
   readonly VITE_AUTOCOMPLETE_LIMIT?: string
   readonly VITE_RUNNING_QUERIES_REFRESH_MS?: string
   // Opt-in product telemetry (off by default). See lib/telemetry/.

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -135,6 +135,10 @@ const CLIENT_ENV = {
   // off in BOTH modes until Postgres connectivity lands — not `isCloud`-gated.
   VITE_FEATURE_POSTGRES_SOURCE:
     e.VITE_FEATURE_POSTGRES_SOURCE ?? e.CHM_FEATURE_POSTGRES_SOURCE ?? 'false',
+  // $199 "Fleet" mid-anchor tier experiment (#2381). Fail-closed: default off
+  // in both modes — a presentation-only pricing A/B, not `isCloud`-gated.
+  VITE_FEATURE_FLEET_TIER:
+    e.VITE_FEATURE_FLEET_TIER ?? e.CHM_FEATURE_FLEET_TIER ?? 'false',
   VITE_AUTOCOMPLETE_LIMIT:
     e.VITE_AUTOCOMPLETE_LIMIT ?? e.NEXT_PUBLIC_AUTOCOMPLETE_LIMIT ?? '',
   VITE_RUNNING_QUERIES_REFRESH_MS:

--- a/apps/landing/src/components/Pricing.astro
+++ b/apps/landing/src/components/Pricing.astro
@@ -27,14 +27,14 @@ const outlineBtn = btnOutlineBlock
 const outlineBtnAuto = btnOutline
 
 // Tiers are separated by surface, not by hue — the featured tier is marked with
-// a brand hairline rather than a second brand color.
-const cardColors = [
-  'bg-[var(--canvas-soft)] border-border',                       // Free
-  'bg-card border-[var(--brand)]/40 ring-1 ring-[var(--brand)]/20', // Pro (featured)
-  'bg-[var(--canvas-soft)] border-border',                       // Max
-  'bg-[var(--canvas-soft)] border-border',                       // Enterprise
-]
-const featuredCta = [false, true, false, false] // Pro is the featured tier
+// a brand hairline rather than a second brand color. Keyed by plan id (not
+// position) so the optional #2381 Fleet tier slots in without reordering
+// these lookups.
+const FEATURED_COLOR =
+  'bg-card border-[var(--brand)]/40 ring-1 ring-[var(--brand)]/20'
+const DEFAULT_COLOR = 'bg-[var(--canvas-soft)] border-border'
+const cardColor = (id: string) => (id === 'pro' ? FEATURED_COLOR : DEFAULT_COLOR)
+const isFeaturedCta = (id: string) => id === 'pro' // Pro is the featured tier
 ---
 <section id="pricing" class="py-14 sm:py-20 md:py-24">
   <div class="mx-auto max-w-[1080px] px-4 sm:px-6">
@@ -70,9 +70,9 @@ const featuredCta = [false, true, false, false] // Pro is the featured tier
       </div>
     </div>
 
-    <div class="cloud-grid reveal mt-5 grid items-stretch gap-3 sm:gap-4 sm:grid-cols-2 lg:grid-cols-4" data-period="yearly">
-      {tiers.map((t, idx) => (
-        <div class={`flex flex-col rounded-xl border p-5 sm:p-6 shadow-xs transition-colors ${cardColors[idx]}`}>
+    <div class={`cloud-grid reveal mt-5 grid items-stretch gap-3 sm:gap-4 sm:grid-cols-2 ${tiers.length > 4 ? 'lg:grid-cols-5' : 'lg:grid-cols-4'}`} data-period="yearly">
+      {tiers.map((t) => (
+        <div class={`flex flex-col rounded-xl border p-5 sm:p-6 shadow-xs transition-colors ${cardColor(t.id)}`}>
           <div>
             <div class="flex flex-wrap items-center gap-2">
               <span class="font-bold text-lg tracking-tight">{t.name}</span>
@@ -112,7 +112,7 @@ const featuredCta = [false, true, false, false] // Pro is the featured tier
           </ul>
           <div class="mt-auto pt-6">
             <a
-              class={featuredCta[idx] ? btnPrimaryBlock : (t.cta.primary ? primaryBtn : outlineBtn)}
+              class={isFeaturedCta(t.id) ? btnPrimaryBlock : (t.cta.primary ? primaryBtn : outlineBtn)}
               href={t.cta.href}
               target="_blank"
               rel="noopener"

--- a/apps/landing/src/data/pricing.ts
+++ b/apps/landing/src/data/pricing.ts
@@ -9,10 +9,10 @@
  */
 
 import {
-  BILLING_PLAN_LIST,
   type Plan,
   type PlanCapability,
   type PlanId,
+  getVisiblePlans,
   planAiUsage,
   planAlertRules,
   planHasCapability,
@@ -22,7 +22,16 @@ import {
   yearlyMonthsFree,
 } from '@chm/pricing'
 
+/**
+ * B4 "Fleet" tier experiment (#2381), read at build time so a static Astro
+ * build either fully includes or fully excludes it — fail-closed like the
+ * dashboard's `CHM_FEATURE_FLEET_TIER` (`lib/feature-flags.ts`), same flag
+ * name so the two surfaces can never drift on whether it's live.
+ */
+const FLEET_TIER_ENABLED = import.meta.env.PUBLIC_FEATURE_FLEET_TIER === 'true'
+
 export interface PricingTier {
+  id: PlanId
   name: string
   badge?: { label: string; cls: string }
   highlight?: boolean
@@ -50,6 +59,13 @@ const PRESENTATION: Record<
   pro: {
     cta: { label: 'Get started', href: DASH, primary: true },
   },
+  // Experiment tier (#2381) — not wired to self-serve checkout yet, so the
+  // CTA is sales-assisted like Enterprise (honest paywall: don't offer a
+  // checkout button that doesn't work).
+  fleet: {
+    badge: { label: 'New', cls: 'ptag-beta' },
+    cta: { label: 'Contact us', href: 'mailto:hello@chmonitor.dev' },
+  },
   max: { cta: { label: 'Get started', href: DASH } },
   enterprise: {
     cta: { label: 'Contact us', href: 'mailto:hello@chmonitor.dev' },
@@ -62,7 +78,10 @@ function yearlyPerMo(plan: Plan): number | null {
   return Math.round(plan.priceYearlyUsd / 12)
 }
 
-export const pricingTiers: PricingTier[] = BILLING_PLAN_LIST.map((plan) => ({
+export const pricingTiers: PricingTier[] = getVisiblePlans(
+  FLEET_TIER_ENABLED
+).map((plan) => ({
+  id: plan.id,
   name: plan.name,
   badge: PRESENTATION[plan.id].badge,
   highlight: PRESENTATION[plan.id].highlight,
@@ -96,8 +115,8 @@ export type CompareCell = boolean | string
 
 export interface CompareRow {
   label: string
-  /** [Free, Pro, Max, Enterprise] */
-  values: [CompareCell, CompareCell, CompareCell, CompareCell]
+  /** [Free, Pro, (Fleet,) Max, Enterprise] — Fleet only when the #2381 experiment is on. */
+  values: CompareCell[]
 }
 
 export interface CompareGroup {
@@ -105,17 +124,14 @@ export interface CompareGroup {
   rows: CompareRow[]
 }
 
-/** Plan column order for the matrix header (derived from the canonical order). */
-export const compareColumns = BILLING_PLAN_LIST.map((p) => p.name) as [
-  string,
-  string,
-  string,
-  string,
-]
+const VISIBLE_PLANS = getVisiblePlans(FLEET_TIER_ENABLED)
 
-/** Map a per-plan function across the 4 tiers into a comparison tuple. */
+/** Plan column order for the matrix header (derived from the canonical order). */
+export const compareColumns: string[] = VISIBLE_PLANS.map((p) => p.name)
+
+/** Map a per-plan function across the visible tiers into a comparison row. */
 function across(fn: (plan: Plan) => CompareCell): CompareRow['values'] {
-  return BILLING_PLAN_LIST.map(fn) as CompareRow['values']
+  return VISIBLE_PLANS.map(fn)
 }
 
 /** ✓/— tuple for a capability flag. */
@@ -127,6 +143,7 @@ function capRow(cap: PlanCapability): CompareRow['values'] {
 const SUPPORT: Record<PlanId, string> = {
   free: 'Community',
   pro: 'Email',
+  fleet: 'Email',
   max: 'Priority',
   enterprise: 'SLA + dedicated',
 }

--- a/apps/landing/src/pages/pricing.astro
+++ b/apps/landing/src/pages/pricing.astro
@@ -58,7 +58,7 @@ const breadcrumbJsonLd = {
         <div class="sec-head reveal" style="text-align:center">
           <span class="eyebrow">Compare</span>
           <h2>Every plan, side by side</h2>
-          <p>Limits and features across all four tiers. Self-hosting includes everything, with no caps.</p>
+          <p>Limits and features across all {compareColumns.length} tiers. Self-hosting includes everything, with no caps.</p>
         </div>
 
         <div class="cmp-wrap reveal">

--- a/packages/pricing/src/plans.ts
+++ b/packages/pricing/src/plans.ts
@@ -22,7 +22,17 @@
  */
 
 export const PLAN_IDS = ['free', 'pro', 'max', 'enterprise'] as const
-export type PlanId = (typeof PLAN_IDS)[number]
+/**
+ * `'fleet'` is the B4 experiment tier (#2381) — a $199/mo mid-anchor plan for
+ * 5-10 host clusters, gated behind `CHM_FEATURE_FLEET_TIER` (see
+ * `getVisiblePlans`). Deliberately NOT in `PLAN_IDS`/`BILLING_PLAN_LIST`: it is
+ * not (yet) a real checkout/entitlement target, only a presentation-layer A/B
+ * variant, so it must never silently appear in the canonical plan list that
+ * checkout, entitlements, and existing tests key off. Included in the `PlanId`
+ * union (and `BILLING_PLANS`) purely so `getPlan('fleet')` / `Plan` typing work
+ * for the surfaces that opt in via `getVisiblePlans(true)`.
+ */
+export type PlanId = (typeof PLAN_IDS)[number] | 'fleet'
 
 /**
  * Capabilities a plan unlocks (the benefit ladder). Self-contained on purpose —
@@ -187,6 +197,46 @@ export const BILLING_PLANS: Record<PlanId, Plan> = {
       'Priority support',
     ],
   },
+  /**
+   * B4 experiment (#2381): mid-anchor tier between Pro and Max for teams that
+   * outgrow Pro's 1 host but don't need Max's full feature set — 5 hosts
+   * included at a flat $199 avoids the "surprise overage bill" objection from
+   * stacking Pro/Max host overage. Not in `PLAN_IDS`; only rendered when
+   * `getVisiblePlans(true)` is called behind `CHM_FEATURE_FLEET_TIER`.
+   */
+  fleet: {
+    id: 'fleet',
+    name: 'Fleet',
+    tagline: 'For 5–10 host clusters — no overage surprise.',
+    priceMonthlyUsd: 199,
+    priceYearlyUsd: 1990,
+    seats: 10,
+    hosts: 5,
+    hostOverage: { usdPer: 19 }, // soft-cap: 6th+ host bills $19/mo each (same rate as Max)
+    aiMonthlyUsdBudget: 10,
+    aiRequestsPerDay: 500,
+    aiOverage: { usdPer: 5, messages: 2000 },
+    alertRules: 25,
+    retentionDays: 60,
+    capabilities: [
+      ...CORE,
+      'ai_agent',
+      'ai_insights_scheduled',
+      'alerting_basic',
+      'data_export',
+      'anomaly_detection',
+      'fleet_view',
+    ],
+    highlights: [
+      'Everything in Pro',
+      '5 hosts included, 10 seats — extra hosts $19/mo each',
+      'AI agent — 500 messages / day, then $5 / 2,000',
+      'Fleet view + basic alerting',
+      'Anomaly detection + data export',
+      '60-day conversation & insights history',
+      'Email support',
+    ],
+  },
   enterprise: {
     id: 'enterprise',
     name: 'Enterprise',
@@ -229,6 +279,25 @@ export const BILLING_PLANS: Record<PlanId, Plan> = {
 
 /** Ordered list for rendering (free → enterprise). */
 export const BILLING_PLAN_LIST: Plan[] = PLAN_IDS.map((id) => BILLING_PLANS[id])
+
+/**
+ * Rendering list for surfaces that want to A/B the B4 "Fleet" experiment tier
+ * (#2381). `includeFleet` should come from the `CHM_FEATURE_FLEET_TIER` flag
+ * (env-gated, off by default, fail-closed like other `CHM_FEATURE_*` flags —
+ * see `apps/dashboard/src/lib/feature-flags.ts`). When off this returns the
+ * exact same array as `BILLING_PLAN_LIST`; when on, Fleet is inserted between
+ * Pro and Max (its mid-anchor position) on BOTH the landing pricing page and
+ * the in-app billing card, so the two surfaces never drift.
+ */
+export function getVisiblePlans(includeFleet: boolean): Plan[] {
+  if (!includeFleet) return BILLING_PLAN_LIST
+  const proIndex = BILLING_PLAN_LIST.findIndex((p) => p.id === 'pro')
+  return [
+    ...BILLING_PLAN_LIST.slice(0, proIndex + 1),
+    BILLING_PLANS.fleet,
+    ...BILLING_PLAN_LIST.slice(proIndex + 1),
+  ]
+}
 
 export function getPlan(id: PlanId): Plan {
   return BILLING_PLANS[id]


### PR DESCRIPTION
## Summary
- Add an optional **Fleet** tier ($199/mo, 5 hosts included) between Pro and Max — for 5–10 host clusters, to avoid overage surprise vs stacking Pro/Max host overage.
- Ship behind `CHM_FEATURE_FLEET_TIER` — fail-closed, off by default, pure env gate (no Clerk requirement), same pattern as `CHM_FEATURE_POSTGRES_SOURCE`.
- Fleet is additive-only in `@chm/pricing`: NOT part of `PLAN_IDS`/`BILLING_PLAN_LIST` (so checkout/entitlements/existing tests are untouched), exposed only via `getVisiblePlans(includeFleet)`, which both the landing pricing page and the in-app billing card now call — so they can never drift on whether the tier is live.
- CTA is sales-assisted (mailto), matching the Enterprise pattern, since Fleet isn't wired to self-serve Polar checkout yet — honest paywall, no broken checkout button.

## Files changed
- `packages/pricing/src/plans.ts` — Fleet plan data + `getVisiblePlans()`
- `apps/dashboard/src/lib/feature-flags.ts` (+ `.env.example`, `vite.config.ts`, `vite-env.d.ts`) — `CHM_FEATURE_FLEET_TIER`
- `apps/dashboard/src/routes/(dashboard)/billing.tsx` — in-app billing card renders Fleet when flag is on
- `apps/landing/src/data/pricing.ts`, `apps/landing/src/components/Pricing.astro`, `apps/landing/src/pages/pricing.astro` — landing pricing cards + comparison matrix render Fleet when flag is on

## Test plan
- [x] `pnpm run type-check` (pre-existing routeTree noise unrelated to this change, verified identical on main)
- [x] `pnpm run lint`
- [x] `bun test src/lib/billing src/lib/feature-flags.test.ts --isolate` — 196+65 pass
- [x] `apps/landing` build verified manually with flag off (no Fleet tier card, only the pre-existing "Fleet view" capability row) and flag on (Fleet tier card + comparison column present)

Closes #2381