### PR TITLE
feat(traffic): per-table ingestion breakdown and compression ratio

### DIFF
--- a/apps/dashboard/src/components/charts/traffic/traffic-summary-kpis.tsx
+++ b/apps/dashboard/src/components/charts/traffic/traffic-summary-kpis.tsx
@@ -1,4 +1,4 @@
-import { ArrowDownToLine, Database, FileInput } from 'lucide-react'
+import { ArrowDownToLine, Database, FileInput, Shrink } from 'lucide-react'
 
 import { memo } from 'react'
 import { KpiCard } from '@/components/overview-charts/kpi-card'
@@ -16,6 +16,15 @@ interface TrafficSummaryRow {
   readable_rows_24h: string
   readable_bytes_24h: string
   readable_inserts_24h: string
+  [key: string]: unknown
+}
+
+interface TrafficCompressionRow {
+  compressed_bytes: number
+  uncompressed_bytes: number
+  compression_ratio: number
+  readable_compressed_bytes: string
+  readable_uncompressed_bytes: string
   [key: string]: unknown
 }
 
@@ -53,13 +62,21 @@ export const TrafficSummaryKpis = memo(function TrafficSummaryKpis({
     refreshInterval: REFRESH_INTERVAL.SLOW_2M,
   })
 
+  const compression = useChartData<TrafficCompressionRow>({
+    chartName: 'traffic-compression',
+    hostId,
+    refreshInterval: REFRESH_INTERVAL.SLOW_2M,
+  })
+
   const s = summary.data?.[0]
   const hasData = !summary.error && !!s
+  const c = compression.data?.[0]
+  const hasCompression = !compression.error && !!c && !!c.compression_ratio
 
   return (
     <div
       className={cn(
-        'grid auto-rows-fr grid-cols-1 gap-2 sm:gap-3 sm:grid-cols-3',
+        'grid auto-rows-fr grid-cols-1 gap-2 sm:gap-3 sm:grid-cols-2 md:grid-cols-4',
         className
       )}
     >
@@ -88,6 +105,18 @@ export const TrafficSummaryKpis = memo(function TrafficSummaryKpis({
           hasData ? deltaSub(s!.inserts_24h, s!.inserts_prev_24h) : undefined
         }
         isLoading={summary.isLoading}
+      />
+      <KpiCard
+        icon={Shrink}
+        tone="amber"
+        label="Compression"
+        value={hasCompression ? `${c!.compression_ratio}×` : DASH}
+        sub={
+          hasCompression
+            ? `${c!.readable_compressed_bytes} on disk of ${c!.readable_uncompressed_bytes}`
+            : undefined
+        }
+        isLoading={compression.isLoading}
       />
     </div>
   )

--- a/apps/dashboard/src/lib/api/charts/traffic-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/traffic-charts.ts
@@ -48,6 +48,23 @@ export const trafficCharts: Record<string, ChartQueryBuilder> = {
   }),
 
   /**
+   * Overall compression across active parts — how much smaller data is on
+   * disk vs its raw (uncompressed) form. system.parts is always available.
+   */
+  'traffic-compression': () => ({
+    query: `
+    SELECT
+      sum(data_compressed_bytes) AS compressed_bytes,
+      sum(data_uncompressed_bytes) AS uncompressed_bytes,
+      round(uncompressed_bytes / nullIf(compressed_bytes, 0), 2) AS compression_ratio,
+      formatReadableSize(compressed_bytes) AS readable_compressed_bytes,
+      formatReadableSize(uncompressed_bytes) AS readable_uncompressed_bytes
+    FROM system.parts
+    WHERE active
+  `,
+  }),
+
+  /**
    * Rows ingested over time (uncompressed source of truth: query_log).
    */
   'traffic-inserted-rows': ({ interval = 'toStartOfHour', lastHours = 24 }) => {

--- a/apps/dashboard/src/lib/query-config/index.ts
+++ b/apps/dashboard/src/lib/query-config/index.ts
@@ -132,6 +132,7 @@ import { replicationQueueConfig } from './tables/replication-queue'
 import { tablesOverviewConfig } from './tables/tables-overview'
 import { userProcessesConfig } from './tables/user-processes'
 import { viewRefreshesConfig } from './tables/view-refreshes'
+import { trafficPerTableConfig } from './traffic/per-table-ingestion'
 export const queries: Array<QueryConfig> = [
   // Explorer
   explorerDatabasesConfig,
@@ -189,6 +190,9 @@ export const queries: Array<QueryConfig> = [
   mergePerformanceConfig,
   mutationsConfig,
   partLogConfig,
+
+  // Traffic
+  trafficPerTableConfig,
 
   // Settings
   settingsConfig,

--- a/apps/dashboard/src/lib/query-config/traffic/per-table-ingestion.ts
+++ b/apps/dashboard/src/lib/query-config/traffic/per-table-ingestion.ts
@@ -1,0 +1,66 @@
+import type { QueryConfig } from '@/types/query-config'
+
+import { ColumnFormat } from '@/types/column-format'
+
+/**
+ * Per-table ingestion over the last 24h (system.part_log NewPart events),
+ * joined with the table's overall compression ratio from system.parts.
+ * part_log is opt-in, so the whole view is optional.
+ */
+export const trafficPerTableConfig: QueryConfig = {
+  name: 'traffic-per-table',
+  description:
+    'Tables ranked by data ingested in the last 24 hours: rows, on-disk bytes, parts created, and overall compression ratio',
+  optional: true,
+  tableCheck: 'system.part_log',
+  sql: `
+      SELECT
+        table,
+        rows_added,
+        formatReadableQuantity(rows_added) AS readable_rows_added,
+        round(rows_added * 100.0 / nullIf(max(rows_added) OVER (), 0), 2) AS pct_rows_added,
+        bytes_added,
+        formatReadableSize(bytes_added) AS readable_bytes_added,
+        round(bytes_added * 100.0 / nullIf(max(bytes_added) OVER (), 0), 2) AS pct_bytes_added,
+        parts_created,
+        formatReadableQuantity(parts_created) AS readable_parts_created,
+        round(parts_created * 100.0 / nullIf(max(parts_created) OVER (), 0), 2) AS pct_parts_created,
+        round(uncompressed / nullIf(compressed, 0), 2) AS compression_ratio
+      FROM (
+        SELECT
+          database || '.' || table AS table,
+          sum(rows) AS rows_added,
+          sum(size_in_bytes) AS bytes_added,
+          count() AS parts_created
+        FROM system.part_log
+        WHERE event_type = 'NewPart'
+          AND event_time >= now() - INTERVAL 24 HOUR
+        GROUP BY 1
+      ) AS ingest
+      LEFT JOIN (
+        SELECT
+          database || '.' || table AS table,
+          sum(data_compressed_bytes) AS compressed,
+          sum(data_uncompressed_bytes) AS uncompressed
+        FROM system.parts
+        WHERE active
+        GROUP BY 1
+      ) AS parts USING (table)
+      ORDER BY bytes_added DESC
+      LIMIT 100
+    `,
+  columns: [
+    'table',
+    'readable_rows_added',
+    'readable_bytes_added',
+    'readable_parts_created',
+    'compression_ratio',
+  ],
+  columnFormats: {
+    table: ColumnFormat.ColoredBadge,
+    readable_rows_added: ColumnFormat.BackgroundBar,
+    readable_bytes_added: ColumnFormat.BackgroundBar,
+    readable_parts_created: ColumnFormat.BackgroundBar,
+    compression_ratio: ColumnFormat.Number,
+  },
+}

--- a/apps/dashboard/src/routes/(dashboard)/traffic.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/traffic.tsx
@@ -17,8 +17,10 @@ import { ChartInsertedBytesOverTime } from '@/components/charts/traffic/inserted
 import { ChartInsertedRowsOverTime } from '@/components/charts/traffic/inserted-rows-over-time'
 import { TrafficSummaryKpis } from '@/components/charts/traffic/traffic-summary-kpis'
 import { PageHeader } from '@/components/layout/page-header'
+import { PageLayout } from '@/components/layout/query-page'
 import { PageSkeleton } from '@/components/skeletons'
 import { pageOgHead } from '@/lib/og'
+import { trafficPerTableConfig } from '@/lib/query-config/traffic/per-table-ingestion'
 
 const CHART_CLASS = 'h-64 min-h-0 w-full'
 const CHART_CARD_CONTENT_CLASS = 'flex min-h-0 flex-1 flex-col px-3 pb-3 pt-0'
@@ -51,6 +53,11 @@ function TrafficPageContent() {
           chartCardContentClassName={CHART_CARD_CONTENT_CLASS}
         />
       </div>
+
+      <PageLayout
+        queryConfig={trafficPerTableConfig}
+        title="Top Tables by Ingestion (24h)"
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

PR 2 of the cluster-traffic series (follows #2644).

- **Top Tables by Ingestion (24h)** table on /traffic: rows added, on-disk bytes, parts created (`system.part_log` NewPart), joined with each table's overall **compression ratio** from `system.parts`. Optional + tableCheck so it degrades gracefully without part_log.
- **Compression KPI card**: cluster-wide on-disk vs raw size (e.g. "8.4×"), from `system.parts` (always available). KPI strip goes 3 → 4 cards.

## Verification
- `pnpm run type-check` (dashboard) ✅
- Biome lint ✅

https://claude.ai/code/session_015Mq6c6bQstbRwQnKt9htbE