### PR TITLE
feat(traffic): cluster traffic page with ingestion charts and KPIs

### DIFF
--- a/apps/dashboard/src/components/charts/traffic/bytes-on-disk-over-time.tsx
+++ b/apps/dashboard/src/components/charts/traffic/bytes-on-disk-over-time.tsx
@@ -1,0 +1,26 @@
+import type { ChartProps } from '@/components/charts/chart-props'
+
+import { createAreaChart } from '@/components/charts/factory'
+import { chartTickFormatters } from '@/lib/utils'
+
+export const ChartBytesOnDiskOverTime = createAreaChart({
+  chartName: 'traffic-bytes-on-disk',
+  index: 'event_time',
+  categories: ['bytes_on_disk'],
+  defaultTitle: 'Written to Disk (compressed)',
+  defaultInterval: 'toStartOfHour',
+  defaultLastHours: 24,
+  dataTestId: 'traffic-bytes-on-disk-chart',
+  dateRangeConfig: 'operations',
+  areaChartProps: {
+    readable: 'bytes',
+    showXAxis: true,
+    showCartesianGrid: true,
+    colors: ['--chart-3'],
+    yAxisTickFormatter: chartTickFormatters.bytes,
+  },
+})
+
+export type ChartBytesOnDiskOverTimeProps = ChartProps
+
+export default ChartBytesOnDiskOverTime

--- a/apps/dashboard/src/components/charts/traffic/insert-queries-over-time.tsx
+++ b/apps/dashboard/src/components/charts/traffic/insert-queries-over-time.tsx
@@ -1,0 +1,26 @@
+import type { ChartProps } from '@/components/charts/chart-props'
+
+import { createBarChart } from '@/components/charts/factory'
+import { chartTickFormatters } from '@/lib/utils'
+
+export const ChartInsertQueriesOverTime = createBarChart({
+  chartName: 'traffic-insert-queries',
+  index: 'event_time',
+  categories: ['insert_queries', 'failed_inserts'],
+  defaultTitle: 'Insert Queries',
+  defaultInterval: 'toStartOfHour',
+  defaultLastHours: 24,
+  dataTestId: 'traffic-insert-queries-chart',
+  dateRangeConfig: 'operations',
+  xAxisDateFormat: true,
+  barChartProps: {
+    stack: true,
+    showLegend: true,
+    colors: ['--chart-4', '--chart-red'],
+    yAxisTickFormatter: chartTickFormatters.count,
+  },
+})
+
+export type ChartInsertQueriesOverTimeProps = ChartProps
+
+export default ChartInsertQueriesOverTime

--- a/apps/dashboard/src/components/charts/traffic/inserted-bytes-over-time.tsx
+++ b/apps/dashboard/src/components/charts/traffic/inserted-bytes-over-time.tsx
@@ -1,0 +1,26 @@
+import type { ChartProps } from '@/components/charts/chart-props'
+
+import { createAreaChart } from '@/components/charts/factory'
+import { chartTickFormatters } from '@/lib/utils'
+
+export const ChartInsertedBytesOverTime = createAreaChart({
+  chartName: 'traffic-inserted-bytes',
+  index: 'event_time',
+  categories: ['inserted_bytes'],
+  defaultTitle: 'Data Ingested (uncompressed)',
+  defaultInterval: 'toStartOfHour',
+  defaultLastHours: 24,
+  dataTestId: 'traffic-inserted-bytes-chart',
+  dateRangeConfig: 'operations',
+  areaChartProps: {
+    readable: 'bytes',
+    showXAxis: true,
+    showCartesianGrid: true,
+    colors: ['--chart-2'],
+    yAxisTickFormatter: chartTickFormatters.bytes,
+  },
+})
+
+export type ChartInsertedBytesOverTimeProps = ChartProps
+
+export default ChartInsertedBytesOverTime

--- a/apps/dashboard/src/components/charts/traffic/inserted-rows-over-time.tsx
+++ b/apps/dashboard/src/components/charts/traffic/inserted-rows-over-time.tsx
@@ -1,0 +1,26 @@
+import type { ChartProps } from '@/components/charts/chart-props'
+
+import { createAreaChart } from '@/components/charts/factory'
+import { chartTickFormatters } from '@/lib/utils'
+
+export const ChartInsertedRowsOverTime = createAreaChart({
+  chartName: 'traffic-inserted-rows',
+  index: 'event_time',
+  categories: ['inserted_rows'],
+  defaultTitle: 'Rows Ingested',
+  defaultInterval: 'toStartOfHour',
+  defaultLastHours: 24,
+  dataTestId: 'traffic-inserted-rows-chart',
+  dateRangeConfig: 'operations',
+  areaChartProps: {
+    readable: 'quantity',
+    showXAxis: true,
+    showCartesianGrid: true,
+    colors: ['--chart-1'],
+    yAxisTickFormatter: chartTickFormatters.count,
+  },
+})
+
+export type ChartInsertedRowsOverTimeProps = ChartProps
+
+export default ChartInsertedRowsOverTime

--- a/apps/dashboard/src/components/charts/traffic/traffic-summary-kpis.tsx
+++ b/apps/dashboard/src/components/charts/traffic/traffic-summary-kpis.tsx
@@ -1,0 +1,96 @@
+import { ArrowDownToLine, Database, FileInput } from 'lucide-react'
+
+import { memo } from 'react'
+import { KpiCard } from '@/components/overview-charts/kpi-card'
+import { useChartData } from '@/lib/query/use-chart-data'
+import { REFRESH_INTERVAL, useHostId } from '@/lib/swr'
+import { cn } from '@/lib/utils'
+
+interface TrafficSummaryRow {
+  rows_24h: number
+  rows_prev_24h: number
+  bytes_24h: number
+  bytes_prev_24h: number
+  inserts_24h: number
+  inserts_prev_24h: number
+  readable_rows_24h: string
+  readable_bytes_24h: string
+  readable_inserts_24h: string
+  [key: string]: unknown
+}
+
+const DASH = '—'
+
+/** "+12.3% vs prev 24h" delta line, or a neutral hint when there is no baseline. */
+function deltaSub(current?: number, previous?: number) {
+  const cur = Number(current ?? 0)
+  const prev = Number(previous ?? 0)
+  if (!prev) return 'last 24h'
+  const pct = ((cur - prev) / prev) * 100
+  const sign = pct >= 0 ? '+' : ''
+  return (
+    <span className={cn('tabular-nums', pct < 0 && 'text-muted-foreground')}>
+      {sign}
+      {pct.toFixed(1)}% vs prev 24h
+    </span>
+  )
+}
+
+/**
+ * Ingestion KPI strip for /traffic: last-24h totals from system.query_log
+ * with a delta against the previous 24h window.
+ */
+export const TrafficSummaryKpis = memo(function TrafficSummaryKpis({
+  className,
+}: {
+  className?: string
+}) {
+  const hostId = useHostId()
+
+  const summary = useChartData<TrafficSummaryRow>({
+    chartName: 'traffic-summary',
+    hostId,
+    refreshInterval: REFRESH_INTERVAL.SLOW_2M,
+  })
+
+  const s = summary.data?.[0]
+  const hasData = !summary.error && !!s
+
+  return (
+    <div
+      className={cn(
+        'grid auto-rows-fr grid-cols-1 gap-2 sm:gap-3 sm:grid-cols-3',
+        className
+      )}
+    >
+      <KpiCard
+        icon={Database}
+        tone="blue"
+        label="Rows Ingested"
+        value={hasData ? s!.readable_rows_24h || DASH : DASH}
+        sub={hasData ? deltaSub(s!.rows_24h, s!.rows_prev_24h) : undefined}
+        isLoading={summary.isLoading}
+      />
+      <KpiCard
+        icon={ArrowDownToLine}
+        tone="green"
+        label="Data Ingested"
+        value={hasData ? s!.readable_bytes_24h || DASH : DASH}
+        sub={hasData ? deltaSub(s!.bytes_24h, s!.bytes_prev_24h) : undefined}
+        isLoading={summary.isLoading}
+      />
+      <KpiCard
+        icon={FileInput}
+        tone="violet"
+        label="Insert Queries"
+        value={hasData ? s!.readable_inserts_24h || DASH : DASH}
+        sub={
+          hasData ? deltaSub(s!.inserts_24h, s!.inserts_prev_24h) : undefined
+        }
+        isLoading={summary.isLoading}
+      />
+    </div>
+  )
+})
+
+export default TrafficSummaryKpis

--- a/apps/dashboard/src/lib/api/chart-registry.ts
+++ b/apps/dashboard/src/lib/api/chart-registry.ts
@@ -33,6 +33,7 @@ import { replicationCharts } from './charts/replication-charts'
 import { securityCharts } from './charts/security-charts'
 import { systemCharts } from './charts/system-charts'
 import { threadCharts } from './charts/thread-charts'
+import { trafficCharts } from './charts/traffic-charts'
 import { zookeeperCharts } from './charts/zookeeper-charts'
 
 /** Cache policy → Cache-Control TTL bucket (handler maps to headers). */
@@ -183,4 +184,5 @@ registerChartQueries({
   ...queryPerfCharts,
   ...insightCharts,
   ...queryInsightsCharts,
+  ...trafficCharts,
 })

--- a/apps/dashboard/src/lib/api/charts/traffic-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/traffic-charts.ts
@@ -1,0 +1,149 @@
+/**
+ * Traffic / Ingestion Charts
+ * Charts answering "how much data is flowing into this cluster?" —
+ * rows/bytes written over time, insert query counts, and a 24h KPI summary.
+ *
+ * Data sources:
+ * - system.query_log (Insert queries): written_rows / written_bytes are the
+ *   UNCOMPRESSED payload as ingested.
+ * - system.part_log (NewPart events): size_in_bytes is the ON-DISK
+ *   (compressed) size of each new part. part_log is opt-in, so every chart
+ *   using it is marked optional with a tableCheck.
+ */
+
+import type { ChartQueryBuilder } from './types'
+
+import { applyInterval, buildTimeFilter, fillStep, nowOrToday } from './types'
+
+export const trafficCharts: Record<string, ChartQueryBuilder> = {
+  /**
+   * KPI summary: last 24h vs previous 24h ingestion totals from query_log.
+   * Single-row result consumed by the /traffic KPI strip.
+   */
+  'traffic-summary': () => ({
+    query: `
+    SELECT
+      sumIf(written_rows, recent) AS rows_24h,
+      sumIf(written_rows, NOT recent) AS rows_prev_24h,
+      sumIf(written_bytes, recent) AS bytes_24h,
+      sumIf(written_bytes, NOT recent) AS bytes_prev_24h,
+      countIf(recent) AS inserts_24h,
+      countIf(NOT recent) AS inserts_prev_24h,
+      formatReadableQuantity(rows_24h) AS readable_rows_24h,
+      formatReadableSize(bytes_24h) AS readable_bytes_24h,
+      formatReadableQuantity(inserts_24h) AS readable_inserts_24h
+    FROM (
+      SELECT
+        written_rows,
+        written_bytes,
+        event_time >= now() - INTERVAL 24 HOUR AS recent
+      FROM system.query_log
+      WHERE type = 'QueryFinish'
+        AND query_kind = 'Insert'
+        AND event_time >= now() - INTERVAL 48 HOUR
+    )
+  `,
+    optional: true,
+    tableCheck: 'system.query_log',
+  }),
+
+  /**
+   * Rows ingested over time (uncompressed source of truth: query_log).
+   */
+  'traffic-inserted-rows': ({ interval = 'toStartOfHour', lastHours = 24 }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    return {
+      query: `
+    SELECT ${applyInterval(interval, 'event_time')},
+           sum(written_rows) AS inserted_rows,
+           formatReadableQuantity(inserted_rows) AS readable_inserted_rows
+    FROM system.query_log
+    WHERE type = 'QueryFinish'
+      AND query_kind = 'Insert'
+      ${timeFilter ? `AND ${timeFilter}` : ''}
+    GROUP BY 1
+    ORDER BY 1
+    WITH FILL TO ${nowOrToday(interval)} STEP ${fillStep(interval)}
+  `,
+      optional: true,
+      tableCheck: 'system.query_log',
+    }
+  },
+
+  /**
+   * Bytes ingested over time — uncompressed payload from query_log.
+   */
+  'traffic-inserted-bytes': ({
+    interval = 'toStartOfHour',
+    lastHours = 24,
+  }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    return {
+      query: `
+    SELECT ${applyInterval(interval, 'event_time')},
+           sum(written_bytes) AS inserted_bytes,
+           formatReadableSize(inserted_bytes) AS readable_inserted_bytes
+    FROM system.query_log
+    WHERE type = 'QueryFinish'
+      AND query_kind = 'Insert'
+      ${timeFilter ? `AND ${timeFilter}` : ''}
+    GROUP BY 1
+    ORDER BY 1
+    WITH FILL TO ${nowOrToday(interval)} STEP ${fillStep(interval)}
+  `,
+      optional: true,
+      tableCheck: 'system.query_log',
+    }
+  },
+
+  /**
+   * Bytes written to disk over time — compressed on-disk size of new parts
+   * (part_log NewPart). Compare against traffic-inserted-bytes to read the
+   * effective compression of incoming data.
+   */
+  'traffic-bytes-on-disk': ({ interval = 'toStartOfHour', lastHours = 24 }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    return {
+      query: `
+    SELECT ${applyInterval(interval, 'event_time')},
+           sum(size_in_bytes) AS bytes_on_disk,
+           formatReadableSize(bytes_on_disk) AS readable_bytes_on_disk
+    FROM system.part_log
+    WHERE event_type = 'NewPart'
+      ${timeFilter ? `AND ${timeFilter}` : ''}
+    GROUP BY 1
+    ORDER BY 1
+    WITH FILL TO ${nowOrToday(interval)} STEP ${fillStep(interval)}
+  `,
+      optional: true,
+      tableCheck: 'system.part_log',
+    }
+  },
+
+  /**
+   * Insert query count over time, split by success/failure so ingestion
+   * incidents are visible at a glance.
+   */
+  'traffic-insert-queries': ({
+    interval = 'toStartOfHour',
+    lastHours = 24,
+  }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    return {
+      query: `
+    SELECT ${applyInterval(interval, 'event_time')},
+           countIf(type = 'QueryFinish') AS insert_queries,
+           countIf(type IN ('ExceptionBeforeStart', 'ExceptionWhileProcessing')) AS failed_inserts
+    FROM system.query_log
+    WHERE query_kind = 'Insert'
+      AND type != 'QueryStart'
+      ${timeFilter ? `AND ${timeFilter}` : ''}
+    GROUP BY 1
+    ORDER BY 1
+    WITH FILL TO ${nowOrToday(interval)} STEP ${fillStep(interval)}
+  `,
+      optional: true,
+      tableCheck: 'system.query_log',
+    }
+  },
+}

--- a/apps/dashboard/src/lib/og.ts
+++ b/apps/dashboard/src/lib/og.ts
@@ -108,6 +108,12 @@ export const OG_PAGES: Record<string, OgPage> = {
     title: 'Expensive Queries',
     description: 'Queries ranked by memory and resource consumption.',
   },
+  traffic: {
+    eyebrow: 'TRAFFIC',
+    title: 'Cluster Traffic',
+    description:
+      'Rows, bytes and insert queries flowing into the cluster over time.',
+  },
   merges: {
     eyebrow: 'MERGES',
     title: 'Merge Operations',

--- a/apps/dashboard/src/menu.ts
+++ b/apps/dashboard/src/menu.ts
@@ -18,6 +18,7 @@ import {
 import {
   ActivityIcon,
   AlertTriangleIcon,
+  ArrowDownToLineIcon,
   BookOpenIcon,
   CircleDollarSignIcon,
   CloudIcon,
@@ -168,6 +169,17 @@ export const menuItemsConfig: MenuItem[] = [
     icon: HeartPulseIcon,
     section: 'main',
     permission: { feature: 'health' },
+  },
+  {
+    title: 'Traffic',
+    href: '/traffic',
+    description:
+      'Data flowing into the cluster: rows, bytes and insert queries over time',
+    icon: ArrowDownToLineIcon,
+    section: 'main',
+    isNew: true,
+    tableCheck: 'system.query_log',
+    permission: { feature: 'metrics' },
   },
   {
     title: 'Inbound Events',

--- a/apps/dashboard/src/routes/(dashboard)/traffic.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/traffic.tsx
@@ -1,0 +1,69 @@
+/**
+ * Traffic Page
+ * Route: /(dashboard)/traffic
+ *
+ * Quick answers to "how much data is flowing into this cluster?" —
+ * last-24h ingestion KPIs plus rows/bytes/insert-query volume over time
+ * (hour/day/month via the chart date-range selector). Sources:
+ * system.query_log (uncompressed ingest) and system.part_log (on-disk size).
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { Suspense } from 'react'
+import { ChartBytesOnDiskOverTime } from '@/components/charts/traffic/bytes-on-disk-over-time'
+import { ChartInsertQueriesOverTime } from '@/components/charts/traffic/insert-queries-over-time'
+import { ChartInsertedBytesOverTime } from '@/components/charts/traffic/inserted-bytes-over-time'
+import { ChartInsertedRowsOverTime } from '@/components/charts/traffic/inserted-rows-over-time'
+import { TrafficSummaryKpis } from '@/components/charts/traffic/traffic-summary-kpis'
+import { PageHeader } from '@/components/layout/page-header'
+import { PageSkeleton } from '@/components/skeletons'
+import { pageOgHead } from '@/lib/og'
+
+const CHART_CLASS = 'h-64 min-h-0 w-full'
+const CHART_CARD_CONTENT_CLASS = 'flex min-h-0 flex-1 flex-col px-3 pb-3 pt-0'
+
+function TrafficPageContent() {
+  return (
+    <div className="flex flex-col gap-3 sm:gap-4">
+      <PageHeader
+        title="Traffic"
+        description="Data flowing into the cluster: rows, bytes, and insert queries over time"
+      />
+
+      <TrafficSummaryKpis />
+
+      <div className="grid grid-cols-1 gap-3 sm:gap-4 lg:grid-cols-2">
+        <ChartInsertedRowsOverTime
+          chartClassName={CHART_CLASS}
+          chartCardContentClassName={CHART_CARD_CONTENT_CLASS}
+        />
+        <ChartInsertQueriesOverTime
+          chartClassName={CHART_CLASS}
+          chartCardContentClassName={CHART_CARD_CONTENT_CLASS}
+        />
+        <ChartInsertedBytesOverTime
+          chartClassName={CHART_CLASS}
+          chartCardContentClassName={CHART_CARD_CONTENT_CLASS}
+        />
+        <ChartBytesOnDiskOverTime
+          chartClassName={CHART_CLASS}
+          chartCardContentClassName={CHART_CARD_CONTENT_CLASS}
+        />
+      </div>
+    </div>
+  )
+}
+
+function TrafficPage() {
+  return (
+    <Suspense fallback={<PageSkeleton />}>
+      <TrafficPageContent />
+    </Suspense>
+  )
+}
+
+export const Route = createFileRoute('/(dashboard)/traffic')({
+  component: TrafficPage,
+  head: () => pageOgHead('traffic'),
+})


### PR DESCRIPTION
## Summary

New **/traffic** page giving quick answers to "how much data is flowing into this cluster?" (PR 1 of a series — see plan below).

- **KPI strip**: last-24h rows ingested / data ingested / insert queries, each with a delta vs the previous 24h window (`system.query_log`)
- **Rows Ingested** area chart (`query_log` written_rows)
- **Data Ingested (uncompressed)** area chart (`query_log` written_bytes)
- **Written to Disk (compressed)** area chart (`part_log` NewPart size_in_bytes) — optional + tableCheck, degrades gracefully when part_log is not configured
- **Insert Queries** stacked bar chart incl. failed inserts
- Hour/day/month granularity via the standard date-range selector (operations preset)
- Menu entry in the main section (gated on `system.query_log`), OG card

## Series plan
1. **This PR** — page + ingestion volume charts + KPIs
2. Per-table ingestion breakdown + compression ratio
3. Merge/move volume + write amplification
4. Cluster smart-detection + replication/distributed traffic sections
5. PeerDB ingestion section (conditional)

## Verification
- `pnpm run type-check` (dashboard) ✅
- `bun test` registry-completeness + chart-registry-imports + menu invariants ✅
- Biome lint ✅

https://claude.ai/code/session_015Mq6c6bQstbRwQnKt9htbE