### PR TITLE
feat(traffic): merge and data movement volume charts

### DIFF
--- a/apps/dashboard/src/components/charts/traffic/merged-bytes-over-time.tsx
+++ b/apps/dashboard/src/components/charts/traffic/merged-bytes-over-time.tsx
@@ -1,0 +1,26 @@
+import type { ChartProps } from '@/components/charts/chart-props'
+
+import { createAreaChart } from '@/components/charts/factory'
+import { chartTickFormatters } from '@/lib/utils'
+
+export const ChartMergedBytesOverTime = createAreaChart({
+  chartName: 'traffic-merged-bytes',
+  index: 'event_time',
+  categories: ['merged_bytes'],
+  defaultTitle: 'Data Merged',
+  defaultInterval: 'toStartOfHour',
+  defaultLastHours: 24,
+  dataTestId: 'traffic-merged-bytes-chart',
+  dateRangeConfig: 'operations',
+  areaChartProps: {
+    readable: 'bytes',
+    showXAxis: true,
+    showCartesianGrid: true,
+    colors: ['--chart-4'],
+    yAxisTickFormatter: chartTickFormatters.bytes,
+  },
+})
+
+export type ChartMergedBytesOverTimeProps = ChartProps
+
+export default ChartMergedBytesOverTime

--- a/apps/dashboard/src/components/charts/traffic/part-moves-over-time.tsx
+++ b/apps/dashboard/src/components/charts/traffic/part-moves-over-time.tsx
@@ -1,0 +1,24 @@
+import type { ChartProps } from '@/components/charts/chart-props'
+
+import { createBarChart } from '@/components/charts/factory'
+import { chartTickFormatters } from '@/lib/utils'
+
+export const ChartPartMovesOverTime = createBarChart({
+  chartName: 'traffic-part-moves',
+  index: 'event_time',
+  categories: ['moves'],
+  defaultTitle: 'Part Moves',
+  defaultInterval: 'toStartOfHour',
+  defaultLastHours: 24,
+  dataTestId: 'traffic-part-moves-chart',
+  dateRangeConfig: 'operations',
+  xAxisDateFormat: true,
+  barChartProps: {
+    colors: ['--chart-5'],
+    yAxisTickFormatter: chartTickFormatters.count,
+  },
+})
+
+export type ChartPartMovesOverTimeProps = ChartProps
+
+export default ChartPartMovesOverTime

--- a/apps/dashboard/src/components/charts/traffic/write-amplification-over-time.tsx
+++ b/apps/dashboard/src/components/charts/traffic/write-amplification-over-time.tsx
@@ -1,0 +1,26 @@
+import type { ChartProps } from '@/components/charts/chart-props'
+
+import { createAreaChart } from '@/components/charts/factory'
+import { chartTickFormatters } from '@/lib/utils'
+
+export const ChartWriteAmplificationOverTime = createAreaChart({
+  chartName: 'traffic-write-amplification',
+  index: 'event_time',
+  categories: ['write_amplification'],
+  defaultTitle: 'Write Amplification',
+  defaultInterval: 'toStartOfHour',
+  defaultLastHours: 24,
+  dataTestId: 'traffic-write-amplification-chart',
+  dateRangeConfig: 'operations',
+  areaChartProps: {
+    readable: 'number',
+    showXAxis: true,
+    showCartesianGrid: true,
+    colors: ['--chart-red'],
+    yAxisTickFormatter: chartTickFormatters.default,
+  },
+})
+
+export type ChartWriteAmplificationOverTimeProps = ChartProps
+
+export default ChartWriteAmplificationOverTime

--- a/apps/dashboard/src/lib/api/charts/traffic-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/traffic-charts.ts
@@ -1,14 +1,16 @@
 /**
  * Traffic / Ingestion Charts
  * Charts answering "how much data is flowing into this cluster?" —
- * rows/bytes written over time, insert query counts, and a 24h KPI summary.
+ * rows/bytes written over time, insert query counts, a 24h KPI summary, plus
+ * merges & data movement (merge volume, part moves, write amplification).
  *
  * Data sources:
  * - system.query_log (Insert queries): written_rows / written_bytes are the
  *   UNCOMPRESSED payload as ingested.
- * - system.part_log (NewPart events): size_in_bytes is the ON-DISK
- *   (compressed) size of each new part. part_log is opt-in, so every chart
- *   using it is marked optional with a tableCheck.
+ * - system.part_log: NewPart size_in_bytes is the ON-DISK (compressed) size of
+ *   each new part; MergeParts / MovePart events drive the merge and
+ *   data-movement charts. part_log is opt-in, so every chart using it is marked
+ *   optional with a tableCheck.
  */
 
 import type { ChartQueryBuilder } from './types'
@@ -161,6 +163,85 @@ export const trafficCharts: Record<string, ChartQueryBuilder> = {
   `,
       optional: true,
       tableCheck: 'system.query_log',
+    }
+  },
+
+  /**
+   * Data merged over time — total on-disk size of parts produced by merges
+   * (part_log MergeParts). High merge volume is background write work that
+   * competes with ingestion for disk and CPU.
+   */
+  'traffic-merged-bytes': ({ interval = 'toStartOfHour', lastHours = 24 }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    return {
+      query: `
+    SELECT ${applyInterval(interval, 'event_time')},
+           sum(size_in_bytes) AS merged_bytes,
+           sum(rows) AS merged_rows,
+           count() AS merges,
+           formatReadableSize(merged_bytes) AS readable_merged_bytes
+    FROM system.part_log
+    WHERE event_type = 'MergeParts'
+      ${timeFilter ? `AND ${timeFilter}` : ''}
+    GROUP BY 1
+    ORDER BY 1
+    WITH FILL TO ${nowOrToday(interval)} STEP ${fillStep(interval)}
+  `,
+      optional: true,
+      tableCheck: 'system.part_log',
+    }
+  },
+
+  /**
+   * Part moves over time — count and size of parts relocated across volumes
+   * (part_log MovePart), e.g. TTL-driven moves to cold storage. Spikes signal
+   * tiered-storage churn.
+   */
+  'traffic-part-moves': ({ interval = 'toStartOfHour', lastHours = 24 }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    return {
+      query: `
+    SELECT ${applyInterval(interval, 'event_time')},
+           count() AS moves,
+           sum(size_in_bytes) AS moved_bytes,
+           formatReadableSize(moved_bytes) AS readable_moved_bytes
+    FROM system.part_log
+    WHERE event_type = 'MovePart'
+      ${timeFilter ? `AND ${timeFilter}` : ''}
+    GROUP BY 1
+    ORDER BY 1
+    WITH FILL TO ${nowOrToday(interval)} STEP ${fillStep(interval)}
+  `,
+      optional: true,
+      tableCheck: 'system.part_log',
+    }
+  },
+
+  /**
+   * Write amplification over time — bytes merged ÷ bytes newly written per
+   * bucket (part_log MergeParts vs NewPart). A ratio well above 1 means the
+   * cluster rewrites much more than it ingests; useful for spotting overly
+   * aggressive merges or small-insert patterns.
+   */
+  'traffic-write-amplification': ({
+    interval = 'toStartOfHour',
+    lastHours = 24,
+  }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    return {
+      query: `
+    SELECT ${applyInterval(interval, 'event_time')},
+           round(sumIf(size_in_bytes, event_type = 'MergeParts')
+             / nullIf(sumIf(size_in_bytes, event_type = 'NewPart'), 0), 2) AS write_amplification
+    FROM system.part_log
+    WHERE event_type IN ('NewPart', 'MergeParts')
+      ${timeFilter ? `AND ${timeFilter}` : ''}
+    GROUP BY 1
+    ORDER BY 1
+    WITH FILL TO ${nowOrToday(interval)} STEP ${fillStep(interval)}
+  `,
+      optional: true,
+      tableCheck: 'system.part_log',
     }
   },
 }

--- a/apps/dashboard/src/routes/(dashboard)/traffic.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/traffic.tsx
@@ -4,10 +4,13 @@
  *
  * Quick answers to "how much data is flowing into this cluster?" —
  * last-24h ingestion KPIs plus rows/bytes/insert-query volume over time
- * (hour/day/month via the chart date-range selector). Sources:
- * system.query_log (uncompressed ingest) and system.part_log (on-disk size).
+ * (hour/day/month via the chart date-range selector), and a "Merges & Data
+ * Movement" section covering merge volume, part moves, and write
+ * amplification. Sources: system.query_log (uncompressed ingest) and
+ * system.part_log (on-disk size, merges, and part moves).
  */
 
+import { CombineIcon } from 'lucide-react'
 import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
@@ -15,7 +18,10 @@ import { ChartBytesOnDiskOverTime } from '@/components/charts/traffic/bytes-on-d
 import { ChartInsertQueriesOverTime } from '@/components/charts/traffic/insert-queries-over-time'
 import { ChartInsertedBytesOverTime } from '@/components/charts/traffic/inserted-bytes-over-time'
 import { ChartInsertedRowsOverTime } from '@/components/charts/traffic/inserted-rows-over-time'
+import { ChartMergedBytesOverTime } from '@/components/charts/traffic/merged-bytes-over-time'
+import { ChartPartMovesOverTime } from '@/components/charts/traffic/part-moves-over-time'
 import { TrafficSummaryKpis } from '@/components/charts/traffic/traffic-summary-kpis'
+import { ChartWriteAmplificationOverTime } from '@/components/charts/traffic/write-amplification-over-time'
 import { PageHeader } from '@/components/layout/page-header'
 import { PageLayout } from '@/components/layout/query-page'
 import { PageSkeleton } from '@/components/skeletons'
@@ -49,6 +55,31 @@ function TrafficPageContent() {
           chartCardContentClassName={CHART_CARD_CONTENT_CLASS}
         />
         <ChartBytesOnDiskOverTime
+          chartClassName={CHART_CLASS}
+          chartCardContentClassName={CHART_CARD_CONTENT_CLASS}
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <CombineIcon
+          className="size-4 text-muted-foreground"
+          strokeWidth={1.5}
+        />
+        <h2 className="text-sm font-medium text-foreground">
+          Merges &amp; Data Movement
+        </h2>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 sm:gap-4 lg:grid-cols-2">
+        <ChartMergedBytesOverTime
+          chartClassName={CHART_CLASS}
+          chartCardContentClassName={CHART_CARD_CONTENT_CLASS}
+        />
+        <ChartPartMovesOverTime
+          chartClassName={CHART_CLASS}
+          chartCardContentClassName={CHART_CARD_CONTENT_CLASS}
+        />
+        <ChartWriteAmplificationOverTime
           chartClassName={CHART_CLASS}
           chartCardContentClassName={CHART_CARD_CONTENT_CLASS}
         />


### PR DESCRIPTION
## Summary

PR 3 of the cluster-traffic series (follows #2644, #2645).

New **Merges & Data Movement** section on /traffic (all from `system.part_log`, optional + tableCheck):
- **Data Merged** — bytes rewritten by merges over time
- **Part Moves** — MovePart count over time
- **Write Amplification** — merged bytes ÷ newly written bytes per bucket

## Verification
- `pnpm run type-check` (dashboard) ✅
- Biome lint ✅

https://claude.ai/code/session_015Mq6c6bQstbRwQnKt9htbE