### PR TITLE
feat(alerts): wire the Telegram alert channel end-to-end

### DIFF
--- a/apps/dashboard/src/components/health/alert-routing-dialog.tsx
+++ b/apps/dashboard/src/components/health/alert-routing-dialog.tsx
@@ -33,7 +33,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { firePagerDutyTest, fireWebhook } from '@/lib/health/alert-dispatcher'
+import {
+  firePagerDutyTest,
+  fireTelegramTest,
+  fireWebhook,
+} from '@/lib/health/alert-dispatcher'
 import {
   useAlertRoutes,
   useAlertRoutesMutations,
@@ -51,6 +55,7 @@ function RouteRow({
   const [busy, setBusy] = useState(false)
   const { deleteRoute } = useAlertRoutesMutations()
   const isPagerDuty = route.provider === 'pagerduty'
+  const isTelegram = route.provider === 'telegram'
 
   const handleDelete = async () => {
     setBusy(true)
@@ -88,6 +93,15 @@ function RouteRow({
         )
         return
       }
+      // Same tradeoff as PagerDuty above: a Telegram route's bot token is a
+      // masked secret never returned to the client after storage, so an
+      // existing route can only be re-tested by re-creating it.
+      if (isTelegram) {
+        toast.info(
+          'Re-create the route to send another Telegram test message (the bot token is never re-shown once saved).'
+        )
+        return
+      }
       const ok = await fireWebhook(testAlert, route.channelUrl)
       if (ok) toast.success('Test alert sent')
       else toast.error('Webhook request failed')
@@ -101,6 +115,7 @@ function RouteRow({
       <div className="flex min-w-0 flex-col gap-1">
         <div className="flex flex-wrap items-center gap-1.5">
           {isPagerDuty && <Badge variant="default">PagerDuty</Badge>}
+          {isTelegram && <Badge variant="default">Telegram</Badge>}
           <Badge variant="outline">rule: {route.matchRule}</Badge>
           <Badge variant="outline">host: {route.matchHost}</Badge>
           {!route.enabled && <Badge variant="secondary">disabled</Badge>}
@@ -108,7 +123,9 @@ function RouteRow({
         <span className="truncate text-sm text-muted-foreground">
           {isPagerDuty
             ? `${route.serviceName || 'PagerDuty service'} — ${route.routingKeyMasked}`
-            : route.channelUrl}
+            : isTelegram
+              ? `chat ${route.telegramChatId} — bot ${route.telegramBotTokenMasked}`
+              : route.channelUrl}
         </span>
       </div>
       <div className="flex shrink-0 items-center gap-2">
@@ -136,6 +153,8 @@ function AddRouteForm({ onCreated }: { onCreated: () => void }) {
   const [pdServiceId, setPdServiceId] = useState('')
   const [pdServiceName, setPdServiceName] = useState('')
   const [pdRoutingKey, setPdRoutingKey] = useState('')
+  const [tgBotToken, setTgBotToken] = useState('')
+  const [tgChatId, setTgChatId] = useState('')
   const [busy, setBusy] = useState(false)
   const { createRoute } = useAlertRoutesMutations()
   const { services: pdServices, isLoading: pdServicesLoading } =
@@ -148,12 +167,19 @@ function AddRouteForm({ onCreated }: { onCreated: () => void }) {
     setPdServiceId('')
     setPdServiceName('')
     setPdRoutingKey('')
+    setTgBotToken('')
+    setTgChatId('')
   }
 
   const handleSubmit = async () => {
     if (provider === 'pagerduty') {
       if (!pdRoutingKey.trim()) {
         toast.error("Enter the service's PagerDuty routing/integration key")
+        return
+      }
+    } else if (provider === 'telegram') {
+      if (!tgBotToken.trim() || !tgChatId.trim()) {
+        toast.error('Enter the Telegram bot token and chat id')
         return
       }
     } else if (!channelUrl.trim()) {
@@ -172,7 +198,13 @@ function AddRouteForm({ onCreated }: { onCreated: () => void }) {
               serviceName: pdServiceName.trim() || undefined,
               routingKey: pdRoutingKey.trim(),
             }
-          : { channelUrl: channelUrl.trim() }),
+          : provider === 'telegram'
+            ? {
+                provider: 'telegram',
+                telegramBotToken: tgBotToken.trim(),
+                telegramChatId: tgChatId.trim(),
+              }
+            : { channelUrl: channelUrl.trim() }),
       })
       toast.success('Route created')
       reset()
@@ -209,6 +241,32 @@ function AddRouteForm({ onCreated }: { onCreated: () => void }) {
     }
   }
 
+  const handleSendTelegramTest = async () => {
+    if (!tgBotToken.trim() || !tgChatId.trim()) {
+      toast.error('Enter the Telegram bot token and chat id')
+      return
+    }
+    setBusy(true)
+    try {
+      const ok = await fireTelegramTest(
+        {
+          checkId: 'test',
+          title: 'Test Alert',
+          severity: 'warning',
+          value: 0,
+          label: 'This is a test alert from chmonitor',
+          hostId: 0,
+        },
+        tgBotToken.trim(),
+        tgChatId.trim()
+      )
+      if (ok) toast.success('Test message sent to Telegram')
+      else toast.error('Telegram Bot API request failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
   return (
     <div className="flex flex-col gap-2 rounded-md border p-3">
       <Label className="text-sm font-medium">Add route</Label>
@@ -226,6 +284,7 @@ function AddRouteForm({ onCreated }: { onCreated: () => void }) {
               Channel webhook (Slack/Discord/…)
             </SelectItem>
             <SelectItem value="pagerduty">PagerDuty service</SelectItem>
+            <SelectItem value="telegram">Telegram chat</SelectItem>
           </SelectContent>
         </Select>
       </div>
@@ -305,6 +364,42 @@ function AddRouteForm({ onCreated }: { onCreated: () => void }) {
             onClick={handleSendTest}
           >
             Send test event
+          </Button>
+        </>
+      ) : provider === 'telegram' ? (
+        <>
+          <Label
+            htmlFor="route-telegram-token"
+            className="text-xs text-muted-foreground"
+          >
+            Bot token
+          </Label>
+          <Input
+            id="route-telegram-token"
+            placeholder="123456:ABC-DEF..."
+            value={tgBotToken}
+            onChange={(e) => setTgBotToken(e.target.value)}
+          />
+          <Label
+            htmlFor="route-telegram-chat"
+            className="text-xs text-muted-foreground"
+          >
+            Chat id
+          </Label>
+          <Input
+            id="route-telegram-chat"
+            placeholder="-1001234567890 or @channelname"
+            value={tgChatId}
+            onChange={(e) => setTgChatId(e.target.value)}
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            className="self-start"
+            disabled={busy}
+            onClick={handleSendTelegramTest}
+          >
+            Send test message
           </Button>
         </>
       ) : (

--- a/apps/dashboard/src/components/health/health-settings-dialog.tsx
+++ b/apps/dashboard/src/components/health/health-settings-dialog.tsx
@@ -51,6 +51,9 @@ export function HealthSettingsDialog() {
     configured: boolean
     region: string | null
   } | null>(null)
+  const [telegramStatus, setTelegramStatus] = useState<{
+    configured: boolean
+  } | null>(null)
 
   useEffect(() => {
     if (!open) return
@@ -64,6 +67,10 @@ export function HealthSettingsDialog() {
         )
       )
       .catch(() => setOpsgenieStatus(null))
+    fetch('/api/v1/health/telegram-test')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => setTelegramStatus(data as { configured: boolean } | null))
+      .catch(() => setTelegramStatus(null))
   }, [open])
 
   const handleThresholdChange = (
@@ -183,6 +190,25 @@ export function HealthSettingsDialog() {
       }
     } catch {
       toast.error('Opsgenie test alert failed')
+    }
+  }
+
+  const handleTestTelegram = async () => {
+    try {
+      const res = await fetch('/api/v1/health/telegram-test', {
+        method: 'POST',
+      })
+      if (res.ok) {
+        toast.success('Telegram test message sent')
+      } else {
+        const body = await res.json().catch(() => null)
+        toast.error(
+          (body as { error?: { message?: string } } | null)?.error?.message ??
+            'Telegram test message failed'
+        )
+      }
+    } catch {
+      toast.error('Telegram test message failed')
     }
   }
 
@@ -485,6 +511,40 @@ export function HealthSettingsDialog() {
                     size="sm"
                     onClick={handleTestOpsgenie}
                     disabled={!opsgenieStatus?.configured}
+                  >
+                    Send test
+                  </Button>
+                </div>
+
+                <Separator />
+
+                <div className="flex items-center justify-between rounded-md border p-3">
+                  <div className="flex flex-col">
+                    <div className="flex items-center gap-2">
+                      <Label className="text-sm font-medium">
+                        Telegram alerts
+                      </Label>
+                      <Badge
+                        variant={
+                          telegramStatus?.configured ? 'default' : 'secondary'
+                        }
+                      >
+                        {telegramStatus?.configured
+                          ? 'Configured'
+                          : 'Not configured'}
+                      </Badge>
+                    </div>
+                    <span className="text-xs text-muted-foreground">
+                      Set HEALTH_ALERT_TELEGRAM_BOT_TOKEN and
+                      HEALTH_ALERT_TELEGRAM_CHAT_ID on the server to enable —
+                      the bot token is never exposed to the browser
+                    </span>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleTestTelegram}
+                    disabled={!telegramStatus?.configured}
                   >
                     Send test
                   </Button>

--- a/apps/dashboard/src/db/conversations-migrations/0019_alert_routes_telegram.sql
+++ b/apps/dashboard/src/db/conversations-migrations/0019_alert_routes_telegram.sql
@@ -1,0 +1,16 @@
+-- Telegram alert channel routing (feat #2655): extend the plan-30
+-- `alert_routes` table again rather than shipping a separate schema, exactly
+-- as plan 34 did for PagerDuty. A route's `provider` may now also be
+-- `'telegram'` — delivering the finding to a Telegram chat via the Bot API
+-- `sendMessage` endpoint (`https://api.telegram.org/bot<token>/sendMessage`).
+-- Existing rows keep `provider = 'webhook'` so plan-30/34 behavior is
+-- unchanged.
+--
+-- `telegram_bot_token` is the Bot API token — a secret, stored at rest the
+-- same way `channel_url` carries Slack/Discord webhook secrets and
+-- `routing_key` carries the PagerDuty integration key. It is only ever used to
+-- build the outbound sendMessage URL and is masked (never returned in full)
+-- by the routes API, like the PagerDuty routing key. `telegram_chat_id` is the
+-- target chat id (not a secret).
+ALTER TABLE alert_routes ADD COLUMN telegram_bot_token TEXT;
+ALTER TABLE alert_routes ADD COLUMN telegram_chat_id TEXT;

--- a/apps/dashboard/src/lib/health/alert-dispatcher.ts
+++ b/apps/dashboard/src/lib/health/alert-dispatcher.ts
@@ -1,4 +1,4 @@
-import { buildPagerDutyBody } from './adapters'
+import { buildPagerDutyBody, buildTelegramBody } from './adapters'
 import { loadAlertSettings } from './alert-settings-storage'
 
 // Duplicated (not imported) from `pagerduty-config.ts` on purpose: that
@@ -226,6 +226,53 @@ export async function firePagerDutyTest(
       body: JSON.stringify({
         url: PAGERDUTY_EVENTS_API_URL,
         provider: 'pagerduty',
+        payload: body,
+      }),
+      signal: controller.signal,
+    })
+    return res.ok
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+/**
+ * Send a test Telegram message to a specific bot token + chat id, via the
+ * `/api/v1/health/webhook` proxy's `provider`-hint path (verbatim body
+ * forward — see `webhook.ts`) so the routing dialog (#2655) never needs a
+ * direct browser→Telegram fetch. The token is only ever sent to our own proxy
+ * at creation time (the user just typed it), same posture as the PagerDuty
+ * routing-key test above; it is never echoed back to the client after storage.
+ */
+export async function fireTelegramTest(
+  alert: HealthAlertEvent,
+  botToken: string,
+  chatId: string
+): Promise<boolean> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 10_000)
+  try {
+    const body = buildTelegramBody(
+      {
+        severity: alert.severity,
+        hostLabel: `host ${alert.hostId}`,
+        hostId: alert.hostId,
+        metric: alert.checkId,
+        value: alert.value,
+        title: alert.title,
+        label: alert.label,
+        timestamp: new Date().toISOString(),
+      },
+      { token: botToken, chatId }
+    )
+    const res = await fetch('/api/v1/health/webhook', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        url: `https://api.telegram.org/bot${botToken}/sendMessage`,
+        provider: 'telegram',
         payload: body,
       }),
       signal: controller.signal,

--- a/apps/dashboard/src/lib/health/alert-routing.test.ts
+++ b/apps/dashboard/src/lib/health/alert-routing.test.ts
@@ -26,6 +26,8 @@ interface FakeRow {
   provider: string
   service_name: string | null
   routing_key: string | null
+  telegram_bot_token?: string | null
+  telegram_chat_id?: string | null
 }
 
 function makeFakeD1() {
@@ -52,6 +54,8 @@ function makeFakeD1() {
                 provider,
                 service_name,
                 routing_key,
+                telegram_bot_token,
+                telegram_chat_id,
               ] = params as [
                 string,
                 string,
@@ -61,6 +65,8 @@ function makeFakeD1() {
                 number,
                 number,
                 string,
+                string | null,
+                string | null,
                 string | null,
                 string | null,
               ]
@@ -75,6 +81,8 @@ function makeFakeD1() {
                 provider,
                 service_name,
                 routing_key,
+                telegram_bot_token,
+                telegram_chat_id,
               })
               return { meta: { changes: 1 } }
             }
@@ -135,6 +143,7 @@ const {
   matchRoutes,
   resolvePagerDutyTargets,
   resolveTargets,
+  resolveTelegramTargets,
 } = await import('./alert-routing')
 
 import type { AlertRoute, RouteMatchTarget } from './alert-routing'
@@ -151,6 +160,8 @@ function route(overrides: Partial<AlertRoute> = {}): AlertRoute {
     provider: 'webhook',
     serviceName: null,
     routingKey: null,
+    telegramBotToken: null,
+    telegramChatId: null,
     ...overrides,
   }
 }
@@ -364,6 +375,92 @@ describe('resolvePagerDutyTargets (pure) — plan 34', () => {
   })
 })
 
+describe('resolveTelegramTargets (pure) — #2655', () => {
+  const ENV_FALLBACK = { botToken: 'env-tok', chatId: 'env-chat' }
+
+  test('matches a telegram route and returns its bot token + chat id', () => {
+    const r = route({
+      matchRule: 'disk-usage',
+      provider: 'telegram',
+      telegramBotToken: '123:ABC',
+      telegramChatId: '-100',
+    })
+    expect(resolveTelegramTargets([r], TARGET, null)).toEqual([
+      { botToken: '123:ABC', chatId: '-100' },
+    ])
+  })
+
+  test('matches a telegram route via glob and the * host wildcard', () => {
+    const r = route({
+      matchRule: 'disk-*',
+      matchHost: '*',
+      provider: 'telegram',
+      telegramBotToken: '123:ABC',
+      telegramChatId: '-100',
+    })
+    expect(resolveTelegramTargets([r], TARGET, null)).toEqual([
+      { botToken: '123:ABC', chatId: '-100' },
+    ])
+  })
+
+  test('ignores webhook-provider routes even if matched', () => {
+    const r = route({ matchRule: 'disk-usage', provider: 'webhook' })
+    expect(resolveTelegramTargets([r], TARGET, ENV_FALLBACK)).toEqual([])
+  })
+
+  test('a matched webhook route suppresses the env Telegram fallback (no double-fire)', () => {
+    const webhook = route({ matchRule: 'disk-usage', provider: 'webhook' })
+    expect(resolveTelegramTargets([webhook], TARGET, ENV_FALLBACK)).toEqual([])
+  })
+
+  test('deduplicates matched routes sharing the same token + chat id', () => {
+    const r1 = route({
+      id: 'a',
+      matchRule: 'disk-usage',
+      provider: 'telegram',
+      telegramBotToken: '123:ABC',
+      telegramChatId: '-100',
+    })
+    const r2 = route({
+      id: 'b',
+      matchRule: '*',
+      provider: 'telegram',
+      telegramBotToken: '123:ABC',
+      telegramChatId: '-100',
+    })
+    expect(resolveTelegramTargets([r1, r2], TARGET, null)).toEqual([
+      { botToken: '123:ABC', chatId: '-100' },
+    ])
+  })
+
+  test('a telegram route missing token or chat id never dispatches, and still suppresses the env fallback', () => {
+    const r = route({
+      matchRule: 'disk-usage',
+      provider: 'telegram',
+      telegramBotToken: '123:ABC',
+      telegramChatId: null,
+    })
+    expect(resolveTelegramTargets([r], TARGET, ENV_FALLBACK)).toEqual([])
+  })
+
+  test('falls back to the env config when nothing matches', () => {
+    const r = route({ matchRule: 'replication-*', provider: 'telegram' })
+    expect(resolveTelegramTargets([r], TARGET, ENV_FALLBACK)).toEqual([
+      ENV_FALLBACK,
+    ])
+  })
+
+  test('empty route list falls back to the env config', () => {
+    expect(resolveTelegramTargets([], TARGET, ENV_FALLBACK)).toEqual([
+      ENV_FALLBACK,
+    ])
+  })
+
+  test('no match and no env config -> empty (no Telegram dispatch)', () => {
+    expect(resolveTelegramTargets([], TARGET, null)).toEqual([])
+  })
+})
+
 describe('D1-backed alert-routing CRUD', () => {
   test('listRoutes returns [] when D1 binding is missing (self-hosted/OSS)', async () => {
     currentDb = null
@@ -436,6 +533,29 @@ describe('D1-backed alert-routing CRUD', () => {
     expect(listed.provider).toBe('pagerduty')
     expect(listed.serviceName).toBe('DB On-call')
     expect(listed.routingKey).toBe('R-abc')
+  })
+
+  test('create -> list round-trip persists telegram provider fields', async () => {
+    const fakeDb = makeFakeD1()
+    currentDb = fakeDb
+
+    const created = await createRoute({
+      ownerId: 'owner-1',
+      matchRule: 'disk-*',
+      matchHost: '*',
+      channelUrl: '',
+      provider: 'telegram',
+      telegramBotToken: '123:ABC',
+      telegramChatId: '-100',
+    })
+    expect(created?.provider).toBe('telegram')
+    expect(created?.telegramBotToken).toBe('123:ABC')
+    expect(created?.telegramChatId).toBe('-100')
+
+    const [listed] = await listRoutes('owner-1')
+    expect(listed.provider).toBe('telegram')
+    expect(listed.telegramBotToken).toBe('123:ABC')
+    expect(listed.telegramChatId).toBe('-100')
   })
 
   test('legacy row with no provider column value defaults to webhook', async () => {

--- a/apps/dashboard/src/lib/health/alert-routing.ts
+++ b/apps/dashboard/src/lib/health/alert-routing.ts
@@ -37,9 +37,10 @@ const TABLE = 'alert_routes'
  * `channelUrl` exactly as plan 30 shipped — Slack/Discord/generic JSON.
  * `'pagerduty'` (plan 34) routes to a PagerDuty service's Events API v2
  * integration key (`routingKey`) instead, letting PagerDuty apply that
- * service's own escalation policy + on-call schedule.
+ * service's own escalation policy + on-call schedule. `'telegram'` (#2655)
+ * routes to a Telegram chat via a bot token + chat id.
  */
-export type AlertRouteProvider = 'webhook' | 'pagerduty'
+export type AlertRouteProvider = 'webhook' | 'pagerduty' | 'telegram'
 
 /** A configured alert route: match criteria → destination channel. */
 export interface AlertRoute {
@@ -58,6 +59,10 @@ export interface AlertRoute {
   serviceName: string | null
   /** PagerDuty Events API v2 integration/routing key (provider `'pagerduty'` only). */
   routingKey: string | null
+  /** Telegram Bot API token — a secret (provider `'telegram'` only). */
+  telegramBotToken: string | null
+  /** Telegram target chat id (provider `'telegram'` only). */
+  telegramChatId: string | null
 }
 
 interface D1AlertRouteRow {
@@ -71,6 +76,8 @@ interface D1AlertRouteRow {
   provider: string | null
   service_name: string | null
   routing_key: string | null
+  telegram_bot_token: string | null
+  telegram_chat_id: string | null
 }
 
 function getDb(): D1Database | null {
@@ -89,9 +96,16 @@ function rowToRoute(row: D1AlertRouteRow): AlertRoute {
     // Legacy plan-30 rows have no `provider` column value yet (pre-migration
     // fake D1s in tests, or a row inserted before 0016 ran) — default to the
     // webhook behavior they already have.
-    provider: row.provider === 'pagerduty' ? 'pagerduty' : 'webhook',
+    provider:
+      row.provider === 'pagerduty'
+        ? 'pagerduty'
+        : row.provider === 'telegram'
+          ? 'telegram'
+          : 'webhook',
     serviceName: row.service_name ?? null,
     routingKey: row.routing_key ?? null,
+    telegramBotToken: row.telegram_bot_token ?? null,
+    telegramChatId: row.telegram_chat_id ?? null,
   }
 }
 
@@ -109,7 +123,7 @@ export async function listRoutes(ownerId: string): Promise<AlertRoute[]> {
     const result = await db
       .prepare(
         `SELECT id, owner_id, match_rule, match_host, channel_url, enabled, created_at,
-                provider, service_name, routing_key
+                provider, service_name, routing_key, telegram_bot_token, telegram_chat_id
          FROM ${TABLE}
          WHERE owner_id = ?1
          ORDER BY created_at DESC`
@@ -136,6 +150,10 @@ export interface CreateRouteInput {
   serviceName?: string | null
   /** PagerDuty Events API v2 integration/routing key (provider `'pagerduty'` only). */
   routingKey?: string | null
+  /** Telegram Bot API token — a secret (provider `'telegram'` only). */
+  telegramBotToken?: string | null
+  /** Telegram target chat id (provider `'telegram'` only). */
+  telegramChatId?: string | null
 }
 
 /**
@@ -161,14 +179,16 @@ export async function createRoute(
       provider: input.provider ?? 'webhook',
       serviceName: input.serviceName?.trim() || null,
       routingKey: input.routingKey?.trim() || null,
+      telegramBotToken: input.telegramBotToken?.trim() || null,
+      telegramChatId: input.telegramChatId?.trim() || null,
     }
 
     await db
       .prepare(
         `INSERT INTO ${TABLE}
            (id, owner_id, match_rule, match_host, channel_url, enabled, created_at,
-            provider, service_name, routing_key)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)`
+            provider, service_name, routing_key, telegram_bot_token, telegram_chat_id)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)`
       )
       .bind(
         route.id,
@@ -180,7 +200,9 @@ export async function createRoute(
         route.createdAt,
         route.provider,
         route.serviceName,
-        route.routingKey
+        route.routingKey,
+        route.telegramBotToken,
+        route.telegramChatId
       )
       .run()
 
@@ -352,4 +374,56 @@ export function resolvePagerDutyTargets(
   return envFallbackKey
     ? [{ serviceName: 'default', routingKey: envFallbackKey }]
     : []
+}
+
+/** One Telegram dispatch target: a bot token + the chat id to send to. */
+export interface TelegramTarget {
+  botToken: string
+  chatId: string
+}
+
+/**
+ * Resolve the Telegram chats a finding should message (#2655 — extends the
+ * plan-30/34 routing model, mirroring {@link resolvePagerDutyTargets}): every
+ * ENABLED, matched route with `provider === 'telegram'` that carries both a
+ * bot token and a chat id, deduplicated by `botToken:chatId`. When NO route
+ * matched at all (any provider), falls back to `[envFallback]` when the
+ * env-configured global Telegram config is present — preserving the
+ * single-destination behavior for deployments that never configure a route.
+ * Returns `[]` when there is no env fallback, OR when a route of a different
+ * provider matched instead — the same cross-provider suppression
+ * {@link resolveTargets} / {@link resolvePagerDutyTargets} apply, so an
+ * operator who explicitly routed a rule to Slack/PagerDuty is not ALSO
+ * messaged on the env-configured Telegram chat. Pure — no I/O.
+ */
+export function resolveTelegramTargets(
+  routes: readonly AlertRoute[],
+  target: RouteMatchTarget,
+  envFallback: TelegramTarget | null
+): TelegramTarget[] {
+  const matched = matchRoutes(routes, target)
+  const telegramMatched = matched.filter(
+    (
+      r
+    ): r is AlertRoute & { telegramBotToken: string; telegramChatId: string } =>
+      r.provider === 'telegram' &&
+      Boolean(r.telegramBotToken) &&
+      Boolean(r.telegramChatId)
+  )
+
+  if (telegramMatched.length > 0) {
+    const seen = new Set<string>()
+    const out: TelegramTarget[] = []
+    for (const r of telegramMatched) {
+      const key = `${r.telegramBotToken}:${r.telegramChatId}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      out.push({ botToken: r.telegramBotToken, chatId: r.telegramChatId })
+    }
+    return out
+  }
+
+  if (matched.length > 0) return []
+
+  return envFallback ? [envFallback] : []
 }

--- a/apps/dashboard/src/lib/health/server-alert-config.test.ts
+++ b/apps/dashboard/src/lib/health/server-alert-config.test.ts
@@ -2,6 +2,7 @@ import {
   getServerAlertConfig,
   getServerEmailConfig,
   getServerOpsgenieConfig,
+  getServerTelegramConfig,
 } from './server-alert-config'
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 
@@ -356,6 +357,58 @@ describe('getServerEmailConfig', () => {
       healthchecksUrl: '',
       minSeverity: 'warning',
       browserNotificationsEnabled: false,
+    })
+  })
+})
+
+const TELEGRAM_ENV_KEYS = [
+  'HEALTH_ALERT_TELEGRAM_BOT_TOKEN',
+  'HEALTH_ALERT_TELEGRAM_CHAT_ID',
+] as const
+
+describe('getServerTelegramConfig', () => {
+  const original: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    for (const key of TELEGRAM_ENV_KEYS) {
+      original[key] = process.env[key]
+      delete process.env[key]
+    }
+  })
+
+  afterEach(() => {
+    for (const key of TELEGRAM_ENV_KEYS) {
+      if (original[key] === undefined) delete process.env[key]
+      else process.env[key] = original[key]
+    }
+  })
+
+  it('returns null when neither var is set', () => {
+    expect(getServerTelegramConfig()).toBeNull()
+  })
+
+  it('returns null when only the bot token is set', () => {
+    process.env.HEALTH_ALERT_TELEGRAM_BOT_TOKEN = '123:ABC'
+    expect(getServerTelegramConfig()).toBeNull()
+  })
+
+  it('returns null when only the chat id is set', () => {
+    process.env.HEALTH_ALERT_TELEGRAM_CHAT_ID = '-100'
+    expect(getServerTelegramConfig()).toBeNull()
+  })
+
+  it('returns null when a var is whitespace-only', () => {
+    process.env.HEALTH_ALERT_TELEGRAM_BOT_TOKEN = '   '
+    process.env.HEALTH_ALERT_TELEGRAM_CHAT_ID = '-100'
+    expect(getServerTelegramConfig()).toBeNull()
+  })
+
+  it('trims and returns both values when set', () => {
+    process.env.HEALTH_ALERT_TELEGRAM_BOT_TOKEN = '  123:ABC  '
+    process.env.HEALTH_ALERT_TELEGRAM_CHAT_ID = '  -100  '
+    expect(getServerTelegramConfig()).toEqual({
+      botToken: '123:ABC',
+      chatId: '-100',
     })
   })
 })

--- a/apps/dashboard/src/lib/health/server-alert-config.ts
+++ b/apps/dashboard/src/lib/health/server-alert-config.ts
@@ -183,6 +183,36 @@ export function getServerOpsgenieConfig(): ServerOpsgenieConfig | null {
   return { apiKey, region }
 }
 
+/** Resolved server-side Telegram config: the bot token plus the target chat id. */
+export interface ServerTelegramConfig {
+  botToken: string
+  chatId: string
+}
+
+/**
+ * Server-side Telegram config, sourced from environment variables:
+ *
+ *   - HEALTH_ALERT_TELEGRAM_BOT_TOKEN → botToken (default '')
+ *   - HEALTH_ALERT_TELEGRAM_CHAT_ID   → chatId   (default '')
+ *
+ * Returns null unless BOTH are configured — Telegram delivery is opt-in and
+ * fails open (either value missing ⇒ the sweep skips the Telegram dispatch
+ * entirely). This is the global fallback used when no per-rule/per-host
+ * Telegram route matches, mirroring the PagerDuty routing-key fallback (#2655).
+ *
+ * NOTE: exposed as a companion function (matching
+ * {@link getServerOpsgenieConfig}) rather than folded into
+ * {@link getServerAlertConfig}'s return value — that shape is shared with the
+ * client's localStorage settings and asserted deeply by its tests, and the bot
+ * token is a server-only secret that must never round-trip through it.
+ */
+export function getServerTelegramConfig(): ServerTelegramConfig | null {
+  const botToken = process.env.HEALTH_ALERT_TELEGRAM_BOT_TOKEN?.trim() || ''
+  const chatId = process.env.HEALTH_ALERT_TELEGRAM_CHAT_ID?.trim() || ''
+  if (!botToken || !chatId) return null
+  return { botToken, chatId }
+}
+
 /** Default cron re-notify cooldown, in minutes, when the env var is unset. */
 export const DEFAULT_ALERT_COOLDOWN_MINUTES = 60
 

--- a/apps/dashboard/src/lib/health/server-sweep.ts
+++ b/apps/dashboard/src/lib/health/server-sweep.ts
@@ -20,6 +20,7 @@ import {
   listRoutes,
   resolvePagerDutyTargets,
   resolveTargets,
+  resolveTelegramTargets,
 } from './alert-routing'
 import { alertStateStore, evaluateAlert } from './alert-state-store'
 import { loadCustomRulesIntoRegistry } from './custom-rules-store'
@@ -35,8 +36,10 @@ import {
   getServerAlertCooldownMs,
   getServerEmailConfig,
   getServerOpsgenieConfig,
+  getServerTelegramConfig,
   getServerThresholdOverrides,
 } from './server-alert-config'
+import { dispatchTelegram } from './telegram-dispatch'
 import { fetchData, getClickHouseConfigs } from '@chm/clickhouse-client'
 import { debug, error } from '@chm/logger'
 import { registerBuiltinRules } from '@/lib/alerting/builtin-rules'
@@ -360,13 +363,15 @@ export async function runHealthSweep(): Promise<SweepSummary> {
   const pagerDutyFallbackKey = getPagerDutyFallbackRoutingKey()
   const opsgenieConfig = getServerOpsgenieConfig()
   const emailConfig = getServerEmailConfig()
+  const telegramFallback = getServerTelegramConfig()
   const canDispatch =
     settings.webhookEnabled &&
     (webhookConfigured ||
       routes.length > 0 ||
       Boolean(pagerDutyFallbackKey) ||
       Boolean(opsgenieConfig) ||
-      Boolean(emailConfig))
+      Boolean(emailConfig) ||
+      Boolean(telegramFallback))
   const minRank = SEVERITY_ORDER[settings.minSeverity]
   const cooldownMs = getServerAlertCooldownMs()
 
@@ -552,6 +557,17 @@ export async function runHealthSweep(): Promise<SweepSummary> {
         routes,
         { ruleId, ruleType, hostId, hostName: name },
         pagerDutyFallbackKey
+      )
+
+      // Telegram chats (#2655): resolved separately from the generic webhook
+      // fan-out — a Telegram target needs the Bot API `sendMessage` body/URL
+      // (token in the path), not the `{ text, content }` wrapper. Falls back
+      // to the env-configured global chat when no route matches, same
+      // fail-open contract as the webhook/PagerDuty paths.
+      const telegramTargets = resolveTelegramTargets(
+        routes,
+        { ruleId, ruleType, hostId, hostName: name },
+        telegramFallback
       )
 
       let anyDelivered = false
@@ -764,6 +780,53 @@ export async function runHealthSweep(): Promise<SweepSummary> {
         }
       }
 
+      // Telegram (#2655): every resolved chat (matched routes, or the
+      // env-configured global chat when nothing matched). `dispatchTelegram`
+      // renders the MarkdownV2 body and never throws (fails open), matching
+      // every other channel here.
+      for (const target of telegramTargets) {
+        const alertSeverity: AlertSeverity =
+          decision.kind === 'recovery'
+            ? 'recovery'
+            : (effective as 'warning' | 'critical')
+        const ok = await dispatchTelegram(
+          {
+            severity: alertSeverity,
+            hostLabel: name,
+            hostId,
+            metric: ruleId,
+            value,
+            warnThreshold,
+            critThreshold,
+            title: ruleTitle,
+            label,
+            timestamp: new Date().toISOString(),
+          },
+          { botToken: target.botToken, chatId: target.chatId }
+        )
+        if (ok) anyDelivered = true
+
+        try {
+          await recordAlertEvent(
+            buildAlertEventRecord({
+              hostId,
+              hostLabel: name,
+              ruleId,
+              decision,
+              value,
+              delivered: ok,
+              error: ok ? undefined : 'Telegram dispatch failed',
+              channel: 'telegram',
+            })
+          )
+        } catch (err) {
+          debug(
+            `[health-sweep] alert-history record failed for host ${hostId} rule ${ruleId}`,
+            err instanceof Error ? err.message : String(err)
+          )
+        }
+      }
+
       // Persist "notified" only when there was nothing to deliver (no
       // targets at all across every channel — not a failure) or at least one
       // channel succeeded. A failed delivery with no successes leaves no
@@ -771,6 +834,7 @@ export async function runHealthSweep(): Promise<SweepSummary> {
       if (
         targets.length +
           pagerDutyTargets.length +
+          telegramTargets.length +
           (opsgenieConfig ? 1 : 0) +
           (emailConfig ? 1 : 0) ===
           0 ||

--- a/apps/dashboard/src/lib/health/telegram-dispatch.test.ts
+++ b/apps/dashboard/src/lib/health/telegram-dispatch.test.ts
@@ -1,0 +1,99 @@
+import type { AlertPayload } from './adapters/types'
+
+import { buildTelegramBody } from './adapters/telegram'
+import { dispatchTelegram, telegramSendMessageUrl } from './telegram-dispatch'
+import { describe, expect, test } from 'bun:test'
+
+/** A fetch stub that records the request it was called with. */
+function stubFetch(response: Response = new Response('ok', { status: 200 })) {
+  const calls: { url: string; init: RequestInit }[] = []
+  const fetchImpl = (async (input: unknown, init?: RequestInit) => {
+    calls.push({ url: String(input), init: init ?? {} })
+    return response
+  }) as unknown as typeof fetch
+  return { calls, fetchImpl }
+}
+
+function throwingFetch(err: unknown) {
+  return (async () => {
+    throw err
+  }) as unknown as typeof fetch
+}
+
+const CONFIG = { botToken: '123456:ABC-DEF', chatId: '-1001234567890' }
+
+const CRITICAL: AlertPayload = {
+  severity: 'critical',
+  hostLabel: 'prod-1',
+  hostId: 2,
+  metric: 'failed-mutations',
+  value: 7,
+  warnThreshold: 1,
+  critThreshold: 5,
+  title: 'Failed mutations',
+  label: '7 failed mutations',
+  timestamp: '2026-07-02T10:00:00.000Z',
+}
+
+const RECOVERY: AlertPayload = {
+  ...CRITICAL,
+  severity: 'recovery',
+  value: 0,
+  label: 'recovered',
+}
+
+describe('telegramSendMessageUrl', () => {
+  test('puts the token in the Bot API path', () => {
+    expect(telegramSendMessageUrl('123456:ABC')).toBe(
+      'https://api.telegram.org/bot123456:ABC/sendMessage'
+    )
+  })
+})
+
+describe('dispatchTelegram — send', () => {
+  test('POSTs the built MarkdownV2 body to the sendMessage endpoint', async () => {
+    const { calls, fetchImpl } = stubFetch()
+    const ok = await dispatchTelegram(CRITICAL, CONFIG, { fetchImpl })
+
+    expect(ok).toBe(true)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toBe(
+      'https://api.telegram.org/bot123456:ABC-DEF/sendMessage'
+    )
+    expect(calls[0].init.method).toBe('POST')
+    expect(
+      (calls[0].init.headers as Record<string, string>)['Content-Type']
+    ).toBe('application/json')
+    expect(JSON.parse(String(calls[0].init.body))).toEqual(
+      buildTelegramBody(CRITICAL, {
+        token: CONFIG.botToken,
+        chatId: CONFIG.chatId,
+      })
+    )
+  })
+
+  test('sends a recovery message on the same endpoint', async () => {
+    const { calls, fetchImpl } = stubFetch()
+    const ok = await dispatchTelegram(RECOVERY, CONFIG, { fetchImpl })
+
+    expect(ok).toBe(true)
+    const body = JSON.parse(String(calls[0].init.body)) as { text: string }
+    // MarkdownV2 header for a recovery renders RECOVERY.
+    expect(body.text).toContain('RECOVERY')
+  })
+
+  test('returns false when Telegram responds non-OK, without throwing', async () => {
+    const { fetchImpl } = stubFetch(new Response('nope', { status: 400 }))
+    const ok = await dispatchTelegram(CRITICAL, CONFIG, { fetchImpl })
+    expect(ok).toBe(false)
+  })
+})
+
+describe('dispatchTelegram — fail-open', () => {
+  test('returns false, never throws, when the fetch itself rejects', async () => {
+    const fetchImpl = throwingFetch(new Error('network down'))
+    await expect(
+      dispatchTelegram(CRITICAL, CONFIG, { fetchImpl })
+    ).resolves.toBe(false)
+  })
+})

--- a/apps/dashboard/src/lib/health/telegram-dispatch.ts
+++ b/apps/dashboard/src/lib/health/telegram-dispatch.ts
@@ -1,0 +1,74 @@
+/**
+ * Telegram dispatch (transport layer).
+ *
+ * Builds the MarkdownV2 message body with the pure formatter
+ * (`adapters/telegram.ts`) and POSTs it to the Telegram Bot API `sendMessage`
+ * endpoint (`https://api.telegram.org/bot<token>/sendMessage`). The bot token
+ * goes into the URL path (never the browser); this module is the only place
+ * that actually talks to Telegram — mirrors the auth/transport separation
+ * Opsgenie/PagerDuty document (the adapter stays network-free).
+ *
+ * The endpoint host is fixed (`api.telegram.org`) — only the token in the path
+ * varies — so there is no caller-controlled SSRF sink here (unlike
+ * `webhook.ts`, which fetches an arbitrary operator URL). Same reasoning as
+ * `postPagerDutyEvent`, which likewise talks to a fixed endpoint without an
+ * extra `validateHostUrl` guard.
+ *
+ * Never throws: a delivery failure must not abort the health sweep loop
+ * (fail-open, matching `postWebhook` / `dispatchOpsgenie`).
+ */
+
+import type { AlertPayload } from './adapters/types'
+import type { ServerTelegramConfig } from './server-alert-config'
+
+import { buildTelegramBody } from './adapters/telegram'
+import { error } from '@chm/logger'
+
+/** Injectable dependencies (tests override fetch). */
+export interface TelegramDispatchDeps {
+  fetchImpl?: typeof fetch
+}
+
+/** Build the Bot API `sendMessage` URL for a token. */
+export function telegramSendMessageUrl(botToken: string): string {
+  return `https://api.telegram.org/bot${botToken}/sendMessage`
+}
+
+/**
+ * Dispatch one alert to a Telegram chat: renders the payload as MarkdownV2 and
+ * POSTs it to the bot's `sendMessage` endpoint. Returns whether the request
+ * succeeded; never throws.
+ */
+export async function dispatchTelegram(
+  payload: AlertPayload,
+  config: ServerTelegramConfig,
+  deps: TelegramDispatchDeps = {}
+): Promise<boolean> {
+  const doFetch = deps.fetchImpl ?? fetch
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 10_000)
+  try {
+    const body = buildTelegramBody(payload, {
+      token: config.botToken,
+      chatId: config.chatId,
+    })
+    const res = await doFetch(telegramSendMessageUrl(config.botToken), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    })
+    if (!res.ok) {
+      error(
+        '[health] Telegram dispatch returned non-OK status',
+        new Error(`Status ${res.status}`)
+      )
+    }
+    return res.ok
+  } catch (err) {
+    error('[health] Telegram dispatch failed', err as Error)
+    return false
+  } finally {
+    clearTimeout(timeout)
+  }
+}

--- a/apps/dashboard/src/lib/hooks/use-alert-routes.ts
+++ b/apps/dashboard/src/lib/hooks/use-alert-routes.ts
@@ -12,8 +12,11 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { throwIfNotOk } from '@/lib/swr/fetch-error'
 
-/** Destination provider: `'webhook'` (plan 30) or `'pagerduty'` (plan 34). */
-export type AlertRouteProvider = 'webhook' | 'pagerduty'
+/**
+ * Destination provider: `'webhook'` (plan 30), `'pagerduty'` (plan 34), or
+ * `'telegram'` (#2655).
+ */
+export type AlertRouteProvider = 'webhook' | 'pagerduty' | 'telegram'
 
 export interface AlertRouteInfo {
   id: string
@@ -26,6 +29,10 @@ export interface AlertRouteInfo {
   serviceName: string | null
   /** Masked routing key (last 4 chars only) — never the raw secret. */
   routingKeyMasked: string | null
+  /** Telegram target chat id (not a secret). */
+  telegramChatId: string | null
+  /** Masked Telegram bot token (last 4 chars only) — never the raw secret. */
+  telegramBotTokenMasked: string | null
 }
 
 export const ALERT_ROUTES_QUERY_KEY = ['/api/v1/health/routes'] as const
@@ -67,6 +74,8 @@ export function useAlertRoutesMutations() {
     provider?: AlertRouteProvider
     serviceName?: string
     routingKey?: string
+    telegramBotToken?: string
+    telegramChatId?: string
   }): Promise<AlertRouteInfo> => {
     const response = await apiFetch('/api/v1/health/routes', {
       method: 'POST',

--- a/apps/dashboard/src/routes/api/v1/health/routes.ts
+++ b/apps/dashboard/src/routes/api/v1/health/routes.ts
@@ -58,6 +58,14 @@ function toPublicRoute(route: Awaited<ReturnType<typeof listRoutes>>[number]) {
     routingKeyMasked: route.routingKey
       ? maskRoutingKey(route.routingKey)
       : null,
+    // Telegram (#2655): the bot token is a bare secret (like a PagerDuty
+    // routing key), never returned in full once stored — only the last 4
+    // chars. The chat id is not a secret and is returned as-is so the UI can
+    // show which chat a route targets.
+    telegramChatId: route.telegramChatId,
+    telegramBotTokenMasked: route.telegramBotToken
+      ? maskRoutingKey(route.telegramBotToken)
+      : null,
   }
 }
 
@@ -75,12 +83,16 @@ interface CreateRouteBody {
   matchHost?: unknown
   channelUrl?: unknown
   enabled?: unknown
-  /** `'webhook'` (default) or `'pagerduty'` (plan 34). */
+  /** `'webhook'` (default), `'pagerduty'` (plan 34), or `'telegram'` (#2655). */
   provider?: unknown
   /** PagerDuty-only: display label for the service. */
   serviceName?: unknown
   /** PagerDuty-only: the service's Events API v2 integration/routing key. */
   routingKey?: unknown
+  /** Telegram-only: the Bot API token (a secret). */
+  telegramBotToken?: unknown
+  /** Telegram-only: the target chat id. */
+  telegramChatId?: unknown
 }
 
 async function handlePost(request: Request): Promise<Response> {
@@ -97,7 +109,11 @@ async function handlePost(request: Request): Promise<Response> {
   }
 
   const provider: AlertRouteProvider =
-    body.provider === 'pagerduty' ? 'pagerduty' : 'webhook'
+    body.provider === 'pagerduty'
+      ? 'pagerduty'
+      : body.provider === 'telegram'
+        ? 'telegram'
+        : 'webhook'
 
   const matchRule =
     typeof body.matchRule === 'string' && body.matchRule.trim()
@@ -133,6 +149,48 @@ async function handlePost(request: Request): Promise<Response> {
       provider: 'pagerduty',
       serviceName: serviceName || null,
       routingKey,
+    })
+
+    if (!created) {
+      return jsonError(
+        'Alert routing storage is not configured (no D1 binding) or the write failed.',
+        501
+      )
+    }
+
+    return Response.json(
+      { success: true, route: toPublicRoute(created) },
+      { status: 201 }
+    )
+  }
+
+  if (provider === 'telegram') {
+    const telegramBotToken =
+      typeof body.telegramBotToken === 'string'
+        ? body.telegramBotToken.trim()
+        : ''
+    const telegramChatId =
+      typeof body.telegramChatId === 'string' ? body.telegramChatId.trim() : ''
+    if (!telegramBotToken || !telegramChatId) {
+      return jsonError(
+        'Missing required "telegramBotToken" and/or "telegramChatId" for a Telegram route',
+        400
+      )
+    }
+
+    // The Telegram Bot API endpoint host is fixed (`api.telegram.org`) — only
+    // the token in the path varies — so there is no caller-supplied SSRF sink
+    // here (unlike the webhook path below). `channelUrl` stays empty; the
+    // sweep builds the outbound URL from the token at send time.
+    const created = await createRoute({
+      ownerId,
+      matchRule,
+      matchHost,
+      channelUrl: '',
+      enabled,
+      provider: 'telegram',
+      telegramBotToken,
+      telegramChatId,
     })
 
     if (!created) {

--- a/apps/dashboard/src/routes/api/v1/health/telegram-test.test.ts
+++ b/apps/dashboard/src/routes/api/v1/health/telegram-test.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// Same auth-gate mock pattern as opsgenie-test.test.ts / webhook.test.ts.
+let authorizeFeatureRequest = mock(
+  async (
+    _permission: unknown,
+    _request: Request,
+    _options?: { allowAgentBearerToken?: boolean }
+  ): Promise<Response | null> => null
+)
+mock.module('@/lib/feature-permissions/server', () => ({
+  getAppConfig: () => ({ authProvider: 'none' as const, features: {} }),
+  _resetAppConfigCache: () => {},
+  publicReadEnabled: () => true,
+  authorizeFeatureRequest: (
+    permission: unknown,
+    request: Request,
+    options?: { allowAgentBearerToken?: boolean }
+  ) => authorizeFeatureRequest(permission, request, options),
+}))
+
+const TELEGRAM_ENV_KEYS = [
+  'HEALTH_ALERT_TELEGRAM_BOT_TOKEN',
+  'HEALTH_ALERT_TELEGRAM_CHAT_ID',
+] as const
+
+const { __handleGetForTests: handleGet, __handlePostForTests: handlePost } =
+  await import('./telegram-test')
+
+const originalEnv: Record<string, string | undefined> = {}
+for (const key of TELEGRAM_ENV_KEYS) originalEnv[key] = process.env[key]
+
+beforeEach(() => {
+  authorizeFeatureRequest = mock(async () => null)
+  for (const key of TELEGRAM_ENV_KEYS) delete process.env[key]
+})
+
+function makeRequest(): Request {
+  return new Request('https://dash.example.com/api/v1/health/telegram-test', {
+    method: 'POST',
+  })
+}
+
+describe('GET /api/v1/health/telegram-test', () => {
+  test('reports not configured when no bot token/chat id is set', async () => {
+    const res = await handleGet()
+    const body = (await res.json()) as { configured: boolean }
+    expect(body).toEqual({ configured: false })
+  })
+
+  test('reports not configured when only the token is set', async () => {
+    process.env.HEALTH_ALERT_TELEGRAM_BOT_TOKEN = 'tok'
+    const res = await handleGet()
+    const body = (await res.json()) as { configured: boolean }
+    expect(body).toEqual({ configured: false })
+  })
+
+  test('reports configured when both token and chat id are set', async () => {
+    process.env.HEALTH_ALERT_TELEGRAM_BOT_TOKEN = 'tok'
+    process.env.HEALTH_ALERT_TELEGRAM_CHAT_ID = '-100'
+    const res = await handleGet()
+    const body = (await res.json()) as { configured: boolean }
+    expect(body).toEqual({ configured: true })
+  })
+})
+
+describe('POST /api/v1/health/telegram-test — auth gate', () => {
+  test('anonymous is blocked, no egress', async () => {
+    process.env.HEALTH_ALERT_TELEGRAM_BOT_TOKEN = 'tok'
+    process.env.HEALTH_ALERT_TELEGRAM_CHAT_ID = '-100'
+    authorizeFeatureRequest = mock(
+      async () => new Response(null, { status: 401 })
+    )
+    const fetchImpl = mock(async () => new Response('ok', { status: 200 }))
+    const res = await handlePost(makeRequest(), {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })
+
+    expect(res.status).toBe(401)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/v1/health/telegram-test — dispatch', () => {
+  test('400s when Telegram is not configured', async () => {
+    const fetchImpl = mock(async () => new Response('ok', { status: 200 }))
+    const res = await handlePost(makeRequest(), {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })
+
+    expect(res.status).toBe(400)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  test('sends a real test dispatch when configured', async () => {
+    process.env.HEALTH_ALERT_TELEGRAM_BOT_TOKEN = '123:ABC'
+    process.env.HEALTH_ALERT_TELEGRAM_CHAT_ID = '-100'
+    const fetchImpl = mock(
+      async (_url: string, _init?: RequestInit) =>
+        new Response('ok', { status: 200 })
+    )
+    const res = await handlePost(makeRequest(), {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })
+
+    expect(res.status).toBe(200)
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    const [url] = fetchImpl.mock.calls[0]
+    expect(url).toBe('https://api.telegram.org/bot123:ABC/sendMessage')
+  })
+
+  test('502s when the Telegram request fails', async () => {
+    process.env.HEALTH_ALERT_TELEGRAM_BOT_TOKEN = '123:ABC'
+    process.env.HEALTH_ALERT_TELEGRAM_CHAT_ID = '-100'
+    const fetchImpl = mock(async () => new Response('nope', { status: 400 }))
+    const res = await handlePost(makeRequest(), {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })
+
+    expect(res.status).toBe(502)
+  })
+})

--- a/apps/dashboard/src/routes/api/v1/health/telegram-test.ts
+++ b/apps/dashboard/src/routes/api/v1/health/telegram-test.ts
@@ -1,0 +1,104 @@
+/**
+ * Telegram Test-Message Endpoint
+ * GET  /api/v1/health/telegram-test  — is Telegram configured server-side?
+ * POST /api/v1/health/telegram-test  — send a synthetic test message
+ *
+ * The Telegram bot token (`HEALTH_ALERT_TELEGRAM_BOT_TOKEN`) is a server-only
+ * secret (see `server-alert-config.ts`) that must never round-trip to the
+ * browser — like the Opsgenie API key, there is no client-supplied credential
+ * for the env-configured global chat. This endpoint lets the settings UI (a)
+ * show whether Telegram is configured and (b) fire a real test dispatch through
+ * the server's own config, without ever exposing the token (#2655).
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { TelegramDispatchDeps } from '@/lib/health/telegram-dispatch'
+
+import { debug } from '@chm/logger'
+import { createErrorResponse } from '@/lib/api/shared/response-builder'
+import { ApiErrorType } from '@/lib/api/types'
+import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
+import { getServerTelegramConfig } from '@/lib/health/server-alert-config'
+import { dispatchTelegram } from '@/lib/health/telegram-dispatch'
+
+const ROUTE_CONTEXT = {
+  route: '/api/v1/health/telegram-test',
+  method: 'POST',
+} as const
+
+async function handleGet(): Promise<Response> {
+  const config = getServerTelegramConfig()
+  return Response.json({ configured: config !== null })
+}
+
+async function handlePost(
+  request: Request,
+  deps: TelegramDispatchDeps = {}
+): Promise<Response> {
+  // Write gate, same posture as /api/v1/health/webhook — this triggers a
+  // real outbound Telegram dispatch, so anonymous callers must not reach it.
+  const permissionResponse = await authorizeFeatureRequest(
+    { feature: 'settings', defaultAccess: 'authenticated', operation: 'write' },
+    request,
+    { allowAgentBearerToken: true }
+  )
+  if (permissionResponse) return permissionResponse
+
+  const config = getServerTelegramConfig()
+  if (!config) {
+    return createErrorResponse(
+      {
+        type: ApiErrorType.ValidationError,
+        message:
+          'Telegram is not configured. Set HEALTH_ALERT_TELEGRAM_BOT_TOKEN and HEALTH_ALERT_TELEGRAM_CHAT_ID on the server.',
+      },
+      400,
+      ROUTE_CONTEXT
+    )
+  }
+
+  debug('[POST /api/v1/health/telegram-test] Sending test message')
+
+  const ok = await dispatchTelegram(
+    {
+      severity: 'warning',
+      hostLabel: 'test-host',
+      hostId: 0,
+      metric: 'test',
+      value: 0,
+      warnThreshold: null,
+      critThreshold: null,
+      title: 'Test Alert',
+      label: 'This is a test alert from chmonitor',
+      timestamp: new Date().toISOString(),
+    },
+    config,
+    deps
+  )
+
+  if (!ok) {
+    return createErrorResponse(
+      {
+        type: ApiErrorType.NetworkError,
+        message: 'Telegram test message failed. Check the server logs.',
+      },
+      502,
+      ROUTE_CONTEXT
+    )
+  }
+
+  return Response.json({ success: true }, { status: 200 })
+}
+
+export const Route = createFileRoute('/api/v1/health/telegram-test')({
+  server: {
+    handlers: {
+      GET: async () => handleGet(),
+      POST: async ({ request }) => handlePost(request),
+    },
+  },
+})
+
+// Exported for unit tests only.
+export { handleGet as __handleGetForTests, handlePost as __handlePostForTests }

--- a/docs/content/guide/features/health.mdx
+++ b/docs/content/guide/features/health.mdx
@@ -98,6 +98,8 @@ The health-sweep endpoint runs checks over all configured hosts and sends a webh
 | `HEALTH_ALERT_ENABLED` | `false` | Set to `true` to enable webhook dispatch. |
 | `HEALTH_ALERT_WEBHOOK_URL` | (required if enabled) | Slack or Discord incoming webhook URL. Payload is `{"text": "...", "content": "..."}` so both render it. See [Alerting to Slack and Discord](/guide/guides/alerting-slack-discord) for setup examples. |
 | `HEALTH_ALERT_MIN_SEVERITY` | `warning` | Minimum severity that triggers a notification. Values: `warning` or `critical`. |
+| `HEALTH_ALERT_TELEGRAM_BOT_TOKEN` | (unset = Telegram disabled) | Telegram Bot API token. Server-only secret — never exposed to the browser. Set together with `HEALTH_ALERT_TELEGRAM_CHAT_ID` to enable the global Telegram channel; each finding is sent to the chat via the Bot API `sendMessage` endpoint. Per-rule/per-host Telegram routes (Routing tab) override this fallback. |
+| `HEALTH_ALERT_TELEGRAM_CHAT_ID` | (unset = Telegram disabled) | Target Telegram chat id (e.g. `-1001234567890`, or `@channelname`). Both this and `HEALTH_ALERT_TELEGRAM_BOT_TOKEN` must be set for the global Telegram channel to fire. |
 
 <Callout type="warn" title="CRON_SECRET is required">
 `CRON_SECRET` is **required** for the cron endpoints. When it is unset, `/api/cron/health-sweep` and `/api/cron/retention-prune` **fail closed and return HTTP 503** (they do not run) — `retention-prune` is destructive, so it must never be reachable unauthenticated. Set `CRON_SECRET` and pass it as `Authorization: Bearer <secret>` from your cron caller.
@@ -112,6 +114,8 @@ Example for Cloudflare Workers (using `wrangler secret put`):
 ```bash
 wrangler secret put CRON_SECRET
 wrangler secret put HEALTH_ALERT_WEBHOOK_URL
+# Optional: Telegram channel (bot token is a secret; chat id is a plain var)
+wrangler secret put HEALTH_ALERT_TELEGRAM_BOT_TOKEN
 ```
 </Step>
 <Step>


### PR DESCRIPTION
## What

`apps/dashboard/src/lib/health/adapters/telegram.ts` (the tested MarkdownV2 formatter) had **zero non-test callers**. This wires it end-to-end so health-sweep findings actually reach a Telegram chat.

## Changes

- **Config** — `HEALTH_ALERT_TELEGRAM_BOT_TOKEN` + `HEALTH_ALERT_TELEGRAM_CHAT_ID` env vars (`getServerTelegramConfig`, server-only global fallback), plus a `telegram` provider on alert routes storing bot token + chat id per route (follows the PagerDuty `provider` pattern). D1 migration `0019_alert_routes_telegram.sql` adds `telegram_bot_token` + `telegram_chat_id`.
- **Dispatch** — new `telegram-dispatch.ts` (`dispatchTelegram`, fixed-host transport, never throws) wired into `server-sweep.ts` via a new `resolveTelegramTargets` fan-out (per-route matches, else env fallback), recorded in alert history with channel label `telegram`. Recovery (`resolved`) path included.
- **Routing UI** — Telegram option + bot-token/chat-id fields and a Send-test in `alert-routing-dialog.tsx`. The bot token is masked on read-back (last 4 chars), never re-shown — same posture as the PagerDuty routing key.
- **Test button** — `GET/POST /api/v1/health/telegram-test` (mirrors `opsgenie-test.ts`) + a configured/not-configured Badge and Send-test button in the Health Settings **Alerts** tab.
- **Secret hygiene** — the bot token never reaches the browser (server-only env, masked D1); the per-route creation test send goes through the existing `/api/v1/health/webhook` proxy (`provider: 'telegram'`).
- **Docs** — env-var table in `docs/content/guide/features/health.mdx`.

## Tests

- `getServerTelegramConfig` parsing (both-required, trim, whitespace).
- `dispatchTelegram` transport (endpoint URL, built body, non-OK, fail-open).
- `resolveTelegramTargets` pure resolution + cross-provider suppression + env fallback + D1 round-trip.
- `telegram-test` route (GET status, POST auth gate / dispatch / 502).

`pnpm exec biome check` clean, `pnpm run type-check` passes, all touched suites green (88 + 30 tests).

## Notes / deviations from the spec

- Minimal D1 migration (0019) added as anticipated — the routing store can't hold a chat id + token without it; follows the plan-34 PagerDuty `ALTER TABLE` pattern exactly.
- Sweep dispatch is factored through `dispatchTelegram` (like `dispatchOpsgenie`) rather than an inline `postWebhook`-style helper, so the test route and sweep share one transport.

Closes #2655