### PR TITLE
feat(alerts): smart auto-suggest alert rules from live cluster behavior

### DIFF
--- a/apps/dashboard/src/components/health/alert-suggestions-panel.tsx
+++ b/apps/dashboard/src/components/health/alert-suggestions-panel.tsx
@@ -1,0 +1,215 @@
+/**
+ * Suggested alerts panel (issue #2667).
+ *
+ * Renders the server-computed smart alert suggestions as cards: a reason, the
+ * proposed thresholds (editable inline), and Accept / Dismiss. Accepting posts
+ * the (possibly edited) thresholds through the same custom-rules path the rule
+ * builder uses, so a one-click accept lands a working custom rule. There is no
+ * free-form SQL surface — every suggestion targets a whitelisted metric.
+ */
+
+import { Lightbulb } from 'lucide-react'
+import { toast } from 'sonner'
+
+import type {
+  AlertSuggestionInfo,
+  SuggestionSource,
+} from '@/lib/hooks/use-alert-suggestions'
+
+import { useState } from 'react'
+import { EmptyState } from '@/components/empty-state'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  useAlertSuggestionMutations,
+  useAlertSuggestions,
+} from '@/lib/hooks/use-alert-suggestions'
+import { cn } from '@/lib/utils'
+
+const SOURCE_LABELS: Record<SuggestionSource, string> = {
+  'recurring-finding': 'Recurring',
+  baseline: 'Baseline',
+  'near-threshold': 'Near threshold',
+  'cluster-shape': 'Cluster shape',
+}
+
+function SuggestionCard({
+  suggestion,
+  onChanged,
+}: {
+  suggestion: AlertSuggestionInfo
+  onChanged: () => void
+}) {
+  const { acceptSuggestion, dismissSuggestion } = useAlertSuggestionMutations()
+  const [warning, setWarning] = useState(String(suggestion.warning))
+  const [critical, setCritical] = useState(String(suggestion.critical))
+  const [busy, setBusy] = useState<'accept' | 'dismiss' | null>(null)
+
+  const handleAccept = async () => {
+    const warningNum = Number(warning)
+    const criticalNum = Number(critical)
+    if (!Number.isFinite(warningNum) || !Number.isFinite(criticalNum)) {
+      toast.error('Thresholds must be numbers')
+      return
+    }
+    setBusy('accept')
+    try {
+      await acceptSuggestion({
+        name: suggestion.title,
+        metric: suggestion.metric,
+        op: suggestion.op,
+        warning: warningNum,
+        critical: criticalNum,
+      })
+      toast.success('Rule created from suggestion')
+      onChanged()
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : 'Failed to accept suggestion'
+      )
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const handleDismiss = async () => {
+    setBusy('dismiss')
+    try {
+      await dismissSuggestion(suggestion.key)
+      onChanged()
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : 'Failed to dismiss suggestion'
+      )
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-3 rounded-md border p-3">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex min-w-0 flex-col gap-1">
+          <span className="truncate text-sm font-medium">
+            {suggestion.title}
+          </span>
+          <div className="flex flex-wrap items-center gap-1 text-xs text-muted-foreground">
+            <Badge variant="secondary">
+              {SOURCE_LABELS[suggestion.source]}
+            </Badge>
+            <Badge variant="outline">{suggestion.metric}</Badge>
+            <span>{suggestion.hostName}</span>
+          </div>
+        </div>
+      </div>
+
+      <p className="text-xs text-muted-foreground">{suggestion.reason}</p>
+
+      <div className="flex flex-wrap items-end gap-2">
+        <div className="flex flex-col gap-1">
+          <Label className="text-xs text-muted-foreground">
+            Warning {suggestion.op}
+          </Label>
+          <Input
+            type="number"
+            inputMode="decimal"
+            className="w-[120px]"
+            value={warning}
+            onChange={(e) => setWarning(e.target.value)}
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label className="text-xs text-muted-foreground">
+            Critical {suggestion.op}
+          </Label>
+          <Input
+            type="number"
+            inputMode="decimal"
+            className="w-[120px]"
+            value={critical}
+            onChange={(e) => setCritical(e.target.value)}
+          />
+        </div>
+        <span className="self-end pb-2 text-xs text-muted-foreground">
+          {suggestion.unit}
+          {suggestion.currentValue !== null
+            ? ` · now ${suggestion.currentValue}`
+            : ''}
+        </span>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button size="sm" disabled={busy !== null} onClick={handleAccept}>
+          {busy === 'accept' ? 'Accepting…' : 'Accept'}
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          disabled={busy !== null}
+          onClick={handleDismiss}
+        >
+          {busy === 'dismiss' ? 'Dismissing…' : 'Dismiss'}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export function AlertSuggestionsPanel({ className }: { className?: string }) {
+  const { suggestions, isLoading, error, refetch } = useAlertSuggestions()
+
+  // 501 when no D1 binding — mirror RuleBuilderPanel's "not available" note.
+  const notConfigured =
+    error !== null &&
+    typeof error === 'object' &&
+    'status' in error &&
+    (error as { status?: number }).status === 501
+
+  if (notConfigured) {
+    return (
+      <p className={cn('text-sm text-muted-foreground', className)}>
+        Alert suggestions require a configured database backend (cloud
+        deployments, or self-hosted with a D1 database configured). Not
+        available on this deployment.
+      </p>
+    )
+  }
+
+  return (
+    <div className={cn('flex flex-col gap-3', className)}>
+      <p className="text-xs text-muted-foreground">
+        Smart suggestions from this cluster's live behaviour — near-threshold
+        metrics, learned baselines, cluster shape, and recurring findings. Each
+        maps to a vetted, read-only metric; accepting one creates a custom rule
+        evaluated on every sweep.
+      </p>
+
+      {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+
+      {!isLoading && suggestions.length === 0 && (
+        <EmptyState
+          icon={
+            <Lightbulb
+              className="size-6 text-muted-foreground"
+              strokeWidth={1.5}
+            />
+          }
+          title="No suggestions right now"
+          description="This cluster looks well-covered. New suggestions appear as behaviour changes or findings recur."
+        />
+      )}
+
+      <div className="flex flex-col gap-2">
+        {suggestions.map((suggestion) => (
+          <SuggestionCard
+            key={suggestion.key}
+            suggestion={suggestion}
+            onChanged={() => refetch()}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/health/health-settings-dialog.tsx
+++ b/apps/dashboard/src/components/health/health-settings-dialog.tsx
@@ -3,6 +3,7 @@ import { toast } from 'sonner'
 
 import { ActiveAlertsPanel } from './active-alerts-panel'
 import { AlertRoutingPanel } from './alert-routing-dialog'
+import { AlertSuggestionsPanel } from './alert-suggestions-panel'
 import { HEALTH_CHECKS } from './health-checks'
 import { MaintenanceWindowsPanel } from './maintenance-windows-panel'
 import { RecentAlertsCard } from './recent-alerts-card'
@@ -273,6 +274,7 @@ export function HealthSettingsDialog() {
               <TabsTrigger value="routing">Routing</TabsTrigger>
               <TabsTrigger value="webhooks">Webhooks</TabsTrigger>
               <TabsTrigger value="maintenance">Maintenance</TabsTrigger>
+              <TabsTrigger value="suggested">Suggested</TabsTrigger>
               <TabsTrigger value="custom-rules">Custom Rules</TabsTrigger>
             </TabsList>
           </div>
@@ -627,6 +629,12 @@ export function HealthSettingsDialog() {
           <TabsContent value="maintenance" className="min-h-0 overflow-hidden">
             <ScrollArea className="h-full pr-3">
               <MaintenanceWindowsPanel />
+            </ScrollArea>
+          </TabsContent>
+
+          <TabsContent value="suggested" className="min-h-0 overflow-hidden">
+            <ScrollArea className="h-full pr-3">
+              <AlertSuggestionsPanel />
             </ScrollArea>
           </TabsContent>
 

--- a/apps/dashboard/src/db/conversations-migrations/0020_alert_suggestion_dismissals.sql
+++ b/apps/dashboard/src/db/conversations-migrations/0020_alert_suggestion_dismissals.sql
@@ -1,0 +1,18 @@
+-- Smart alert-rule suggestions (issue #2667): persist which suggested rules an
+-- owner has dismissed, so a dismissed suggestion stays dismissed across
+-- recomputes. Mirrors the AI-insights stable-key dismissal pattern, but
+-- server-side in D1 because suggestions are computed server-side (the insight
+-- cards dismiss in localStorage instead). `suggestion_key` is the stable
+-- `${metric}:host:${hostId}` key emitted by lib/health/alert-suggestions.ts —
+-- never free-form SQL. `owner_id` follows the same single-tenant convention as
+-- custom_alert_rules / alert_routes: 'oss' (self-hosted / no Clerk) or the
+-- Clerk user id in cloud mode.
+CREATE TABLE IF NOT EXISTS alert_suggestion_dismissals (
+  owner_id       TEXT NOT NULL,
+  suggestion_key TEXT NOT NULL,
+  dismissed_at   INTEGER NOT NULL,
+  PRIMARY KEY (owner_id, suggestion_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_alert_suggestion_dismissals_owner
+  ON alert_suggestion_dismissals (owner_id);

--- a/apps/dashboard/src/lib/health/alert-suggestion-dismissals-store.test.ts
+++ b/apps/dashboard/src/lib/health/alert-suggestion-dismissals-store.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for the D1-backed alert-suggestion dismissal store (issue #2667).
+ *
+ * A behavioral fake of D1Database (prepare/bind/run/all) injected via a mocked
+ * @chm/platform exercises the real SQL: dismissal persists per owner+key,
+ * survives a re-list, is idempotent (ON CONFLICT DO NOTHING), stays owner
+ * scoped, the READ path fails OPEN (empty set, never throws) when no binding is
+ * present, and the WRITE path fails LOUD (throws NOT_CONFIGURED) so a no-op
+ * dismissal can't silently resurrect a card. Mirrors `baseline-store.test.ts`.
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+interface FakeDismissalRow {
+  owner_id: string
+  suggestion_key: string
+  dismissed_at: number
+}
+
+function makeFakeD1() {
+  const rows = new Map<string, FakeDismissalRow>()
+  const keyFor = (owner: string, key: string) => `${owner}::${key}`
+
+  function prepare(sql: string) {
+    const isInsert = /INSERT INTO/i.test(sql)
+    return {
+      // The lazy migration runs `.run()` directly off prepare() (no bind()).
+      async run() {
+        return { meta: { changes: 0 } }
+      },
+      bind(...args: unknown[]) {
+        return {
+          async run() {
+            if (isInsert) {
+              const [owner, key, at] = args as [string, string, number]
+              const k = keyFor(owner, key)
+              if (!rows.has(k)) {
+                rows.set(k, {
+                  owner_id: owner,
+                  suggestion_key: key,
+                  dismissed_at: at,
+                })
+              }
+            }
+            return { meta: { changes: 1 } }
+          },
+          async all<T>(): Promise<{ results: T[] }> {
+            const [owner] = args as [string]
+            const out = [...rows.values()].filter((r) => r.owner_id === owner)
+            return { results: out as unknown as T[] }
+          },
+        }
+      },
+    }
+  }
+
+  return { prepare, _rows: rows }
+}
+
+let currentDb: ReturnType<typeof makeFakeD1> | null = null
+
+mock.module('@chm/platform', () => ({
+  getPlatformBindings: () => ({
+    getD1Database: () => currentDb,
+  }),
+}))
+
+const {
+  listDismissedSuggestionKeys,
+  dismissSuggestion,
+  SuggestionDismissalStoreError,
+  _resetSuggestionDismissalMigration,
+} = await import('./alert-suggestion-dismissals-store')
+
+beforeEach(() => {
+  currentDb = makeFakeD1()
+  _resetSuggestionDismissalMigration()
+})
+
+describe('alert-suggestion-dismissals-store', () => {
+  test('dismiss then list round-trips the key, owner-scoped', async () => {
+    await dismissSuggestion('oss', 'disk-usage-percent:host:0')
+    const keys = await listDismissedSuggestionKeys('oss')
+    expect(keys.has('disk-usage-percent:host:0')).toBe(true)
+
+    // A different owner sees nothing.
+    expect((await listDismissedSuggestionKeys('other')).size).toBe(0)
+  })
+
+  test('dismiss is idempotent (no duplicate rows)', async () => {
+    await dismissSuggestion('oss', 'stuck-merges:host:1')
+    await dismissSuggestion('oss', 'stuck-merges:host:1')
+    const keys = await listDismissedSuggestionKeys('oss')
+    expect([...keys]).toEqual(['stuck-merges:host:1'])
+  })
+
+  test('list returns an empty set for an owner with no dismissals', async () => {
+    expect((await listDismissedSuggestionKeys('oss')).size).toBe(0)
+  })
+
+  test('read fails OPEN (empty set) when no D1 binding is present', async () => {
+    currentDb = null
+    expect((await listDismissedSuggestionKeys('oss')).size).toBe(0)
+  })
+
+  test('write fails LOUD (NOT_CONFIGURED) when no D1 binding is present', async () => {
+    currentDb = null
+    let thrown: unknown
+    try {
+      await dismissSuggestion('oss', 'x:host:0')
+    } catch (err) {
+      thrown = err
+    }
+    expect(thrown).toBeInstanceOf(SuggestionDismissalStoreError)
+    expect(
+      (thrown as InstanceType<typeof SuggestionDismissalStoreError>).code
+    ).toBe('NOT_CONFIGURED')
+  })
+})

--- a/apps/dashboard/src/lib/health/alert-suggestion-dismissals-store.ts
+++ b/apps/dashboard/src/lib/health/alert-suggestion-dismissals-store.ts
@@ -1,0 +1,130 @@
+/**
+ * D1-backed dismissal store for alert suggestions (issue #2667).
+ *
+ * A dismissed suggestion must STAY dismissed across recomputes, so we persist
+ * the stable suggestion key (`${metric}:host:${hostId}`) per owner — mirroring
+ * the AI-insights stable-key dismissal pattern, but server-side in D1 (shared
+ * `CHM_CLOUD_D1` binding) rather than per-browser localStorage, because the
+ * suggestion set is computed server-side.
+ *
+ * Ownership is scoped exactly like `custom-rules-store.ts` (`owner_id`): the
+ * fixed `oss` tenant when Clerk is unconfigured, the Clerk user id otherwise.
+ *
+ * READ path fails OPEN ({@link listDismissedSuggestionKeys} → empty set on any
+ * error) so a missing binding just means "nothing dismissed yet" and the GET
+ * endpoint keeps working. WRITE path fails LOUD
+ * ({@link dismissSuggestion} throws {@link SuggestionDismissalStoreError}) so the
+ * POST endpoint can return an honest 501/500 instead of pretending a dismissal
+ * stuck when it didn't. The table is created lazily (idempotent DDL) in addition
+ * to the `0020_alert_suggestion_dismissals` migration.
+ */
+
+import { debug } from '@chm/logger'
+import { getPlatformBindings } from '@chm/platform'
+
+const D1_BINDING_NAME = 'CHM_CLOUD_D1'
+const TABLE = 'alert_suggestion_dismissals'
+
+const MIGRATION_SQL = `
+  CREATE TABLE IF NOT EXISTS ${TABLE} (
+    owner_id TEXT NOT NULL,
+    suggestion_key TEXT NOT NULL,
+    dismissed_at INTEGER NOT NULL,
+    PRIMARY KEY (owner_id, suggestion_key)
+  )
+`
+
+export class SuggestionDismissalStoreError extends Error {
+  constructor(
+    message: string,
+    public readonly code: 'NOT_CONFIGURED' | 'STORAGE_ERROR',
+    public readonly cause?: unknown
+  ) {
+    super(message)
+    this.name = 'SuggestionDismissalStoreError'
+  }
+}
+
+function getDb(): D1Database | null {
+  return getPlatformBindings().getD1Database(D1_BINDING_NAME)
+}
+
+// Single-flight lazy migration: idempotent DDL runs at most once per process; a
+// failure clears the memo so the next call retries.
+let migration: Promise<void> | null = null
+function ensureMigrated(db: D1Database): Promise<void> {
+  if (!migration) {
+    migration = db
+      .prepare(MIGRATION_SQL)
+      .run()
+      .then(() => undefined)
+      .catch((err) => {
+        migration = null
+        throw err
+      })
+  }
+  return migration
+}
+
+/**
+ * All suggestion keys the owner has dismissed. Fails OPEN: any error (no
+ * binding, unmigrated table, query failure) resolves to an empty set so the
+ * compute path degrades to "show everything" rather than throwing.
+ */
+export async function listDismissedSuggestionKeys(
+  ownerId: string
+): Promise<Set<string>> {
+  try {
+    const db = getDb()
+    if (!db) return new Set()
+    await ensureMigrated(db)
+    const result = await db
+      .prepare(`SELECT suggestion_key FROM ${TABLE} WHERE owner_id = ?1`)
+      .bind(ownerId)
+      .all<{ suggestion_key: string }>()
+    return new Set((result.results ?? []).map((r) => r.suggestion_key))
+  } catch (err) {
+    debug('[alert-suggestion-dismissals] read failed', String(err))
+    return new Set()
+  }
+}
+
+/**
+ * Persist a dismissal (idempotent). Fails LOUD so the API can report an honest
+ * error when D1 is unavailable — a dismissal that silently no-ops would let the
+ * card immediately resurrect on the next poll.
+ */
+export async function dismissSuggestion(
+  ownerId: string,
+  key: string
+): Promise<void> {
+  const db = getDb()
+  if (!db) {
+    throw new SuggestionDismissalStoreError(
+      `${D1_BINDING_NAME} binding not found. Dismissing suggestions requires a configured D1 database.`,
+      'NOT_CONFIGURED'
+    )
+  }
+  try {
+    await ensureMigrated(db)
+    await db
+      .prepare(
+        `INSERT INTO ${TABLE} (owner_id, suggestion_key, dismissed_at)
+         VALUES (?1, ?2, ?3)
+         ON CONFLICT (owner_id, suggestion_key) DO NOTHING`
+      )
+      .bind(ownerId, key, Date.now())
+      .run()
+  } catch (err) {
+    throw new SuggestionDismissalStoreError(
+      `Failed to persist suggestion dismissal: ${err instanceof Error ? err.message : 'Unknown error'}`,
+      'STORAGE_ERROR',
+      err
+    )
+  }
+}
+
+/** Test-only: reset the lazy-migration memo so the next call re-runs DDL. */
+export function _resetSuggestionDismissalMigration(): void {
+  migration = null
+}

--- a/apps/dashboard/src/lib/health/alert-suggestions-compute.ts
+++ b/apps/dashboard/src/lib/health/alert-suggestions-compute.ts
@@ -1,0 +1,270 @@
+/**
+ * I/O orchestrator for the alert-suggestion engine (issue #2667).
+ *
+ * Gathers the four signal sources per host and hands them to the PURE scorer in
+ * `alert-suggestions.ts`. Kept separate from that module so the heuristics stay
+ * unit-testable without pulling in the ClickHouse client / D1 / insights store.
+ *
+ * Everything here is best-effort and read-only: a failed probe on one host or
+ * one metric is skipped, never fatal, mirroring `current-findings.ts`. A short
+ * per-owner TTL cache keeps the GET endpoint cheap under repeated polling.
+ */
+
+import type { ClickHouseConfig } from '@chm/clickhouse-client'
+import type {
+  AlertSuggestion,
+  BaselineSignal,
+  ClusterShape,
+  HostSignals,
+  RecurringFindingSignal,
+} from './alert-suggestions'
+import type { MetricKey } from './rule-builder-schema'
+
+import { listDismissedSuggestionKeys } from './alert-suggestion-dismissals-store'
+import { buildSuggestions } from './alert-suggestions'
+import { listCustomRules } from './custom-rules-store'
+import { METRIC_CATALOG } from './rule-builder-schema'
+import { fetchData, getClickHouseConfigs } from '@chm/clickhouse-client'
+import { debug } from '@chm/logger'
+import { listBaselines } from '@/lib/insights/baseline-store'
+import { resolveInsightsStore } from '@/lib/insights/store/resolve-store'
+
+const CATALOG_KEYS = Object.keys(METRIC_CATALOG) as MetricKey[]
+
+/** Lookback window for recurring insight findings. */
+const FINDINGS_LOOKBACK = '7 DAY'
+/** A finding must recur at least this many times to count as "recurring". */
+const RECURRENCE_THRESHOLD = 2
+
+/** TTL for the compute cache (ms). Suggestions move slowly; keep GET cheap. */
+const CACHE_TTL_MS = 60_000
+
+interface CacheEntry {
+  at: number
+  value: AlertSuggestion[]
+}
+const cache = new Map<string, CacheEntry>()
+
+function hostLabel(config: ClickHouseConfig): string {
+  return config.customName?.trim() || config.host
+}
+
+/**
+ * Normalize an arbitrary baseline/finding metric string to a catalog key.
+ * Matches the catalog key directly first, then a small alias table (collectors
+ * and baselines use their own metric ids). Returns null when nothing maps —
+ * unknown metrics are silently ignored, never guessed.
+ */
+const METRIC_ALIASES: Record<string, MetricKey> = {
+  'replication-lag': 'replication-max-lag',
+  'absolute-delay': 'replication-max-lag',
+  'max-lag': 'replication-max-lag',
+  'readonly-replica': 'readonly-replicas',
+  'disk-usage': 'disk-usage-percent',
+  'disk-percent': 'disk-usage-percent',
+  'failed-mutation': 'failed-mutations',
+  'stuck-merge': 'stuck-merges',
+  'active-mutation': 'active-mutations',
+  'long-running-query': 'long-running-queries',
+  'running-query': 'running-queries',
+  'parts-per-partition': 'parts-per-partition-max',
+  'replication-queue': 'replication-queue-max',
+}
+
+export function mapToMetricKey(raw: string): MetricKey | null {
+  const norm = raw.trim().toLowerCase().replace(/_/g, '-')
+  if (!norm) return null
+  if ((CATALOG_KEYS as string[]).includes(norm)) return norm as MetricKey
+  return METRIC_ALIASES[norm] ?? null
+}
+
+async function runReadonly<T>(
+  sql: string,
+  hostId: number
+): Promise<T[] | null> {
+  try {
+    const result = await fetchData<T[]>({
+      query: sql,
+      hostId,
+      format: 'JSONEachRow',
+      clickhouse_settings: { readonly: '1' },
+    })
+    if (result.error) return null
+    return Array.isArray(result.data) ? result.data : null
+  } catch {
+    return null
+  }
+}
+
+async function getExistingSystemTables(
+  hostId: number
+): Promise<Set<string> | null> {
+  const rows = await runReadonly<{ full: string }>(
+    `SELECT concat(database, '.', name) AS full FROM system.tables WHERE database = 'system'`,
+    hostId
+  )
+  if (!rows) return null
+  return new Set(rows.map((r) => String(r.full)))
+}
+
+async function probeClusterShape(hostId: number): Promise<ClusterShape | null> {
+  const rows = await runReadonly<{
+    replicated_tables: unknown
+    disks: unknown
+  }>(
+    `SELECT
+       (SELECT count() FROM system.replicas) AS replicated_tables,
+       (SELECT count() FROM system.disks) AS disks`,
+    hostId
+  )
+  const row = rows?.[0]
+  if (!row) return null
+  return {
+    replicatedTables: Number(row.replicated_tables) || 0,
+    disks: Number(row.disks) || 0,
+  }
+}
+
+/** Sample the current value of every catalog metric whose table exists. */
+async function probeMetricValues(
+  hostId: number,
+  tables: Set<string> | null
+): Promise<Partial<Record<MetricKey, number>>> {
+  const values: Partial<Record<MetricKey, number>> = {}
+  for (const metric of CATALOG_KEYS) {
+    const entry = METRIC_CATALOG[metric]
+    if (entry.tableCheck && tables && !tables.has(entry.tableCheck)) continue
+    const rows = await runReadonly<Record<string, unknown>>(entry.sql, hostId)
+    const raw = rows?.[0]?.[entry.valueKey]
+    if (raw === null || raw === undefined) continue
+    const num = Number(raw)
+    if (Number.isFinite(num)) values[metric] = num
+  }
+  return values
+}
+
+async function gatherBaselines(
+  hostId: number
+): Promise<Partial<Record<MetricKey, BaselineSignal>>> {
+  const out: Partial<Record<MetricKey, BaselineSignal>> = {}
+  try {
+    const baselines = await listBaselines(String(hostId))
+    for (const b of baselines) {
+      const metric = mapToMetricKey(b.metric)
+      // First baseline that maps to a given catalog key wins (listBaselines is
+      // ordered by metric name, deterministic).
+      if (metric && !out[metric]) {
+        out[metric] = {
+          mean: b.mean,
+          stddev: b.stddev,
+          sampleCount: b.sampleCount,
+        }
+      }
+    }
+  } catch (err) {
+    debug('[alert-suggestions] baseline gather failed', String(err))
+  }
+  return out
+}
+
+async function gatherRecurringFindings(
+  hostId: number
+): Promise<Partial<Record<MetricKey, RecurringFindingSignal>>> {
+  const out: Partial<Record<MetricKey, RecurringFindingSignal>> = {}
+  try {
+    const store = await resolveInsightsStore()
+    const rows = await store.list(hostId, {
+      since: FINDINGS_LOOKBACK,
+      limit: 500,
+    })
+    // rows are newest-first; count per mapped metric, keep the newest title.
+    for (const row of rows) {
+      const metric = mapToMetricKey(row.metric || row.category || '')
+      if (!metric) continue
+      const existing = out[metric]
+      if (existing) {
+        existing.count += 1
+      } else {
+        out[metric] = { count: 1, lastTitle: row.title }
+      }
+    }
+  } catch (err) {
+    debug('[alert-suggestions] findings gather failed', String(err))
+  }
+  // Drop below-threshold recurrences so the scorer only sees genuine repeats.
+  for (const metric of Object.keys(out) as MetricKey[]) {
+    if ((out[metric]?.count ?? 0) < RECURRENCE_THRESHOLD) delete out[metric]
+  }
+  return out
+}
+
+/** Catalog metrics already covered by a custom rule for this owner. */
+async function existingRuleMetrics(ownerId: string): Promise<Set<MetricKey>> {
+  const set = new Set<MetricKey>()
+  try {
+    const rules = await listCustomRules(ownerId)
+    for (const rule of rules) {
+      const metric = mapToMetricKey(rule.metric)
+      if (metric) set.add(metric)
+    }
+  } catch (err) {
+    // No D1 / storage error → treat as "no existing rules" (fail open: we may
+    // suggest something already covered, which is harmless and dismissible).
+    debug('[alert-suggestions] existing-rule gather failed', String(err))
+  }
+  return set
+}
+
+/**
+ * Compute alert suggestions across every configured host for `ownerId`,
+ * filtering out keys the owner has already dismissed. Memoized per owner for
+ * {@link CACHE_TTL_MS}. Pass `force` to bypass the cache (e.g. right after an
+ * accept/dismiss mutation invalidates it).
+ */
+export async function computeAlertSuggestions(
+  ownerId: string,
+  { force = false }: { force?: boolean } = {}
+): Promise<AlertSuggestion[]> {
+  const cached = cache.get(ownerId)
+  if (!force && cached && Date.now() - cached.at < CACHE_TTL_MS) {
+    return cached.value
+  }
+
+  const existing = await existingRuleMetrics(ownerId)
+  const configs = getClickHouseConfigs()
+
+  const hosts: HostSignals[] = []
+  for (const config of configs) {
+    const hostId = config.id
+    const tables = await getExistingSystemTables(hostId)
+    const [clusterShape, metricValues, baselines, recurringFindings] =
+      await Promise.all([
+        probeClusterShape(hostId),
+        probeMetricValues(hostId, tables),
+        gatherBaselines(hostId),
+        gatherRecurringFindings(hostId),
+      ])
+    hosts.push({
+      hostId,
+      hostName: hostLabel(config),
+      existingRuleMetrics: existing,
+      clusterShape,
+      metricValues,
+      baselines,
+      recurringFindings,
+    })
+  }
+
+  const all = buildSuggestions(hosts)
+
+  const dismissed = await listDismissedSuggestionKeys(ownerId)
+  const visible = all.filter((s) => !dismissed.has(s.key))
+
+  cache.set(ownerId, { at: Date.now(), value: visible })
+  return visible
+}
+
+/** Drop the memoized compute for an owner (after accept/dismiss). */
+export function invalidateAlertSuggestionsCache(ownerId: string): void {
+  cache.delete(ownerId)
+}

--- a/apps/dashboard/src/lib/health/alert-suggestions.test.ts
+++ b/apps/dashboard/src/lib/health/alert-suggestions.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Tests for the PURE alert-suggestion scorer (issue #2667).
+ *
+ * These lock the intent of each heuristic — WHY a suggestion fires — not just
+ * that some suggestion appears: near-threshold needs a value ≥70% of the
+ * default; a baseline yields p95/p99-shaped thresholds; cluster-shape fires only
+ * on a replicated/multi-disk cluster; a recurring finding is codified; an
+ * already-covered metric is never re-suggested; and same-metric collisions
+ * resolve by source priority. No I/O — the scorer is a pure function.
+ */
+
+import type { HostSignals } from './alert-suggestions'
+
+import {
+  buildSuggestions,
+  METRIC_SUGGESTION_DEFAULTS,
+  NEAR_THRESHOLD_FRACTION,
+} from './alert-suggestions'
+import { compileCustomRule } from './rule-builder-schema'
+import { describe, expect, test } from 'bun:test'
+
+function host(over: Partial<HostSignals> = {}): HostSignals {
+  return {
+    hostId: 0,
+    hostName: 'ch-0',
+    existingRuleMetrics: new Set(),
+    clusterShape: null,
+    metricValues: {},
+    baselines: {},
+    recurringFindings: {},
+    ...over,
+  }
+}
+
+describe('buildSuggestions — near-threshold', () => {
+  test('fires when a metric sits at ≥70% of its default warning', () => {
+    const warn = METRIC_SUGGESTION_DEFAULTS['disk-usage-percent'].warning
+    const suggestions = buildSuggestions([
+      host({
+        metricValues: { 'disk-usage-percent': warn * NEAR_THRESHOLD_FRACTION },
+      }),
+    ])
+    const s = suggestions.find((x) => x.metric === 'disk-usage-percent')
+    expect(s).toBeDefined()
+    expect(s?.source).toBe('near-threshold')
+    expect(s?.warning).toBe(warn)
+    expect(s?.key).toBe('disk-usage-percent:host:0')
+  })
+
+  test('does NOT fire below 70% of the default warning', () => {
+    const warn = METRIC_SUGGESTION_DEFAULTS['disk-usage-percent'].warning
+    const suggestions = buildSuggestions([
+      host({ metricValues: { 'disk-usage-percent': warn * 0.5 } }),
+    ])
+    expect(
+      suggestions.find((x) => x.metric === 'disk-usage-percent')
+    ).toBeUndefined()
+  })
+
+  test('does NOT fire on a zero value (idle metric)', () => {
+    const suggestions = buildSuggestions([
+      host({ metricValues: { 'stuck-merges': 0 } }),
+    ])
+    expect(suggestions.find((x) => x.metric === 'stuck-merges')).toBeUndefined()
+  })
+})
+
+describe('buildSuggestions — baseline', () => {
+  test('yields warning≈mean+2σ (p95) and critical≈mean+3σ (p99)', () => {
+    const suggestions = buildSuggestions([
+      host({
+        baselines: {
+          'running-queries': { mean: 300, stddev: 50, sampleCount: 200 },
+        },
+      }),
+    ])
+    const s = suggestions.find((x) => x.metric === 'running-queries')
+    expect(s?.source).toBe('baseline')
+    expect(s?.warning).toBe(400) // 300 + 2*50
+    expect(s?.critical).toBe(450) // 300 + 3*50
+  })
+
+  test('is ignored when the baseline is too thin (few samples)', () => {
+    const suggestions = buildSuggestions([
+      host({
+        baselines: {
+          'running-queries': { mean: 300, stddev: 50, sampleCount: 5 },
+        },
+      }),
+    ])
+    expect(
+      suggestions.find((x) => x.metric === 'running-queries')
+    ).toBeUndefined()
+  })
+
+  test('never proposes a warning below the metric default (quiet baseline)', () => {
+    // mean ~0 baseline would otherwise suggest firing on the first blip.
+    const suggestions = buildSuggestions([
+      host({
+        baselines: {
+          'failed-mutations': { mean: 0, stddev: 0.1, sampleCount: 200 },
+        },
+      }),
+    ])
+    const s = suggestions.find((x) => x.metric === 'failed-mutations')
+    expect(s?.warning).toBeGreaterThanOrEqual(
+      METRIC_SUGGESTION_DEFAULTS['failed-mutations'].warning
+    )
+  })
+})
+
+describe('buildSuggestions — cluster-shape', () => {
+  test('suggests replication alerts on a replicated cluster', () => {
+    const suggestions = buildSuggestions([
+      host({ clusterShape: { replicatedTables: 12, disks: 1 } }),
+    ])
+    const metrics = suggestions.map((s) => s.metric)
+    expect(metrics).toContain('replication-max-lag')
+    expect(metrics).toContain('readonly-replicas')
+    expect(metrics).toContain('replication-queue-max')
+    expect(
+      suggestions.find((s) => s.metric === 'replication-max-lag')?.source
+    ).toBe('cluster-shape')
+  })
+
+  test('does NOT suggest replication alerts on a non-replicated cluster', () => {
+    const suggestions = buildSuggestions([
+      host({ clusterShape: { replicatedTables: 0, disks: 1 } }),
+    ])
+    expect(
+      suggestions.find((s) => s.metric === 'replication-max-lag')
+    ).toBeUndefined()
+  })
+
+  test('suggests disk-usage on a multi-disk (tiered) cluster', () => {
+    const suggestions = buildSuggestions([
+      host({ clusterShape: { replicatedTables: 0, disks: 3 } }),
+    ])
+    expect(
+      suggestions.find((s) => s.metric === 'disk-usage-percent')?.source
+    ).toBe('cluster-shape')
+  })
+})
+
+describe('buildSuggestions — recurring findings', () => {
+  test('codifies a finding that recurred ≥2 times', () => {
+    const suggestions = buildSuggestions([
+      host({
+        recurringFindings: {
+          'stuck-merges': { count: 4, lastTitle: 'Merges piling up' },
+        },
+      }),
+    ])
+    const s = suggestions.find((x) => x.metric === 'stuck-merges')
+    expect(s?.source).toBe('recurring-finding')
+    expect(s?.reason).toContain('Merges piling up')
+  })
+})
+
+describe('buildSuggestions — dedup & exclusion', () => {
+  test('never re-suggests a metric that already has a rule', () => {
+    const suggestions = buildSuggestions([
+      host({
+        existingRuleMetrics: new Set(['disk-usage-percent']),
+        metricValues: { 'disk-usage-percent': 99 },
+        clusterShape: { replicatedTables: 0, disks: 5 },
+      }),
+    ])
+    expect(
+      suggestions.find((s) => s.metric === 'disk-usage-percent')
+    ).toBeUndefined()
+  })
+
+  test('one suggestion per metric — highest-priority source wins', () => {
+    // disk-usage fires from BOTH near-threshold and cluster-shape; recurring
+    // outranks both.
+    const suggestions = buildSuggestions([
+      host({
+        metricValues: { 'disk-usage-percent': 99 },
+        clusterShape: { replicatedTables: 0, disks: 5 },
+        recurringFindings: {
+          'disk-usage-percent': { count: 3, lastTitle: 'Disk filling' },
+        },
+      }),
+    ])
+    const disk = suggestions.filter((s) => s.metric === 'disk-usage-percent')
+    expect(disk).toHaveLength(1)
+    expect(disk[0].source).toBe('recurring-finding')
+  })
+
+  test('scopes keys per host', () => {
+    const suggestions = buildSuggestions([
+      host({ hostId: 0, metricValues: { 'stuck-merges': 2 } }),
+      host({
+        hostId: 1,
+        hostName: 'ch-1',
+        metricValues: { 'stuck-merges': 2 },
+      }),
+    ])
+    const keys = suggestions
+      .filter((s) => s.metric === 'stuck-merges')
+      .map((s) => s.key)
+      .sort()
+    expect(keys).toEqual(['stuck-merges:host:0', 'stuck-merges:host:1'])
+  })
+})
+
+describe('buildSuggestions — invariants', () => {
+  test('every suggestion targets a catalog metric with sane thresholds', () => {
+    const suggestions = buildSuggestions([
+      host({
+        clusterShape: { replicatedTables: 5, disks: 3 },
+        metricValues: { 'stuck-merges': 5, 'failed-mutations': 2 },
+      }),
+    ])
+    expect(suggestions.length).toBeGreaterThan(0)
+    for (const s of suggestions) {
+      expect(s.op).toBe('>=')
+      // higher-is-worse: critical must be ≥ warning
+      expect(s.critical).toBeGreaterThanOrEqual(s.warning)
+      expect(s.reason.length).toBeGreaterThan(0)
+    }
+  })
+
+  test('accepting any suggestion compiles into a working custom rule', () => {
+    // The accept path feeds (name/metric/op/warning/critical) straight into
+    // createCustomRule → compileCustomRule. Every suggestion must survive that.
+    const suggestions = buildSuggestions([
+      host({
+        clusterShape: { replicatedTables: 5, disks: 3 },
+        metricValues: { 'stuck-merges': 5 },
+        baselines: {
+          'running-queries': { mean: 300, stddev: 50, sampleCount: 200 },
+        },
+        recurringFindings: {
+          'failed-mutations': { count: 3, lastTitle: 'Mutations failing' },
+        },
+      }),
+    ])
+    expect(suggestions.length).toBeGreaterThan(0)
+    for (const s of suggestions) {
+      const rule = compileCustomRule({
+        name: s.title,
+        metric: s.metric,
+        op: s.op,
+        warning: s.warning,
+        critical: s.critical,
+      })
+      expect(rule.sql).toBeTruthy()
+      expect(rule.type).toBe('custom')
+      expect(rule.defaults).toEqual({
+        warning: s.warning,
+        critical: s.critical,
+      })
+    }
+  })
+})

--- a/apps/dashboard/src/lib/health/alert-suggestions.ts
+++ b/apps/dashboard/src/lib/health/alert-suggestions.ts
@@ -1,0 +1,316 @@
+/**
+ * Smart alert-rule suggestion engine (issue #2667).
+ *
+ * The dashboard already has every signal needed to PROPOSE alert rules — it
+ * just never did. This module analyzes per-host live behaviour and emits
+ * suggested custom rules, each with a human reason + proposed thresholds.
+ *
+ * ## Hard invariant (read before touching)
+ *
+ * Every suggestion compiles to a metric in {@link METRIC_CATALOG} (the vetted,
+ * no-SQL rule builder) — NEVER raw SQL. Accepting a suggestion goes through the
+ * exact same `createCustomRule` → `compileCustomRule` path the RuleBuilderPanel
+ * uses, so an accepted suggestion is indistinguishable from a hand-built rule.
+ * The engine can therefore only ever propose thresholds on a fixed, reviewable
+ * set of metrics.
+ *
+ * ## Structure
+ *
+ * The scoring is a PURE function ({@link buildSuggestions}) over already-gathered
+ * signals, so every heuristic is unit-testable without a database or a cluster.
+ * {@link computeAlertSuggestions} is the thin I/O orchestrator that gathers those
+ * signals (current metric values, statistical baselines, cluster shape, recurring
+ * insight findings) per host and filters out dismissed keys.
+ *
+ * Four signal sources, all mapped to catalog metrics:
+ *  1. near-threshold — a metric currently sitting at >70% of a sensible default
+ *     warning threshold, with no rule enabled yet.
+ *  2. baseline       — a fitted mean+stddev → warning ≈ p95 (mean+2σ),
+ *     critical ≈ p99 (mean+3σ).
+ *  3. cluster-shape  — replicated cluster with no replication alert, disks with
+ *     no disk-usage alert, etc.
+ *  4. recurring      — an insight finding that maps to a catalog metric and has
+ *     recurred, suggesting it be codified as a hard rule.
+ */
+
+import type { MetricKey } from './rule-builder-schema'
+
+import { METRIC_CATALOG } from './rule-builder-schema'
+
+/** Where a suggestion came from (drives the reason text + de-dup priority). */
+export type SuggestionSource =
+  | 'recurring-finding'
+  | 'baseline'
+  | 'near-threshold'
+  | 'cluster-shape'
+
+/** Priority when the same metric fires from multiple sources (lower wins). */
+const SOURCE_PRIORITY: Record<SuggestionSource, number> = {
+  'recurring-finding': 0,
+  baseline: 1,
+  'near-threshold': 2,
+  'cluster-shape': 3,
+}
+
+export interface AlertSuggestion {
+  /** Stable key: `${metric}:host:${hostId}`. Dismissals persist on this. */
+  key: string
+  metric: MetricKey
+  /** Human title for the card, e.g. "Alert on replication lag". */
+  title: string
+  /** Why we're proposing this (deterministic, LLM-free). */
+  reason: string
+  source: SuggestionSource
+  op: '>' | '>=' | '<' | '<='
+  warning: number
+  critical: number
+  unit: string
+  hostId: number
+  hostName: string
+  /** The metric's current value, when we sampled one (for display). */
+  currentValue: number | null
+}
+
+/**
+ * Sensible default thresholds per catalog metric. Reuse the built-in rule
+ * defaults where a matching built-in exists (so a suggestion and its built-in
+ * cousin agree), and pick conservative operational values for the rest. Every
+ * catalog metric is "higher = worse", so the operator is always `>=`.
+ */
+export const METRIC_SUGGESTION_DEFAULTS: Record<
+  MetricKey,
+  { warning: number; critical: number }
+> = {
+  'active-mutations': { warning: 20, critical: 100 },
+  'failed-mutations': { warning: 1, critical: 5 },
+  'parts-per-partition-max': { warning: 200, critical: 300 },
+  'readonly-replicas': { warning: 1, critical: 3 },
+  'replication-max-lag': { warning: 30, critical: 300 },
+  'replication-queue-max': { warning: 20, critical: 100 },
+  'disk-usage-percent': { warning: 80, critical: 95 },
+  'running-queries': { warning: 100, critical: 200 },
+  'long-running-queries': { warning: 1, critical: 5 },
+  'stuck-merges': { warning: 1, critical: 3 },
+}
+
+/** Replication-related catalog metrics — suggested when the cluster replicates. */
+const REPLICATION_METRICS: readonly MetricKey[] = [
+  'replication-max-lag',
+  'readonly-replicas',
+  'replication-queue-max',
+]
+
+/** A single fitted baseline, already resolved to a catalog metric key. */
+export interface BaselineSignal {
+  mean: number
+  stddev: number
+  sampleCount: number
+}
+
+/** A recurring insight finding, already resolved to a catalog metric key. */
+export interface RecurringFindingSignal {
+  /** How many times this finding recurred over the lookback. */
+  count: number
+  /** Most recent finding title (used verbatim in the reason). */
+  lastTitle: string
+}
+
+/** Cluster shape probe result (see traffic-cluster-shape idiom). */
+export interface ClusterShape {
+  /** Number of rows in system.replicas (>0 ⇒ cluster replicates). */
+  replicatedTables: number
+  /** Number of configured disks (>1 ⇒ likely tiered storage). */
+  disks: number
+}
+
+/** Everything the pure scorer needs for one host. */
+export interface HostSignals {
+  hostId: number
+  hostName: string
+  /** Catalog metrics that ALREADY have a custom rule — never re-suggested. */
+  existingRuleMetrics: ReadonlySet<MetricKey>
+  clusterShape: ClusterShape | null
+  /** Latest sampled value per catalog metric (point-in-time probe). */
+  metricValues: Partial<Record<MetricKey, number>>
+  baselines: Partial<Record<MetricKey, BaselineSignal>>
+  recurringFindings: Partial<Record<MetricKey, RecurringFindingSignal>>
+}
+
+/** Fraction of the default warning threshold that counts as "approaching". */
+export const NEAR_THRESHOLD_FRACTION = 0.7
+
+/** A baseline needs at least this many samples before we trust its shape. */
+const MIN_BASELINE_SAMPLES = 30
+
+function suggestionKey(metric: MetricKey, hostId: number): string {
+  return `${metric}:host:${hostId}`
+}
+
+/** Round a proposed threshold to a clean, human-facing number. */
+function roundThreshold(v: number): number {
+  if (!Number.isFinite(v)) return 0
+  const abs = Math.abs(v)
+  if (abs >= 100) return Math.round(v)
+  if (abs >= 10) return Math.round(v * 10) / 10
+  return Math.round(v * 100) / 100
+}
+
+function titleFor(metric: MetricKey): string {
+  return `Alert on ${METRIC_CATALOG[metric].label.toLowerCase()}`
+}
+
+/**
+ * Build baseline thresholds: warning ≈ p95 (mean + 2σ), critical ≈ p99
+ * (mean + 3σ). Never propose a threshold below the metric's default warning —
+ * a baseline of "always ~0" shouldn't yield a rule that fires on the first
+ * blip. Returns null when the baseline is too thin or the fit is degenerate.
+ */
+function baselineThresholds(
+  metric: MetricKey,
+  baseline: BaselineSignal
+): { warning: number; critical: number } | null {
+  if (baseline.sampleCount < MIN_BASELINE_SAMPLES) return null
+  if (!(baseline.stddev > 0)) return null
+
+  const floor = METRIC_SUGGESTION_DEFAULTS[metric].warning
+  const warning = roundThreshold(
+    Math.max(baseline.mean + 2 * baseline.stddev, floor)
+  )
+  let critical = roundThreshold(baseline.mean + 3 * baseline.stddev)
+  // Keep the direction sane: critical must be at least as extreme as warning.
+  if (critical <= warning) critical = roundThreshold(warning * 1.5)
+  return { warning, critical }
+}
+
+/**
+ * Pure scorer: turn gathered per-host signals into de-duplicated suggestions.
+ *
+ * At most ONE suggestion per (metric, host) survives — when several sources
+ * point at the same metric, the highest-priority source wins (recurring finding
+ * > baseline > near-threshold > cluster-shape). Deterministic and side-effect
+ * free, so the whole heuristic surface is unit-testable.
+ */
+export function buildSuggestions(
+  hosts: readonly HostSignals[]
+): AlertSuggestion[] {
+  const out: AlertSuggestion[] = []
+
+  for (const host of hosts) {
+    // Collect candidate suggestions per metric, then keep the best-priority one.
+    const byMetric = new Map<MetricKey, AlertSuggestion>()
+
+    const consider = (candidate: AlertSuggestion) => {
+      const existing = byMetric.get(candidate.metric)
+      if (
+        !existing ||
+        SOURCE_PRIORITY[candidate.source] < SOURCE_PRIORITY[existing.source]
+      ) {
+        byMetric.set(candidate.metric, candidate)
+      }
+    }
+
+    const base = (
+      metric: MetricKey,
+      source: SuggestionSource,
+      thresholds: { warning: number; critical: number },
+      reason: string
+    ): AlertSuggestion => ({
+      key: suggestionKey(metric, host.hostId),
+      metric,
+      title: titleFor(metric),
+      reason,
+      source,
+      op: '>=',
+      warning: thresholds.warning,
+      critical: thresholds.critical,
+      unit: METRIC_CATALOG[metric].unit,
+      hostId: host.hostId,
+      hostName: host.hostName,
+      currentValue: host.metricValues[metric] ?? null,
+    })
+
+    for (const metric of Object.keys(METRIC_CATALOG) as MetricKey[]) {
+      if (host.existingRuleMetrics.has(metric)) continue
+
+      const defaults = METRIC_SUGGESTION_DEFAULTS[metric]
+
+      // 1. Recurring insight finding mapped to this metric.
+      const recurring = host.recurringFindings[metric]
+      if (recurring && recurring.count >= 2) {
+        consider(
+          base(
+            metric,
+            'recurring-finding',
+            defaults,
+            `Flagged ${recurring.count} times recently in insights (“${recurring.lastTitle}”). Codify it as a rule so it pages instead of just showing up in the feed.`
+          )
+        )
+      }
+
+      // 2. Statistical baseline → p95/p99 thresholds.
+      const baseline = host.baselines[metric]
+      if (baseline) {
+        const th = baselineThresholds(metric, baseline)
+        if (th) {
+          consider(
+            base(
+              metric,
+              'baseline',
+              th,
+              `Learned baseline over recent samples (mean ${roundThreshold(baseline.mean)}${METRIC_CATALOG[metric].unit}, σ ${roundThreshold(baseline.stddev)}). Proposed warning ≈ p95, critical ≈ p99.`
+            )
+          )
+        }
+      }
+
+      // 3. Near-threshold: currently sitting close to a sensible default.
+      const value = host.metricValues[metric]
+      if (
+        typeof value === 'number' &&
+        value > 0 &&
+        value >= NEAR_THRESHOLD_FRACTION * defaults.warning
+      ) {
+        consider(
+          base(
+            metric,
+            'near-threshold',
+            defaults,
+            `Currently ${roundThreshold(value)} ${METRIC_CATALOG[metric].unit} — within ${Math.round(NEAR_THRESHOLD_FRACTION * 100)}% of a typical warning threshold of ${defaults.warning}. Enable an alert before it breaches.`
+          )
+        )
+      }
+
+      // 4. Cluster-shape aware.
+      const shape = host.clusterShape
+      if (shape) {
+        if (
+          REPLICATION_METRICS.includes(metric) &&
+          shape.replicatedTables > 0
+        ) {
+          consider(
+            base(
+              metric,
+              'cluster-shape',
+              defaults,
+              `This cluster has ${shape.replicatedTables} replicated table(s) but no ${METRIC_CATALOG[metric].label.toLowerCase()} alert. Replicated clusters should watch this.`
+            )
+          )
+        }
+        if (metric === 'disk-usage-percent' && shape.disks > 1) {
+          consider(
+            base(
+              metric,
+              'cluster-shape',
+              defaults,
+              `Multiple storage volumes detected (${shape.disks} disks, likely tiered storage) with no disk-usage alert. Watch worst-case utilization so part moves don't fill a volume unnoticed.`
+            )
+          )
+        }
+      }
+    }
+
+    for (const suggestion of byMetric.values()) out.push(suggestion)
+  }
+
+  return out
+}

--- a/apps/dashboard/src/lib/hooks/use-alert-suggestions.ts
+++ b/apps/dashboard/src/lib/hooks/use-alert-suggestions.ts
@@ -1,0 +1,99 @@
+/**
+ * Smart alert suggestions (issue #2667). Like custom rules this works
+ * self-hosted without Clerk too — the API resolves a fixed single-tenant owner
+ * id server-side, so the query is always enabled. GET is 501-tolerant (surfaced
+ * so the panel can show a "requires a database backend" note, mirroring the
+ * rule builder).
+ */
+
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { CUSTOM_ALERT_RULES_QUERY_KEY } from './use-custom-alert-rules'
+import { apiFetch } from '@/lib/swr/api-fetch'
+import { throwIfNotOk } from '@/lib/swr/fetch-error'
+
+export type SuggestionSource =
+  | 'recurring-finding'
+  | 'baseline'
+  | 'near-threshold'
+  | 'cluster-shape'
+
+export interface AlertSuggestionInfo {
+  key: string
+  metric: string
+  title: string
+  reason: string
+  source: SuggestionSource
+  op: '>' | '>=' | '<' | '<='
+  warning: number
+  critical: number
+  unit: string
+  hostId: number
+  hostName: string
+  currentValue: number | null
+}
+
+export const ALERT_SUGGESTIONS_QUERY_KEY = [
+  '/api/v1/health/alert-suggestions',
+] as const
+
+export function useAlertSuggestions() {
+  const query = useQuery({
+    queryKey: ALERT_SUGGESTIONS_QUERY_KEY,
+    queryFn: async () => {
+      const response = await apiFetch('/api/v1/health/alert-suggestions')
+      await throwIfNotOk(response, 'Failed to load alert suggestions')
+      const json = (await response.json()) as {
+        success: boolean
+        data: AlertSuggestionInfo[]
+      }
+      return json.data ?? []
+    },
+    staleTime: 60_000,
+  })
+
+  return {
+    suggestions: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
+  }
+}
+
+export function useAlertSuggestionMutations() {
+  const queryClient = useQueryClient()
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ALERT_SUGGESTIONS_QUERY_KEY })
+    // Accepting a suggestion creates a custom rule — keep that list fresh too.
+    queryClient.invalidateQueries({ queryKey: CUSTOM_ALERT_RULES_QUERY_KEY })
+  }
+
+  const acceptSuggestion = async (input: {
+    name: string
+    metric: string
+    op: string
+    warning: number
+    critical: number
+  }): Promise<void> => {
+    const response = await apiFetch('/api/v1/health/alert-suggestions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'accept', ...input }),
+    })
+    await throwIfNotOk(response, 'Failed to accept suggestion')
+    invalidate()
+  }
+
+  const dismissSuggestion = async (key: string): Promise<void> => {
+    const response = await apiFetch('/api/v1/health/alert-suggestions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'dismiss', key }),
+    })
+    await throwIfNotOk(response, 'Failed to dismiss suggestion')
+    invalidate()
+  }
+
+  return { acceptSuggestion, dismissSuggestion, invalidate }
+}

--- a/apps/dashboard/src/routes/api/v1/health/alert-suggestions.ts
+++ b/apps/dashboard/src/routes/api/v1/health/alert-suggestions.ts
@@ -1,0 +1,146 @@
+/**
+ * Smart alert-rule suggestions API (issue #2667).
+ *
+ *   GET  /api/v1/health/alert-suggestions        — compute (cached) the current
+ *        suggestions for the caller, minus anything they've dismissed.
+ *   POST /api/v1/health/alert-suggestions        — body `{ action }`:
+ *        - `{ action: 'accept', name, metric, op, warning, critical }`
+ *          → creates a custom rule via custom-rules-store (SAME path the rule
+ *            builder uses); inline-edited thresholds flow straight through.
+ *        - `{ action: 'dismiss', key }`
+ *          → persists the dismissal so the suggestion stays hidden.
+ *
+ * There is NO free-form SQL anywhere: `metric` must be a `METRIC_CATALOG` key,
+ * validated + compiled by `createCustomRule` before it ever reaches D1.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
+import { createSuccessResponse } from '@/lib/api/shared/response-builder'
+import { ApiErrorType } from '@/lib/api/types'
+import {
+  dismissSuggestion,
+  SuggestionDismissalStoreError,
+} from '@/lib/health/alert-suggestion-dismissals-store'
+import {
+  computeAlertSuggestions,
+  invalidateAlertSuggestionsCache,
+} from '@/lib/health/alert-suggestions-compute'
+import { mapCustomRuleApiError } from '@/lib/health/custom-rules-api-errors'
+import { resolveCustomRuleOwnerId } from '@/lib/health/custom-rules-auth'
+import { createCustomRule } from '@/lib/health/custom-rules-store'
+
+const ROUTE_GET = { route: '/api/v1/health/alert-suggestions', method: 'GET' }
+const ROUTE_POST = { route: '/api/v1/health/alert-suggestions', method: 'POST' }
+
+async function handleGet(): Promise<Response> {
+  try {
+    const ownerId = await resolveCustomRuleOwnerId()
+    const suggestions = await computeAlertSuggestions(ownerId)
+    return createSuccessResponse(suggestions)
+  } catch (error) {
+    return mapCustomRuleApiError(error, ROUTE_GET)
+  }
+}
+
+interface PostBody {
+  action?: unknown
+  // accept
+  name?: unknown
+  metric?: unknown
+  op?: unknown
+  warning?: unknown
+  critical?: unknown
+  // dismiss
+  key?: unknown
+}
+
+async function handleAccept(
+  ownerId: string,
+  body: PostBody
+): Promise<Response> {
+  // `createCustomRule` runs the zod schema (rejects off-catalog metrics,
+  // non-numeric thresholds, empty names) AND compiles + deny-list-checks the
+  // resulting SQL before anything touches D1.
+  const created = await createCustomRule(ownerId, body as never)
+  invalidateAlertSuggestionsCache(ownerId)
+  return createSuccessResponse(
+    { accepted: true, rule: created },
+    undefined,
+    201
+  )
+}
+
+async function handleDismiss(
+  ownerId: string,
+  body: PostBody
+): Promise<Response> {
+  const key = typeof body.key === 'string' ? body.key.trim() : ''
+  if (!key) {
+    return createApiErrorResponse(
+      {
+        type: ApiErrorType.ValidationError,
+        message: '"key" is required to dismiss a suggestion',
+      },
+      400,
+      ROUTE_POST
+    )
+  }
+  await dismissSuggestion(ownerId, key)
+  invalidateAlertSuggestionsCache(ownerId)
+  return createSuccessResponse({ dismissed: true, key })
+}
+
+async function handlePost(request: Request): Promise<Response> {
+  let body: PostBody
+  try {
+    body = (await request.json()) as PostBody
+  } catch {
+    return createApiErrorResponse(
+      {
+        type: ApiErrorType.ValidationError,
+        message: 'Request body must be valid JSON',
+      },
+      400,
+      ROUTE_POST
+    )
+  }
+
+  const action = body.action
+  if (action !== 'accept' && action !== 'dismiss') {
+    return createApiErrorResponse(
+      {
+        type: ApiErrorType.ValidationError,
+        message: '"action" must be "accept" or "dismiss"',
+      },
+      400,
+      ROUTE_POST
+    )
+  }
+
+  try {
+    const ownerId = await resolveCustomRuleOwnerId()
+    return action === 'accept'
+      ? await handleAccept(ownerId, body)
+      : await handleDismiss(ownerId, body)
+  } catch (error) {
+    if (error instanceof SuggestionDismissalStoreError) {
+      return createApiErrorResponse(
+        { type: ApiErrorType.PermissionError, message: error.message },
+        error.code === 'NOT_CONFIGURED' ? 501 : 500,
+        ROUTE_POST
+      )
+    }
+    return mapCustomRuleApiError(error, ROUTE_POST)
+  }
+}
+
+export const Route = createFileRoute('/api/v1/health/alert-suggestions')({
+  server: {
+    handlers: {
+      GET: async () => handleGet(),
+      POST: async ({ request }) => handlePost(request),
+    },
+  },
+})


### PR DESCRIPTION
## Summary

Implements #2667: the dashboard now PROPOSES alert rules from live cluster behaviour instead of leaving every rule to be hand-built. Every suggestion compiles to a `METRIC_CATALOG` metric (the vetted no-SQL rule builder) — never raw SQL — and accepting one goes through the exact same `createCustomRule` → `compileCustomRule` path the RuleBuilderPanel uses, so an accepted suggestion is a normal custom rule evaluated by the next sweep.

## Heuristics (pure, work with no LLM key)

- **near-threshold** — a metric currently at ≥70% of a sensible default warning, no rule yet.
- **baseline** — fitted mean+σ → warning ≈ p95 (mean+2σ), critical ≈ p99 (mean+3σ), floored at the metric default.
- **cluster-shape** — replicated cluster (system.replicas > 0) → replication-lag / readonly-replicas / replication-queue alerts; multi-disk (tiered storage) → disk-usage alert.
- **recurring insight findings** mapped to a catalog metric → codify as a rule.

Scoring is a **pure** `buildSuggestions()` over gathered signals (fully unit-tested); one suggestion per (metric, host), highest-priority source wins. `alert-suggestions-compute.ts` is the read-only I/O orchestrator (per-host probes, 60s per-owner cache).

## Dedup / state

Dismissals persist server-side in D1 (`alert_suggestion_dismissals`, migration `0020`) keyed by the stable `${metric}:host:${hostId}` scope — mirrors the AI-insights stable-key dismissal pattern. Read path fails open (no D1 → empty dismissals, suggestions still compute); write path (dismiss) fails loud (501 without D1).

## API + UI

- `GET /api/v1/health/alert-suggestions` — compute (cached).
- `POST` `{action:'accept', ...thresholds}` → creates a custom rule; `{action:'dismiss', key}` → persists dismissal.
- New **Suggested** tab in the Health Settings dialog: cards with reason, editable warning/critical, Accept / Dismiss, EmptyState when clear.

## Notes

- `server-sweep.ts` untouched.
- Optional LLM reason-polish skipped — reasons are deterministic and useful without a key.

## Tests

- `alert-suggestions.test.ts` — every heuristic trigger, dedup priority, existing-rule exclusion, baseline p95/p99 math, and **accept → rule compilation** invariant.
- `alert-suggestion-dismissals-store.test.ts` — dismiss/list round-trip, owner scope, idempotency, read-fails-open / write-fails-loud.

Closes #2667

https://claude.ai/code/session_015Mq6c6bQstbRwQnKt9htbE