### PR TITLE
fix(api): remove bogus overflow_mode setting, add any-version fallback + live CI test

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -24,7 +24,7 @@
     "type-check": "tsc --noEmit",
     "type-check:test": "tsc -p tsconfig.test.json --noEmit",
     "test": "bun test src/ --isolate",
-    "test:query-config": "bun test src/lib/query-config --isolate",
+    "test:query-config": "bun test src/lib/query-config src/lib/api/__tests__/query-cache-settings-live.test.ts --isolate",
     "test:coverage": "bun test src/ --isolate --coverage --coverage-reporter=lcov --coverage-reporter=text",
     "test:coverage:ci": "bun test src/ --isolate --coverage --coverage-reporter=lcov",
     "test:pg-integration": "bun test src/lib/connection-query/execute-pg-query.integration.test.ts --isolate",

--- a/apps/dashboard/src/lib/api/__tests__/query-cache-settings-live.test.ts
+++ b/apps/dashboard/src/lib/api/__tests__/query-cache-settings-live.test.ts
@@ -4,54 +4,41 @@
  * service container, `CLICKHOUSE_HOST` set workflow-wide) and self-skips
  * everywhere else.
  *
- * Regression context: a bare `overflow_mode: 'throw'` was once added to
- * `buildQueryCacheSettings` — a setting name that does not exist in ANY
- * ClickHouse version — which failed every cache-enabled query with
- * "Setting overflow_mode is neither a builtin setting nor started with the
- * prefix 'SQL_'". Unit tests with mocked versions can't catch a hallucinated
- * setting name; only a real server can. This test:
+ * Regression guard for the removed bare `overflow_mode` — see the NOTE in
+ * query-cache-settings.ts. Unit tests with mocked versions can't catch a
+ * hallucinated setting NAME; only a real server can:
  *
- * 1. Asserts every setting name emitted for the live server's version exists
- *    in that server's `system.settings` (catches unknown-setting names).
- * 2. Executes a real `system.*` query with the settings applied (catches
- *    interaction failures like error 719 QUERY_CACHE_USED_WITH_SYSTEM_TABLE
- *    or 731 QUERY_CACHE_USED_WITH_NON_THROW_OVERFLOW_MODE).
+ * 1. Every setting name emitted for the live server's version must exist in
+ *    that server's `system.settings` (catches unknown-setting names).
+ * 2. A real `system.*` query must execute with the settings applied (catches
+ *    interaction failures like errors 719/731).
  */
+
+import type { ClickHouseVersion } from '@chm/clickhouse-client/clickhouse-version'
 
 import { beforeAll, describe, expect, it } from 'bun:test'
 import { fetchData } from '@chm/clickhouse-client'
-import { parseVersion } from '@chm/clickhouse-client/clickhouse-version'
+import { getClickHouseVersion } from '@chm/clickhouse-client/clickhouse-version'
 import { buildQueryCacheSettings } from '@/lib/api/query-cache-settings'
 
-async function getLiveVersion(): Promise<string | null> {
+async function getLiveVersion(): Promise<ClickHouseVersion | null> {
   if (!process.env.CLICKHOUSE_HOST) return null
   try {
     const timeout = new Promise<never>((_, reject) =>
       setTimeout(() => reject(new Error('Connection timeout')), 3000)
     )
-    const result = await Promise.race([
-      fetchData<{ v: string }[]>({
-        query: 'SELECT version() AS v',
-        hostId: 0,
-        format: 'JSONEachRow',
-      }),
-      timeout,
-    ])
-    if (result.error || !Array.isArray(result.data) || !result.data[0]?.v) {
-      return null
-    }
-    return result.data[0].v
+    return await Promise.race([getClickHouseVersion(0), timeout])
   } catch {
     return null
   }
 }
 
 describe('query-cache settings against a live ClickHouse (optional)', () => {
-  let rawVersion: string | null = null
+  let liveVersion: ClickHouseVersion | null = null
 
   beforeAll(async () => {
-    rawVersion = await getLiveVersion()
-    if (!rawVersion) {
+    liveVersion = await getLiveVersion()
+    if (!liveVersion) {
       console.log(
         '⏭️  Skipping live query-cache tests - ClickHouse not available (set CLICKHOUSE_HOST)'
       )
@@ -59,10 +46,10 @@ describe('query-cache settings against a live ClickHouse (optional)', () => {
   }, 10000)
 
   it('emits only setting names the live server recognizes', async () => {
-    if (!rawVersion) return // Skip - no live ClickHouse
+    if (!liveVersion) return // Skip - no live ClickHouse
 
     const settings = buildQueryCacheSettings({
-      version: parseVersion(rawVersion),
+      version: liveVersion,
       ttlSeconds: 30,
     })
     const names = Object.keys(settings)
@@ -87,10 +74,10 @@ describe('query-cache settings against a live ClickHouse (optional)', () => {
   })
 
   it('executes a system.* query successfully with the cache settings applied', async () => {
-    if (!rawVersion) return // Skip - no live ClickHouse
+    if (!liveVersion) return // Skip - no live ClickHouse
 
     const settings = buildQueryCacheSettings({
-      version: parseVersion(rawVersion),
+      version: liveVersion,
       ttlSeconds: 30,
     })
 

--- a/apps/dashboard/src/lib/api/__tests__/query-cache-settings.test.ts
+++ b/apps/dashboard/src/lib/api/__tests__/query-cache-settings.test.ts
@@ -11,7 +11,11 @@
 import type { ClickHouseVersion } from '@chm/clickhouse-client/clickhouse-version'
 
 import { describe, expect, test } from 'bun:test'
-import { buildQueryCacheSettings } from '@/lib/api/query-cache-settings'
+import {
+  buildQueryCacheSettings,
+  isUnknownSettingError,
+  withUnknownSettingRetry,
+} from '@/lib/api/query-cache-settings'
 
 function version(major: number, minor: number, patch = 0): ClickHouseVersion {
   return { major, minor, patch, raw: `${major}.${minor}.${patch}` }
@@ -119,5 +123,150 @@ describe('buildQueryCacheSettings', () => {
       expect(settings.use_query_cache).toBe(1)
       expect(settings.query_cache_system_table_handling).toBe('save')
     }
+  })
+
+  test('emits only real ClickHouse setting names, on every version', () => {
+    // Regression for the hallucinated bare `overflow_mode: 'throw'` (there is
+    // no such setting in ANY ClickHouse version — only result_overflow_mode,
+    // timeout_overflow_mode, etc.). An unrecognized name fails the entire
+    // query with "Setting X is neither a builtin setting…", so every emitted
+    // key must come from this verified allowlist. The live counterpart
+    // (query-cache-settings-live.test.ts) checks the names against a real
+    // server's system.settings in CI.
+    const KNOWN_SETTINGS = new Set([
+      'use_query_cache',
+      'query_cache_ttl',
+      'query_cache_nondeterministic_function_handling',
+      'query_cache_store_results_of_queries_with_nondeterministic_functions',
+      'query_cache_system_table_handling',
+    ])
+    for (const v of [
+      version(23, 5),
+      version(24, 1),
+      version(24, 2),
+      version(24, 4),
+      version(25, 1),
+      version(26, 3),
+      version(99, 9),
+    ]) {
+      const settings = buildQueryCacheSettings({ version: v, ttlSeconds: 30 })
+      for (const key of Object.keys(settings)) {
+        expect(KNOWN_SETTINGS.has(key)).toBe(true)
+      }
+    }
+  })
+})
+
+describe('isUnknownSettingError', () => {
+  test('matches both UNKNOWN_SETTING message wordings and code 115', () => {
+    expect(
+      isUnknownSettingError(
+        new Error(
+          "Setting overflow_mode is neither a builtin setting nor started with the prefix 'SQL_' registered for user-defined settings"
+        )
+      )
+    ).toBe(true)
+    expect(
+      isUnknownSettingError({ message: "Unknown setting 'use_query_cache'" })
+    ).toBe(true)
+    expect(isUnknownSettingError('Code: 115. DB::Exception: something')).toBe(
+      true
+    )
+  })
+
+  test('does not match unrelated errors', () => {
+    expect(isUnknownSettingError(new Error('Connection refused'))).toBe(false)
+    expect(isUnknownSettingError({ message: 'Code: 719. system table' })).toBe(
+      false
+    )
+    expect(isUnknownSettingError(undefined)).toBe(false)
+    expect(isUnknownSettingError(null)).toBe(false)
+  })
+})
+
+describe('withUnknownSettingRetry', () => {
+  const cacheSettings = { use_query_cache: 1, query_cache_ttl: 30 }
+  const unknownSettingError = {
+    type: 'query_error',
+    message:
+      "Setting use_query_cache is neither a builtin setting nor started with the prefix 'SQL_' registered for user-defined settings",
+  }
+
+  test('passes settings through on success (no retry)', async () => {
+    const calls: object[] = []
+    const result = await withUnknownSettingRetry(
+      cacheSettings,
+      async (settings) => {
+        calls.push(settings)
+        return { data: [1] }
+      },
+      () => undefined
+    )
+    expect(result).toEqual({ data: [1] })
+    expect(calls).toEqual([cacheSettings])
+  })
+
+  test('retries without settings when the result carries an unknown-setting error', async () => {
+    const calls: object[] = []
+    const result = await withUnknownSettingRetry(
+      cacheSettings,
+      async (settings) => {
+        calls.push(settings)
+        return Object.keys(settings).length > 0
+          ? { data: null, error: unknownSettingError }
+          : { data: [1], error: undefined }
+      },
+      (r) => r.error
+    )
+    expect(result.error).toBeUndefined()
+    expect(result.data).toEqual([1])
+    expect(calls).toEqual([cacheSettings, {}])
+  })
+
+  test('retries without settings when the query throws an unknown-setting error', async () => {
+    const calls: object[] = []
+    const result = await withUnknownSettingRetry(
+      cacheSettings,
+      async (settings) => {
+        calls.push(settings)
+        if (Object.keys(settings).length > 0) {
+          throw new Error(unknownSettingError.message)
+        }
+        return 'ok'
+      }
+    )
+    expect(result).toBe('ok')
+    expect(calls).toEqual([cacheSettings, {}])
+  })
+
+  test('does not retry on unrelated errors (returned or thrown)', async () => {
+    let runs = 0
+    const result = await withUnknownSettingRetry(
+      cacheSettings,
+      async () => {
+        runs++
+        return { error: { type: 'network_error', message: 'timeout' } }
+      },
+      (r) => r.error
+    )
+    expect(runs).toBe(1)
+    expect(result.error?.type).toBe('network_error')
+
+    await expect(
+      withUnknownSettingRetry(cacheSettings, async () => {
+        throw new Error('Connection refused')
+      })
+    ).rejects.toThrow('Connection refused')
+  })
+
+  test('skips the fallback machinery entirely when settings are empty', async () => {
+    let runs = 0
+    await withUnknownSettingRetry({}, async () => {
+      runs++
+      return { error: unknownSettingError }
+    })
+    // An unknown-setting error WITHOUT cache settings can't be caused by us —
+    // never retried, surfaced as-is.
+    expect(runs).toBe(1)
   })
 })

--- a/apps/dashboard/src/lib/api/__tests__/query-cache-settings.test.ts
+++ b/apps/dashboard/src/lib/api/__tests__/query-cache-settings.test.ts
@@ -8,12 +8,16 @@
  * for the version history this encodes.
  */
 
+import type { ClickHouseSettings } from '@clickhouse/client'
+
 import type { ClickHouseVersion } from '@chm/clickhouse-client/clickhouse-version'
 
-import { describe, expect, test } from 'bun:test'
+import { beforeEach, describe, expect, test } from 'bun:test'
 import {
   buildQueryCacheSettings,
+  clearUnknownSettingRejections,
   isUnknownSettingError,
+  runWithQueryCache,
   withUnknownSettingRetry,
 } from '@/lib/api/query-cache-settings'
 
@@ -126,13 +130,9 @@ describe('buildQueryCacheSettings', () => {
   })
 
   test('emits only real ClickHouse setting names, on every version', () => {
-    // Regression for the hallucinated bare `overflow_mode: 'throw'` (there is
-    // no such setting in ANY ClickHouse version — only result_overflow_mode,
-    // timeout_overflow_mode, etc.). An unrecognized name fails the entire
-    // query with "Setting X is neither a builtin setting…", so every emitted
-    // key must come from this verified allowlist. The live counterpart
-    // (query-cache-settings-live.test.ts) checks the names against a real
-    // server's system.settings in CI.
+    // Regression guard for the removed bare `overflow_mode` — see the NOTE in
+    // query-cache-settings.ts. The live counterpart (query-cache-settings-live
+    // .test.ts) checks these names against a real server's system.settings.
     const KNOWN_SETTINGS = new Set([
       'use_query_cache',
       'query_cache_ttl',
@@ -150,9 +150,9 @@ describe('buildQueryCacheSettings', () => {
       version(99, 9),
     ]) {
       const settings = buildQueryCacheSettings({ version: v, ttlSeconds: 30 })
-      for (const key of Object.keys(settings)) {
-        expect(KNOWN_SETTINGS.has(key)).toBe(true)
-      }
+      expect(Object.keys(settings).every((k) => KNOWN_SETTINGS.has(k))).toBe(
+        true
+      )
     }
   })
 })
@@ -169,9 +169,9 @@ describe('isUnknownSettingError', () => {
     expect(
       isUnknownSettingError({ message: "Unknown setting 'use_query_cache'" })
     ).toBe(true)
-    expect(isUnknownSettingError('Code: 115. DB::Exception: something')).toBe(
-      true
-    )
+    expect(
+      isUnknownSettingError({ message: 'Code: 115. DB::Exception: something' })
+    ).toBe(true)
   })
 
   test('does not match unrelated errors', () => {
@@ -185,38 +185,43 @@ describe('isUnknownSettingError', () => {
 })
 
 describe('withUnknownSettingRetry', () => {
-  const cacheSettings = { use_query_cache: 1, query_cache_ttl: 30 }
+  const cacheSettings: ClickHouseSettings = {
+    use_query_cache: 1,
+    query_cache_ttl: 30,
+  }
   const unknownSettingError = {
     type: 'query_error',
     message:
       "Setting use_query_cache is neither a builtin setting nor started with the prefix 'SQL_' registered for user-defined settings",
   }
 
+  beforeEach(() => {
+    clearUnknownSettingRejections()
+  })
+
   test('passes settings through on success (no retry)', async () => {
-    const calls: object[] = []
+    const calls: ClickHouseSettings[] = []
     const result = await withUnknownSettingRetry(
       cacheSettings,
       async (settings) => {
         calls.push(settings)
         return { data: [1] }
-      },
-      () => undefined
+      }
     )
     expect(result).toEqual({ data: [1] })
     expect(calls).toEqual([cacheSettings])
   })
 
   test('retries without settings when the result carries an unknown-setting error', async () => {
-    const calls: object[] = []
+    const calls: ClickHouseSettings[] = []
     const result = await withUnknownSettingRetry(
       cacheSettings,
       async (settings) => {
         calls.push(settings)
         return Object.keys(settings).length > 0
-          ? { data: null, error: unknownSettingError }
-          : { data: [1], error: undefined }
-      },
-      (r) => r.error
+          ? { data: null as number[] | null, error: unknownSettingError }
+          : { data: [1] as number[] | null, error: undefined }
+      }
     )
     expect(result.error).toBeUndefined()
     expect(result.data).toEqual([1])
@@ -224,7 +229,7 @@ describe('withUnknownSettingRetry', () => {
   })
 
   test('retries without settings when the query throws an unknown-setting error', async () => {
-    const calls: object[] = []
+    const calls: ClickHouseSettings[] = []
     const result = await withUnknownSettingRetry(
       cacheSettings,
       async (settings) => {
@@ -241,14 +246,10 @@ describe('withUnknownSettingRetry', () => {
 
   test('does not retry on unrelated errors (returned or thrown)', async () => {
     let runs = 0
-    const result = await withUnknownSettingRetry(
-      cacheSettings,
-      async () => {
-        runs++
-        return { error: { type: 'network_error', message: 'timeout' } }
-      },
-      (r) => r.error
-    )
+    const result = await withUnknownSettingRetry(cacheSettings, async () => {
+      runs++
+      return { error: { type: 'network_error', message: 'timeout' } }
+    })
     expect(runs).toBe(1)
     expect(result.error?.type).toBe('network_error')
 
@@ -268,5 +269,58 @@ describe('withUnknownSettingRetry', () => {
     // An unknown-setting error WITHOUT cache settings can't be caused by us —
     // never retried, surfaced as-is.
     expect(runs).toBe(1)
+  })
+
+  test('remembers the rejection per host and skips settings on later calls', async () => {
+    const calls: ClickHouseSettings[] = []
+    const run = async (settings: ClickHouseSettings) => {
+      calls.push(settings)
+      return Object.keys(settings).length > 0
+        ? { error: unknownSettingError }
+        : { error: undefined }
+    }
+    // First call: attempt + retry (2 executions).
+    await withUnknownSettingRetry(cacheSettings, run, 7)
+    // Second call on the SAME host: goes straight to no-settings (1 execution)
+    // instead of paying the failed round-trip on every poll.
+    await withUnknownSettingRetry(cacheSettings, run, 7)
+    expect(calls).toEqual([cacheSettings, {}, {}])
+
+    // A DIFFERENT host is unaffected by host 7's rejection memo.
+    await withUnknownSettingRetry(cacheSettings, run, 8)
+    expect(calls.at(-2)).toEqual(cacheSettings)
+    expect(calls.at(-1)).toEqual({})
+  })
+})
+
+describe('runWithQueryCache', () => {
+  beforeEach(() => {
+    clearUnknownSettingRejections()
+  })
+
+  test('builds version-gated settings and runs under the safety net in one step', async () => {
+    const calls: ClickHouseSettings[] = []
+    await runWithQueryCache(
+      { version: version(24, 8), ttlSeconds: 30, hostId: 0 },
+      async (settings) => {
+        calls.push(settings)
+        return { data: [] }
+      }
+    )
+    expect(calls).toHaveLength(1)
+    expect(calls[0].use_query_cache).toBe(1)
+    expect(calls[0].query_cache_ttl).toBe(30)
+  })
+
+  test('passes {} straight through for unsupported versions', async () => {
+    const calls: ClickHouseSettings[] = []
+    await runWithQueryCache(
+      { version: null, ttlSeconds: 30, hostId: 0 },
+      async (settings) => {
+        calls.push(settings)
+        return { data: [] }
+      }
+    )
+    expect(calls).toEqual([{}])
   })
 })

--- a/apps/dashboard/src/lib/api/query-cache-settings.ts
+++ b/apps/dashboard/src/lib/api/query-cache-settings.ts
@@ -159,15 +159,13 @@ export function buildQueryCacheSettings({
  * - "Unknown setting 'use_query_cache'" (older servers)
  * - "Setting x is neither a builtin setting nor started with the prefix
  *   'SQL_' registered for user-defined settings" (newer servers)
- * Accepts a thrown Error, a `FetchDataResult['error']` object, or a string.
+ * Accepts a thrown Error or a `FetchDataResult['error']`-shaped object.
  */
 export function isUnknownSettingError(err: unknown): boolean {
   const message =
-    typeof err === 'string'
-      ? err
-      : err && typeof err === 'object' && 'message' in err
-        ? String((err as { message?: unknown }).message ?? '')
-        : ''
+    err && typeof err === 'object' && 'message' in err
+      ? String((err as { message?: unknown }).message ?? '')
+      : ''
   if (!message) return false
   return (
     /unknown setting/i.test(message) ||
@@ -176,38 +174,81 @@ export function isUnknownSettingError(err: unknown): boolean {
   )
 }
 
+const UNKNOWN_SETTING_RETRY_WARNING =
+  '[query-cache] host rejected a query-cache setting as unknown; retrying without cache settings'
+
+/**
+ * Hosts that rejected the cache settings, so subsequent polls skip sending
+ * them instead of paying a failed query + retry on EVERY poll. Mirrors the
+ * 24h TTL of the per-host version cache that produced the wrong settings.
+ */
+const rejectedHosts = new Map<string, number>()
+const REJECTION_TTL_MS = 24 * 60 * 60 * 1000
+
+/** Test-only: forget remembered per-host rejections. */
+export function clearUnknownSettingRejections(): void {
+  rejectedHosts.clear()
+}
+
 /**
  * Any-ClickHouse-version safety net: the query cache is an optimization, so
  * its settings must NEVER fail a query. Version gating above handles the
  * versions we know about, but a host outside the tested matrix (very old,
  * very new, or a fork) may still reject a setting name as unknown — in that
- * case, retry ONCE without the cache settings instead of surfacing the error.
+ * case, retry ONCE without the cache settings instead of surfacing the
+ * error, and remember the rejection per host so later polls skip the wasted
+ * round-trip.
  *
- * `fetchData` returns errors on the result (`result.error`) while raw client
- * calls throw, so both paths are handled: pass `extractError` for
- * result-shaped errors.
+ * Errors are detected on both conventions: a thrown error (raw client calls)
+ * and a `result.error` field (`fetchData`-shaped results).
  */
 export async function withUnknownSettingRetry<T>(
   cacheSettings: ClickHouseSettings,
   run: (settings: ClickHouseSettings) => Promise<T>,
-  extractError: (result: T) => unknown = () => undefined
+  hostId?: number | string
 ): Promise<T> {
   if (Object.keys(cacheSettings).length === 0) return run(cacheSettings)
-  let result: T
+
+  const hostKey = hostId === undefined ? undefined : String(hostId)
+  if (hostKey !== undefined) {
+    const expiry = rejectedHosts.get(hostKey)
+    if (expiry !== undefined && expiry > Date.now()) return run({})
+    if (expiry !== undefined) rejectedHosts.delete(hostKey)
+  }
+
+  let result: T | undefined
+  let resolved = false
+  let err: unknown
   try {
     result = await run(cacheSettings)
-  } catch (err) {
-    if (!isUnknownSettingError(err)) throw err
-    warn(
-      '[query-cache] host rejected a query-cache setting as unknown; retrying without cache settings',
-      err
-    )
-    return run({})
+    resolved = true
+    err = (result as { error?: unknown } | null | undefined)?.error
+  } catch (thrown) {
+    if (!isUnknownSettingError(thrown)) throw thrown
+    err = thrown
   }
-  if (!isUnknownSettingError(extractError(result))) return result
-  warn(
-    '[query-cache] host rejected a query-cache setting as unknown; retrying without cache settings',
-    extractError(result)
-  )
+  if (resolved && !isUnknownSettingError(err)) return result as T
+
+  warn(UNKNOWN_SETTING_RETRY_WARNING, err)
+  if (hostKey !== undefined) {
+    rejectedHosts.set(hostKey, Date.now() + REJECTION_TTL_MS)
+  }
   return run({})
+}
+
+/**
+ * The one entry point call sites should use: build the version-gated cache
+ * settings AND run the query under the unknown-setting safety net in a single
+ * step, so no future caller can obtain cache settings without the retry
+ * protection. `hostId` keys the per-host rejection memo.
+ */
+export async function runWithQueryCache<T>(
+  opts: QueryCacheSettingsOptions & { hostId: number | string },
+  run: (settings: ClickHouseSettings) => Promise<T>
+): Promise<T> {
+  return withUnknownSettingRetry(
+    buildQueryCacheSettings(opts),
+    run,
+    opts.hostId
+  )
 }

--- a/apps/dashboard/src/lib/api/query-cache-settings.ts
+++ b/apps/dashboard/src/lib/api/query-cache-settings.ts
@@ -63,6 +63,7 @@ import type { ClickHouseSettings } from '@clickhouse/client'
 import type { ClickHouseVersion } from '@chm/clickhouse-client/clickhouse-version'
 
 import { meetsMinVersion } from '@chm/clickhouse-client/clickhouse-version'
+import { warn } from '@chm/logger'
 
 /** ClickHouse added the query cache (`use_query_cache`) in 23.5. */
 const MIN_QUERY_CACHE_VERSION = { major: 23, minor: 5 } as const
@@ -150,4 +151,63 @@ export function buildQueryCacheSettings({
   }
 
   return settings
+}
+
+/**
+ * Detect ClickHouse's UNKNOWN_SETTING rejection (error code 115). The message
+ * wording varies across versions:
+ * - "Unknown setting 'use_query_cache'" (older servers)
+ * - "Setting x is neither a builtin setting nor started with the prefix
+ *   'SQL_' registered for user-defined settings" (newer servers)
+ * Accepts a thrown Error, a `FetchDataResult['error']` object, or a string.
+ */
+export function isUnknownSettingError(err: unknown): boolean {
+  const message =
+    typeof err === 'string'
+      ? err
+      : err && typeof err === 'object' && 'message' in err
+        ? String((err as { message?: unknown }).message ?? '')
+        : ''
+  if (!message) return false
+  return (
+    /unknown setting/i.test(message) ||
+    /neither a builtin setting/i.test(message) ||
+    /\bCode:\s*115\b/.test(message)
+  )
+}
+
+/**
+ * Any-ClickHouse-version safety net: the query cache is an optimization, so
+ * its settings must NEVER fail a query. Version gating above handles the
+ * versions we know about, but a host outside the tested matrix (very old,
+ * very new, or a fork) may still reject a setting name as unknown — in that
+ * case, retry ONCE without the cache settings instead of surfacing the error.
+ *
+ * `fetchData` returns errors on the result (`result.error`) while raw client
+ * calls throw, so both paths are handled: pass `extractError` for
+ * result-shaped errors.
+ */
+export async function withUnknownSettingRetry<T>(
+  cacheSettings: ClickHouseSettings,
+  run: (settings: ClickHouseSettings) => Promise<T>,
+  extractError: (result: T) => unknown = () => undefined
+): Promise<T> {
+  if (Object.keys(cacheSettings).length === 0) return run(cacheSettings)
+  let result: T
+  try {
+    result = await run(cacheSettings)
+  } catch (err) {
+    if (!isUnknownSettingError(err)) throw err
+    warn(
+      '[query-cache] host rejected a query-cache setting as unknown; retrying without cache settings',
+      err
+    )
+    return run({})
+  }
+  if (!isUnknownSettingError(extractError(result))) return result
+  warn(
+    '[query-cache] host rejected a query-cache setting as unknown; retrying without cache settings',
+    extractError(result)
+  )
+  return run({})
 }

--- a/apps/dashboard/src/lib/api/query-cache-settings.ts
+++ b/apps/dashboard/src/lib/api/query-cache-settings.ts
@@ -110,14 +110,16 @@ export function buildQueryCacheSettings({
     return {}
   }
 
+  // NOTE: do NOT add a bare `overflow_mode` setting here — no such setting
+  // exists in ANY ClickHouse version (only `result_overflow_mode`,
+  // `timeout_overflow_mode`, etc.), and an unknown setting name fails the
+  // entire query with "Setting overflow_mode is neither a builtin setting…".
+  // Error 731 (QUERY_CACHE_USED_WITH_NON_THROW_OVERFLOW_MODE) is instead
+  // handled by the callers, which skip the query cache whenever a non-'throw'
+  // `result_overflow_mode` is in effect (see query-executor.ts).
   const settings: ClickHouseSettings = {
     use_query_cache: 1,
     query_cache_ttl: ttlSeconds,
-    // ClickHouse 26.3 requires `overflow_mode = 'throw'` whenever
-    // `use_query_cache = 1` is set, else the query fails with error 731
-    // (`QUERY_CACHE_USED_WITH_NON_THROW_OVERFLOW_MODE`). Setting it here keeps
-    // the query cache opt-in compatible with that host version.
-    overflow_mode: 'throw',
   }
 
   if (

--- a/apps/dashboard/src/lib/api/query-executor.ts
+++ b/apps/dashboard/src/lib/api/query-executor.ts
@@ -34,10 +34,7 @@ import {
   selectVersionedSql,
 } from '@chm/clickhouse-client/clickhouse-version'
 import { error } from '@chm/logger'
-import {
-  buildQueryCacheSettings,
-  withUnknownSettingRetry,
-} from '@/lib/api/query-cache-settings'
+import { runWithQueryCache } from '@/lib/api/query-cache-settings'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import {
   getTableClickHouseSettings,
@@ -202,15 +199,14 @@ export async function executeTableConfig<
   // Read-only GET path (routes/api/v1/tables/$name.ts, explorer/*): safe to
   // opt into the ClickHouse query cache (#2182). `queryConfig.clickhouseSettings`
   // is spread after so a config can still override any of these explicitly.
-  const cacheSettings = buildQueryCacheSettings({
-    version: clickhouseVersion,
-    ttlSeconds: tableCacheTtlSeconds(queryConfig.refreshInterval),
-    disabled: queryConfig.disableQueryCache || overflowModeBlocksCache,
-  })
-
   const result = await withClickHouseQuerySpan(() =>
-    withUnknownSettingRetry(
-      cacheSettings,
+    runWithQueryCache(
+      {
+        version: clickhouseVersion,
+        ttlSeconds: tableCacheTtlSeconds(queryConfig.refreshInterval),
+        disabled: queryConfig.disableQueryCache || overflowModeBlocksCache,
+        hostId,
+      },
       (cache) =>
         fetchData<T[]>({
           query: executedSql,
@@ -230,8 +226,7 @@ export async function executeTableConfig<
                 optional: true,
               }
             : undefined,
-        }),
-      (r) => r.error
+        })
     )
   )
 
@@ -282,15 +277,14 @@ export async function executeChartQuery(
 
   // Read-only GET path (routes/api/v1/charts/$name.ts, health/checks.ts):
   // safe to opt into the ClickHouse query cache (#2182).
-  const cacheSettings = buildQueryCacheSettings({
-    version: clickhouseVersion,
-    ttlSeconds: opts.ttlSeconds ?? 0,
-    disabled: opts.disableQueryCache,
-  })
-
   const result = await withClickHouseQuerySpan(() =>
-    withUnknownSettingRetry(
-      cacheSettings,
+    runWithQueryCache(
+      {
+        version: clickhouseVersion,
+        ttlSeconds: opts.ttlSeconds ?? 0,
+        disabled: opts.disableQueryCache,
+        hostId,
+      },
       (cache) =>
         fetchJsonEachRowAsNormalizedJson({
           query: executedSql,
@@ -308,8 +302,7 @@ export async function executeChartQuery(
                 optional: true,
               }
             : undefined,
-        }),
-      (r) => r.error
+        })
     )
   )
 
@@ -352,28 +345,26 @@ export async function executeMultiChartQuery(
   // Read-only GET path (routes/api/v1/charts/$name.ts summary charts): safe
   // to opt into the ClickHouse query cache (#2182). Resolved once per call —
   // getClickHouseVersion caches per host for 24h, so this is cheap.
-  const cacheSettings = buildQueryCacheSettings({
+  const cacheOpts = {
     version: await getClickHouseVersion(toNumericHostId(hostId)),
     ttlSeconds: opts.ttlSeconds ?? 0,
     disabled: opts.disableQueryCache,
-  })
+    hostId,
+  }
 
   const results = await Promise.all(
     queries.map(async (q) => {
       try {
         const r = await withClickHouseQuerySpan(() =>
-          withUnknownSettingRetry(
-            cacheSettings,
-            (cache) =>
-              fetchJsonEachRowAsNormalizedJson({
-                query: q.query,
-                hostId,
-                clickhouse_settings: {
-                  ...cache,
-                  ...(opts.timezone ? { session_timezone: opts.timezone } : {}),
-                },
-              }),
-            (res) => res.error
+          runWithQueryCache(cacheOpts, (cache) =>
+            fetchJsonEachRowAsNormalizedJson({
+              query: q.query,
+              hostId,
+              clickhouse_settings: {
+                ...cache,
+                ...(opts.timezone ? { session_timezone: opts.timezone } : {}),
+              },
+            })
           )
         )
         return { key: q.key, dataJson: r.dataJson ?? 'null', error: r.error }

--- a/apps/dashboard/src/lib/api/query-executor.ts
+++ b/apps/dashboard/src/lib/api/query-executor.ts
@@ -34,7 +34,10 @@ import {
   selectVersionedSql,
 } from '@chm/clickhouse-client/clickhouse-version'
 import { error } from '@chm/logger'
-import { buildQueryCacheSettings } from '@/lib/api/query-cache-settings'
+import {
+  buildQueryCacheSettings,
+  withUnknownSettingRetry,
+} from '@/lib/api/query-cache-settings'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import {
   getTableClickHouseSettings,
@@ -206,25 +209,30 @@ export async function executeTableConfig<
   })
 
   const result = await withClickHouseQuerySpan(() =>
-    fetchData<T[]>({
-      query: executedSql,
-      query_params: queryParams,
-      hostId,
-      format: 'JSONEachRow',
-      clickhouse_settings: {
-        ...cacheSettings,
-        ...tableSettings,
-      },
-      // Pass the config so fetchData can existence-check optional tables.
-      queryConfig: queryConfig.optional
-        ? {
-            name: queryConfig.name,
-            sql: executedSql,
-            tableCheck: queryConfig.tableCheck,
-            optional: true,
-          }
-        : undefined,
-    })
+    withUnknownSettingRetry(
+      cacheSettings,
+      (cache) =>
+        fetchData<T[]>({
+          query: executedSql,
+          query_params: queryParams,
+          hostId,
+          format: 'JSONEachRow',
+          clickhouse_settings: {
+            ...cache,
+            ...tableSettings,
+          },
+          // Pass the config so fetchData can existence-check optional tables.
+          queryConfig: queryConfig.optional
+            ? {
+                name: queryConfig.name,
+                sql: executedSql,
+                tableCheck: queryConfig.tableCheck,
+                optional: true,
+              }
+            : undefined,
+        }),
+      (r) => r.error
+    )
   )
 
   if (result.error) {
@@ -281,23 +289,28 @@ export async function executeChartQuery(
   })
 
   const result = await withClickHouseQuerySpan(() =>
-    fetchJsonEachRowAsNormalizedJson({
-      query: executedSql,
-      query_params: queryParams,
-      hostId,
-      clickhouse_settings: {
-        ...cacheSettings,
-        ...(opts.timezone ? { session_timezone: opts.timezone } : {}),
-      },
-      queryConfig: opts.optional
-        ? {
-            name: chartName,
-            sql: executedSql,
-            tableCheck: opts.tableCheck,
-            optional: true,
-          }
-        : undefined,
-    })
+    withUnknownSettingRetry(
+      cacheSettings,
+      (cache) =>
+        fetchJsonEachRowAsNormalizedJson({
+          query: executedSql,
+          query_params: queryParams,
+          hostId,
+          clickhouse_settings: {
+            ...cache,
+            ...(opts.timezone ? { session_timezone: opts.timezone } : {}),
+          },
+          queryConfig: opts.optional
+            ? {
+                name: chartName,
+                sql: executedSql,
+                tableCheck: opts.tableCheck,
+                optional: true,
+              }
+            : undefined,
+        }),
+      (r) => r.error
+    )
   )
 
   if (result.error) {
@@ -349,14 +362,19 @@ export async function executeMultiChartQuery(
     queries.map(async (q) => {
       try {
         const r = await withClickHouseQuerySpan(() =>
-          fetchJsonEachRowAsNormalizedJson({
-            query: q.query,
-            hostId,
-            clickhouse_settings: {
-              ...cacheSettings,
-              ...(opts.timezone ? { session_timezone: opts.timezone } : {}),
-            },
-          })
+          withUnknownSettingRetry(
+            cacheSettings,
+            (cache) =>
+              fetchJsonEachRowAsNormalizedJson({
+                query: q.query,
+                hostId,
+                clickhouse_settings: {
+                  ...cache,
+                  ...(opts.timezone ? { session_timezone: opts.timezone } : {}),
+                },
+              }),
+            (res) => res.error
+          )
         )
         return { key: q.key, dataJson: r.dataJson ?? 'null', error: r.error }
       } catch (err) {

--- a/apps/dashboard/src/lib/query-config/__tests__/query-cache-settings-live.test.ts
+++ b/apps/dashboard/src/lib/query-config/__tests__/query-cache-settings-live.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Live integration test for the query-cache settings (#2182) against a REAL
+ * ClickHouse server. Runs in CI's `test-queries-config` job (live ClickHouse
+ * service container, `CLICKHOUSE_HOST` set workflow-wide) and self-skips
+ * everywhere else.
+ *
+ * Regression context: a bare `overflow_mode: 'throw'` was once added to
+ * `buildQueryCacheSettings` — a setting name that does not exist in ANY
+ * ClickHouse version — which failed every cache-enabled query with
+ * "Setting overflow_mode is neither a builtin setting nor started with the
+ * prefix 'SQL_'". Unit tests with mocked versions can't catch a hallucinated
+ * setting name; only a real server can. This test:
+ *
+ * 1. Asserts every setting name emitted for the live server's version exists
+ *    in that server's `system.settings` (catches unknown-setting names).
+ * 2. Executes a real `system.*` query with the settings applied (catches
+ *    interaction failures like error 719 QUERY_CACHE_USED_WITH_SYSTEM_TABLE
+ *    or 731 QUERY_CACHE_USED_WITH_NON_THROW_OVERFLOW_MODE).
+ */
+
+import { beforeAll, describe, expect, it } from 'bun:test'
+import { fetchData } from '@chm/clickhouse-client'
+import { parseVersion } from '@chm/clickhouse-client/clickhouse-version'
+import { buildQueryCacheSettings } from '@/lib/api/query-cache-settings'
+
+async function getLiveVersion(): Promise<string | null> {
+  if (!process.env.CLICKHOUSE_HOST) return null
+  try {
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('Connection timeout')), 3000)
+    )
+    const result = await Promise.race([
+      fetchData<{ v: string }[]>({
+        query: 'SELECT version() AS v',
+        hostId: 0,
+        format: 'JSONEachRow',
+      }),
+      timeout,
+    ])
+    if (result.error || !Array.isArray(result.data) || !result.data[0]?.v) {
+      return null
+    }
+    return result.data[0].v
+  } catch {
+    return null
+  }
+}
+
+describe('query-cache settings against a live ClickHouse (optional)', () => {
+  let rawVersion: string | null = null
+
+  beforeAll(async () => {
+    rawVersion = await getLiveVersion()
+    if (!rawVersion) {
+      console.log(
+        '⏭️  Skipping live query-cache tests - ClickHouse not available (set CLICKHOUSE_HOST)'
+      )
+    }
+  }, 10000)
+
+  it('emits only setting names the live server recognizes', async () => {
+    if (!rawVersion) return // Skip - no live ClickHouse
+
+    const settings = buildQueryCacheSettings({
+      version: parseVersion(rawVersion),
+      ttlSeconds: 30,
+    })
+    const names = Object.keys(settings)
+    // On >=23.5 servers (all CI containers) the cache must actually engage.
+    expect(names.length).toBeGreaterThan(0)
+
+    const inList = names.map((n) => `'${n}'`).join(', ')
+    const result = await fetchData<{ name: string }[]>({
+      query: `SELECT name FROM system.settings WHERE name IN (${inList})`,
+      hostId: 0,
+      format: 'JSONEachRow',
+    })
+    expect(result.error).toBeUndefined()
+    const known = new Set(
+      (Array.isArray(result.data) ? result.data : []).map((r) => r.name)
+    )
+    for (const name of names) {
+      // A name missing from system.settings would fail EVERY cache-enabled
+      // query on this server with an unknown-setting error.
+      expect(known.has(name)).toBe(true)
+    }
+  })
+
+  it('executes a system.* query successfully with the cache settings applied', async () => {
+    if (!rawVersion) return // Skip - no live ClickHouse
+
+    const settings = buildQueryCacheSettings({
+      version: parseVersion(rawVersion),
+      ttlSeconds: 30,
+    })
+
+    // system.* is what every dashboard poll reads; this exercises the
+    // unknown-setting, 719 (system table), and 731 (overflow mode) failure
+    // modes end-to-end on whatever version the CI container runs.
+    const result = await fetchData<{ c: string }[]>({
+      query: 'SELECT count() AS c FROM system.metrics',
+      hostId: 0,
+      format: 'JSONEachRow',
+      clickhouse_settings: settings,
+    })
+    expect(result.error).toBeUndefined()
+    expect(Array.isArray(result.data)).toBe(true)
+  })
+})

--- a/apps/dashboard/src/routes/api/v1/host-status.ts
+++ b/apps/dashboard/src/routes/api/v1/host-status.ts
@@ -9,10 +9,7 @@ import {
   classifyError,
   getStatusCodeForErrorType,
 } from '@/lib/api/error-handler'
-import {
-  buildQueryCacheSettings,
-  withUnknownSettingRetry,
-} from '@/lib/api/query-cache-settings'
+import { runWithQueryCache } from '@/lib/api/query-cache-settings'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import { isDemoHostBlockedForRequest } from '@/lib/cloud/reject-demo-host'
 
@@ -93,24 +90,22 @@ export const Route = createFileRoute('/api/v1/host-status')({
           // the `bindings`-derived clientConfig above, so getClickHouseVersion
           // (cached 24h per host) resolves the same host.
           bridgeClickHouseEnv(bindings)
-          const cacheSettings = buildQueryCacheSettings({
+          const cacheOpts = {
             version: await getClickHouseVersion(hostId),
             ttlSeconds: HOST_STATUS_CACHE_TTL_SECONDS,
-          })
-
-          // Raw client calls THROW on error (unlike fetchData), so the
-          // unknown-setting fallback catches instead of extracting.
-          const resultSet = await withUnknownSettingRetry(
-            cacheSettings,
-            (cache) =>
-              client.query({
-                query: `${QUERY_COMMENT}SELECT
+            hostId,
+          }
+          // Raw client calls THROW on error (unlike fetchData); the
+          // unknown-setting fallback inside runWithQueryCache handles both.
+          const resultSet = await runWithQueryCache(cacheOpts, (cache) =>
+            client.query({
+              query: `${QUERY_COMMENT}SELECT
   version() AS version,
   formatReadableTimeDelta(uptime()) AS uptime,
   hostName() AS hostname`,
-                format: 'JSONEachRow',
-                clickhouse_settings: cache,
-              })
+              format: 'JSONEachRow',
+              clickhouse_settings: cache,
+            })
           )
 
           // JSONEachRow returns rows directly: json<Row>() => Row[]
@@ -136,14 +131,16 @@ export const Route = createFileRoute('/api/v1/host-status')({
           } = {}
           if (wantCounts) {
             try {
-              const countsSet = await client.query({
-                query: `${QUERY_COMMENT}SELECT
+              const countsSet = await runWithQueryCache(cacheOpts, (cache) =>
+                client.query({
+                  query: `${QUERY_COMMENT}SELECT
   (SELECT count() FROM system.databases) AS databases,
   (SELECT count() FROM system.tables) AS tables,
   (SELECT uniqExact(host_name) FROM system.clusters) AS clusterNodes`,
-                format: 'JSONEachRow',
-                clickhouse_settings: cacheSettings,
-              })
+                  format: 'JSONEachRow',
+                  clickhouse_settings: cache,
+                })
+              )
               const countRows = await countsSet.json<{
                 databases: string | number
                 tables: string | number

--- a/apps/dashboard/src/routes/api/v1/host-status.ts
+++ b/apps/dashboard/src/routes/api/v1/host-status.ts
@@ -9,7 +9,10 @@ import {
   classifyError,
   getStatusCodeForErrorType,
 } from '@/lib/api/error-handler'
-import { buildQueryCacheSettings } from '@/lib/api/query-cache-settings'
+import {
+  buildQueryCacheSettings,
+  withUnknownSettingRetry,
+} from '@/lib/api/query-cache-settings'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import { isDemoHostBlockedForRequest } from '@/lib/cloud/reject-demo-host'
 
@@ -95,14 +98,20 @@ export const Route = createFileRoute('/api/v1/host-status')({
             ttlSeconds: HOST_STATUS_CACHE_TTL_SECONDS,
           })
 
-          const resultSet = await client.query({
-            query: `${QUERY_COMMENT}SELECT
+          // Raw client calls THROW on error (unlike fetchData), so the
+          // unknown-setting fallback catches instead of extracting.
+          const resultSet = await withUnknownSettingRetry(
+            cacheSettings,
+            (cache) =>
+              client.query({
+                query: `${QUERY_COMMENT}SELECT
   version() AS version,
   formatReadableTimeDelta(uptime()) AS uptime,
   hostName() AS hostname`,
-            format: 'JSONEachRow',
-            clickhouse_settings: cacheSettings,
-          })
+                format: 'JSONEachRow',
+                clickhouse_settings: cache,
+              })
+          )
 
           // JSONEachRow returns rows directly: json<Row>() => Row[]
           const rows = await resultSet.json<{

--- a/apps/dashboard/src/routes/api/v1/menu-counts/$key.ts
+++ b/apps/dashboard/src/routes/api/v1/menu-counts/$key.ts
@@ -21,7 +21,10 @@ import {
   getMenuCountQuery,
   hasMenuCountKey,
 } from '@/lib/api/menu-count-registry'
-import { buildQueryCacheSettings } from '@/lib/api/query-cache-settings'
+import {
+  buildQueryCacheSettings,
+  withUnknownSettingRetry,
+} from '@/lib/api/query-cache-settings'
 import { HostIdSchema, MenuCountKeySchema } from '@/lib/api/schemas'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import {
@@ -169,12 +172,17 @@ async function handler(
     })
 
     // Execute the query
-    const result = await fetchData({
-      query: menuCount.query,
-      format: 'JSONEachRow',
-      hostId,
-      clickhouse_settings: cacheSettings,
-    })
+    const result = await withUnknownSettingRetry(
+      cacheSettings,
+      (cache) =>
+        fetchData({
+          query: menuCount.query,
+          format: 'JSONEachRow',
+          hostId,
+          clickhouse_settings: cache,
+        }),
+      (r) => r.error
+    )
 
     // Handle errors - for optional tables, return null count only when the
     // table genuinely does not exist. Other failures (permissions, timeouts,

--- a/apps/dashboard/src/routes/api/v1/menu-counts/$key.ts
+++ b/apps/dashboard/src/routes/api/v1/menu-counts/$key.ts
@@ -21,10 +21,7 @@ import {
   getMenuCountQuery,
   hasMenuCountKey,
 } from '@/lib/api/menu-count-registry'
-import {
-  buildQueryCacheSettings,
-  withUnknownSettingRetry,
-} from '@/lib/api/query-cache-settings'
+import { runWithQueryCache } from '@/lib/api/query-cache-settings'
 import { HostIdSchema, MenuCountKeySchema } from '@/lib/api/schemas'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import {
@@ -164,24 +161,21 @@ async function handler(
 
     // Read-only GET path: safe to opt into the ClickHouse query cache
     // (#2182). getClickHouseVersion caches per host for 24h, so this is
-    // cheap; buildQueryCacheSettings fails closed on an unknown version.
-    const cacheSettings = buildQueryCacheSettings({
-      version: await getClickHouseVersion(hostId),
-      ttlSeconds: MENU_COUNT_CACHE_TTL_SECONDS,
-      disabled: menuCount.disableQueryCache,
-    })
-
-    // Execute the query
-    const result = await withUnknownSettingRetry(
-      cacheSettings,
+    // cheap; runWithQueryCache fails closed on an unknown version.
+    const result = await runWithQueryCache(
+      {
+        version: await getClickHouseVersion(hostId),
+        ttlSeconds: MENU_COUNT_CACHE_TTL_SECONDS,
+        disabled: menuCount.disableQueryCache,
+        hostId,
+      },
       (cache) =>
         fetchData({
           query: menuCount.query,
           format: 'JSONEachRow',
           hostId,
           clickhouse_settings: cache,
-        }),
-      (r) => r.error
+        })
     )
 
     // Handle errors - for optional tables, return null count only when the

--- a/apps/dashboard/src/routes/api/v1/menu-counts/index.ts
+++ b/apps/dashboard/src/routes/api/v1/menu-counts/index.ts
@@ -27,8 +27,8 @@ import {
   getMenuCountQuery,
 } from '@/lib/api/menu-count-registry'
 import {
-  buildQueryCacheSettings,
-  withUnknownSettingRetry,
+  type QueryCacheSettingsOptions,
+  runWithQueryCache,
 } from '@/lib/api/query-cache-settings'
 import { HostIdSchema } from '@/lib/api/schemas'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
@@ -65,21 +65,20 @@ async function resolveCount(
   countKey: string,
   hostId: number,
   requestId: string,
-  cacheSettings: ReturnType<typeof buildQueryCacheSettings>
+  cacheOpts: Omit<QueryCacheSettingsOptions, 'disabled'>
 ): Promise<number | null | undefined> {
   const menuCount = getMenuCountQuery(countKey)
   if (!menuCount) return undefined
 
-  const result = await withUnknownSettingRetry(
-    menuCount.disableQueryCache ? {} : cacheSettings,
+  const result = await runWithQueryCache(
+    { ...cacheOpts, disabled: menuCount.disableQueryCache, hostId },
     (cache) =>
       fetchData({
         query: menuCount.query,
         format: 'JSONEachRow',
         hostId,
         clickhouse_settings: cache,
-      }),
-    (r) => r.error
+      })
   )
 
   if (result.error) {
@@ -178,11 +177,11 @@ export async function handler(request: Request): Promise<Response> {
 
     // Read-only GET path: safe to opt into the ClickHouse query cache
     // (#2182). getClickHouseVersion caches per host for 24h, so this is
-    // cheap; buildQueryCacheSettings fails closed on an unknown version.
-    const cacheSettings = buildQueryCacheSettings({
+    // cheap; runWithQueryCache fails closed on an unknown version.
+    const cacheOpts = {
       version: await getClickHouseVersion(hostId),
       ttlSeconds: MENU_COUNT_CACHE_TTL_SECONDS,
-    })
+    }
 
     const keys = getAvailableMenuCountKeys()
 
@@ -234,14 +233,16 @@ export async function handler(request: Request): Promise<Response> {
 
     if (selectSubqueries.length > 0) {
       const combinedQuery = `SELECT ${selectSubqueries.join(', ')}`
-      const result = await fetchData({
-        query: combinedQuery,
-        format: 'JSONEachRow',
-        hostId,
-        clickhouse_settings: combinedQueryCacheDisabled
-          ? undefined
-          : cacheSettings,
-      })
+      const result = await runWithQueryCache(
+        { ...cacheOpts, disabled: combinedQueryCacheDisabled, hostId },
+        (cache) =>
+          fetchData({
+            query: combinedQuery,
+            format: 'JSONEachRow',
+            hostId,
+            clickhouse_settings: cache,
+          })
+      )
 
       if (result.error) {
         // Fall back to original resolveCount loop if the combined query fails
@@ -255,7 +256,7 @@ export async function handler(request: Request): Promise<Response> {
         )
         const resolved = await Promise.all(
           keys.map(async (k) => {
-            const val = await resolveCount(k, hostId, requestId, cacheSettings)
+            const val = await resolveCount(k, hostId, requestId, cacheOpts)
             return [k, val] as const
           })
         )

--- a/apps/dashboard/src/routes/api/v1/menu-counts/index.ts
+++ b/apps/dashboard/src/routes/api/v1/menu-counts/index.ts
@@ -26,7 +26,10 @@ import {
   getAvailableMenuCountKeys,
   getMenuCountQuery,
 } from '@/lib/api/menu-count-registry'
-import { buildQueryCacheSettings } from '@/lib/api/query-cache-settings'
+import {
+  buildQueryCacheSettings,
+  withUnknownSettingRetry,
+} from '@/lib/api/query-cache-settings'
 import { HostIdSchema } from '@/lib/api/schemas'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import {
@@ -67,14 +70,17 @@ async function resolveCount(
   const menuCount = getMenuCountQuery(countKey)
   if (!menuCount) return undefined
 
-  const result = await fetchData({
-    query: menuCount.query,
-    format: 'JSONEachRow',
-    hostId,
-    clickhouse_settings: menuCount.disableQueryCache
-      ? undefined
-      : cacheSettings,
-  })
+  const result = await withUnknownSettingRetry(
+    menuCount.disableQueryCache ? {} : cacheSettings,
+    (cache) =>
+      fetchData({
+        query: menuCount.query,
+        format: 'JSONEachRow',
+        hostId,
+        clickhouse_settings: cache,
+      }),
+    (r) => r.error
+  )
 
   if (result.error) {
     if (


### PR DESCRIPTION
## Problem

Every query-cache-enabled query failed on real hosts with:

```
Setting overflow_mode is neither a builtin setting nor started with the prefix 'SQL_' registered for user-defined settings: Maybe you meant ['set_overflow_mode']
```

Commit 914d279ff added a bare `overflow_mode: 'throw'` to `buildQueryCacheSettings` — **no such setting exists in any ClickHouse version** (verified against ClickHouse master `Settings.cpp`; only `result_overflow_mode`, `timeout_overflow_mode`, etc. exist). Error 731 (QUERY_CACHE_USED_WITH_NON_THROW_OVERFLOW_MODE, [ClickHouse#69549](https://github.com/ClickHouse/ClickHouse/pull/69549)) was already handled correctly in `query-executor.ts` by skipping the cache when `result_overflow_mode` is non-throw.

## Fix

1. **Remove** the hallucinated `overflow_mode: 'throw'` (+ guard comment).
2. **Any-version safety net** (`withUnknownSettingRetry`): cache settings are an optimization and must never fail a query — if any host (old, new, fork) rejects a setting name as unknown (error 115), retry once without cache settings. Wired into all 6 execution sites.
3. **Tests that would have caught this:**
   - allowlist regression test: only verified-real setting names may be emitted, on every version
   - live integration test in the `test-queries-config` CI job (real ClickHouse 26.2): asserts every emitted name exists in the server's `system.settings` and executes a real `system.*` query with the settings applied
   - unit tests for the error classifier and retry helper (returned + thrown error shapes)

Verified locally: re-injecting `overflow_mode: 'throw'` makes the allowlist test fail; 28 tests pass, `tsc` and biome clean.

https://claude.ai/code/session_015Mq6c6bQstbRwQnKt9htbE