### PR TITLE
feat(alerts): per-URL adapter bodies in webhook dispatch (Discord embeds, Slack fallback)

### DIFF
--- a/apps/dashboard/src/lib/health/adapters/__tests__/webhook-dispatch-body.test.ts
+++ b/apps/dashboard/src/lib/health/adapters/__tests__/webhook-dispatch-body.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for `buildWebhookDispatchBody` — the pure URL → per-channel body
+ * mapping shared by the server sweep and the client "Send test" proxy path
+ * (#2656).
+ *
+ * Asserts the exact shape each adapter produces:
+ *   - Discord URL → verbatim `provider: 'discord'` + rich embed (severity
+ *     colour, host, metric, value) instead of plain `content`.
+ *   - Slack URL → the existing `{ text, content }` wrapper, plus `blocks` only
+ *     when the caller supplies them (native Slack app, server sweep only).
+ *   - Generic / unknown URL → the exact original `{ text, content }` wrapper —
+ *     zero behavior change.
+ *   - Recovery variant maps to the green recovery embed.
+ *
+ * Runs in Bun's test runner (everything here is pure — no transport).
+ */
+
+import type { AlertPayload } from '@/lib/health/adapters'
+
+import { describe, expect, test } from 'bun:test'
+import {
+  buildDiscordBody,
+  buildWebhookDispatchBody,
+} from '@/lib/health/adapters'
+
+const DISCORD_URL = 'https://discord.com/api/webhooks/123/abc'
+const SLACK_URL = 'https://hooks.slack.com/services/T000/B000/xxxx'
+const GENERIC_URL = 'https://example.com/hooks/alerts'
+
+const CRITICAL: AlertPayload = {
+  severity: 'critical',
+  hostLabel: 'prod-1',
+  hostId: 2,
+  metric: 'failed-mutations',
+  value: 7,
+  warnThreshold: 1,
+  critThreshold: 5,
+  title: 'Failed mutations',
+  label: '7 failed mutations',
+  timestamp: '2026-07-16T10:00:00.000Z',
+}
+
+const RECOVERY: AlertPayload = {
+  ...CRITICAL,
+  severity: 'recovery',
+  label: 'resolved',
+}
+
+const TEXT = '[CRITICAL] Failed mutations — 7 failed mutations (host prod-1)'
+
+describe('buildWebhookDispatchBody', () => {
+  test('Discord URL → verbatim provider + rich embed', () => {
+    const result = buildWebhookDispatchBody({
+      url: DISCORD_URL,
+      text: TEXT,
+      payload: CRITICAL,
+    })
+
+    expect(result.adapterId).toBe('discord')
+    expect(result.provider).toBe('discord')
+    // Body is the exact Discord embed body — not the generic `{ text, content }`.
+    expect(result.body).toEqual(buildDiscordBody(CRITICAL))
+
+    const body = result.body as ReturnType<typeof buildDiscordBody>
+    expect(body.embeds).toHaveLength(1)
+    // Critical severity → red embed (0xdc2626).
+    expect(body.embeds[0].color).toBe(0xdc2626)
+    const fieldByName = (name: string) =>
+      body.embeds[0].fields.find((f) => f.name === name)?.value
+    expect(fieldByName('Host')).toBe('prod-1 (id 2)')
+    expect(fieldByName('Metric')).toBe('failed-mutations')
+    expect(fieldByName('Value')).toBe('7')
+  })
+
+  test('Discord recovery variant → green recovery embed', () => {
+    const result = buildWebhookDispatchBody({
+      url: DISCORD_URL,
+      text: '[RECOVERY] Failed mutations — resolved (host prod-1)',
+      payload: RECOVERY,
+    })
+
+    expect(result.provider).toBe('discord')
+    const body = result.body as ReturnType<typeof buildDiscordBody>
+    // Recovery severity → green embed (0x16a34a) and RECOVERY heading.
+    expect(body.embeds[0].color).toBe(0x16a34a)
+    expect(body.embeds[0].title).toContain('RECOVERY')
+  })
+
+  test('Slack URL without blocks → plain { text, content } wrapper', () => {
+    const result = buildWebhookDispatchBody({
+      url: SLACK_URL,
+      text: TEXT,
+      payload: CRITICAL,
+    })
+
+    expect(result.adapterId).toBe('slack')
+    // No verbatim provider — the proxy builds the wrapper from `text`.
+    expect(result.provider).toBeUndefined()
+    expect(result.body).toEqual({ text: TEXT, content: TEXT })
+  })
+
+  test('Slack URL with blocks → wrapper + blocks (native Slack app path)', () => {
+    const blocks = [{ type: 'section', text: { type: 'mrkdwn', text: 'hi' } }]
+    const result = buildWebhookDispatchBody({
+      url: SLACK_URL,
+      text: TEXT,
+      payload: CRITICAL,
+      slackBlocks: blocks,
+    })
+
+    expect(result.adapterId).toBe('slack')
+    expect(result.provider).toBeUndefined()
+    expect(result.body).toEqual({ text: TEXT, content: TEXT, blocks })
+  })
+
+  test('Generic URL → exact original { text, content } wrapper (zero change)', () => {
+    const result = buildWebhookDispatchBody({
+      url: GENERIC_URL,
+      text: TEXT,
+      payload: CRITICAL,
+    })
+
+    expect(result.adapterId).toBe('generic-json')
+    expect(result.provider).toBeUndefined()
+    expect(result.body).toEqual({ text: TEXT, content: TEXT })
+  })
+
+  test('Generic URL ignores slackBlocks — stays the plain wrapper', () => {
+    const result = buildWebhookDispatchBody({
+      url: GENERIC_URL,
+      text: TEXT,
+      payload: CRITICAL,
+      slackBlocks: [{ type: 'section' }],
+    })
+
+    expect(result.body).toEqual({ text: TEXT, content: TEXT })
+  })
+})

--- a/apps/dashboard/src/lib/health/adapters/index.ts
+++ b/apps/dashboard/src/lib/health/adapters/index.ts
@@ -47,9 +47,9 @@ export {
   telegramAdapter,
 } from './telegram'
 
-import type { NotificationAdapter } from './types'
+import type { AlertPayload, NotificationAdapter } from './types'
 
-import { discordAdapter } from './discord'
+import { buildDiscordBody, discordAdapter } from './discord'
 import { emailAdapter } from './email'
 import { genericJsonAdapter } from './generic-json'
 import { opsgenieAdapter } from './opsgenie'
@@ -93,4 +93,68 @@ export function detectAdapter(url: string): NotificationAdapter {
     if (adapter.detect?.(url)) return adapter
   }
   return genericJsonAdapter
+}
+
+/**
+ * The concrete body to POST to a single webhook target, chosen by the target
+ * URL's adapter. Shared by the server sweep ({@link file://../server-sweep.ts})
+ * and the client "Send test" proxy path ({@link file://../alert-dispatcher.ts})
+ * so both preview/deliver the same per-channel shape.
+ */
+export interface WebhookDispatchBody {
+  /** Adapter id chosen for this URL (used for the per-channel audit label). */
+  adapterId: string
+  /**
+   * Proxy provider hint. Set to the adapter id when `body` is a
+   * provider-specific shape that must be forwarded verbatim (Discord embeds).
+   * Undefined for the generic `{ text, content }` wrapper — the client then
+   * posts the backward-compatible `{ url, text }` and the proxy builds the
+   * wrapper itself.
+   */
+  provider?: string
+  /** The JSON body to POST (the server sweep posts this object directly). */
+  body: unknown
+}
+
+/**
+ * Pick the per-URL webhook body for an alert. Discord targets get rich embeds
+ * ({@link buildDiscordBody}); Slack incoming webhooks get the caller's rich
+ * blocks when provided (the native Slack app, server sweep only) and otherwise
+ * the plain `{ text, content }` wrapper; every generic/unknown URL keeps the
+ * exact original `{ text, content }` wrapper — zero behavior change. Pure: no
+ * transport, so the URL → body-shape mapping is unit-testable per adapter.
+ */
+export function buildWebhookDispatchBody(params: {
+  url: string
+  /** Pre-rendered one-line summary (severity/recovery aware). */
+  text: string
+  payload: AlertPayload
+  /** Slack rich blocks — server sweep only, when the Slack app is configured. */
+  slackBlocks?: unknown[]
+}): WebhookDispatchBody {
+  const adapter = detectAdapter(params.url)
+
+  if (adapter.id === 'discord') {
+    return {
+      adapterId: adapter.id,
+      provider: 'discord',
+      body: buildDiscordBody(params.payload),
+    }
+  }
+
+  if (adapter.id === 'slack' && params.slackBlocks) {
+    return {
+      adapterId: adapter.id,
+      body: {
+        text: params.text,
+        content: params.text,
+        blocks: params.slackBlocks,
+      },
+    }
+  }
+
+  return {
+    adapterId: adapter.id,
+    body: { text: params.text, content: params.text },
+  }
 }

--- a/apps/dashboard/src/lib/health/alert-dispatcher.ts
+++ b/apps/dashboard/src/lib/health/alert-dispatcher.ts
@@ -1,4 +1,8 @@
-import { buildPagerDutyBody, buildTelegramBody } from './adapters'
+import {
+  buildPagerDutyBody,
+  buildTelegramBody,
+  buildWebhookDispatchBody,
+} from './adapters'
 import { loadAlertSettings } from './alert-settings-storage'
 
 // Duplicated (not imported) from `pagerduty-config.ts` on purpose: that
@@ -146,10 +150,33 @@ export async function fireWebhook(
   const timeout = setTimeout(() => controller.abort(), 10_000)
   try {
     const text = `[${alertPrefix(alert)}] ${alert.title} — ${alert.label} (host ${alert.hostId})`
+    // Per-URL body selection (#2656): a Discord target previews the real rich
+    // embed via the proxy's verbatim `provider` path; every other URL keeps the
+    // backward-compatible `{ url, text }` (the proxy wraps it as
+    // `{ text, content }`). The client can't know if the server-side Slack app
+    // is configured, so Slack stays plain text here — matching the pre-#2656
+    // behavior.
+    const dispatch = buildWebhookDispatchBody({
+      url,
+      text,
+      payload: {
+        severity: alert.kind === 'recovery' ? 'recovery' : alert.severity,
+        hostLabel: `host ${alert.hostId}`,
+        hostId: alert.hostId,
+        metric: alert.checkId,
+        value: alert.value,
+        title: alert.title,
+        label: alert.label,
+        timestamp: new Date().toISOString(),
+      },
+    })
+    const requestBody = dispatch.provider
+      ? { url, provider: dispatch.provider, payload: dispatch.body }
+      : { url, text }
     const res = await fetch('/api/v1/health/webhook', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ url, text }),
+      body: JSON.stringify(requestBody),
       signal: controller.signal,
     })
     return res.ok

--- a/apps/dashboard/src/lib/health/server-sweep.ts
+++ b/apps/dashboard/src/lib/health/server-sweep.ts
@@ -13,7 +13,12 @@ import type { AlertEventRecord } from './alert-history-store'
 import type { AlertRoute } from './alert-routing'
 import type { AlertDecision } from './alert-state-store'
 
-import { buildEmailBody, buildPagerDutyBody, detectAdapter } from './adapters'
+import {
+  buildEmailBody,
+  buildPagerDutyBody,
+  buildWebhookDispatchBody,
+  detectAdapter,
+} from './adapters'
 import { clearAck, isAcked, listActiveAcks } from './alert-ack-store'
 import { recordAlertEvent } from './alert-history-store'
 import {
@@ -193,32 +198,20 @@ interface WebhookResult {
 }
 
 /**
- * POST an alert to the configured webhook using the EXACT payload shape the
- * `/api/v1/health/webhook` proxy forwards upstream (`{ text, content: text }`),
- * so Slack (`text`) and Discord (`content`) both render it. Server-side, no CORS
- * proxy needed — we post directly to the operator-configured webhook URL.
- *
- * When `blocks` is provided (only for a Slack incoming webhook with the native
- * Slack app configured — see the call site) it is added to the body so Slack
- * renders the rich message with an "Acknowledge" button; `text` stays as the
- * notification fallback and Discord/others ignore the extra field. Absent
- * `blocks`, the body is byte-for-byte the original `{ text, content }` — the
- * OSS/self-hosted path is unchanged.
+ * POST a pre-built webhook body to the operator-configured URL. The body is
+ * chosen per target by {@link buildWebhookDispatchBody} (Discord embeds, Slack
+ * blocks, or the generic `{ text, content }` wrapper) — this function only owns
+ * transport (timeout + non-OK handling), so the URL → shape decision stays pure
+ * and unit-testable. Server-side, no CORS proxy needed.
  */
-async function postWebhook(
-  url: string,
-  text: string,
-  blocks?: unknown[]
-): Promise<WebhookResult> {
+async function postWebhook(url: string, body: unknown): Promise<WebhookResult> {
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), 10_000)
   try {
     const res = await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(
-        blocks ? { text, content: text, blocks } : { text, content: text }
-      ),
+      body: JSON.stringify(body),
       signal: controller.signal,
     })
     if (!res.ok) {
@@ -570,6 +563,27 @@ export async function runHealthSweep(): Promise<SweepSummary> {
         telegramFallback
       )
 
+      // Normalized payload shared by every per-URL body builder below (Discord
+      // embeds carry host/value/thresholds; the Slack/generic wrapper carries
+      // `text`). One timestamp per finding so the embed and any Slack ack block
+      // agree.
+      const webhookTimestamp = new Date().toISOString()
+      const webhookPayload: AlertPayload = {
+        severity:
+          decision.kind === 'recovery'
+            ? 'recovery'
+            : (effective as 'warning' | 'critical'),
+        hostLabel: name,
+        hostId,
+        metric: ruleId,
+        value,
+        warnThreshold,
+        critThreshold,
+        title: ruleTitle,
+        label,
+        timestamp: webhookTimestamp,
+      }
+
       let anyDelivered = false
       for (const url of targets) {
         const adapter = detectAdapter(url)
@@ -596,13 +610,23 @@ export async function runHealthSweep(): Promise<SweepSummary> {
               value,
               title: ruleTitle,
               label,
-              timestamp: new Date().toISOString(),
+              timestamp: webhookTimestamp,
             },
             { hostId, ruleId, severity: effective }
           )
         }
 
-        const result = await postWebhook(url, text, ackBlocks)
+        // Per-URL body selection (#2656): Discord targets get rich embeds,
+        // Slack targets get `ackBlocks` when the app is configured (else the
+        // plain wrapper), and generic/unknown URLs keep the exact original
+        // `{ text, content }` — zero behavior change.
+        const dispatch = buildWebhookDispatchBody({
+          url,
+          text,
+          payload: webhookPayload,
+          slackBlocks: ackBlocks,
+        })
+        const result = await postWebhook(url, dispatch.body)
         if (result.ok) anyDelivered = true
 
         // Best-effort audit trail per channel — recorded on both success and


### PR DESCRIPTION
## What

Selects the outgoing webhook body **per target URL** instead of sending the same generic `{ text, content }` to every channel.

- **Discord** targets → `buildDiscordBody` rich embeds (severity colour, host, metric, value) — previously dead in dispatch.
- **Slack** incoming webhooks → existing path (native-app ack blocks when the Slack app is configured, else the plain `{ text, content }` wrapper).
- **Generic / unknown** URLs → byte-for-byte unchanged (`{ text, content }`).

The URL → body-shape decision is a new pure `buildWebhookDispatchBody` in the adapters layer, shared by:
1. the server sweep (`server-sweep.ts` — `postWebhook` now only owns transport), and
2. the client **"Send test"** proxy path (`alert-dispatcher.ts` → `routes/api/v1/health/webhook.ts`), so a Discord test previews the real embed via the proxy's verbatim `provider` path.

Recovery messages use the `severity: 'recovery'` variant.

## Not touched
- SSRF guard (`validateHostUrl`, HTTPS-only) in the webhook proxy.
- Telegram / PagerDuty / Opsgenie dispatch blocks.

## Tests
New `webhook-dispatch-body.test.ts`: URL → body-shape mapping per adapter (discord / slack-with-blocks / slack-plain / generic), including the recovery variant and the generic zero-change guarantee.

Verified locally: `biome check` clean, `tsc --noEmit` clean, adapter + health suites pass (the pre-existing `maintenance-windows` cross-file mock-leak failures exist on `main` too and are unrelated).

Closes #2656

https://claude.ai/code/session_015Mq6c6bQstbRwQnKt9htbE