### PR TITLE
chore(health): schedule the health-sweep cron with an enablement gate

### DIFF
--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -306,6 +306,12 @@ AGENTSTATE_API_KEY=
 # Health-sweep cron alerting.
 # CRON_SECRET= / HEALTH_ALERT_ENABLED=false / HEALTH_ALERT_MIN_SEVERITY=warning
 # HEALTH_ALERT_WEBHOOK_URL=
+# Scheduled (headless) health-sweep gate. On Cloudflare the `*/10 * * * *` cron
+# (wrangler.toml) fires GET /api/cron/health-sweep unattended; this switch turns
+# that scheduled run on/off. Unset = enabled iff CRON_SECRET is set (fail-closed:
+# a self-hoster who never configured cron auth never sweeps on a schedule).
+# Set true to force-enable, false to pause. Truthy: 1/true/yes/on.
+# CHM_HEALTH_SWEEP_ENABLED=
 # PagerDuty escalation / on-call routing (plan 34): HEALTH_ALERT_PAGERDUTY_ROUTING_KEY
 # is the legacy single-service Events API v2 routing key, used as a fallback
 # when no per-rule/per-host PagerDuty route is configured (Health settings >

--- a/apps/dashboard/.env.production
+++ b/apps/dashboard/.env.production
@@ -76,6 +76,15 @@ CHM_POLAR_PRODUCT_PRO_YEARLY=8c1f511b-f334-4693-8459-8325a2a82694
 CHM_POLAR_PRODUCT_MAX_MONTHLY=90883973-1cac-43d0-9a19-64ca23d9ce11
 CHM_POLAR_PRODUCT_MAX_YEARLY=2dcdc758-d919-41af-a503-bc77e5b4f27f
 
+# ── Headless health-sweep (cron alerting) ───────────────────────────────────
+# Enables the scheduled health-sweep (wrangler.toml `*/10 * * * *` → GET
+# /api/cron/health-sweep). The route still requires the CRON_SECRET secret
+# (set via scripts/set-secrets.ts). When unset this defaults to enabled iff
+# CRON_SECRET is configured; we set it explicitly here so the hosted product's
+# alerting runs unattended. Set to false to pause scheduled sweeps without
+# removing the cron. See docs/content/guide/features/health.mdx.
+CHM_HEALTH_SWEEP_ENABLED=true
+
 # ── Runtime / platform ──────────────────────────────────────────────────────
 # Marks the Cloudflare Worker runtime (set only in the worker, not Docker/Node).
 CLOUDFLARE_WORKERS=1

--- a/apps/dashboard/src/lib/health/sweep-schedule.test.ts
+++ b/apps/dashboard/src/lib/health/sweep-schedule.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for isHealthSweepEnabled — the scheduled health-sweep enablement gate
+ * (issue #2666). Encodes the resolution contract the cron dispatch depends on:
+ *   - explicit CHM_HEALTH_SWEEP_ENABLED wins (truthy → run, falsy → skip)
+ *   - unset/junk falls back to the CRON_SECRET posture (fail-closed)
+ *
+ * Pure function, so drive it with a plain map-backed env getter — no process.env
+ * or worker-binding mocking needed.
+ */
+
+import { isHealthSweepEnabled } from './sweep-schedule'
+import { describe, expect, test } from 'bun:test'
+
+function getter(env: Record<string, string | undefined>) {
+  return (key: string) => env[key]
+}
+
+describe('isHealthSweepEnabled', () => {
+  describe('explicit CHM_HEALTH_SWEEP_ENABLED overrides the default', () => {
+    for (const v of ['1', 'true', 'TRUE', 'yes', 'on', ' true ']) {
+      test(`truthy "${v}" → enabled (even without CRON_SECRET)`, () => {
+        expect(
+          isHealthSweepEnabled(getter({ CHM_HEALTH_SWEEP_ENABLED: v }))
+        ).toBe(true)
+      })
+    }
+
+    for (const v of ['0', 'false', 'FALSE', 'no', 'off']) {
+      test(`falsy "${v}" → disabled (even with CRON_SECRET set)`, () => {
+        expect(
+          isHealthSweepEnabled(
+            getter({ CHM_HEALTH_SWEEP_ENABLED: v, CRON_SECRET: 's3cret' })
+          )
+        ).toBe(false)
+      })
+    }
+  })
+
+  describe('default (flag unset/junk) follows the CRON_SECRET posture', () => {
+    test('CRON_SECRET set → enabled', () => {
+      expect(isHealthSweepEnabled(getter({ CRON_SECRET: 's3cret' }))).toBe(true)
+    })
+
+    test('CRON_SECRET unset → disabled (fail-closed)', () => {
+      expect(isHealthSweepEnabled(getter({}))).toBe(false)
+    })
+
+    test('CRON_SECRET empty/whitespace → disabled', () => {
+      expect(isHealthSweepEnabled(getter({ CRON_SECRET: '   ' }))).toBe(false)
+    })
+
+    test('unrecognized flag value → falls through to CRON_SECRET default', () => {
+      expect(
+        isHealthSweepEnabled(
+          getter({ CHM_HEALTH_SWEEP_ENABLED: 'maybe', CRON_SECRET: 's3cret' })
+        )
+      ).toBe(true)
+      expect(
+        isHealthSweepEnabled(getter({ CHM_HEALTH_SWEEP_ENABLED: 'maybe' }))
+      ).toBe(false)
+    })
+  })
+})

--- a/apps/dashboard/src/lib/health/sweep-schedule.ts
+++ b/apps/dashboard/src/lib/health/sweep-schedule.ts
@@ -1,0 +1,48 @@
+/**
+ * Health-sweep cron enablement gate.
+ *
+ * The autonomous health-sweep (`GET /api/cron/health-sweep`, wired to the
+ * Cloudflare Cron trigger in `wrangler.toml`) runs the health/anomaly sweep and
+ * fans out webhook alerts with NO dashboard tab open. Scheduling it means it
+ * fires unattended, so operators need a single switch to turn the *scheduled*
+ * run on/off independently of the CRON_SECRET auth gate.
+ *
+ * `isHealthSweepEnabled` is that switch:
+ *   - `CHM_HEALTH_SWEEP_ENABLED` set to a truthy value  → enabled
+ *   - `CHM_HEALTH_SWEEP_ENABLED` set to a falsy value    → disabled (opt-out)
+ *   - unset / junk → DEFAULT: enabled only when `CRON_SECRET` is configured,
+ *     disabled otherwise. Fail-closed, mirroring `lib/cloud` / `lib/edition`:
+ *     a self-hoster who never set up cron auth never runs the sweep on a
+ *     schedule by accident.
+ *
+ * Pure — pass any env getter (Worker binding, `process.env`, or a mock).
+ */
+
+export type EnvGetter = (key: string) => string | undefined
+
+/**
+ * Tri-state boolean parse (shared shape with lib/config/deployment-mode.ts):
+ * returns `undefined` for unset/empty/unrecognized so callers can fall through
+ * to a default.
+ */
+function parseBool(value: string | undefined): boolean | undefined {
+  if (value === undefined || value === '') return undefined
+  const n = value.trim().toLowerCase()
+  if (['1', 'true', 'yes', 'on'].includes(n)) return true
+  if (['0', 'false', 'no', 'off'].includes(n)) return false
+  return undefined
+}
+
+/**
+ * Whether the scheduled health-sweep is allowed to RUN. See module docstring
+ * for the resolution order.
+ */
+export function isHealthSweepEnabled(getEnv: EnvGetter): boolean {
+  const explicit = parseBool(getEnv('CHM_HEALTH_SWEEP_ENABLED'))
+  if (explicit !== undefined) return explicit
+
+  // Default: fail-closed to the CRON_SECRET posture. If cron auth is configured
+  // the operator clearly runs cron jobs, so the sweep runs; otherwise it does
+  // not (and the route also 503s on the missing secret anyway).
+  return Boolean(getEnv('CRON_SECRET')?.trim())
+}

--- a/apps/dashboard/src/routes/api/cron/__tests__/health-sweep.test.ts
+++ b/apps/dashboard/src/routes/api/cron/__tests__/health-sweep.test.ts
@@ -19,10 +19,30 @@
  * reading when the relevant function is not exported.
  */
 
-import { describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { secretsMatch } from '@/lib/auth/providers/constant-time'
+
+// `cloudflare:workers` is stubbed so `import { env } from 'cloudflare:workers'`
+// resolves under bun; the route then falls through to the process.env fallback
+// it already supports, and CHM_HEALTH_SWEEP_ENABLED / CRON_SECRET are driven via
+// process.env below. `runHealthSweep` is replaced with a call-recording stub so
+// the flag-gating tests assert whether the sweep actually ran without touching
+// ClickHouse. (Both mocks are file-scoped — bun runs each test file in one
+// process — but the structural/behavioral suites above do not import the route,
+// so they are unaffected.)
+mock.module('cloudflare:workers', () => ({ env: {} }))
+
+let sweepCalls = 0
+mock.module('@/lib/health/server-sweep', () => ({
+  runHealthSweep: async () => {
+    sweepCalls++
+    return { hosts: [], findings: [] }
+  },
+}))
+
+const { __handlerForTests: handler } = await import('../health-sweep')
 
 const SOURCE = readFileSync(
   join((import.meta as any).dir, '..', 'health-sweep.ts'),
@@ -57,6 +77,14 @@ describe('health-sweep.ts CRON_SECRET authorization (structural)', () => {
     // branch remained the route would leak timing information.
     expect(SOURCE).not.toMatch(/authHeader === `Bearer/)
     expect(SOURCE).not.toMatch(/searchParams\.get\(['"]secret['"]\) ===/)
+  })
+
+  test('gates the scheduled run on CHM_HEALTH_SWEEP_ENABLED', () => {
+    // issue #2666: the route must consult the enablement gate before sweeping.
+    expect(SOURCE).toContain(
+      "import { isHealthSweepEnabled } from '@/lib/health/sweep-schedule'"
+    )
+    expect(SOURCE).toMatch(/isHealthSweepEnabled\(/)
   })
 
   test('fails closed when CRON_SECRET is unset (503, not open)', () => {
@@ -104,5 +132,71 @@ describe('secretsMatch (behavioral, from constant-time module)', () => {
 
   test('returns false on length mismatch (longer provided)', () => {
     expect(secretsMatch('longsecret', 'short')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Behavioral: the handler's auth gate + scheduled-run enablement gate (#2666)
+// ---------------------------------------------------------------------------
+
+describe('health-sweep handler (behavioral: auth + enablement gate)', () => {
+  const SECRET = 'test-cron-secret'
+  const savedSecret = process.env.CRON_SECRET
+  const savedEnabled = process.env.CHM_HEALTH_SWEEP_ENABLED
+
+  beforeEach(() => {
+    sweepCalls = 0
+    delete process.env.CHM_HEALTH_SWEEP_ENABLED
+  })
+
+  afterEach(() => {
+    if (savedSecret === undefined) delete process.env.CRON_SECRET
+    else process.env.CRON_SECRET = savedSecret
+    if (savedEnabled === undefined) delete process.env.CHM_HEALTH_SWEEP_ENABLED
+    else process.env.CHM_HEALTH_SWEEP_ENABLED = savedEnabled
+  })
+
+  const req = (secret?: string) =>
+    new Request('https://x/api/cron/health-sweep', {
+      headers: secret ? { authorization: `Bearer ${secret}` } : {},
+    })
+
+  test('CRON_SECRET unset → 503 and does not sweep', async () => {
+    delete process.env.CRON_SECRET
+    const res = await handler(req(SECRET))
+    expect(res.status).toBe(503)
+    expect(sweepCalls).toBe(0)
+  })
+
+  test('wrong secret → 401 and does not sweep', async () => {
+    process.env.CRON_SECRET = SECRET
+    const res = await handler(req('nope'))
+    expect(res.status).toBe(401)
+    expect(sweepCalls).toBe(0)
+  })
+
+  test('authorized + flag unset (CRON_SECRET set) → sweeps (200)', async () => {
+    process.env.CRON_SECRET = SECRET
+    const res = await handler(req(SECRET))
+    expect(res.status).toBe(200)
+    expect(sweepCalls).toBe(1)
+  })
+
+  test('authorized + CHM_HEALTH_SWEEP_ENABLED=false → 200 no-op, no sweep', async () => {
+    process.env.CRON_SECRET = SECRET
+    process.env.CHM_HEALTH_SWEEP_ENABLED = 'false'
+    const res = await handler(req(SECRET))
+    expect(res.status).toBe(200)
+    expect(sweepCalls).toBe(0)
+    const body = (await res.json()) as { skipped?: boolean }
+    expect(body.skipped).toBe(true)
+  })
+
+  test('authorized + CHM_HEALTH_SWEEP_ENABLED=true → sweeps', async () => {
+    process.env.CRON_SECRET = SECRET
+    process.env.CHM_HEALTH_SWEEP_ENABLED = 'true'
+    const res = await handler(req(SECRET))
+    expect(res.status).toBe(200)
+    expect(sweepCalls).toBe(1)
   })
 })

--- a/apps/dashboard/src/routes/api/cron/health-sweep.ts
+++ b/apps/dashboard/src/routes/api/cron/health-sweep.ts
@@ -2,10 +2,14 @@
  * Autonomous Health Sweep Cron Endpoint — GET /api/cron/health-sweep
  *
  * Invoked by the Cloudflare Cron Trigger (see wrangler.toml `[triggers] crons`)
- * every 5 minutes. The @cloudflare/vite-plugin worker routes scheduled events to
- * the fetch handler, so the cron hits this GET route. Runs the health/anomaly
+ * every 10 minutes. The @cloudflare/vite-plugin worker routes scheduled events
+ * to the fetch handler, so the cron hits this GET route. Runs the health/anomaly
  * sweep over all hosts and dispatches webhook alerts for findings at/above the
  * configured severity.
+ *
+ * Two gates apply, in order: (1) CRON_SECRET auth (below), then (2) the
+ * CHM_HEALTH_SWEEP_ENABLED enablement switch (see lib/health/sweep-schedule.ts)
+ * — a falsy value makes the scheduled run a 200 no-op without removing the cron.
  *
  * Guarded by a shared secret (CRON_SECRET) supplied via the `Authorization:
  * Bearer <secret>` header or the `?secret=` query param. Returns 401 on
@@ -36,6 +40,7 @@ import { error, warn } from '@chm/logger'
 import { bridgeClickHouseEnv, bridgePostgresEnv } from '@/lib/api/server-env'
 import { secretsMatch } from '@/lib/auth/providers/constant-time'
 import { runHealthSweep } from '@/lib/health/server-sweep'
+import { isHealthSweepEnabled } from '@/lib/health/sweep-schedule'
 
 /**
  * Authorize a cron request. Returns a short-circuit `Response` when the request
@@ -75,6 +80,26 @@ async function handler(request: Request): Promise<Response> {
   const denied = authorizeCron(request)
   if (denied) return denied
 
+  // Scheduled-run enablement gate (issue #2666). The `*/10 * * * *` Cloudflare
+  // Cron trigger fires this route unattended, so operators get a single switch
+  // (CHM_HEALTH_SWEEP_ENABLED) to disable the *scheduled* sweep without removing
+  // the cron or the secret. Reads the Worker binding first (authoritative on
+  // workerd), then process.env (node/dev). Default when unset: enabled because
+  // we are already past the CRON_SECRET auth gate above. Returns 200 (a no-op
+  // success, not an error) so the scheduler treats a disabled sweep as "ran
+  // fine, nothing to do".
+  const bindings = env as Record<string, string | undefined>
+  if (
+    !isHealthSweepEnabled(
+      (key) => bindings[key] ?? process.env[key] ?? undefined
+    )
+  ) {
+    return Response.json(
+      { skipped: true, reason: 'CHM_HEALTH_SWEEP_ENABLED is falsy' },
+      { status: 200 }
+    )
+  }
+
   // Copy CLICKHOUSE_* from the Worker binding onto process.env so
   // getClickHouseConfigs() (inside runHealthSweep) can resolve hosts. Also
   // bridge the POSTGRES_* lists + feature flag so the sweep's env-gated Postgres
@@ -103,3 +128,5 @@ export const Route = createFileRoute('/api/cron/health-sweep')({
     },
   },
 })
+
+export { handler as __handlerForTests }

--- a/apps/dashboard/wrangler.toml
+++ b/apps/dashboard/wrangler.toml
@@ -194,14 +194,18 @@ simple = { limit = 10, period = 60 }
 # <secret>` (an external scheduler, or a Cloudflare Cron that forwards the
 # secret to the route's URL — see docs/content/guide/features/health.mdx). The
 # schedules below document each cadence:
-#   - "0 3 * * *"  → retention-prune, daily at 03:00 UTC.
-#   - "0 8 * * 1"  → weekly-report, Mondays at 08:00 UTC (per-host opt-in via
+#   - "0 3 * * *"    → retention-prune, daily at 03:00 UTC.
+#   - "0 8 * * 1"    → weekly-report, Mondays at 08:00 UTC (per-host opt-in via
 #     CHM_WEEKLY_REPORT_HOSTS; no-op when unset).
-# health-sweep (every 5 min) should be added here when that route is confirmed
-# working end-to-end.
+#   - "*/10 * * * *" → health-sweep, every 10 minutes (issue #2666). Runs the
+#     health/anomaly sweep + webhook alert fan-out with no dashboard tab open.
+#     Gated at runtime by CHM_HEALTH_SWEEP_ENABLED (see .env.production /
+#     .env.example): when falsy the route no-ops (200); when unset it defaults to
+#     enabled iff CRON_SECRET is configured. 10 min (not 5) leaves CPU headroom
+#     since the sweep also generates AI insights per host.
 # ─────────────────────────────────────────────────────────────────────────────
 [triggers]
-crons = ["0 3 * * *", "0 8 * * 1"]
+crons = ["0 3 * * *", "0 8 * * 1", "*/10 * * * *"]
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Preview environment for PR deployments

--- a/docs/content/guide/features/health.mdx
+++ b/docs/content/guide/features/health.mdx
@@ -95,6 +95,7 @@ The health-sweep endpoint runs checks over all configured hosts and sends a webh
 | Variable | Default | Description |
 |---|---|---|
 | `CRON_SECRET` | (unset = **endpoint disabled**) | **Required.** Guards `GET /api/cron/health-sweep` and `GET /api/cron/retention-prune`. Pass as `Authorization: Bearer <secret>` (or `?secret=<secret>`). When it is **unset/empty the endpoints fail closed and return HTTP 503** — they do not run. Note that `retention-prune` is **destructive** (it deletes conversation rows past each plan's retention window), which is why these routes refuse to run unauthenticated. |
+| `CHM_HEALTH_SWEEP_ENABLED` | (unset = enabled iff `CRON_SECRET` is set) | Gates the **scheduled** (headless) sweep fired by the Cloudflare Cron trigger. Set `true` to force-enable, `false` to pause scheduled sweeps without removing the cron. When unset it fails closed to the `CRON_SECRET` posture. Does not affect manual `curl` hits (those only need a valid `CRON_SECRET`). Truthy values: `1`/`true`/`yes`/`on`. |
 | `HEALTH_ALERT_ENABLED` | `false` | Set to `true` to enable webhook dispatch. |
 | `HEALTH_ALERT_WEBHOOK_URL` | (required if enabled) | Slack or Discord incoming webhook URL. Payload is `{"text": "...", "content": "..."}` so both render it. See [Alerting to Slack and Discord](/guide/guides/alerting-slack-discord) for setup examples. |
 | `HEALTH_ALERT_MIN_SEVERITY` | `warning` | Minimum severity that triggers a notification. Values: `warning` or `critical`. |
@@ -144,14 +145,19 @@ The endpoint returns a JSON array of check results. It always returns HTTP 200; 
 
 ### Scheduling (Cloudflare Cron)
 
-In `wrangler.toml`:
+The hosted deploy schedules the sweep every 10 minutes. In `wrangler.toml`:
 
 ```toml
 [triggers]
-crons = ["*/5 * * * *"]
+crons = ["0 3 * * *", "0 8 * * 1", "*/10 * * * *"]  # retention, weekly-report, health-sweep
 ```
 
-The Cloudflare scheduled trigger is routed to the route's `GET` handler. Because that handler now **requires** `CRON_SECRET` (it returns HTTP 503 when unset), make sure the secret is configured before relying on the schedule, and invoke the endpoint with the `Authorization: Bearer <secret>` header (or `?secret=<secret>`) so the request is authorized — e.g. from an external scheduler, or a Worker Cron that forwards the secret. An unauthenticated scheduled hit will be rejected by design.
+The Cloudflare scheduled trigger is routed to the route's `GET` handler. Two gates apply, in order:
+
+1. **Auth** — the handler **requires** `CRON_SECRET` (returns HTTP 503 when unset). Configure the secret and invoke with `Authorization: Bearer <secret>` (or `?secret=<secret>`) — e.g. from an external scheduler, or a Worker Cron that forwards the secret. An unauthenticated scheduled hit is rejected by design.
+2. **Enablement** — after auth, the handler consults `CHM_HEALTH_SWEEP_ENABLED`. When it is falsy the route returns `200 {"skipped": true}` **without running the sweep**, so you can pause scheduled alerting without touching the cron or the secret. When unset it defaults to enabled (since `CRON_SECRET` is already present at that point).
+
+The `*/10` cadence (rather than `*/5`) leaves CPU-time headroom: the sweep also generates AI insights per host, so its cost scales with the number of configured `CLICKHOUSE_HOST` entries. For very large host fleets, either lengthen the cadence or pause the scheduled sweep (`CHM_HEALTH_SWEEP_ENABLED=false`) and drive it from an external scheduler.
 
 ## Notes & limitations
 

--- a/docs/knowledge/deployment.md
+++ b/docs/knowledge/deployment.md
@@ -270,6 +270,25 @@ wrangler secret put CLICKHOUSE_PASSWORD
 pnpm run cf:health
 ```
 
+### Cron triggers (headless jobs)
+
+`wrangler.toml` `[triggers] crons` schedules the secret-gated GET routes under
+`src/routes/api/cron/`. The Cloudflare scheduled trigger is routed to the route's
+`GET` handler; each route requires `CRON_SECRET` (`Authorization: Bearer` or
+`?secret=`) and **fails closed (503) when it is unset**.
+
+| Cron | Route | Notes |
+|------|-------|-------|
+| `0 3 * * *` | `retention-prune` | Daily 03:00 UTC. **Destructive** (deletes conversation rows past each plan's retention window). |
+| `0 8 * * 1` | `weekly-report` | Mondays 08:00 UTC. Per-host opt-in via `CHM_WEEKLY_REPORT_HOSTS`; no-op when unset. |
+| `*/10 * * * *` | `health-sweep` | Every 10 min (#2666). Runs health/anomaly checks + webhook alert fan-out headlessly. Gated by `CHM_HEALTH_SWEEP_ENABLED` (falsy → route no-ops 200; unset → enabled iff `CRON_SECRET` set). Also generates AI insights per host, so its cost scales with `CLICKHOUSE_HOST` count — 10 min (not 5) leaves CPU headroom; lengthen the cadence or set `CHM_HEALTH_SWEEP_ENABLED=false` for very large fleets. |
+
+`CHM_HEALTH_SWEEP_ENABLED` is a non-secret Worker var: committed in
+`apps/dashboard/.env.production` (`=true` for the hosted product) and documented
+in `.env.example` for self-hosters. The `[env.preview]` worker declares no
+`[triggers]`, so preview never runs these crons. See
+`docs/content/guide/features/health.mdx` for the full alerting setup.
+
 ## Edge Routing & Host Redirects (4-worker topology)
 
 Production runs four workers on the `chmonitor.dev` zone:


### PR DESCRIPTION
## What

Schedules the autonomous health-sweep (`GET /api/cron/health-sweep`, built in #2666's predecessor) so alerts fire from a schedule with **no dashboard tab open**, and adds a runtime switch to pause it.

## Changes

- **`wrangler.toml`** — add `*/10 * * * *` to `[triggers] crons` (now `retention` + `weekly-report` + `health-sweep`); document each cadence. `[env.preview]` declares no triggers, so preview never runs crons.
- **`lib/health/sweep-schedule.ts`** (new) — `isHealthSweepEnabled(getEnv)`: explicit `CHM_HEALTH_SWEEP_ENABLED` truthy/falsy wins; **unset/junk → enabled iff `CRON_SECRET` is set** (fail-closed, mirrors `lib/cloud`/`lib/edition`).
- **`routes/api/cron/health-sweep.ts`** — after the existing CRON_SECRET auth gate, consult the enablement gate; a falsy flag returns `200 {"skipped": true}` **without running the sweep** (a no-op success, so the scheduler sees "ran fine"). Exports `__handlerForTests`. `server-sweep.ts` internals untouched (parallel PRs edit it).
- **`.env.production`** — `CHM_HEALTH_SWEEP_ENABLED=true` (enables the hosted product's headless alerting; injected as a Worker var by `patch-wrangler-env.ts`, no `[vars]` block added). **`.env.example`** — documented + commented for self-hosters.
- **Docs** — `docs/content/guide/features/health.mdx` (two-gate scheduling, `*/10` CPU note, new env row) + `docs/knowledge/deployment.md` (cron-triggers table).

## Decisions

- **Cadence `*/10` not `*/5`** — the sweep also generates AI insights per host, so cost scales with `CLICKHOUSE_HOST` count. 10 min leaves Workers CPU headroom. Rather than restructure `server-sweep.ts` (out of scope; other PRs touch it) I documented the mitigation: lengthen the cadence or set `CHM_HEALTH_SWEEP_ENABLED=false` and drive from an external scheduler for very large fleets. A host-cap / skip-insights-on-cron knob would require editing `server-sweep.ts` internals and is deferred to avoid conflicts.
- **Default = enabled when `CRON_SECRET` is set** — a self-hoster who never configured cron auth never sweeps on a schedule by accident; the hosted product sets the flag explicitly.

## Tests

- `lib/health/sweep-schedule.test.ts` — resolver contract (truthy/falsy override, CRON_SECRET fallback, empty/whitespace/junk).
- `routes/api/cron/__tests__/health-sweep.test.ts` — added behavioral handler tests via `__handlerForTests`: unset secret → 503 (no sweep), wrong secret → 401 (no sweep), authorized+unset flag → sweeps, `=false` → 200 no-op (no sweep), `=true` → sweeps; plus a structural assertion that the route wires the gate.
- `bun test` both files: 33 pass / 0 fail. `tsc --noEmit` clean, `biome check` clean.

## Manual prod verification (not doable from CI — test plan)

- [ ] Confirm `CRON_SECRET` + `HEALTH_ALERT_*` are set on the `chmonitor-dash` worker, then hit `GET /api/cron/health-sweep` with `Authorization: Bearer $CRON_SECRET` and verify HTTP 200 + a test-channel alert + alert-history row.
- [ ] After deploy, confirm the `*/10` Cloudflare Cron fires and alerts arrive with no browser open.
- [ ] Watch Worker CPU-time metrics across a few ticks for the demo host fleet — confirm no CPU-limit regressions.

Closes #2666

https://claude.ai/code/session_015Mq6c6bQstbRwQnKt9htbE