### PR TITLE
feat(traffic): smart-detected replication and distribution section

### DIFF
--- a/apps/dashboard/src/components/charts/traffic/distributed-queries-over-time.tsx
+++ b/apps/dashboard/src/components/charts/traffic/distributed-queries-over-time.tsx
@@ -1,0 +1,26 @@
+import type { ChartProps } from '@/components/charts/chart-props'
+
+import { createBarChart } from '@/components/charts/factory'
+import { chartTickFormatters } from '@/lib/utils'
+
+export const ChartDistributedQueriesOverTime = createBarChart({
+  chartName: 'traffic-distributed-queries',
+  index: 'event_time',
+  categories: ['initial_queries', 'secondary_queries'],
+  defaultTitle: 'Distributed Queries',
+  defaultInterval: 'toStartOfHour',
+  defaultLastHours: 24,
+  dataTestId: 'traffic-distributed-queries-chart',
+  dateRangeConfig: 'operations',
+  xAxisDateFormat: true,
+  barChartProps: {
+    stack: true,
+    showLegend: true,
+    colors: ['--chart-1', '--chart-3'],
+    yAxisTickFormatter: chartTickFormatters.count,
+  },
+})
+
+export type ChartDistributedQueriesOverTimeProps = ChartProps
+
+export default ChartDistributedQueriesOverTime

--- a/apps/dashboard/src/components/charts/traffic/replica-fetch-traffic.tsx
+++ b/apps/dashboard/src/components/charts/traffic/replica-fetch-traffic.tsx
@@ -1,0 +1,26 @@
+import type { ChartProps } from '@/components/charts/chart-props'
+
+import { createAreaChart } from '@/components/charts/factory'
+import { chartTickFormatters } from '@/lib/utils'
+
+export const ChartReplicaFetchTraffic = createAreaChart({
+  chartName: 'traffic-replica-fetches',
+  index: 'event_time',
+  categories: ['fetched_bytes'],
+  defaultTitle: 'Replica Fetch Traffic',
+  defaultInterval: 'toStartOfHour',
+  defaultLastHours: 24,
+  dataTestId: 'traffic-replica-fetches-chart',
+  dateRangeConfig: 'operations',
+  areaChartProps: {
+    readable: 'bytes',
+    showXAxis: true,
+    showCartesianGrid: true,
+    colors: ['--chart-2'],
+    yAxisTickFormatter: chartTickFormatters.bytes,
+  },
+})
+
+export type ChartReplicaFetchTrafficProps = ChartProps
+
+export default ChartReplicaFetchTraffic

--- a/apps/dashboard/src/components/charts/traffic/traffic-replication-section.tsx
+++ b/apps/dashboard/src/components/charts/traffic/traffic-replication-section.tsx
@@ -1,0 +1,87 @@
+import { GitCompareArrowsIcon } from 'lucide-react'
+
+import { memo } from 'react'
+import { ChartDistributedQueriesOverTime } from '@/components/charts/traffic/distributed-queries-over-time'
+import { ChartReplicaFetchTraffic } from '@/components/charts/traffic/replica-fetch-traffic'
+import { useChartData } from '@/lib/query/use-chart-data'
+import { REFRESH_INTERVAL, useHostId } from '@/lib/swr'
+
+interface ClusterShapeRow {
+  replicated_tables: number
+  max_replicas: number
+  clusters: number
+  max_shards: number
+  [key: string]: unknown
+}
+
+interface TrafficReplicationSectionProps {
+  chartClassName?: string
+  chartCardContentClassName?: string
+}
+
+/**
+ * Smart-detected "Replication & Distribution" section for /traffic.
+ *
+ * Probes the cluster shape once (traffic-cluster-shape: cheap one-row query of
+ * system.replicas / system.clusters) and renders only what is actually relevant:
+ * - Replica Fetch Traffic when the cluster replicates (replicated_tables > 0)
+ * - Distributed Queries when the cluster shards (max_shards > 1)
+ *
+ * On a plain single-node instance neither condition holds, so the section is
+ * absent entirely. While loading or on error it returns null (no skeleton flash)
+ * so the page never shows an empty replication header.
+ */
+export const TrafficReplicationSection = memo(
+  function TrafficReplicationSection({
+    chartClassName,
+    chartCardContentClassName,
+  }: TrafficReplicationSectionProps) {
+    const hostId = useHostId()
+
+    const shape = useChartData<ClusterShapeRow>({
+      chartName: 'traffic-cluster-shape',
+      hostId,
+      refreshInterval: REFRESH_INTERVAL.SLOW_2M,
+    })
+
+    if (shape.isLoading || shape.error) return null
+
+    const row = shape.data?.[0]
+    if (!row) return null
+
+    const hasReplication = Number(row.replicated_tables ?? 0) > 0
+    const hasShards = Number(row.max_shards ?? 0) > 1
+
+    if (!hasReplication && !hasShards) return null
+
+    return (
+      <div className="flex flex-col gap-3 sm:gap-4">
+        <div className="flex items-center gap-2">
+          <GitCompareArrowsIcon
+            className="size-4 text-muted-foreground"
+            strokeWidth={1.5}
+          />
+          <h2 className="text-sm font-medium text-foreground">
+            Replication & Distribution
+          </h2>
+        </div>
+        <div className="grid grid-cols-1 gap-3 sm:gap-4 lg:grid-cols-2">
+          {hasReplication ? (
+            <ChartReplicaFetchTraffic
+              chartClassName={chartClassName}
+              chartCardContentClassName={chartCardContentClassName}
+            />
+          ) : null}
+          {hasShards ? (
+            <ChartDistributedQueriesOverTime
+              chartClassName={chartClassName}
+              chartCardContentClassName={chartCardContentClassName}
+            />
+          ) : null}
+        </div>
+      </div>
+    )
+  }
+)
+
+export default TrafficReplicationSection

--- a/apps/dashboard/src/lib/api/charts/traffic-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/traffic-charts.ts
@@ -244,4 +244,77 @@ export const trafficCharts: Record<string, ChartQueryBuilder> = {
       tableCheck: 'system.part_log',
     }
   },
+
+  /**
+   * Cluster shape detection — a single cheap one-row probe of the core
+   * system.replicas / system.clusters tables. Powers the /traffic page's
+   * smart-detection: the "Replication & Distribution" section is rendered only
+   * when the cluster actually replicates (replicated_tables > 0), and the
+   * shard-related charts only when it actually shards (max_shards > 1). Both
+   * source tables are always present, so this needs no tableCheck.
+   */
+  'traffic-cluster-shape': () => ({
+    query: `
+    SELECT
+      (SELECT count() FROM system.replicas) AS replicated_tables,
+      (SELECT max(total_replicas) FROM system.replicas) AS max_replicas,
+      (SELECT count(DISTINCT cluster) FROM system.clusters) AS clusters,
+      (SELECT max(shard_num) FROM system.clusters) AS max_shards
+  `,
+  }),
+
+  /**
+   * Replica fetch traffic — inbound replication volume: parts this replica
+   * downloaded from other replicas (part_log DownloadPart). Non-zero only on a
+   * replicated cluster; part_log is opt-in, hence optional + tableCheck.
+   */
+  'traffic-replica-fetches': ({
+    interval = 'toStartOfHour',
+    lastHours = 24,
+  }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    return {
+      query: `
+    SELECT ${applyInterval(interval, 'event_time')},
+           count() AS fetched_parts,
+           sum(size_in_bytes) AS fetched_bytes,
+           formatReadableSize(fetched_bytes) AS readable_fetched_bytes
+    FROM system.part_log
+    WHERE event_type = 'DownloadPart'
+      ${timeFilter ? `AND ${timeFilter}` : ''}
+    GROUP BY 1
+    ORDER BY 1
+    WITH FILL TO ${nowOrToday(interval)} STEP ${fillStep(interval)}
+  `,
+      optional: true,
+      tableCheck: 'system.part_log',
+    }
+  },
+
+  /**
+   * Distributed query fan-out — initial (client-facing) vs secondary
+   * (shard-local, fanned-out by a Distributed table) queries over time. The
+   * secondary count is only meaningful on a sharded cluster.
+   */
+  'traffic-distributed-queries': ({
+    interval = 'toStartOfHour',
+    lastHours = 24,
+  }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    return {
+      query: `
+    SELECT ${applyInterval(interval, 'event_time')},
+           countIf(is_initial_query) AS initial_queries,
+           countIf(NOT is_initial_query) AS secondary_queries
+    FROM system.query_log
+    WHERE type = 'QueryFinish'
+      ${timeFilter ? `AND ${timeFilter}` : ''}
+    GROUP BY 1
+    ORDER BY 1
+    WITH FILL TO ${nowOrToday(interval)} STEP ${fillStep(interval)}
+  `,
+      optional: true,
+      tableCheck: 'system.query_log',
+    }
+  },
 }

--- a/apps/dashboard/src/routes/(dashboard)/traffic.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/traffic.tsx
@@ -8,6 +8,10 @@
  * Movement" section covering merge volume, part moves, and write
  * amplification. Sources: system.query_log (uncompressed ingest) and
  * system.part_log (on-disk size, merges, and part moves).
+ *
+ * When the cluster actually replicates or shards, a smart-detected
+ * "Replication & Distribution" section is appended (replica fetch traffic and
+ * distributed initial-vs-secondary queries); it is absent on a single node.
  */
 
 import { CombineIcon } from 'lucide-react'
@@ -20,6 +24,7 @@ import { ChartInsertedBytesOverTime } from '@/components/charts/traffic/inserted
 import { ChartInsertedRowsOverTime } from '@/components/charts/traffic/inserted-rows-over-time'
 import { ChartMergedBytesOverTime } from '@/components/charts/traffic/merged-bytes-over-time'
 import { ChartPartMovesOverTime } from '@/components/charts/traffic/part-moves-over-time'
+import { TrafficReplicationSection } from '@/components/charts/traffic/traffic-replication-section'
 import { TrafficSummaryKpis } from '@/components/charts/traffic/traffic-summary-kpis'
 import { ChartWriteAmplificationOverTime } from '@/components/charts/traffic/write-amplification-over-time'
 import { PageHeader } from '@/components/layout/page-header'
@@ -88,6 +93,11 @@ function TrafficPageContent() {
       <PageLayout
         queryConfig={trafficPerTableConfig}
         title="Top Tables by Ingestion (24h)"
+      />
+
+      <TrafficReplicationSection
+        chartClassName={CHART_CLASS}
+        chartCardContentClassName={CHART_CARD_CONTENT_CLASS}
       />
     </div>
   )


### PR DESCRIPTION
## Summary

PR 4 of the cluster-traffic series (follows #2644, #2645, #2646).

**Smart cluster detection**: a cheap one-row `traffic-cluster-shape` probe (system.replicas / system.clusters) decides what the /traffic page shows — the **Replication & Distribution** section only renders when the cluster actually replicates or shards; single-node clusters see nothing extra.

- **Replica Fetch Traffic** — parts downloaded from other replicas (`part_log` DownloadPart), shown when replicated
- **Distributed Queries** — initial vs secondary (fan-out) query counts, shown when sharded

## Verification
- `pnpm run type-check` (dashboard) ✅
- Biome lint ✅

https://claude.ai/code/session_015Mq6c6bQstbRwQnKt9htbE