### PR TITLE
feat(traffic): auto-detected PeerDB ingestion section

### DIFF
--- a/apps/dashboard/src/components/charts/traffic/peerdb-rows-over-time.tsx
+++ b/apps/dashboard/src/components/charts/traffic/peerdb-rows-over-time.tsx
@@ -13,6 +13,7 @@ interface PeerdbRowsRow {
   event_time: string
   table: string
   peerdb_rows: number
+  [key: string]: unknown
 }
 
 /**

--- a/apps/dashboard/src/components/charts/traffic/peerdb-rows-over-time.tsx
+++ b/apps/dashboard/src/components/charts/traffic/peerdb-rows-over-time.tsx
@@ -58,10 +58,10 @@ export const ChartPeerdbRowsOverTime = function ChartPeerdbRowsOverTime({
         // Pivot long rows (event_time, table, peerdb_rows) into wide rows keyed
         // on event_time with one column per table, tracking tables in one pass.
         const tableSet = new Set<string>()
-        const pivoted = (dataArray as PeerdbRowsRow[]).reduce<
+        const pivoted = dataArray.reduce<
           Record<string, Record<string, number>>
         >((acc, cur) => {
-          const { event_time, table, peerdb_rows } = cur
+          const { event_time, table, peerdb_rows } = cur as PeerdbRowsRow
           tableSet.add(table)
           const inner = acc[event_time] ?? {}
           inner[table] = peerdb_rows

--- a/apps/dashboard/src/components/charts/traffic/peerdb-rows-over-time.tsx
+++ b/apps/dashboard/src/components/charts/traffic/peerdb-rows-over-time.tsx
@@ -1,0 +1,115 @@
+import type { ChartProps } from '@/components/charts/chart-props'
+import type { DateRangeValue } from '@/components/date-range'
+
+import { useState } from 'react'
+import { ChartCard } from '@/components/cards/chart-card'
+import { ChartContainer } from '@/components/charts/chart-container'
+import { BarChart } from '@/components/charts/primitives/bar/bar'
+import { resolveDateRangeConfig } from '@/components/date-range'
+import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
+import { cn } from '@/lib/utils'
+
+interface PeerdbRowsRow {
+  event_time: string
+  table: string
+  peerdb_rows: number
+}
+
+/**
+ * PeerDB rows ingested over time, stacked per destination table. Categories are
+ * derived dynamically from the data (one bar series per table), so it uses the
+ * ChartContainer + pivot pattern rather than the static-categories factory.
+ */
+export const ChartPeerdbRowsOverTime = function ChartPeerdbRowsOverTime({
+  title = 'PeerDB Rows Ingested',
+  interval = 'toStartOfHour',
+  lastHours = 24,
+  className,
+  chartClassName,
+  chartCardContentClassName,
+  hostId,
+  ...props
+}: ChartProps) {
+  const [rangeOverride, setRangeOverride] = useState<DateRangeValue | null>(
+    null
+  )
+
+  const effectiveLastHours = rangeOverride?.lastHours ?? lastHours
+  const effectiveInterval = rangeOverride?.interval ?? interval
+
+  const swr = useChartData<PeerdbRowsRow>({
+    chartName: 'traffic-peerdb-rows',
+    hostId,
+    interval: effectiveInterval,
+    lastHours: effectiveLastHours,
+    refreshInterval: REFRESH_INTERVAL.MEDIUM_30S,
+  })
+
+  const dateRangeConfig = resolveDateRangeConfig('operations')
+
+  return (
+    <ChartContainer
+      swr={swr}
+      title={title}
+      className={className}
+      chartClassName={chartClassName}
+    >
+      {(dataArray, sql, metadata, staleError, mutate) => {
+        // Pivot long rows (event_time, table, peerdb_rows) into wide rows keyed
+        // on event_time with one column per table, tracking tables in one pass.
+        const tableSet = new Set<string>()
+        const pivoted = (dataArray as PeerdbRowsRow[]).reduce<
+          Record<string, Record<string, number>>
+        >((acc, cur) => {
+          const { event_time, table, peerdb_rows } = cur
+          tableSet.add(table)
+          const inner = acc[event_time] ?? {}
+          inner[table] = peerdb_rows
+          acc[event_time] = inner
+          return acc
+        }, {})
+
+        const barData = Object.entries(pivoted).map(([event_time, obj]) => ({
+          event_time,
+          ...obj,
+        }))
+        const tables = Array.from(tableSet)
+
+        return (
+          <ChartCard
+            title={title}
+            className={className}
+            sql={sql}
+            data={barData}
+            metadata={metadata}
+            dateRangeConfig={dateRangeConfig}
+            currentRange={rangeOverride?.value}
+            onRangeChange={setRangeOverride}
+            staleError={staleError}
+            onRetry={mutate}
+            contentClassName={chartCardContentClassName}
+            data-testid="traffic-peerdb-rows-chart"
+          >
+            <BarChart
+              className={cn('h-full w-full', chartClassName)}
+              data={barData}
+              index="event_time"
+              categories={tables}
+              colors={[
+                '--chart-1',
+                '--chart-2',
+                '--chart-3',
+                '--chart-4',
+                '--chart-5',
+              ]}
+              stack
+              {...props}
+            />
+          </ChartCard>
+        )
+      }}
+    </ChartContainer>
+  )
+}
+
+export default ChartPeerdbRowsOverTime

--- a/apps/dashboard/src/components/charts/traffic/traffic-peerdb-section.tsx
+++ b/apps/dashboard/src/components/charts/traffic/traffic-peerdb-section.tsx
@@ -1,0 +1,60 @@
+import { memo } from 'react'
+import { ChartPeerdbRowsOverTime } from '@/components/charts/traffic/peerdb-rows-over-time'
+import { PeerDBLogo } from '@/components/icons/peerdb-brand-logo'
+import { REFRESH_INTERVAL, useChartData, useHostId } from '@/lib/swr'
+
+interface PeerdbDetectRow {
+  peerdb_tables: number
+  peerdb_inserts_24h: number
+  [key: string]: unknown
+}
+
+/**
+ * Conditional "PeerDB Ingestion" section for /traffic. Auto-detects whether the
+ * cluster is used as a PeerDB (Postgres CDC → ClickHouse) destination via
+ * `traffic-peerdb-detect`; when no PeerDB tables or recent PeerDB insert
+ * activity is found, the whole section is hidden (renders null). Detection is
+ * cheap and fail-soft — errors also hide the section.
+ */
+export const TrafficPeerdbSection = memo(function TrafficPeerdbSection({
+  chartClassName,
+  chartCardContentClassName,
+}: {
+  chartClassName?: string
+  chartCardContentClassName?: string
+}) {
+  const hostId = useHostId()
+
+  const detect = useChartData<PeerdbDetectRow>({
+    chartName: 'traffic-peerdb-detect',
+    hostId,
+    refreshInterval: REFRESH_INTERVAL.SLOW_2M,
+  })
+
+  const row = detect.data?.[0]
+
+  if (detect.isLoading || detect.error || !row) return null
+  if (
+    Number(row.peerdb_tables ?? 0) === 0 &&
+    Number(row.peerdb_inserts_24h ?? 0) === 0
+  ) {
+    return null
+  }
+
+  return (
+    <div className="flex flex-col gap-3 sm:gap-4">
+      <div className="flex items-center gap-2">
+        <PeerDBLogo className="size-4 text-foreground" />
+        <h2 className="text-sm font-medium text-foreground">
+          PeerDB Ingestion
+        </h2>
+      </div>
+      <ChartPeerdbRowsOverTime
+        chartClassName={chartClassName}
+        chartCardContentClassName={chartCardContentClassName}
+      />
+    </div>
+  )
+})
+
+export default TrafficPeerdbSection

--- a/apps/dashboard/src/lib/api/charts/traffic-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/traffic-charts.ts
@@ -317,4 +317,52 @@ export const trafficCharts: Record<string, ChartQueryBuilder> = {
       tableCheck: 'system.query_log',
     }
   },
+
+  /**
+   * PeerDB smart-detection: a single row reporting whether this cluster is used
+   * as a PeerDB (Postgres CDC → ClickHouse) destination. PeerDB creates helper
+   * tables/databases whose names contain 'peerdb' and runs its insert queries
+   * under a user/client containing 'peerdb'. Powers the conditional "PeerDB
+   * Ingestion" section on /traffic — that section renders only when either
+   * count is > 0, so it stays hidden entirely when PeerDB is not in use.
+   */
+  'traffic-peerdb-detect': () => ({
+    query: `
+    SELECT
+      (SELECT count() FROM system.tables WHERE database ILIKE '%peerdb%' OR name ILIKE '%peerdb%') AS peerdb_tables,
+      (SELECT count() FROM system.query_log
+        WHERE type = 'QueryFinish' AND query_kind = 'Insert'
+          AND event_time >= now() - INTERVAL 24 HOUR
+          AND (user ILIKE '%peerdb%' OR http_user_agent ILIKE '%peerdb%' OR client_name ILIKE '%peerdb%')) AS peerdb_inserts_24h
+  `,
+    optional: true,
+    tableCheck: 'system.query_log',
+  }),
+
+  /**
+   * Rows ingested by PeerDB over time, split by destination table. Only counts
+   * insert queries attributable to PeerDB (user/agent/client contains 'peerdb').
+   * `tables` is an Array column on query_log; we key on the first element,
+   * which is the fully-qualified `db.table` name — simpler and more robust than
+   * reconstructing it from `databases` + `tables`.
+   */
+  'traffic-peerdb-rows': ({ interval = 'toStartOfHour', lastHours = 24 }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    return {
+      query: `
+    SELECT ${applyInterval(interval, 'event_time')},
+           arrayElement(tables, 1) AS table,
+           sum(written_rows) AS peerdb_rows
+    FROM system.query_log
+    WHERE type = 'QueryFinish'
+      AND query_kind = 'Insert'
+      AND (user ILIKE '%peerdb%' OR http_user_agent ILIKE '%peerdb%' OR client_name ILIKE '%peerdb%')
+      ${timeFilter ? `AND ${timeFilter}` : ''}
+    GROUP BY 1, 2
+    ORDER BY 1, 2
+  `,
+      optional: true,
+      tableCheck: 'system.query_log',
+    }
+  },
 }

--- a/apps/dashboard/src/routes/(dashboard)/traffic.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/traffic.tsx
@@ -12,6 +12,10 @@
  * When the cluster actually replicates or shards, a smart-detected
  * "Replication & Distribution" section is appended (replica fetch traffic and
  * distributed initial-vs-secondary queries); it is absent on a single node.
+ *
+ * A conditional "PeerDB Ingestion" section is appended at the end, auto-detected
+ * from system.tables / system.query_log and hidden entirely when this cluster
+ * is not used as a PeerDB (Postgres CDC → ClickHouse) destination.
  */
 
 import { CombineIcon } from 'lucide-react'
@@ -24,6 +28,7 @@ import { ChartInsertedBytesOverTime } from '@/components/charts/traffic/inserted
 import { ChartInsertedRowsOverTime } from '@/components/charts/traffic/inserted-rows-over-time'
 import { ChartMergedBytesOverTime } from '@/components/charts/traffic/merged-bytes-over-time'
 import { ChartPartMovesOverTime } from '@/components/charts/traffic/part-moves-over-time'
+import { TrafficPeerdbSection } from '@/components/charts/traffic/traffic-peerdb-section'
 import { TrafficReplicationSection } from '@/components/charts/traffic/traffic-replication-section'
 import { TrafficSummaryKpis } from '@/components/charts/traffic/traffic-summary-kpis'
 import { ChartWriteAmplificationOverTime } from '@/components/charts/traffic/write-amplification-over-time'
@@ -96,6 +101,11 @@ function TrafficPageContent() {
       />
 
       <TrafficReplicationSection
+        chartClassName={CHART_CLASS}
+        chartCardContentClassName={CHART_CARD_CONTENT_CLASS}
+      />
+
+      <TrafficPeerdbSection
         chartClassName={CHART_CLASS}
         chartCardContentClassName={CHART_CARD_CONTENT_CLASS}
       />


### PR DESCRIPTION
## Summary

PR 5 (final feature PR) of the cluster-traffic series (follows #2644, #2645, #2646, #2647; docs in #2648).

**PeerDB smart-detection**: `traffic-peerdb-detect` probes for peerdb-named tables/databases and PeerDB-attributed insert activity (user / http_user_agent / client_name). The **PeerDB Ingestion** section renders only when detected — clusters not using PeerDB (Postgres CDC → ClickHouse) see nothing.

- **PeerDB Rows Ingested** — stacked per-destination-table rows over time from `system.query_log` (dynamic-category pivot, same pattern as new-parts-created)

## Verification
- `pnpm run type-check` (dashboard) ✅
- Biome lint ✅

https://claude.ai/code/session_015Mq6c6bQstbRwQnKt9htbE