### PR TITLE
fix(traffic): review findings — host routing and undefined chart tokens

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -45,7 +45,10 @@ values and file paths: `docs/knowledge/product-design.md`.
 
 `background foreground card card-foreground popover muted muted-foreground
 primary secondary accent destructive border input ring`. Charts:
-`--chart-1..5` (OKLCH) for series. Radius: `rounded-md` (9px) default,
+`--chart-1..13` for series, plus named accents `--chart-red` (error series),
+`--chart-blue` (info), `--chart-green` (success), `--chart-yellow` (warning) —
+only pass tokens that exist in `styles.css` to a chart's `colors` prop; an
+undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
 `rounded-lg` (10px), `rounded-xl` (14px) for cards. Brand accents: **orange**
 (metrics) + **emerald** (health/live) — see `components/icons/chmonitor-logo.tsx`.
 

--- a/apps/dashboard/src/components/charts/traffic/peerdb-rows-over-time.tsx
+++ b/apps/dashboard/src/components/charts/traffic/peerdb-rows-over-time.tsx
@@ -6,7 +6,7 @@ import { ChartCard } from '@/components/cards/chart-card'
 import { ChartContainer } from '@/components/charts/chart-container'
 import { BarChart } from '@/components/charts/primitives/bar/bar'
 import { resolveDateRangeConfig } from '@/components/date-range'
-import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData, useHostId } from '@/lib/swr'
 import { cn } from '@/lib/utils'
 
 interface PeerdbRowsRow {
@@ -38,9 +38,14 @@ export const ChartPeerdbRowsOverTime = function ChartPeerdbRowsOverTime({
   const effectiveLastHours = rangeOverride?.lastHours ?? lastHours
   const effectiveInterval = rangeOverride?.interval ?? interval
 
+  // Fall back to the route's ?host like the factory charts do — the section
+  // wrapper does not pass hostId, and omitting it silently queries host 0.
+  const routeHostId = useHostId()
+  const resolvedHostId = hostId ?? routeHostId
+
   const swr = useChartData<PeerdbRowsRow>({
     chartName: 'traffic-peerdb-rows',
-    hostId,
+    hostId: resolvedHostId,
     interval: effectiveInterval,
     lastHours: effectiveLastHours,
     refreshInterval: REFRESH_INTERVAL.MEDIUM_30S,

--- a/apps/dashboard/src/components/charts/traffic/traffic-peerdb-section.tsx
+++ b/apps/dashboard/src/components/charts/traffic/traffic-peerdb-section.tsx
@@ -44,7 +44,7 @@ export const TrafficPeerdbSection = memo(function TrafficPeerdbSection({
   return (
     <div className="flex flex-col gap-3 sm:gap-4">
       <div className="flex items-center gap-2">
-        <PeerDBLogo className="size-4 text-foreground" />
+        <PeerDBLogo className="size-4 text-muted-foreground" />
         <h2 className="text-sm font-medium text-foreground">
           PeerDB Ingestion
         </h2>

--- a/apps/dashboard/src/styles.css
+++ b/apps/dashboard/src/styles.css
@@ -459,6 +459,12 @@
   --chart-orange-600: hsl(20.5 90.2% 48.2%);
   --chart-indigo-300: hsl(230 94% 82%);
   --chart-yellow: hsl(45 100% 60%);
+  /* Named accent tokens referenced by chart `colors` props (error/info/success
+     series). These were previously undefined, so `var(--chart-red)` computed
+     to black — invisible against dark surfaces. */
+  --chart-red: hsl(0 84% 60%);
+  --chart-blue: hsl(217 91% 60%);
+  --chart-green: hsl(142 71% 45%);
 
   /* Semantic badge colors for user badges */
   --badge-purple: oklch(0.65 0.2 290);
@@ -612,6 +618,9 @@
   --color-chart-orange-600: var(--chart-orange-600);
   --color-chart-indigo-300: var(--chart-indigo-300);
   --color-chart-yellow: var(--chart-yellow);
+  --color-chart-red: var(--chart-red);
+  --color-chart-blue: var(--chart-blue);
+  --color-chart-green: var(--chart-green);
   --color-sidebar: var(--sidebar);
 }
 

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -3,7 +3,7 @@ id: product-design
 title: Product design system & UX conventions
 type: reference
 status: active
-updated: 2026-07-12
+updated: 2026-07-16
 tags:
   - design-system
   - ui
@@ -39,8 +39,12 @@ oklch(0.556 0 0)`). Dark inverts (`--background: oklch(0.145 0 0)`, `--border:
 oklch(1 0 0 / 10%)`).
 
 Chart series: `--chart-1..5` in OKLCH (orange/blue/dark-blue/yellow-green/green),
-plus HSL extras `--chart-6..13`. Semantic badge pairs exist as
-`--badge-{purple,blue,green,amber,pink,slate}` + `*-bg`.
+plus HSL extras `--chart-6..13`, plus named accents for semantic series:
+`--chart-red` (errors), `--chart-blue` (info), `--chart-green` (success),
+`--chart-yellow` (warnings). Only pass tokens defined in `styles.css` to a
+chart's `colors` prop — `seriesColorVar` emits `var(<name>)` verbatim, so an
+undefined token computes to black (invisible on dark). Semantic badge pairs
+exist as `--badge-{purple,blue,green,amber,pink,slate}` + `*-bg`.
 
 **Series-color arithmetic (one helper).** `area.tsx`, `bar/utils.ts`
 (`colorForCategoryIndex`), and `donut.tsx` all resolve a series/category color


### PR DESCRIPTION
## Summary

Follow-up to the traffic series (#2644–#2649), addressing cross-review findings from the SQL + frontend review agents.

**Confirmed bug — PeerDB chart ignored the selected host.** `ChartPeerdbRowsOverTime` read `hostId` only from props; its section wrapper never passed it, so `useChartData` omitted the param and the server resolved host 0. On `?host=1+` the chart silently queried the wrong cluster. Now falls back to `useHostId()` exactly like the factory charts.

**Latent repo-wide bug — undefined chart color tokens.** `--chart-red` (9 uses), `--chart-blue` (4), `--chart-green` (1) were referenced in chart `colors` props (error-rate-over-time, crash-frequency, thread-utilization + new traffic charts) but never defined in `styles.css` — `seriesColorVar` emits `var()` verbatim, so those series rendered black. Tokens now defined (+ `@theme` mappings), fixing all 14 usages at once.

**Minor:** PeerDB section header icon → `text-muted-foreground` for parity with sibling section headers. Product-design skill + knowledge doc updated in the same change (per the auto-improve standing instruction).

SQL review verdict: clean, no defects (one optional `system.replicas` probe hardening noted, deliberately not rushed).

## Verification
- `pnpm run type-check` (dashboard) ✅
- Biome lint ✅

https://claude.ai/code/session_015Mq6c6bQstbRwQnKt9htbE