### PR TITLE
feat(billing): BYOK model API key for AI advisor (#2380)

### DIFF
--- a/apps/dashboard/src/lib/ai/__tests__/providers.test.ts
+++ b/apps/dashboard/src/lib/ai/__tests__/providers.test.ts
@@ -118,6 +118,38 @@ describe('resolveProvider', () => {
     expect(resolved.sdk).toBe('openai')
   })
 
+  // BYOK: an explicit apiKey override wins over the env key for that provider.
+  test('apiKey override (BYOK) wins over the provider env key', () => {
+    setEnv({ NVIDIA_API_KEY: 'nvapi-env-key' })
+    const resolved = resolveProvider(
+      'nvidia:nvidia/llama-3.1-nemotron-70b-instruct',
+      'nvapi-byok-key'
+    )
+    expect(resolved.apiKey).toBe('nvapi-byok-key')
+  })
+
+  test('apiKey override (BYOK) supplies a key when the env has none', () => {
+    setEnv({ NVIDIA_API_KEY: undefined })
+    const resolved = resolveProvider(
+      'nvidia:nvidia/llama-3.1-nemotron-70b-instruct',
+      'nvapi-byok-key'
+    )
+    expect(resolved.apiKey).toBe('nvapi-byok-key')
+  })
+
+  test('apiKey override applies to the legacy/openrouter fallback path', () => {
+    setEnv({ LLM_API_KEY: undefined })
+    const resolved = resolveProvider('openrouter/free', 'or-byok-key')
+    expect(resolved.providerId).toBe('openrouter')
+    expect(resolved.apiKey).toBe('or-byok-key')
+  })
+
+  test('blank apiKey override falls back to the env key', () => {
+    setEnv({ OPENROUTER_API_KEY: 'or-test-key' })
+    const resolved = resolveProvider('openrouter:qwen/qwen3.5-397b-a17b', '   ')
+    expect(resolved.apiKey).toBe('or-test-key')
+  })
+
   // Regression for the reported 500 model id (slash inside the model name).
   test('resolves anyrouter provider for a slash-containing model id', () => {
     setEnv({ ANYROUTER_API_KEY: 'ar-test-key' })

--- a/apps/dashboard/src/lib/ai/agent/__tests__/byok.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/__tests__/byok.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  BYOK_MAX_KEY_LENGTH,
+  BYOK_MIN_KEY_LENGTH,
+  parseByokApiKey,
+} from '../byok'
+
+describe('parseByokApiKey', () => {
+  test('accepts a typical provider key and trims surrounding whitespace', () => {
+    expect(parseByokApiKey('  sk-abc123DEF456  ')).toBe('sk-abc123DEF456')
+  })
+
+  test('allows punctuation common in real keys (- and _)', () => {
+    expect(parseByokApiKey('sk-or-v1_ABCdef-789')).toBe('sk-or-v1_ABCdef-789')
+  })
+
+  test('rejects non-string input', () => {
+    expect(parseByokApiKey(undefined)).toBeNull()
+    expect(parseByokApiKey(null)).toBeNull()
+    expect(parseByokApiKey(12345678)).toBeNull()
+    expect(parseByokApiKey({ key: 'sk-abc' })).toBeNull()
+  })
+
+  test('rejects empty / too-short keys', () => {
+    expect(parseByokApiKey('')).toBeNull()
+    expect(parseByokApiKey('   ')).toBeNull()
+    expect(parseByokApiKey('a'.repeat(BYOK_MIN_KEY_LENGTH - 1))).toBeNull()
+  })
+
+  test('accepts a key at the minimum length', () => {
+    const key = 'a'.repeat(BYOK_MIN_KEY_LENGTH)
+    expect(parseByokApiKey(key)).toBe(key)
+  })
+
+  test('rejects keys over the maximum length', () => {
+    expect(parseByokApiKey('a'.repeat(BYOK_MAX_KEY_LENGTH + 1))).toBeNull()
+  })
+
+  test('rejects keys containing internal whitespace', () => {
+    expect(parseByokApiKey('sk-abc def')).toBeNull()
+    expect(parseByokApiKey(`sk-abc${String.fromCharCode(9)}def`)).toBeNull()
+    expect(parseByokApiKey(`sk-abc${String.fromCharCode(10)}def`)).toBeNull()
+  })
+
+  test('rejects keys containing control characters', () => {
+    // NUL (0x00), unit-separator (0x1f), DEL (0x7f) embedded in the key.
+    expect(parseByokApiKey(`sk-abc${String.fromCharCode(0)}def`)).toBeNull()
+    expect(parseByokApiKey(`sk-abc${String.fromCharCode(0x1f)}def`)).toBeNull()
+    expect(parseByokApiKey(`sk-abc${String.fromCharCode(0x7f)}def`)).toBeNull()
+  })
+})

--- a/apps/dashboard/src/lib/ai/agent/byok.ts
+++ b/apps/dashboard/src/lib/ai/agent/byok.ts
@@ -1,0 +1,51 @@
+/**
+ * BYOK (bring-your-own-key) support for the AI advisor/agent.
+ *
+ * A user on any plan (Free / Pro / …) may supply their own model-provider API
+ * key with an agent request. When they do, the request runs against *their*
+ * credit with the provider, so chmonitor skips its own included-credit metering
+ * entirely (no daily reservation, no monthly USD budget, no overage) — see the
+ * agent route. This expands the funnel (Free users can keep using the advisor
+ * past the daily cap by paying the provider directly) and protects margin.
+ *
+ * The key is accepted per-request only. It is NEVER persisted server-side and
+ * NEVER logged: it is forwarded straight to the provider SDK for that one
+ * request and then discarded. Keeping it out of any store is deliberate —
+ * secrets don't belong in the conversation history or the D1 usage tables.
+ */
+
+/** Minimum plausible length for a provider API key (rejects stray/empty input). */
+export const BYOK_MIN_KEY_LENGTH = 8
+/** Upper bound — real keys are well under this; guards against abuse/junk. */
+export const BYOK_MAX_KEY_LENGTH = 512
+
+/** True when every character is printable ASCII (0x21–0x7e), i.e. no space or
+ * control character that would break an Authorization header. */
+function isPrintableAsciiToken(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i)
+    if (code < 0x21 || code > 0x7e) return false
+  }
+  return true
+}
+
+/**
+ * Validate and normalize a caller-supplied BYOK API key.
+ *
+ * Returns the trimmed key when it looks like a usable credential, or `null`
+ * when absent/malformed so callers can treat "no BYOK" and "invalid BYOK" the
+ * same way (fall back to the deployment's own provider key + metering).
+ *
+ * Intentionally permissive about *shape* (providers differ) but strict about
+ * safety: single-line, bounded length, printable ASCII only. Punctuation like
+ * `-` / `_` (common in `sk-...` keys) is allowed.
+ */
+export function parseByokApiKey(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null
+  const key = raw.trim()
+  if (key.length < BYOK_MIN_KEY_LENGTH || key.length > BYOK_MAX_KEY_LENGTH) {
+    return null
+  }
+  if (!isPrintableAsciiToken(key)) return null
+  return key
+}

--- a/apps/dashboard/src/lib/ai/agent/clickhouse-agent.ts
+++ b/apps/dashboard/src/lib/ai/agent/clickhouse-agent.ts
@@ -50,6 +50,12 @@ export function createClickHouseAgent(options: {
   sessionId?: string
   /** Additional tools from connected custom MCP servers (prefixed mcp_*). */
   extraTools?: Record<string, unknown>
+  /**
+   * BYOK — a user-supplied provider API key. Overrides the deployment's env
+   * key for this request (see `byok.ts`). Only applied when `model` is a
+   * string (the production path); ignored for a pre-resolved model instance.
+   */
+  apiKey?: string
 }) {
   const {
     model = DEFAULT_MODEL,
@@ -62,6 +68,7 @@ export function createClickHouseAgent(options: {
     includeControlTools = false,
     sessionId = crypto.randomUUID(),
     extraTools,
+    apiKey,
   } = options
 
   const allTools = createAllTools(hostId, includeControlTools)
@@ -76,7 +83,7 @@ export function createClickHouseAgent(options: {
   const hasTools = Object.keys(tools).length > 0
   const modelInstance =
     typeof model === 'string'
-      ? resolveAgentChatModel({ model, hasTools, referer }).model
+      ? resolveAgentChatModel({ model, hasTools, referer, apiKey }).model
       : model
 
   return new ToolLoopAgent({

--- a/apps/dashboard/src/lib/ai/agent/provider-chat-model.ts
+++ b/apps/dashboard/src/lib/ai/agent/provider-chat-model.ts
@@ -84,12 +84,19 @@ export function resolveAgentChatModel({
   model = DEFAULT_MODEL,
   hasTools = false,
   referer,
+  apiKey,
 }: {
   readonly model?: string
   readonly hasTools?: boolean
   readonly referer?: string
+  /**
+   * BYOK — a user-supplied provider API key. When present it overrides the
+   * deployment's env key for this request (see `agent/byok.ts`). The caller
+   * is responsible for skipping included-credit metering when BYOK is active.
+   */
+  readonly apiKey?: string
 }): ResolvedAgentChatModel {
-  const resolved = resolveProvider(model)
+  const resolved = resolveProvider(model, apiKey)
   const { model: modelId } = parseModelId(model)
 
   if (resolved.isOpenRouter) {

--- a/apps/dashboard/src/lib/ai/providers.ts
+++ b/apps/dashboard/src/lib/ai/providers.ts
@@ -96,12 +96,22 @@ export interface ResolvedProvider {
  * 3. Fallback → generic OpenAI-compatible with LLM_API_KEY / LLM_API_BASE
  *
  * Credential cascade:
+ * - `apiKeyOverride` (BYOK — the user's own key) wins over everything below.
  * - OpenRouter/legacy API key: provider-specific env var → LLM_API_KEY
  * - Other explicit provider API keys: provider-specific env var
  * - Base URL: provider-specific env var → provider default
+ *
+ * `apiKeyOverride` powers BYOK (see `agent/byok.ts`): when a user brings their
+ * own provider key it is used verbatim instead of the deployment's env key, so
+ * the request bills their provider account. Absent/empty → env cascade (the
+ * normal metered path).
  */
-export function resolveProvider(id: string): ResolvedProvider {
+export function resolveProvider(
+  id: string,
+  apiKeyOverride?: string
+): ResolvedProvider {
   const { provider: providerId, model } = parseModelId(id)
+  const override = apiKeyOverride?.trim() || undefined
 
   // Legacy model IDs without a recognized provider prefix
   if (!PROVIDERS[providerId]) {
@@ -111,7 +121,7 @@ export function resolveProvider(id: string): ResolvedProvider {
       model.startsWith('openrouter/')
     return {
       providerId: 'openrouter',
-      apiKey: process.env.LLM_API_KEY || '',
+      apiKey: override || process.env.LLM_API_KEY || '',
       baseURL: process.env.LLM_API_BASE || 'https://openrouter.ai/api/v1',
       sdk: isOpenRouter ? 'openrouter' : 'openai',
       isOpenRouter,
@@ -120,6 +130,7 @@ export function resolveProvider(id: string): ResolvedProvider {
 
   const config = PROVIDERS[providerId]
   const apiKey =
+    override ||
     process.env[config.apiKeyEnvVar] ||
     (providerId === 'openrouter' ? process.env.LLM_API_KEY || '' : '')
   const baseURL =

--- a/apps/dashboard/src/lib/billing/ai-usage-store.test.ts
+++ b/apps/dashboard/src/lib/billing/ai-usage-store.test.ts
@@ -133,7 +133,43 @@ const {
   releaseAiUsage,
   getAiSpendThisMonth,
   meterAiOverage,
+  recordByokActivation,
+  getByokActivationsThisMonth,
 } = await import('./ai-usage-store')
+
+/**
+ * In-memory D1 fake for the BYOK activation table (`ai_byok_monthly`). Keyed by
+ * "owner_id::month" → count. Like {@link makeFakeSpendD1} it exposes a top-level
+ * `run()` so `ensureByokTable`'s unbound `CREATE TABLE IF NOT EXISTS` succeeds,
+ * but each bound write increments the count by a fixed 1 (matching the store's
+ * `count = count + 1` INSERT … ON CONFLICT).
+ */
+function makeFakeByokD1(store: Map<string, number>) {
+  function prepare(sql: string) {
+    const isSelect = sql.trimStart().toUpperCase().startsWith('SELECT')
+    return {
+      async run() {
+        return { success: true, results: [], meta: {} }
+      },
+      bind(...values: unknown[]) {
+        const key = `${values[0] as string}::${values[1] as string}`
+        return {
+          async first<T>() {
+            if (!isSelect) return null
+            const count = store.get(key)
+            if (count == null) return null
+            return { count } as unknown as T
+          },
+          async run() {
+            if (!isSelect) store.set(key, (store.get(key) ?? 0) + 1)
+            return { success: true, results: [], meta: {} }
+          },
+        }
+      },
+    }
+  }
+  return { prepare }
+}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -284,5 +320,33 @@ describe('meterAiOverage', () => {
     await expect(
       meterAiOverage(BILLING_PLANS.pro, 'user_pro', 0.1, FIXED_DATE)
     ).resolves.toBeUndefined()
+  })
+})
+
+describe('recordByokActivation + getByokActivationsThisMonth round-trip', () => {
+  beforeEach(() => {
+    currentDb = makeFakeByokD1(new Map())
+  })
+
+  test('count goes 0 → 1 after a single activation', async () => {
+    expect(await getByokActivationsThisMonth('user_abc', FIXED_DATE)).toBe(0)
+    await recordByokActivation('user_abc', FIXED_DATE)
+    expect(await getByokActivationsThisMonth('user_abc', FIXED_DATE)).toBe(1)
+  })
+
+  test('count accumulates across activations and isolates owners', async () => {
+    await recordByokActivation('user_a', FIXED_DATE)
+    await recordByokActivation('user_a', FIXED_DATE)
+    await recordByokActivation('user_b', FIXED_DATE)
+    expect(await getByokActivationsThisMonth('user_a', FIXED_DATE)).toBe(2)
+    expect(await getByokActivationsThisMonth('user_b', FIXED_DATE)).toBe(1)
+  })
+
+  test('fail-open: no-op / 0 when D1 is unavailable', async () => {
+    currentDb = null
+    await expect(
+      recordByokActivation('user_abc', FIXED_DATE)
+    ).resolves.toBeUndefined()
+    expect(await getByokActivationsThisMonth('user_abc', FIXED_DATE)).toBe(0)
   })
 })

--- a/apps/dashboard/src/lib/billing/ai-usage-store.ts
+++ b/apps/dashboard/src/lib/billing/ai-usage-store.ts
@@ -230,6 +230,91 @@ export async function addAiSpend(
   }
 }
 
+// ---------------------------------------------------------------------------
+// BYOK activation counter (per-owner, per UTC month, cloud SaaS only)
+// ---------------------------------------------------------------------------
+
+/**
+ * Lazily ensure the BYOK activation table exists. Cached per worker instance so
+ * the DDL runs at most once. Mirrors the monthly-spend table but stores a plain
+ * count of BYOK-backed agent requests per owner per month — the queryable
+ * signal for measuring BYOK-vs-included-credit conversion (task B3). Kept in the
+ * store (not a migration) so it degrades gracefully wherever the other meters do.
+ */
+let byokTableReady = false
+async function ensureByokTable(
+  db: NonNullable<ReturnType<typeof getDb>>
+): Promise<void> {
+  if (byokTableReady) return
+  await db
+    .prepare(
+      `CREATE TABLE IF NOT EXISTS ai_byok_monthly (
+         owner_id   TEXT NOT NULL,
+         month      TEXT NOT NULL,
+         count      INTEGER NOT NULL DEFAULT 0,
+         updated_at INTEGER NOT NULL,
+         PRIMARY KEY (owner_id, month)
+       )`
+    )
+    .run()
+  byokTableReady = true
+}
+
+/**
+ * Record one BYOK-backed agent request for `ownerId` in the current UTC month.
+ * This is the activation signal for BYOK-vs-included-credit conversion analysis
+ * (task B3) — it does NOT gate or meter anything (BYOK requests bill the user's
+ * own provider account). Best-effort + fail-open: a no-op when D1 is
+ * unavailable, and a missing table / transient error never breaks the request.
+ */
+export async function recordByokActivation(
+  ownerId: string,
+  now: Date = new Date()
+): Promise<void> {
+  const db = getDb()
+  if (!db) return
+  try {
+    await ensureByokTable(db)
+    const updatedAt = Math.floor(now.getTime() / 1000)
+    await db
+      .prepare(
+        `INSERT INTO ai_byok_monthly (owner_id, month, count, updated_at)
+         VALUES (?1, ?2, 1, ?3)
+         ON CONFLICT(owner_id, month) DO UPDATE SET
+           count      = count + 1,
+           updated_at = excluded.updated_at`
+      )
+      .bind(ownerId, utcMonthKey(now), updatedAt)
+      .run()
+  } catch {
+    // Swallow: a missing table or transient D1 error must not break the request.
+  }
+}
+
+/**
+ * Return how many BYOK-backed agent requests `ownerId` has made this UTC month.
+ * Returns 0 when D1 is unavailable or no row exists yet.
+ */
+export async function getByokActivationsThisMonth(
+  ownerId: string,
+  now: Date = new Date()
+): Promise<number> {
+  const db = getDb()
+  if (!db) return 0
+  try {
+    await ensureByokTable(db)
+    const row = await db
+      .prepare(
+        `SELECT count FROM ai_byok_monthly WHERE owner_id = ?1 AND month = ?2`
+      )
+      .bind(ownerId, utcMonthKey(now))
+      .first<{ count: number }>()
+    return row?.count ?? 0
+  } catch {
+    return 0
+  }
+}
+
 /**
  * Meter one request's actual USD cost as overage — but only for plans that
  * publish an overage policy (`plan.aiOverage`).

--- a/apps/dashboard/src/routes/api/v1/agent.ts
+++ b/apps/dashboard/src/routes/api/v1/agent.ts
@@ -42,6 +42,7 @@ import {
 } from 'ai'
 import { createClickHouseAgent } from '@/lib/ai/agent'
 import { aggregateUsageWithCost } from '@/lib/ai/agent/analytics'
+import { parseByokApiKey } from '@/lib/ai/agent/byok'
 import { classifyError } from '@/lib/ai/agent/errors'
 import { AGENT_JSON_RENDER_INLINE_PROMPT } from '@/lib/ai/agent/json-render-inline-prompt'
 import { createJsonRenderPatchGuardStream } from '@/lib/ai/agent/json-render-patch-guard'
@@ -70,6 +71,7 @@ import { isClerkAuthProvider } from '@/lib/auth/provider'
 import {
   getAiSpendThisMonth,
   meterAiOverage,
+  recordByokActivation,
   releaseAiUsage,
   reserveAiUsage,
 } from '@/lib/billing/ai-usage-store'
@@ -117,6 +119,13 @@ type AgentRequestBody = {
   >
   hostId?: number
   model?: string
+  /**
+   * BYOK — the user's own model-provider API key. When present and valid, the
+   * request runs against their provider credit and chmonitor skips its own
+   * included-credit metering (see `lib/ai/agent/byok.ts`). Never persisted or
+   * logged.
+   */
+  apiKey?: string
   disabledTools?: string[]
   sessionId?: string
   mcpServers?: Array<{ id?: unknown; name?: unknown; endpoint?: unknown }>
@@ -515,11 +524,20 @@ async function handlePost(request: Request): Promise<Response> {
       ? body.model.trim()
       : configuredModel || resolveDefaultAgentModel()
 
+  // BYOK: the user may supply their own provider API key. When present and
+  // valid, it (a) overrides the deployment's env key for this request and (b)
+  // makes the request bypass included-credit metering below — the request bills
+  // their provider account. Parsed once here; never logged.
+  const byokApiKey = parseByokApiKey(body.apiKey)
+  const byok = byokApiKey !== null
+
   // Preflight: refuse early if the selected provider has no API key on this
   // deployment. Without this, the upstream provider returns a confusing
   // "Missing Authorization header" error that looks like *our* auth failed.
+  // Skipped for BYOK — the user brings the credential, so a deployment without
+  // its own key for that provider is still fine.
   const { provider: requestedProvider } = parseModelId(model)
-  if (!isProviderConfigured(requestedProvider)) {
+  if (!byok && !isProviderConfigured(requestedProvider)) {
     const classified = classifyError(
       {
         statusCode: 503,
@@ -616,63 +634,77 @@ async function handlePost(request: Request): Promise<Response> {
   let billingOwnerId: string | null = null
   let resolvedPlan: Plan | null = null
   let reservedDailyUsage = false
-  try {
-    const owner = await resolveBillingOwner()
-    const plan = await getPlanForOwner(owner.id)
-    billingOwnerId = owner.id
-    resolvedPlan = plan
-
-    // Monthly LLM spend budget — hard cap (null = Enterprise BYOK / unlimited).
-    if (plan.aiMonthlyUsdBudget != null) {
-      const spentUsd = await getAiSpendThisMonth(owner.id)
-      const budget = checkAiBudget(plan, spentUsd)
-      if (!budget.allowed) {
-        return new Response(
-          JSON.stringify({
-            error: limitMessage(budget),
-            details: {
-              planId: budget.planId,
-              limit: budget.limit ?? plan.aiMonthlyUsdBudget,
-              reason: budget.reason,
-            },
-          }),
-          { status: 402, headers: { 'content-type': 'application/json' } }
-        )
-      }
+  if (byok) {
+    // BYOK bypasses included-credit metering entirely: no daily reservation, no
+    // monthly budget check, no overage. billingOwnerId stays null so the stream
+    // path below never meters this request. Best-effort record the activation
+    // (cloud only) so BYOK-vs-included-credit conversion is measurable — a no-op
+    // on OSS / when no Clerk owner resolves.
+    try {
+      const owner = await resolveBillingOwner()
+      await recordByokActivation(owner.id)
+    } catch {
+      // Not cloud / no Clerk owner → nothing to record; self-hosted stays whole.
     }
+  } else {
+    try {
+      const owner = await resolveBillingOwner()
+      const plan = await getPlanForOwner(owner.id)
+      billingOwnerId = owner.id
+      resolvedPlan = plan
 
-    // Daily message meter — reserve one slot atomically, then decide. The
-    // reservation (post-increment count) is rolled back below if it exceeds the
-    // hard cap, and again in the stream if generation fails before starting.
-    if (plan.aiRequestsPerDay != null) {
-      const reservedCount = await reserveAiUsage(owner.id)
-      if (reservedCount != null) {
-        reservedDailyUsage = true
-        // reservedCount is the count *after* this reservation; usage before this
-        // request is reservedCount - 1.
-        const check = checkAiDailyLimit(plan, reservedCount - 1)
-        if (!check.allowed) {
-          await releaseAiUsage(owner.id)
-          reservedDailyUsage = false
+      // Monthly LLM spend budget — hard cap (null = Enterprise BYOK / unlimited).
+      if (plan.aiMonthlyUsdBudget != null) {
+        const spentUsd = await getAiSpendThisMonth(owner.id)
+        const budget = checkAiBudget(plan, spentUsd)
+        if (!budget.allowed) {
           return new Response(
             JSON.stringify({
-              error: limitMessage(check),
+              error: limitMessage(budget),
               details: {
-                planId: check.planId,
-                limit: check.limit ?? plan.aiRequestsPerDay,
-                reason: check.reason,
+                planId: budget.planId,
+                limit: budget.limit ?? plan.aiMonthlyUsdBudget,
+                reason: budget.reason,
               },
             }),
             { status: 402, headers: { 'content-type': 'application/json' } }
           )
         }
       }
+
+      // Daily message meter — reserve one slot atomically, then decide. The
+      // reservation (post-increment count) is rolled back below if it exceeds the
+      // hard cap, and again in the stream if generation fails before starting.
+      if (plan.aiRequestsPerDay != null) {
+        const reservedCount = await reserveAiUsage(owner.id)
+        if (reservedCount != null) {
+          reservedDailyUsage = true
+          // reservedCount is the count *after* this reservation; usage before this
+          // request is reservedCount - 1.
+          const check = checkAiDailyLimit(plan, reservedCount - 1)
+          if (!check.allowed) {
+            await releaseAiUsage(owner.id)
+            reservedDailyUsage = false
+            return new Response(
+              JSON.stringify({
+                error: limitMessage(check),
+                details: {
+                  planId: check.planId,
+                  limit: check.limit ?? plan.aiRequestsPerDay,
+                  reason: check.reason,
+                },
+              }),
+              { status: 402, headers: { 'content-type': 'application/json' } }
+            )
+          }
+        }
+      }
+    } catch {
+      // Not cloud / no Clerk owner → skip enforcement; self-hosted stays whole.
+      billingOwnerId = null
+      resolvedPlan = null
+      reservedDailyUsage = false
     }
-  } catch {
-    // Not cloud / no Clerk owner → skip enforcement; self-hosted stays whole.
-    billingOwnerId = null
-    resolvedPlan = null
-    reservedDailyUsage = false
   }
 
   // Now that all early (402 / validation) returns are behind us, connect the
@@ -714,6 +746,7 @@ async function handlePost(request: Request): Promise<Response> {
       includeControlTools,
       sessionId,
       extraTools,
+      ...(byokApiKey ? { apiKey: byokApiKey } : {}),
     })
   } catch (error) {
     // Pre-stream failure: close any MCP clients we just opened (onEnd won't run

--- a/docs/content/guide/ai-agent.mdx
+++ b/docs/content/guide/ai-agent.mdx
@@ -82,6 +82,29 @@ settings" link in the chat page's settings panel). It groups four tabs:
   below). This replaces the old standalone `/mcp-servers` page, which now
   redirects to `/agents/settings?tab=mcp`.
 
+## Bring your own key (BYOK)
+
+On the hosted (Cloud) product the AI advisor normally runs on chmonitor's
+included AI credits, which are metered per plan (a daily message allowance plus a
+monthly spend budget). You can instead **bring your own model-provider API key**:
+send it as the `apiKey` field on the agent request (`POST /api/v1/agent`) and the
+request runs against **your** provider account instead.
+
+When a valid BYOK key is supplied:
+
+- The key overrides the deployment's provider key for that request only. It is
+  **never persisted and never logged** — it is forwarded to the provider for the
+  single request and then discarded.
+- chmonitor **skips its own included-credit metering entirely** — no daily
+  reservation, no monthly budget check, no overage. Your usage is billed by your
+  provider, not by chmonitor.
+- BYOK works on any plan (Free / Pro / …), so you can keep using the advisor past
+  the included daily allowance by paying your provider directly.
+
+Self-hosted (OSS) deployments are unaffected — they already run on their own
+`LLM_API_KEY` with no metering. BYOK simply lets a Cloud user do the same
+per-request.
+
 ## Child pages
 
 <Cards>


### PR DESCRIPTION
## Summary

Implements issue #2380 (task B3): allow a user-supplied model-provider API key
(BYOK) for the AI advisor/agent. When BYOK is active, chmonitor skips its own
included-credit metering, and the activation is tracked so BYOK-vs-included-credit
conversion can be measured.

## What changed

- **`lib/ai/agent/byok.ts`** (new) — `parseByokApiKey`: validates/normalizes the
  per-request key (printable ASCII, bounded length). The key is accepted
  per-request only, **never persisted and never logged**.
- **`lib/ai/providers.ts`** — `resolveProvider(id, apiKeyOverride?)`: an explicit
  BYOK key wins over the deployment's env key for that request.
- **`lib/ai/agent/provider-chat-model.ts` + `clickhouse-agent.ts`** — thread the
  optional `apiKey` through to the model resolver.
- **`routes/api/v1/agent.ts`** — read `body.apiKey`; when a valid key is present:
  skip the provider preflight (user brings the credential) and **skip all
  included-credit metering** (no daily reservation, no monthly budget, no
  overage). Best-effort records a BYOK activation instead.
- **`lib/billing/ai-usage-store.ts`** — `recordByokActivation` /
  `getByokActivationsThisMonth`: a fail-open, cloud-only, per-owner monthly
  counter (`ai_byok_monthly`) — the queryable signal for conversion analysis.
- **`docs/content/guide/ai-agent.mdx`** — BYOK section.

## House invariants

- **Self-hosted stays whole** — metering + activation tracking are cloud-only and
  fail open (no-op without Clerk / D1). BYOK is purely additive.
- **Billing gates fail open without Clerk** — the enforcement block stays wrapped
  in try/catch; BYOK skips it entirely.
- **Advisor still only recommends** — no behavior change to tools.
- No new env var (per-request field), so no configuration drift.

## Verification

- `pnpm run type-check` — clean
- `pnpm run lint` (biome) — clean on changed files
- `bun test` (byok, providers, ai-usage-store) — 52 pass / 0 fail

Closes #2380

https://claude.ai/code/session_015JBWcQTqQdE99sq2bQUSfF