### PR TITLE
feat(alerts): ntfy delivery channel

### DIFF
--- a/apps/dashboard/src/components/health/alert-routing-dialog.tsx
+++ b/apps/dashboard/src/components/health/alert-routing-dialog.tsx
@@ -34,6 +34,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import {
+  fireNtfyTest,
   firePagerDutyTest,
   fireTelegramTest,
   fireWebhook,
@@ -56,6 +57,7 @@ function RouteRow({
   const { deleteRoute } = useAlertRoutesMutations()
   const isPagerDuty = route.provider === 'pagerduty'
   const isTelegram = route.provider === 'telegram'
+  const isNtfy = route.provider === 'ntfy'
 
   const handleDelete = async () => {
     setBusy(true)
@@ -102,6 +104,21 @@ function RouteRow({
         )
         return
       }
+      // ntfy: the topic URL is not a secret, so an unprotected topic can be
+      // re-tested directly. A token-protected topic can't — its token is never
+      // re-shown once saved — so fall back to the re-create hint like Telegram.
+      if (isNtfy) {
+        if (route.ntfyTokenMasked) {
+          toast.info(
+            'Re-create the route to send another ntfy test to this protected topic (the token is never re-shown once saved).'
+          )
+          return
+        }
+        const okNtfy = await fireNtfyTest(route.ntfyUrl ?? '')
+        if (okNtfy) toast.success('Test notification sent to ntfy')
+        else toast.error('ntfy request failed')
+        return
+      }
       const ok = await fireWebhook(testAlert, route.channelUrl)
       if (ok) toast.success('Test alert sent')
       else toast.error('Webhook request failed')
@@ -116,6 +133,7 @@ function RouteRow({
         <div className="flex flex-wrap items-center gap-1.5">
           {isPagerDuty && <Badge variant="default">PagerDuty</Badge>}
           {isTelegram && <Badge variant="default">Telegram</Badge>}
+          {isNtfy && <Badge variant="default">ntfy</Badge>}
           <Badge variant="outline">rule: {route.matchRule}</Badge>
           <Badge variant="outline">host: {route.matchHost}</Badge>
           {!route.enabled && <Badge variant="secondary">disabled</Badge>}
@@ -125,7 +143,9 @@ function RouteRow({
             ? `${route.serviceName || 'PagerDuty service'} — ${route.routingKeyMasked}`
             : isTelegram
               ? `chat ${route.telegramChatId} — bot ${route.telegramBotTokenMasked}`
-              : route.channelUrl}
+              : isNtfy
+                ? `${route.ntfyUrl}${route.ntfyTokenMasked ? ` — token ${route.ntfyTokenMasked}` : ''}`
+                : route.channelUrl}
         </span>
       </div>
       <div className="flex shrink-0 items-center gap-2">
@@ -155,6 +175,8 @@ function AddRouteForm({ onCreated }: { onCreated: () => void }) {
   const [pdRoutingKey, setPdRoutingKey] = useState('')
   const [tgBotToken, setTgBotToken] = useState('')
   const [tgChatId, setTgChatId] = useState('')
+  const [ntfyUrl, setNtfyUrl] = useState('')
+  const [ntfyToken, setNtfyToken] = useState('')
   const [busy, setBusy] = useState(false)
   const { createRoute } = useAlertRoutesMutations()
   const { services: pdServices, isLoading: pdServicesLoading } =
@@ -169,6 +191,8 @@ function AddRouteForm({ onCreated }: { onCreated: () => void }) {
     setPdRoutingKey('')
     setTgBotToken('')
     setTgChatId('')
+    setNtfyUrl('')
+    setNtfyToken('')
   }
 
   const handleSubmit = async () => {
@@ -180,6 +204,11 @@ function AddRouteForm({ onCreated }: { onCreated: () => void }) {
     } else if (provider === 'telegram') {
       if (!tgBotToken.trim() || !tgChatId.trim()) {
         toast.error('Enter the Telegram bot token and chat id')
+        return
+      }
+    } else if (provider === 'ntfy') {
+      if (!ntfyUrl.trim()) {
+        toast.error('Enter the ntfy topic URL')
         return
       }
     } else if (!channelUrl.trim()) {
@@ -204,7 +233,13 @@ function AddRouteForm({ onCreated }: { onCreated: () => void }) {
                 telegramBotToken: tgBotToken.trim(),
                 telegramChatId: tgChatId.trim(),
               }
-            : { channelUrl: channelUrl.trim() }),
+            : provider === 'ntfy'
+              ? {
+                  provider: 'ntfy',
+                  ntfyUrl: ntfyUrl.trim(),
+                  ntfyToken: ntfyToken.trim() || undefined,
+                }
+              : { channelUrl: channelUrl.trim() }),
       })
       toast.success('Route created')
       reset()
@@ -267,6 +302,24 @@ function AddRouteForm({ onCreated }: { onCreated: () => void }) {
     }
   }
 
+  const handleSendNtfyTest = async () => {
+    if (!ntfyUrl.trim()) {
+      toast.error('Enter the ntfy topic URL')
+      return
+    }
+    setBusy(true)
+    try {
+      const ok = await fireNtfyTest(
+        ntfyUrl.trim(),
+        ntfyToken.trim() || undefined
+      )
+      if (ok) toast.success('Test notification sent to ntfy')
+      else toast.error('ntfy request failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
   return (
     <div className="flex flex-col gap-2 rounded-md border p-3">
       <Label className="text-sm font-medium">Add route</Label>
@@ -285,6 +338,7 @@ function AddRouteForm({ onCreated }: { onCreated: () => void }) {
             </SelectItem>
             <SelectItem value="pagerduty">PagerDuty service</SelectItem>
             <SelectItem value="telegram">Telegram chat</SelectItem>
+            <SelectItem value="ntfy">ntfy topic</SelectItem>
           </SelectContent>
         </Select>
       </div>
@@ -400,6 +454,42 @@ function AddRouteForm({ onCreated }: { onCreated: () => void }) {
             onClick={handleSendTelegramTest}
           >
             Send test message
+          </Button>
+        </>
+      ) : provider === 'ntfy' ? (
+        <>
+          <Label
+            htmlFor="route-ntfy-url"
+            className="text-xs text-muted-foreground"
+          >
+            Topic URL
+          </Label>
+          <Input
+            id="route-ntfy-url"
+            placeholder="https://ntfy.sh/my-topic"
+            value={ntfyUrl}
+            onChange={(e) => setNtfyUrl(e.target.value)}
+          />
+          <Label
+            htmlFor="route-ntfy-token"
+            className="text-xs text-muted-foreground"
+          >
+            Access token (optional)
+          </Label>
+          <Input
+            id="route-ntfy-token"
+            placeholder="tk_… (only for protected topics)"
+            value={ntfyToken}
+            onChange={(e) => setNtfyToken(e.target.value)}
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            className="self-start"
+            disabled={busy}
+            onClick={handleSendNtfyTest}
+          >
+            Send test notification
           </Button>
         </>
       ) : (

--- a/apps/dashboard/src/components/health/health-settings-dialog.tsx
+++ b/apps/dashboard/src/components/health/health-settings-dialog.tsx
@@ -56,6 +56,9 @@ export function HealthSettingsDialog() {
   const [telegramStatus, setTelegramStatus] = useState<{
     configured: boolean
   } | null>(null)
+  const [ntfyStatus, setNtfyStatus] = useState<{
+    configured: boolean
+  } | null>(null)
 
   useEffect(() => {
     if (!open) return
@@ -73,6 +76,10 @@ export function HealthSettingsDialog() {
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => setTelegramStatus(data as { configured: boolean } | null))
       .catch(() => setTelegramStatus(null))
+    fetch('/api/v1/health/ntfy-test')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => setNtfyStatus(data as { configured: boolean } | null))
+      .catch(() => setNtfyStatus(null))
   }, [open])
 
   const handleThresholdChange = (
@@ -211,6 +218,23 @@ export function HealthSettingsDialog() {
       }
     } catch {
       toast.error('Telegram test message failed')
+    }
+  }
+
+  const handleTestNtfy = async () => {
+    try {
+      const res = await fetch('/api/v1/health/ntfy-test', { method: 'POST' })
+      if (res.ok) {
+        toast.success('ntfy test notification sent')
+      } else {
+        const body = await res.json().catch(() => null)
+        toast.error(
+          (body as { error?: { message?: string } } | null)?.error?.message ??
+            'ntfy test notification failed'
+        )
+      }
+    } catch {
+      toast.error('ntfy test notification failed')
     }
   }
 
@@ -549,6 +573,38 @@ export function HealthSettingsDialog() {
                     size="sm"
                     onClick={handleTestTelegram}
                     disabled={!telegramStatus?.configured}
+                  >
+                    Send test
+                  </Button>
+                </div>
+
+                <Separator />
+
+                <div className="flex items-center justify-between rounded-md border p-3">
+                  <div className="flex flex-col">
+                    <div className="flex items-center gap-2">
+                      <Label className="text-sm font-medium">ntfy alerts</Label>
+                      <Badge
+                        variant={
+                          ntfyStatus?.configured ? 'default' : 'secondary'
+                        }
+                      >
+                        {ntfyStatus?.configured
+                          ? 'Configured'
+                          : 'Not configured'}
+                      </Badge>
+                    </div>
+                    <span className="text-xs text-muted-foreground">
+                      Set HEALTH_ALERT_NTFY_URL (and optional
+                      HEALTH_ALERT_NTFY_TOKEN) on the server to enable — the
+                      token is never exposed to the browser
+                    </span>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleTestNtfy}
+                    disabled={!ntfyStatus?.configured}
                   >
                     Send test
                   </Button>

--- a/apps/dashboard/src/db/conversations-migrations/0021_alert_routes_ntfy.sql
+++ b/apps/dashboard/src/db/conversations-migrations/0021_alert_routes_ntfy.sql
@@ -1,0 +1,16 @@
+-- ntfy alert channel routing (feat #2657): extend the plan-30 `alert_routes`
+-- table again rather than shipping a separate schema, exactly as plan 34 did
+-- for PagerDuty and 0019 did for Telegram. A route's `provider` may now also be
+-- `'ntfy'` — delivering the finding to an ntfy topic (self-hostable) by POSTing
+-- to `ntfy_url` with Title/Priority/Tags headers + a plain-text body. Existing
+-- rows keep `provider = 'webhook'` so plan-30/34 behavior is unchanged.
+--
+-- `ntfy_url` is the full topic URL (e.g. https://ntfy.sh/my-topic). Unlike the
+-- Telegram Bot API's fixed host, this is an OPERATOR-SUPPLIED URL, so the
+-- routes API runs it through the same SSRF guard (`validateHostUrl`, HTTPS-only)
+-- as a generic webhook `channel_url` before storing it. `ntfy_token` is an
+-- optional access token for a protected topic — a secret, stored at rest the
+-- same way `telegram_bot_token` / `routing_key` are, and masked (never returned
+-- in full) by the routes API.
+ALTER TABLE alert_routes ADD COLUMN ntfy_url TEXT;
+ALTER TABLE alert_routes ADD COLUMN ntfy_token TEXT;

--- a/apps/dashboard/src/lib/health/adapters/__tests__/ntfy.test.ts
+++ b/apps/dashboard/src/lib/health/adapters/__tests__/ntfy.test.ts
@@ -1,0 +1,133 @@
+import type { AlertPayload } from '../types'
+
+import {
+  buildNtfyHeaders,
+  buildNtfyMessage,
+  ntfyAdapter,
+  sanitizeHeaderValue,
+} from '../ntfy'
+import { describe, expect, test } from 'bun:test'
+
+const CRITICAL: AlertPayload = {
+  severity: 'critical',
+  hostLabel: 'prod-1',
+  hostId: 2,
+  metric: 'failed-mutations',
+  value: 7,
+  warnThreshold: 1,
+  critThreshold: 5,
+  title: 'Failed mutations',
+  label: '7 failed mutations',
+  timestamp: '2026-07-02T10:00:00.000Z',
+}
+
+const WARNING: AlertPayload = { ...CRITICAL, severity: 'warning', value: 3 }
+const RECOVERY: AlertPayload = {
+  ...CRITICAL,
+  severity: 'recovery',
+  value: 0,
+  label: 'recovered',
+}
+
+describe('buildNtfyMessage — severity → priority/tags', () => {
+  test('critical maps to priority 5 + siren tag', () => {
+    const msg = buildNtfyMessage(CRITICAL)
+    expect(msg.priority).toBe('5')
+    expect(msg.tags).toBe('rotating_light')
+    expect(msg.title).toBe('[CRITICAL] Failed mutations')
+  })
+
+  test('warning maps to priority 4 + warning tag', () => {
+    const msg = buildNtfyMessage(WARNING)
+    expect(msg.priority).toBe('4')
+    expect(msg.tags).toBe('warning')
+    expect(msg.title).toBe('[WARNING] Failed mutations')
+  })
+
+  test('recovery maps to priority 3 + check-mark tag and RECOVERY heading', () => {
+    const msg = buildNtfyMessage(RECOVERY)
+    expect(msg.priority).toBe('3')
+    expect(msg.tags).toBe('white_check_mark')
+    expect(msg.title).toBe('[RECOVERY] Failed mutations')
+  })
+})
+
+describe('buildNtfyMessage — body', () => {
+  test('includes host, metric, value, thresholds, detail and timestamp', () => {
+    const { body } = buildNtfyMessage(CRITICAL)
+    expect(body).toContain('Host: prod-1 (id 2)')
+    expect(body).toContain('Metric: failed-mutations')
+    expect(body).toContain('Value: 7')
+    expect(body).toContain('Thresholds: warn 1 | crit 5')
+    expect(body).toContain('Detail: 7 failed mutations')
+    expect(body).toContain('2026-07-02T10:00:00.000Z')
+  })
+
+  test('renders n/a for a null value and omits absent thresholds', () => {
+    const { body } = buildNtfyMessage({
+      ...CRITICAL,
+      value: null,
+      warnThreshold: null,
+      critThreshold: null,
+    })
+    expect(body).toContain('Value: n/a')
+    expect(body).not.toContain('Thresholds:')
+  })
+
+  test('lists runbook urls when present', () => {
+    const { body } = buildNtfyMessage({
+      ...CRITICAL,
+      runbookUrls: ['https://runbook.example/mutations'],
+    })
+    expect(body).toContain('Runbooks:')
+    expect(body).toContain('- https://runbook.example/mutations')
+  })
+})
+
+describe('buildNtfyHeaders', () => {
+  test('emits Title/Priority/Tags and no Authorization without a token', () => {
+    const headers = buildNtfyHeaders(CRITICAL)
+    expect(headers.Title).toBe('[CRITICAL] Failed mutations')
+    expect(headers.Priority).toBe('5')
+    expect(headers.Tags).toBe('rotating_light')
+    expect(headers.Authorization).toBeUndefined()
+  })
+
+  test('adds a Bearer Authorization header when a token is supplied', () => {
+    const headers = buildNtfyHeaders(CRITICAL, 'tk_secret')
+    expect(headers.Authorization).toBe('Bearer tk_secret')
+  })
+
+  test('ignores a blank/whitespace token', () => {
+    const headers = buildNtfyHeaders(CRITICAL, '   ')
+    expect(headers.Authorization).toBeUndefined()
+  })
+})
+
+describe('sanitizeHeaderValue', () => {
+  test('drops non-ASCII and control characters, collapsing whitespace', () => {
+    expect(sanitizeHeaderValue('café \n\t crash')).toBe('caf crash')
+    expect(sanitizeHeaderValue('[CRITICAL] disk 🚨 full')).toBe(
+      '[CRITICAL] disk full'
+    )
+  })
+
+  test('keeps a plain ASCII title untouched', () => {
+    expect(sanitizeHeaderValue('[WARNING] Failed mutations')).toBe(
+      '[WARNING] Failed mutations'
+    )
+  })
+})
+
+describe('ntfyAdapter', () => {
+  test('buildBody returns the plain-text message body', () => {
+    expect(ntfyAdapter.id).toBe('ntfy')
+    expect(ntfyAdapter.buildBody(CRITICAL)).toBe(
+      buildNtfyMessage(CRITICAL).body
+    )
+  })
+
+  test('has no URL detector (dispatched by config, not URL routing)', () => {
+    expect(ntfyAdapter.detect).toBeUndefined()
+  })
+})

--- a/apps/dashboard/src/lib/health/adapters/index.ts
+++ b/apps/dashboard/src/lib/health/adapters/index.ts
@@ -13,6 +13,7 @@ export type { DiscordWebhookBody } from './discord'
 export type { EmailBody, EmailConfig, EmailProvider } from './email'
 export type { GenericJsonBody } from './generic-json'
 export type { MSTeamsWebhookBody } from './msteams'
+export type { NtfyConfig, NtfyMessage } from './ntfy'
 export type {
   OpsgenieConfig,
   OpsgenieCreateBody,
@@ -35,6 +36,12 @@ export { buildDiscordBody, discordAdapter } from './discord'
 export { buildEmailBody, detectEmailProvider, emailAdapter } from './email'
 export { buildGenericJsonBody, genericJsonAdapter } from './generic-json'
 export { buildMSTeamsBody, msTeamsAdapter } from './msteams'
+export {
+  buildNtfyHeaders,
+  buildNtfyMessage,
+  ntfyAdapter,
+  sanitizeHeaderValue,
+} from './ntfy'
 export { buildOpsgenieBody, opsgenieAdapter, opsgenieAlias } from './opsgenie'
 export {
   buildPagerDutyBody,

--- a/apps/dashboard/src/lib/health/adapters/ntfy.ts
+++ b/apps/dashboard/src/lib/health/adapters/ntfy.ts
@@ -1,0 +1,162 @@
+/**
+ * ntfy notification adapter (pure formatter).
+ *
+ * ntfy (https://ntfy.sh / self-hosted) publishes a push notification by POSTing
+ * to a topic URL (`<server>/<topic>`) with the message as the plain-text body
+ * and a small set of control headers:
+ *
+ *   - `Title`    — the notification title
+ *   - `Priority` — 1 (min) … 5 (max/urgent)
+ *   - `Tags`     — comma-separated emoji shortcodes / labels
+ *   - `Authorization: Bearer <token>` — optional, for protected topics
+ *
+ * This module only SHAPES those headers + body from an {@link AlertPayload};
+ * the caller (dispatch layer) owns the topic URL, the token, and the actual
+ * `fetch`. Pure — no network, no side effects — so it is trivially unit-tested,
+ * mirroring `adapters/telegram.ts`.
+ *
+ * Severity → priority/tag mapping (per issue #2657):
+ *   critical → priority 5 (urgent), 🚨 tag
+ *   warning  → priority 4 (high),   ⚠️ tag
+ *   recovery → priority 3 (default), ✅ tag
+ */
+
+import type { AlertPayload, AlertSeverity, NotificationAdapter } from './types'
+
+/** Severity → ntfy priority (`1`–`5`). Higher = more urgent. */
+const SEVERITY_PRIORITY: Record<AlertSeverity, '3' | '4' | '5'> = {
+  critical: '5',
+  warning: '4',
+  recovery: '3',
+}
+
+/**
+ * Severity → ntfy tag (emoji shortcode). Recovery carries the check-mark the
+ * issue asks for; critical/warning get a siren/warning glyph so the phone
+ * notification is scannable at a glance.
+ */
+const SEVERITY_TAG: Record<AlertSeverity, string> = {
+  critical: 'rotating_light',
+  warning: 'warning',
+  recovery: 'white_check_mark',
+}
+
+/**
+ * Strip a value down to what is safe in an HTTP header (printable ASCII).
+ *
+ * Header values must be Latin-1 with no control characters; `fetch` throws on
+ * anything outside that range. The `Title` header can carry a caller-derived
+ * string (rule title), so we drop control chars and any code point above
+ * `0x7e`, collapsing runs of whitespace — the full, UTF-8-safe detail always
+ * lives in the plain-text body instead.
+ */
+export function sanitizeHeaderValue(value: string): string {
+  let out = ''
+  for (const ch of value) {
+    const code = ch.codePointAt(0) ?? 0
+    if (code >= 0x20 && code <= 0x7e) out += ch
+    else out += ' '
+  }
+  return out.replace(/\s+/g, ' ').trim()
+}
+
+/** The rendered ntfy message: control fields + plain-text body. */
+export interface NtfyMessage {
+  /** `Title` header — `[SEVERITY] <alert title>`. */
+  title: string
+  /** `Priority` header — `'3'` | `'4'` | `'5'`. */
+  priority: '3' | '4' | '5'
+  /** `Tags` header — comma-separated. */
+  tags: string
+  /** Plain-text message body (UTF-8 safe). */
+  body: string
+}
+
+/** Caller-supplied ntfy transport config. */
+export interface NtfyConfig {
+  /** Full topic URL, e.g. `https://ntfy.sh/my-topic`. */
+  url: string
+  /** Optional access token for a protected topic (`Authorization: Bearer …`). */
+  token?: string
+}
+
+/** `RECOVERY` for a resolved incident, otherwise the uppercased severity. */
+function heading(severity: AlertSeverity): string {
+  return severity === 'recovery' ? 'RECOVERY' : severity.toUpperCase()
+}
+
+/**
+ * Build the ntfy message (title/priority/tags/body) for a payload. Exported so
+ * tests and the dispatch layer can assert the rendered shape independent of the
+ * header wrapper.
+ */
+export function buildNtfyMessage(payload: AlertPayload): NtfyMessage {
+  const lines: string[] = [
+    `Host: ${payload.hostLabel} (id ${payload.hostId})`,
+    `Metric: ${payload.metric}`,
+    `Value: ${payload.value === null ? 'n/a' : payload.value}`,
+  ]
+
+  const thresholds: string[] = []
+  if (payload.warnThreshold !== undefined && payload.warnThreshold !== null) {
+    thresholds.push(`warn ${payload.warnThreshold}`)
+  }
+  if (payload.critThreshold !== undefined && payload.critThreshold !== null) {
+    thresholds.push(`crit ${payload.critThreshold}`)
+  }
+  if (thresholds.length > 0) {
+    lines.push(`Thresholds: ${thresholds.join(' | ')}`)
+  }
+
+  lines.push(`Detail: ${payload.label}`)
+
+  if (payload.runbookUrls && payload.runbookUrls.length > 0) {
+    lines.push('')
+    lines.push('Runbooks:')
+    for (const url of payload.runbookUrls) lines.push(`- ${url}`)
+  }
+
+  lines.push('')
+  lines.push(payload.timestamp)
+
+  return {
+    title: `[${heading(payload.severity)}] ${payload.title}`,
+    priority: SEVERITY_PRIORITY[payload.severity],
+    tags: SEVERITY_TAG[payload.severity],
+    body: lines.join('\n'),
+  }
+}
+
+/**
+ * Build the outbound HTTP headers for an ntfy publish. `Title` is sanitized to
+ * header-safe ASCII (the body keeps the full UTF-8 text); `Authorization` is
+ * added only when a token is supplied.
+ */
+export function buildNtfyHeaders(
+  payload: AlertPayload,
+  token?: string
+): Record<string, string> {
+  const message = buildNtfyMessage(payload)
+  const headers: Record<string, string> = {
+    Title: sanitizeHeaderValue(message.title),
+    Priority: message.priority,
+    Tags: message.tags,
+    'Content-Type': 'text/plain; charset=utf-8',
+  }
+  const trimmedToken = token?.trim()
+  if (trimmedToken) headers.Authorization = `Bearer ${trimmedToken}`
+  return headers
+}
+
+/**
+ * ntfy adapter. `buildBody` returns the plain-text body only — ntfy's control
+ * fields (title/priority/tags) travel as HTTP headers via
+ * {@link buildNtfyHeaders}, not in the body, so the dispatch layer uses those
+ * two helpers directly. Deliberately NOT registered in `ADAPTERS` (see
+ * `adapters/index.ts`): ntfy is selected by env/route config, and its
+ * header-driven publish can't ride the generic `{ text, content }` proxy path.
+ */
+export const ntfyAdapter: NotificationAdapter = {
+  id: 'ntfy',
+  buildBody: (payload: AlertPayload) => buildNtfyMessage(payload).body,
+}

--- a/apps/dashboard/src/lib/health/alert-dispatcher.ts
+++ b/apps/dashboard/src/lib/health/alert-dispatcher.ts
@@ -312,6 +312,36 @@ export async function fireTelegramTest(
   }
 }
 
+/**
+ * Send a test ntfy notification to a specific topic URL + optional token, via
+ * the dedicated `/api/v1/health/ntfy-test` route (#2657). Unlike Telegram —
+ * whose fixed Bot API host lets its test ride the generic `/health/webhook`
+ * proxy — ntfy needs Title/Priority/Tags HTTP headers the proxy can't emit, so
+ * the server route builds the request (and SSRF-validates the caller-supplied
+ * URL) instead. The token is only ever sent to our own server at creation time
+ * (the user just typed it), never echoed back to the client after storage.
+ */
+export async function fireNtfyTest(
+  url: string,
+  token?: string
+): Promise<boolean> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 10_000)
+  try {
+    const res = await fetch('/api/v1/health/ntfy-test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(token ? { url, token } : { url }),
+      signal: controller.signal,
+    })
+    return res.ok
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
 export async function dispatchAlert(alert: HealthAlertEvent): Promise<void> {
   try {
     const settings = loadAlertSettings()

--- a/apps/dashboard/src/lib/health/alert-routing.test.ts
+++ b/apps/dashboard/src/lib/health/alert-routing.test.ts
@@ -28,6 +28,8 @@ interface FakeRow {
   routing_key: string | null
   telegram_bot_token?: string | null
   telegram_chat_id?: string | null
+  ntfy_url?: string | null
+  ntfy_token?: string | null
 }
 
 function makeFakeD1() {
@@ -56,6 +58,8 @@ function makeFakeD1() {
                 routing_key,
                 telegram_bot_token,
                 telegram_chat_id,
+                ntfy_url,
+                ntfy_token,
               ] = params as [
                 string,
                 string,
@@ -65,6 +69,8 @@ function makeFakeD1() {
                 number,
                 number,
                 string,
+                string | null,
+                string | null,
                 string | null,
                 string | null,
                 string | null,
@@ -83,6 +89,8 @@ function makeFakeD1() {
                 routing_key,
                 telegram_bot_token,
                 telegram_chat_id,
+                ntfy_url,
+                ntfy_token,
               })
               return { meta: { changes: 1 } }
             }
@@ -141,6 +149,7 @@ const {
   deleteRoute,
   listRoutes,
   matchRoutes,
+  resolveNtfyTargets,
   resolvePagerDutyTargets,
   resolveTargets,
   resolveTelegramTargets,
@@ -162,6 +171,8 @@ function route(overrides: Partial<AlertRoute> = {}): AlertRoute {
     routingKey: null,
     telegramBotToken: null,
     telegramChatId: null,
+    ntfyUrl: null,
+    ntfyToken: null,
     ...overrides,
   }
 }
@@ -461,6 +472,89 @@ describe('resolveTelegramTargets (pure) — #2655', () => {
   })
 })
 
+describe('resolveNtfyTargets (pure) — #2657', () => {
+  const ENV_FALLBACK = { url: 'https://ntfy.sh/env-topic', token: 'env-tok' }
+
+  test('matches an ntfy route and returns its url + token', () => {
+    const r = route({
+      matchRule: 'disk-usage',
+      provider: 'ntfy',
+      ntfyUrl: 'https://ntfy.sh/my-topic',
+      ntfyToken: 'tk_secret',
+    })
+    expect(resolveNtfyTargets([r], TARGET, null)).toEqual([
+      { url: 'https://ntfy.sh/my-topic', token: 'tk_secret' },
+    ])
+  })
+
+  test('returns url-only when the route has no token', () => {
+    const r = route({
+      matchRule: 'disk-*',
+      matchHost: '*',
+      provider: 'ntfy',
+      ntfyUrl: 'https://ntfy.sh/my-topic',
+    })
+    expect(resolveNtfyTargets([r], TARGET, null)).toEqual([
+      { url: 'https://ntfy.sh/my-topic' },
+    ])
+  })
+
+  test('ignores webhook-provider routes even if matched', () => {
+    const r = route({ matchRule: 'disk-usage', provider: 'webhook' })
+    expect(resolveNtfyTargets([r], TARGET, ENV_FALLBACK)).toEqual([])
+  })
+
+  test('a matched webhook route suppresses the env ntfy fallback (no double-fire)', () => {
+    const webhook = route({ matchRule: 'disk-usage', provider: 'webhook' })
+    expect(resolveNtfyTargets([webhook], TARGET, ENV_FALLBACK)).toEqual([])
+  })
+
+  test('deduplicates matched routes sharing the same url', () => {
+    const r1 = route({
+      id: 'a',
+      matchRule: 'disk-usage',
+      provider: 'ntfy',
+      ntfyUrl: 'https://ntfy.sh/my-topic',
+      ntfyToken: 'tk_secret',
+    })
+    const r2 = route({
+      id: 'b',
+      matchRule: '*',
+      provider: 'ntfy',
+      ntfyUrl: 'https://ntfy.sh/my-topic',
+      ntfyToken: 'tk_secret',
+    })
+    expect(resolveNtfyTargets([r1, r2], TARGET, null)).toEqual([
+      { url: 'https://ntfy.sh/my-topic', token: 'tk_secret' },
+    ])
+  })
+
+  test('an ntfy route missing the url never dispatches, and still suppresses the env fallback', () => {
+    const r = route({
+      matchRule: 'disk-usage',
+      provider: 'ntfy',
+      ntfyUrl: null,
+      ntfyToken: 'tk_secret',
+    })
+    expect(resolveNtfyTargets([r], TARGET, ENV_FALLBACK)).toEqual([])
+  })
+
+  test('falls back to the env config when nothing matches', () => {
+    const r = route({ matchRule: 'replication-*', provider: 'ntfy' })
+    expect(resolveNtfyTargets([r], TARGET, ENV_FALLBACK)).toEqual([
+      ENV_FALLBACK,
+    ])
+  })
+
+  test('empty route list falls back to the env config', () => {
+    expect(resolveNtfyTargets([], TARGET, ENV_FALLBACK)).toEqual([ENV_FALLBACK])
+  })
+
+  test('no match and no env config -> empty (no ntfy dispatch)', () => {
+    expect(resolveNtfyTargets([], TARGET, null)).toEqual([])
+  })
+})
+
 describe('D1-backed alert-routing CRUD', () => {
   test('listRoutes returns [] when D1 binding is missing (self-hosted/OSS)', async () => {
     currentDb = null
@@ -556,6 +650,29 @@ describe('D1-backed alert-routing CRUD', () => {
     expect(listed.provider).toBe('telegram')
     expect(listed.telegramBotToken).toBe('123:ABC')
     expect(listed.telegramChatId).toBe('-100')
+  })
+
+  test('create -> list round-trip persists ntfy provider fields', async () => {
+    const fakeDb = makeFakeD1()
+    currentDb = fakeDb
+
+    const created = await createRoute({
+      ownerId: 'owner-1',
+      matchRule: 'disk-*',
+      matchHost: '*',
+      channelUrl: '',
+      provider: 'ntfy',
+      ntfyUrl: 'https://ntfy.sh/my-topic',
+      ntfyToken: 'tk_secret',
+    })
+    expect(created?.provider).toBe('ntfy')
+    expect(created?.ntfyUrl).toBe('https://ntfy.sh/my-topic')
+    expect(created?.ntfyToken).toBe('tk_secret')
+
+    const [listed] = await listRoutes('owner-1')
+    expect(listed.provider).toBe('ntfy')
+    expect(listed.ntfyUrl).toBe('https://ntfy.sh/my-topic')
+    expect(listed.ntfyToken).toBe('tk_secret')
   })
 
   test('legacy row with no provider column value defaults to webhook', async () => {

--- a/apps/dashboard/src/lib/health/alert-routing.ts
+++ b/apps/dashboard/src/lib/health/alert-routing.ts
@@ -38,9 +38,10 @@ const TABLE = 'alert_routes'
  * `'pagerduty'` (plan 34) routes to a PagerDuty service's Events API v2
  * integration key (`routingKey`) instead, letting PagerDuty apply that
  * service's own escalation policy + on-call schedule. `'telegram'` (#2655)
- * routes to a Telegram chat via a bot token + chat id.
+ * routes to a Telegram chat via a bot token + chat id. `'ntfy'` (#2657)
+ * routes to an ntfy topic URL (self-hostable) with an optional access token.
  */
-export type AlertRouteProvider = 'webhook' | 'pagerduty' | 'telegram'
+export type AlertRouteProvider = 'webhook' | 'pagerduty' | 'telegram' | 'ntfy'
 
 /** A configured alert route: match criteria → destination channel. */
 export interface AlertRoute {
@@ -63,6 +64,10 @@ export interface AlertRoute {
   telegramBotToken: string | null
   /** Telegram target chat id (provider `'telegram'` only). */
   telegramChatId: string | null
+  /** ntfy topic URL (provider `'ntfy'` only). */
+  ntfyUrl: string | null
+  /** ntfy access token — a secret (provider `'ntfy'` only). */
+  ntfyToken: string | null
 }
 
 interface D1AlertRouteRow {
@@ -78,6 +83,8 @@ interface D1AlertRouteRow {
   routing_key: string | null
   telegram_bot_token: string | null
   telegram_chat_id: string | null
+  ntfy_url: string | null
+  ntfy_token: string | null
 }
 
 function getDb(): D1Database | null {
@@ -101,11 +108,15 @@ function rowToRoute(row: D1AlertRouteRow): AlertRoute {
         ? 'pagerduty'
         : row.provider === 'telegram'
           ? 'telegram'
-          : 'webhook',
+          : row.provider === 'ntfy'
+            ? 'ntfy'
+            : 'webhook',
     serviceName: row.service_name ?? null,
     routingKey: row.routing_key ?? null,
     telegramBotToken: row.telegram_bot_token ?? null,
     telegramChatId: row.telegram_chat_id ?? null,
+    ntfyUrl: row.ntfy_url ?? null,
+    ntfyToken: row.ntfy_token ?? null,
   }
 }
 
@@ -123,7 +134,8 @@ export async function listRoutes(ownerId: string): Promise<AlertRoute[]> {
     const result = await db
       .prepare(
         `SELECT id, owner_id, match_rule, match_host, channel_url, enabled, created_at,
-                provider, service_name, routing_key, telegram_bot_token, telegram_chat_id
+                provider, service_name, routing_key, telegram_bot_token, telegram_chat_id,
+                ntfy_url, ntfy_token
          FROM ${TABLE}
          WHERE owner_id = ?1
          ORDER BY created_at DESC`
@@ -154,6 +166,10 @@ export interface CreateRouteInput {
   telegramBotToken?: string | null
   /** Telegram target chat id (provider `'telegram'` only). */
   telegramChatId?: string | null
+  /** ntfy topic URL (provider `'ntfy'` only). */
+  ntfyUrl?: string | null
+  /** ntfy access token — a secret (provider `'ntfy'` only). */
+  ntfyToken?: string | null
 }
 
 /**
@@ -181,14 +197,17 @@ export async function createRoute(
       routingKey: input.routingKey?.trim() || null,
       telegramBotToken: input.telegramBotToken?.trim() || null,
       telegramChatId: input.telegramChatId?.trim() || null,
+      ntfyUrl: input.ntfyUrl?.trim() || null,
+      ntfyToken: input.ntfyToken?.trim() || null,
     }
 
     await db
       .prepare(
         `INSERT INTO ${TABLE}
            (id, owner_id, match_rule, match_host, channel_url, enabled, created_at,
-            provider, service_name, routing_key, telegram_bot_token, telegram_chat_id)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)`
+            provider, service_name, routing_key, telegram_bot_token, telegram_chat_id,
+            ntfy_url, ntfy_token)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)`
       )
       .bind(
         route.id,
@@ -202,7 +221,9 @@ export async function createRoute(
         route.serviceName,
         route.routingKey,
         route.telegramBotToken,
-        route.telegramChatId
+        route.telegramChatId,
+        route.ntfyUrl,
+        route.ntfyToken
       )
       .run()
 
@@ -419,6 +440,57 @@ export function resolveTelegramTargets(
       if (seen.has(key)) continue
       seen.add(key)
       out.push({ botToken: r.telegramBotToken, chatId: r.telegramChatId })
+    }
+    return out
+  }
+
+  if (matched.length > 0) return []
+
+  return envFallback ? [envFallback] : []
+}
+
+/** One ntfy dispatch target: a topic URL + an optional access token. */
+export interface NtfyTarget {
+  url: string
+  token?: string
+}
+
+/**
+ * Resolve the ntfy topics a finding should publish to (#2657 — extends the
+ * plan-30/34 routing model, mirroring {@link resolveTelegramTargets}): every
+ * ENABLED, matched route with `provider === 'ntfy'` that carries a topic URL,
+ * deduplicated by `url`. When NO route matched at all (any provider), falls
+ * back to `[envFallback]` when the env-configured global ntfy config is present
+ * — preserving the single-destination behavior for deployments that never
+ * configure a route. Returns `[]` when there is no env fallback, OR when a
+ * route of a different provider matched instead — the same cross-provider
+ * suppression {@link resolveTargets} / {@link resolvePagerDutyTargets} /
+ * {@link resolveTelegramTargets} apply, so an operator who explicitly routed a
+ * rule elsewhere is not ALSO published to the env-configured ntfy topic. Pure
+ * — no I/O.
+ */
+export function resolveNtfyTargets(
+  routes: readonly AlertRoute[],
+  target: RouteMatchTarget,
+  envFallback: NtfyTarget | null
+): NtfyTarget[] {
+  const matched = matchRoutes(routes, target)
+  const ntfyMatched = matched.filter(
+    (r): r is AlertRoute & { ntfyUrl: string } =>
+      r.provider === 'ntfy' && Boolean(r.ntfyUrl)
+  )
+
+  if (ntfyMatched.length > 0) {
+    const seen = new Set<string>()
+    const out: NtfyTarget[] = []
+    for (const r of ntfyMatched) {
+      if (seen.has(r.ntfyUrl)) continue
+      seen.add(r.ntfyUrl)
+      out.push(
+        r.ntfyToken
+          ? { url: r.ntfyUrl, token: r.ntfyToken }
+          : { url: r.ntfyUrl }
+      )
     }
     return out
   }

--- a/apps/dashboard/src/lib/health/ntfy-dispatch.test.ts
+++ b/apps/dashboard/src/lib/health/ntfy-dispatch.test.ts
@@ -1,0 +1,99 @@
+import type { AlertPayload } from './adapters/types'
+
+import { buildNtfyMessage } from './adapters/ntfy'
+import { dispatchNtfy } from './ntfy-dispatch'
+import { describe, expect, test } from 'bun:test'
+
+/** A fetch stub that records the request it was called with. */
+function stubFetch(response: Response = new Response('ok', { status: 200 })) {
+  const calls: { url: string; init: RequestInit }[] = []
+  const fetchImpl = (async (input: unknown, init?: RequestInit) => {
+    calls.push({ url: String(input), init: init ?? {} })
+    return response
+  }) as unknown as typeof fetch
+  return { calls, fetchImpl }
+}
+
+function throwingFetch(err: unknown) {
+  return (async () => {
+    throw err
+  }) as unknown as typeof fetch
+}
+
+const CONFIG = { url: 'https://ntfy.sh/my-topic', token: 'tk_secret' }
+
+const CRITICAL: AlertPayload = {
+  severity: 'critical',
+  hostLabel: 'prod-1',
+  hostId: 2,
+  metric: 'failed-mutations',
+  value: 7,
+  warnThreshold: 1,
+  critThreshold: 5,
+  title: 'Failed mutations',
+  label: '7 failed mutations',
+  timestamp: '2026-07-02T10:00:00.000Z',
+}
+
+const RECOVERY: AlertPayload = {
+  ...CRITICAL,
+  severity: 'recovery',
+  value: 0,
+  label: 'recovered',
+}
+
+describe('dispatchNtfy — send', () => {
+  test('POSTs headers + plain-text body to the topic URL', async () => {
+    const { calls, fetchImpl } = stubFetch()
+    const ok = await dispatchNtfy(CRITICAL, CONFIG, { fetchImpl })
+
+    expect(ok).toBe(true)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toBe('https://ntfy.sh/my-topic')
+    expect(calls[0].init.method).toBe('POST')
+    const headers = calls[0].init.headers as Record<string, string>
+    expect(headers.Title).toBe('[CRITICAL] Failed mutations')
+    expect(headers.Priority).toBe('5')
+    expect(headers.Tags).toBe('rotating_light')
+    expect(headers.Authorization).toBe('Bearer tk_secret')
+    expect(calls[0].init.body).toBe(buildNtfyMessage(CRITICAL).body)
+  })
+
+  test('omits Authorization when no token is configured', async () => {
+    const { calls, fetchImpl } = stubFetch()
+    const ok = await dispatchNtfy(
+      CRITICAL,
+      { url: 'https://ntfy.sh/my-topic' },
+      { fetchImpl }
+    )
+
+    expect(ok).toBe(true)
+    const headers = calls[0].init.headers as Record<string, string>
+    expect(headers.Authorization).toBeUndefined()
+  })
+
+  test('sends a recovery with priority 3 + check-mark tag', async () => {
+    const { calls, fetchImpl } = stubFetch()
+    const ok = await dispatchNtfy(RECOVERY, CONFIG, { fetchImpl })
+
+    expect(ok).toBe(true)
+    const headers = calls[0].init.headers as Record<string, string>
+    expect(headers.Priority).toBe('3')
+    expect(headers.Tags).toBe('white_check_mark')
+  })
+
+  test('returns false when ntfy responds non-OK, without throwing', async () => {
+    const { fetchImpl } = stubFetch(new Response('nope', { status: 403 }))
+    const ok = await dispatchNtfy(CRITICAL, CONFIG, { fetchImpl })
+    expect(ok).toBe(false)
+  })
+})
+
+describe('dispatchNtfy — fail-open', () => {
+  test('returns false, never throws, when the fetch itself rejects', async () => {
+    const fetchImpl = throwingFetch(new Error('network down'))
+    await expect(dispatchNtfy(CRITICAL, CONFIG, { fetchImpl })).resolves.toBe(
+      false
+    )
+  })
+})

--- a/apps/dashboard/src/lib/health/ntfy-dispatch.ts
+++ b/apps/dashboard/src/lib/health/ntfy-dispatch.ts
@@ -1,0 +1,66 @@
+/**
+ * ntfy dispatch (transport layer).
+ *
+ * Builds the control headers + plain-text body with the pure formatter
+ * (`adapters/ntfy.ts`) and POSTs them to the caller-supplied ntfy topic URL
+ * (`<server>/<topic>`). This module is the only place that actually talks to
+ * ntfy — mirrors the auth/transport separation Telegram/Opsgenie document (the
+ * adapter stays network-free).
+ *
+ * Unlike Telegram (fixed `api.telegram.org` host), an ntfy topic URL is
+ * OPERATOR-SUPPLIED (any self-hosted server), so it IS a caller-controlled
+ * SSRF sink — the CRUD/test layers that accept such a URL from the browser
+ * validate it with `validateHostUrl` (HTTPS-only, no private/loopback/metadata
+ * targets) before it ever reaches here, exactly like the generic webhook path.
+ * The env-configured global URL is operator-set and trusted.
+ *
+ * Never throws: a delivery failure must not abort the health sweep loop
+ * (fail-open, matching `dispatchTelegram` / `postWebhook` / `dispatchOpsgenie`).
+ */
+
+import type { AlertPayload } from './adapters/types'
+import type { ServerNtfyConfig } from './server-alert-config'
+
+import { buildNtfyHeaders, buildNtfyMessage } from './adapters/ntfy'
+import { error } from '@chm/logger'
+
+/** Injectable dependencies (tests override fetch). */
+export interface NtfyDispatchDeps {
+  fetchImpl?: typeof fetch
+}
+
+/**
+ * Dispatch one alert to an ntfy topic: renders the payload as headers + a
+ * plain-text body and POSTs it to the topic URL. Returns whether the request
+ * succeeded; never throws.
+ */
+export async function dispatchNtfy(
+  payload: AlertPayload,
+  config: ServerNtfyConfig,
+  deps: NtfyDispatchDeps = {}
+): Promise<boolean> {
+  const doFetch = deps.fetchImpl ?? fetch
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 10_000)
+  try {
+    const { body } = buildNtfyMessage(payload)
+    const res = await doFetch(config.url, {
+      method: 'POST',
+      headers: buildNtfyHeaders(payload, config.token),
+      body,
+      signal: controller.signal,
+    })
+    if (!res.ok) {
+      error(
+        '[health] ntfy dispatch returned non-OK status',
+        new Error(`Status ${res.status}`)
+      )
+    }
+    return res.ok
+  } catch (err) {
+    error('[health] ntfy dispatch failed', err as Error)
+    return false
+  } finally {
+    clearTimeout(timeout)
+  }
+}

--- a/apps/dashboard/src/lib/health/server-alert-config.test.ts
+++ b/apps/dashboard/src/lib/health/server-alert-config.test.ts
@@ -1,6 +1,7 @@
 import {
   getServerAlertConfig,
   getServerEmailConfig,
+  getServerNtfyConfig,
   getServerOpsgenieConfig,
   getServerTelegramConfig,
 } from './server-alert-config'
@@ -409,6 +410,52 @@ describe('getServerTelegramConfig', () => {
     expect(getServerTelegramConfig()).toEqual({
       botToken: '123:ABC',
       chatId: '-100',
+    })
+  })
+})
+
+const NTFY_ENV_KEYS = [
+  'HEALTH_ALERT_NTFY_URL',
+  'HEALTH_ALERT_NTFY_TOKEN',
+] as const
+
+describe('getServerNtfyConfig', () => {
+  const original: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    for (const key of NTFY_ENV_KEYS) {
+      original[key] = process.env[key]
+      delete process.env[key]
+    }
+  })
+
+  afterEach(() => {
+    for (const key of NTFY_ENV_KEYS) {
+      if (original[key] === undefined) delete process.env[key]
+      else process.env[key] = original[key]
+    }
+  })
+
+  it('returns null when the URL is not set', () => {
+    expect(getServerNtfyConfig()).toBeNull()
+  })
+
+  it('returns null when the URL is whitespace-only', () => {
+    process.env.HEALTH_ALERT_NTFY_URL = '   '
+    expect(getServerNtfyConfig()).toBeNull()
+  })
+
+  it('returns the URL alone when no token is set', () => {
+    process.env.HEALTH_ALERT_NTFY_URL = '  https://ntfy.sh/my-topic  '
+    expect(getServerNtfyConfig()).toEqual({ url: 'https://ntfy.sh/my-topic' })
+  })
+
+  it('trims and returns URL + token when both set', () => {
+    process.env.HEALTH_ALERT_NTFY_URL = '  https://ntfy.sh/my-topic  '
+    process.env.HEALTH_ALERT_NTFY_TOKEN = '  tk_secret  '
+    expect(getServerNtfyConfig()).toEqual({
+      url: 'https://ntfy.sh/my-topic',
+      token: 'tk_secret',
     })
   })
 })

--- a/apps/dashboard/src/lib/health/server-alert-config.ts
+++ b/apps/dashboard/src/lib/health/server-alert-config.ts
@@ -213,6 +213,38 @@ export function getServerTelegramConfig(): ServerTelegramConfig | null {
   return { botToken, chatId }
 }
 
+/** Resolved server-side ntfy config: the topic URL plus an optional token. */
+export interface ServerNtfyConfig {
+  /** Full topic URL, e.g. `https://ntfy.sh/my-topic` (may be self-hosted). */
+  url: string
+  /** Optional access token for a protected topic (`Authorization: Bearer …`). */
+  token?: string
+}
+
+/**
+ * Server-side ntfy config, sourced from environment variables:
+ *
+ *   - HEALTH_ALERT_NTFY_URL   → url    (full topic URL, default '')
+ *   - HEALTH_ALERT_NTFY_TOKEN → token  (optional Bearer token, default unset)
+ *
+ * Returns null unless the URL is configured — ntfy delivery is opt-in and
+ * fails open (no URL ⇒ the sweep skips the ntfy dispatch entirely). This is the
+ * global fallback used when no per-rule/per-host ntfy route matches, mirroring
+ * the Telegram fallback (#2655).
+ *
+ * NOTE: exposed as a companion function (matching {@link getServerTelegramConfig})
+ * rather than folded into {@link getServerAlertConfig}'s return value — that
+ * shape is shared with the client's localStorage settings and asserted deeply
+ * by its tests, and the ntfy token is a server-only secret that must never
+ * round-trip through it.
+ */
+export function getServerNtfyConfig(): ServerNtfyConfig | null {
+  const url = process.env.HEALTH_ALERT_NTFY_URL?.trim() || ''
+  if (!url) return null
+  const token = process.env.HEALTH_ALERT_NTFY_TOKEN?.trim() || ''
+  return token ? { url, token } : { url }
+}
+
 /** Default cron re-notify cooldown, in minutes, when the env var is unset. */
 export const DEFAULT_ALERT_COOLDOWN_MINUTES = 60
 

--- a/apps/dashboard/src/lib/health/server-sweep.ts
+++ b/apps/dashboard/src/lib/health/server-sweep.ts
@@ -23,6 +23,7 @@ import { clearAck, isAcked, listActiveAcks } from './alert-ack-store'
 import { recordAlertEvent } from './alert-history-store'
 import {
   listRoutes,
+  resolveNtfyTargets,
   resolvePagerDutyTargets,
   resolveTargets,
   resolveTelegramTargets,
@@ -31,6 +32,7 @@ import { alertStateStore, evaluateAlert } from './alert-state-store'
 import { loadCustomRulesIntoRegistry } from './custom-rules-store'
 import { sendAlertEmail } from './email-transport'
 import { isSuppressed, listWindows } from './maintenance-windows'
+import { dispatchNtfy } from './ntfy-dispatch'
 import { dispatchOpsgenie } from './opsgenie-dispatch'
 import {
   getPagerDutyFallbackRoutingKey,
@@ -48,6 +50,7 @@ import {
   getServerAlertConfig,
   getServerAlertCooldownMs,
   getServerEmailConfig,
+  getServerNtfyConfig,
   getServerOpsgenieConfig,
   getServerTelegramConfig,
   getServerThresholdOverrides,
@@ -367,6 +370,7 @@ export async function runHealthSweep(): Promise<SweepSummary> {
   const opsgenieConfig = getServerOpsgenieConfig()
   const emailConfig = getServerEmailConfig()
   const telegramFallback = getServerTelegramConfig()
+  const ntfyFallback = getServerNtfyConfig()
   const canDispatch =
     settings.webhookEnabled &&
     (webhookConfigured ||
@@ -374,7 +378,8 @@ export async function runHealthSweep(): Promise<SweepSummary> {
       Boolean(pagerDutyFallbackKey) ||
       Boolean(opsgenieConfig) ||
       Boolean(emailConfig) ||
-      Boolean(telegramFallback))
+      Boolean(telegramFallback) ||
+      Boolean(ntfyFallback))
   const minRank = SEVERITY_ORDER[settings.minSeverity]
   const cooldownMs = getServerAlertCooldownMs()
 
@@ -636,6 +641,17 @@ export async function runHealthSweep(): Promise<SweepSummary> {
         routes,
         { ruleId, ruleType, hostId, hostName: name },
         telegramFallback
+      )
+
+      // ntfy topics (#2657): resolved separately from the generic webhook
+      // fan-out — an ntfy target needs the topic URL + Title/Priority/Tags
+      // headers, not the `{ text, content }` wrapper. Falls back to the
+      // env-configured global topic when no route matches, same fail-open
+      // contract as the webhook/PagerDuty/Telegram paths.
+      const ntfyTargets = resolveNtfyTargets(
+        routes,
+        { ruleId, ruleType, hostId, hostName: name },
+        ntfyFallback
       )
 
       // Normalized payload shared by every per-URL body builder below (Discord
@@ -926,6 +942,53 @@ export async function runHealthSweep(): Promise<SweepSummary> {
         }
       }
 
+      // ntfy (#2657): every resolved topic (matched routes, or the
+      // env-configured global topic when nothing matched). `dispatchNtfy`
+      // renders the header + plain-text body and never throws (fails open),
+      // matching every other channel here.
+      for (const target of ntfyTargets) {
+        const alertSeverity: AlertSeverity =
+          decision.kind === 'recovery'
+            ? 'recovery'
+            : (effective as 'warning' | 'critical')
+        const ok = await dispatchNtfy(
+          {
+            severity: alertSeverity,
+            hostLabel: name,
+            hostId,
+            metric: ruleId,
+            value,
+            warnThreshold,
+            critThreshold,
+            title: ruleTitle,
+            label,
+            timestamp: new Date().toISOString(),
+          },
+          { url: target.url, token: target.token }
+        )
+        if (ok) anyDelivered = true
+
+        try {
+          await recordAlertEvent(
+            buildAlertEventRecord({
+              hostId,
+              hostLabel: name,
+              ruleId,
+              decision,
+              value,
+              delivered: ok,
+              error: ok ? undefined : 'ntfy dispatch failed',
+              channel: 'ntfy',
+            })
+          )
+        } catch (err) {
+          debug(
+            `[health-sweep] alert-history record failed for host ${hostId} rule ${ruleId}`,
+            err instanceof Error ? err.message : String(err)
+          )
+        }
+      }
+
       // Persist "notified" only when there was nothing to deliver (no
       // targets at all across every channel — not a failure) or at least one
       // channel succeeded. A failed delivery with no successes leaves no
@@ -934,6 +997,7 @@ export async function runHealthSweep(): Promise<SweepSummary> {
         targets.length +
           pagerDutyTargets.length +
           telegramTargets.length +
+          ntfyTargets.length +
           (opsgenieConfig ? 1 : 0) +
           (emailConfig ? 1 : 0) ===
           0 ||

--- a/apps/dashboard/src/lib/hooks/use-alert-routes.ts
+++ b/apps/dashboard/src/lib/hooks/use-alert-routes.ts
@@ -13,10 +13,10 @@ import { apiFetch } from '@/lib/swr/api-fetch'
 import { throwIfNotOk } from '@/lib/swr/fetch-error'
 
 /**
- * Destination provider: `'webhook'` (plan 30), `'pagerduty'` (plan 34), or
- * `'telegram'` (#2655).
+ * Destination provider: `'webhook'` (plan 30), `'pagerduty'` (plan 34),
+ * `'telegram'` (#2655), or `'ntfy'` (#2657).
  */
-export type AlertRouteProvider = 'webhook' | 'pagerduty' | 'telegram'
+export type AlertRouteProvider = 'webhook' | 'pagerduty' | 'telegram' | 'ntfy'
 
 export interface AlertRouteInfo {
   id: string
@@ -33,6 +33,10 @@ export interface AlertRouteInfo {
   telegramChatId: string | null
   /** Masked Telegram bot token (last 4 chars only) — never the raw secret. */
   telegramBotTokenMasked: string | null
+  /** ntfy topic URL (not a secret). */
+  ntfyUrl: string | null
+  /** Masked ntfy access token (last 4 chars only) — never the raw secret. */
+  ntfyTokenMasked: string | null
 }
 
 export const ALERT_ROUTES_QUERY_KEY = ['/api/v1/health/routes'] as const
@@ -76,6 +80,8 @@ export function useAlertRoutesMutations() {
     routingKey?: string
     telegramBotToken?: string
     telegramChatId?: string
+    ntfyUrl?: string
+    ntfyToken?: string
   }): Promise<AlertRouteInfo> => {
     const response = await apiFetch('/api/v1/health/routes', {
       method: 'POST',

--- a/apps/dashboard/src/routes/api/v1/health/ntfy-test.test.ts
+++ b/apps/dashboard/src/routes/api/v1/health/ntfy-test.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// Same auth-gate mock pattern as telegram-test.test.ts / webhook.test.ts.
+let authorizeFeatureRequest = mock(
+  async (
+    _permission: unknown,
+    _request: Request,
+    _options?: { allowAgentBearerToken?: boolean }
+  ): Promise<Response | null> => null
+)
+mock.module('@/lib/feature-permissions/server', () => ({
+  getAppConfig: () => ({ authProvider: 'none' as const, features: {} }),
+  _resetAppConfigCache: () => {},
+  publicReadEnabled: () => true,
+  authorizeFeatureRequest: (
+    permission: unknown,
+    request: Request,
+    options?: { allowAgentBearerToken?: boolean }
+  ) => authorizeFeatureRequest(permission, request, options),
+}))
+
+const NTFY_ENV_KEYS = [
+  'HEALTH_ALERT_NTFY_URL',
+  'HEALTH_ALERT_NTFY_TOKEN',
+] as const
+
+const { __handleGetForTests: handleGet, __handlePostForTests: handlePost } =
+  await import('./ntfy-test')
+
+const originalEnv: Record<string, string | undefined> = {}
+for (const key of NTFY_ENV_KEYS) originalEnv[key] = process.env[key]
+
+const resolvePublic = async () => ['93.184.216.34']
+const resolvePrivate = async () => ['10.0.0.5']
+
+beforeEach(() => {
+  authorizeFeatureRequest = mock(async () => null)
+  for (const key of NTFY_ENV_KEYS) delete process.env[key]
+})
+
+function makeRequest(body?: unknown): Request {
+  return new Request('https://dash.example.com/api/v1/health/ntfy-test', {
+    method: 'POST',
+    ...(body === undefined
+      ? {}
+      : {
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        }),
+  })
+}
+
+describe('GET /api/v1/health/ntfy-test', () => {
+  test('reports not configured when no URL is set', async () => {
+    const res = await handleGet()
+    const body = (await res.json()) as { configured: boolean }
+    expect(body).toEqual({ configured: false })
+  })
+
+  test('reports configured when the URL is set', async () => {
+    process.env.HEALTH_ALERT_NTFY_URL = 'https://ntfy.sh/my-topic'
+    const res = await handleGet()
+    const body = (await res.json()) as { configured: boolean }
+    expect(body).toEqual({ configured: true })
+  })
+})
+
+describe('POST /api/v1/health/ntfy-test — auth gate', () => {
+  test('anonymous is blocked, no egress', async () => {
+    process.env.HEALTH_ALERT_NTFY_URL = 'https://ntfy.sh/my-topic'
+    authorizeFeatureRequest = mock(
+      async () => new Response(null, { status: 401 })
+    )
+    const fetchImpl = mock(
+      async (_url: string, _init?: RequestInit) =>
+        new Response('ok', { status: 200 })
+    )
+    const res = await handlePost(makeRequest(), {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })
+
+    expect(res.status).toBe(401)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/v1/health/ntfy-test — env-global mode', () => {
+  test('400s when ntfy is not configured', async () => {
+    const fetchImpl = mock(
+      async (_url: string, _init?: RequestInit) =>
+        new Response('ok', { status: 200 })
+    )
+    const res = await handlePost(makeRequest(), {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })
+
+    expect(res.status).toBe(400)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  test('sends a real test dispatch to the env topic when configured', async () => {
+    process.env.HEALTH_ALERT_NTFY_URL = 'https://ntfy.sh/my-topic'
+    process.env.HEALTH_ALERT_NTFY_TOKEN = 'tk_secret'
+    const fetchImpl = mock(
+      async (_url: string, _init?: RequestInit) =>
+        new Response('ok', { status: 200 })
+    )
+    const res = await handlePost(makeRequest(), {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })
+
+    expect(res.status).toBe(200)
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchImpl.mock.calls[0]
+    expect(url).toBe('https://ntfy.sh/my-topic')
+    const headers = (init as RequestInit).headers as Record<string, string>
+    expect(headers.Authorization).toBe('Bearer tk_secret')
+  })
+
+  test('502s when the ntfy request fails', async () => {
+    process.env.HEALTH_ALERT_NTFY_URL = 'https://ntfy.sh/my-topic'
+    const fetchImpl = mock(
+      async (_url: string, _init?: RequestInit) =>
+        new Response('nope', { status: 403 })
+    )
+    const res = await handlePost(makeRequest(), {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })
+
+    expect(res.status).toBe(502)
+  })
+})
+
+describe('POST /api/v1/health/ntfy-test — ad-hoc mode', () => {
+  test('dispatches to a caller-supplied public HTTPS topic', async () => {
+    const fetchImpl = mock(
+      async (_url: string, _init?: RequestInit) =>
+        new Response('ok', { status: 200 })
+    )
+    const res = await handlePost(
+      makeRequest({ url: 'https://ntfy.example.com/topic', token: 'tk_1' }),
+      {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        resolveHostAddresses: resolvePublic,
+      }
+    )
+
+    expect(res.status).toBe(200)
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    const [url] = fetchImpl.mock.calls[0]
+    expect(url).toBe('https://ntfy.example.com/topic')
+  })
+
+  test('rejects a non-HTTPS ad-hoc URL, no egress', async () => {
+    const fetchImpl = mock(
+      async (_url: string, _init?: RequestInit) =>
+        new Response('ok', { status: 200 })
+    )
+    const res = await handlePost(makeRequest({ url: 'http://ntfy.sh/topic' }), {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      resolveHostAddresses: resolvePublic,
+    })
+
+    expect(res.status).toBe(400)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  test('blocks an SSRF-unsafe (private) ad-hoc URL, no egress', async () => {
+    const fetchImpl = mock(
+      async (_url: string, _init?: RequestInit) =>
+        new Response('ok', { status: 200 })
+    )
+    const res = await handlePost(
+      makeRequest({ url: 'https://internal.local/topic' }),
+      {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        resolveHostAddresses: resolvePrivate,
+      }
+    )
+
+    expect(res.status).toBe(400)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+})

--- a/apps/dashboard/src/routes/api/v1/health/ntfy-test.ts
+++ b/apps/dashboard/src/routes/api/v1/health/ntfy-test.ts
@@ -1,0 +1,175 @@
+/**
+ * ntfy Test-Message Endpoint
+ * GET  /api/v1/health/ntfy-test  — is ntfy configured server-side (env global)?
+ * POST /api/v1/health/ntfy-test  — send a synthetic test notification
+ *
+ * Two POST modes:
+ *   - No body (or `{}`)         → test the env-configured global topic
+ *     (`HEALTH_ALERT_NTFY_URL` / `_TOKEN`). Used by the Health Settings button.
+ *   - `{ url, token? }`         → test an ad-hoc topic the operator just typed
+ *     into the routing dialog. Because that URL is caller-supplied, it goes
+ *     through the same SSRF guard (`validateHostUrl`, HTTPS-only) as the generic
+ *     webhook proxy before any egress — unlike Telegram, whose fixed Bot API
+ *     host lets the routing dialog reuse the generic webhook proxy. ntfy needs
+ *     Title/Priority/Tags HTTP headers the generic proxy can't emit, so its
+ *     per-route test rides this route instead (#2657).
+ *
+ * The ntfy token is a server-side secret (never round-tripped to the browser
+ * after storage); in the ad-hoc mode the operator just typed it, same posture
+ * as the Telegram/PagerDuty routing-key tests.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { NtfyDispatchDeps } from '@/lib/health/ntfy-dispatch'
+import type { ServerNtfyConfig } from '@/lib/health/server-alert-config'
+
+import { debug } from '@chm/logger'
+import { createErrorResponse } from '@/lib/api/shared/response-builder'
+import { ApiErrorType } from '@/lib/api/types'
+import {
+  type ResolveHostAddresses,
+  validateHostUrl,
+} from '@/lib/browser-connections/host-url'
+import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
+import { dispatchNtfy } from '@/lib/health/ntfy-dispatch'
+import { getServerNtfyConfig } from '@/lib/health/server-alert-config'
+
+const ROUTE_CONTEXT = {
+  route: '/api/v1/health/ntfy-test',
+  method: 'POST',
+} as const
+
+/** Injectable deps for tests (fetch + DNS resolver for the SSRF guard). */
+interface NtfyTestDeps extends NtfyDispatchDeps {
+  resolveHostAddresses?: ResolveHostAddresses
+}
+
+interface NtfyTestBody {
+  url?: unknown
+  token?: unknown
+}
+
+async function handleGet(): Promise<Response> {
+  const config = getServerNtfyConfig()
+  return Response.json({ configured: config !== null })
+}
+
+async function handlePost(
+  request: Request,
+  deps: NtfyTestDeps = {}
+): Promise<Response> {
+  // Write gate, same posture as /api/v1/health/webhook — this triggers a real
+  // outbound ntfy dispatch, so anonymous callers must not reach it.
+  const permissionResponse = await authorizeFeatureRequest(
+    { feature: 'settings', defaultAccess: 'authenticated', operation: 'write' },
+    request,
+    { allowAgentBearerToken: true }
+  )
+  if (permissionResponse) return permissionResponse
+
+  // Body is optional: absent → env-global test. A supplied `url` switches to
+  // the ad-hoc mode (SSRF-validated below).
+  let body: NtfyTestBody = {}
+  try {
+    const text = await request.text()
+    if (text.trim()) body = JSON.parse(text) as NtfyTestBody
+  } catch {
+    return createErrorResponse(
+      {
+        type: ApiErrorType.ValidationError,
+        message: 'Request body must be valid JSON',
+      },
+      400,
+      ROUTE_CONTEXT
+    )
+  }
+
+  const adHocUrl = typeof body.url === 'string' ? body.url.trim() : ''
+  const adHocToken = typeof body.token === 'string' ? body.token.trim() : ''
+
+  let config: ServerNtfyConfig | null
+  if (adHocUrl) {
+    if (!adHocUrl.startsWith('https://')) {
+      return createErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: 'Invalid "url": expected an HTTPS ntfy topic URL',
+        },
+        400,
+        ROUTE_CONTEXT
+      )
+    }
+    const ssrfError = await validateHostUrl(adHocUrl, deps.resolveHostAddresses)
+    if (ssrfError) {
+      return createErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: 'The ntfy URL is not allowed. Use a public HTTPS endpoint.',
+        },
+        400,
+        ROUTE_CONTEXT
+      )
+    }
+    config = adHocToken
+      ? { url: adHocUrl, token: adHocToken }
+      : { url: adHocUrl }
+  } else {
+    config = getServerNtfyConfig()
+    if (!config) {
+      return createErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message:
+            'ntfy is not configured. Set HEALTH_ALERT_NTFY_URL on the server, or pass a topic URL.',
+        },
+        400,
+        ROUTE_CONTEXT
+      )
+    }
+  }
+
+  debug('[POST /api/v1/health/ntfy-test] Sending test notification')
+
+  const ok = await dispatchNtfy(
+    {
+      severity: 'warning',
+      hostLabel: 'test-host',
+      hostId: 0,
+      metric: 'test',
+      value: 0,
+      warnThreshold: null,
+      critThreshold: null,
+      title: 'Test Alert',
+      label: 'This is a test alert from chmonitor',
+      timestamp: new Date().toISOString(),
+    },
+    config,
+    deps
+  )
+
+  if (!ok) {
+    return createErrorResponse(
+      {
+        type: ApiErrorType.NetworkError,
+        message: 'ntfy test notification failed. Check the server logs.',
+      },
+      502,
+      ROUTE_CONTEXT
+    )
+  }
+
+  return Response.json({ success: true }, { status: 200 })
+}
+
+export const Route = createFileRoute('/api/v1/health/ntfy-test')({
+  server: {
+    handlers: {
+      GET: async () => handleGet(),
+      POST: async ({ request }) => handlePost(request),
+    },
+  },
+})
+
+// Exported for unit tests only.
+export { handleGet as __handleGetForTests, handlePost as __handlePostForTests }

--- a/apps/dashboard/src/routes/api/v1/health/routes.ts
+++ b/apps/dashboard/src/routes/api/v1/health/routes.ts
@@ -66,6 +66,12 @@ function toPublicRoute(route: Awaited<ReturnType<typeof listRoutes>>[number]) {
     telegramBotTokenMasked: route.telegramBotToken
       ? maskRoutingKey(route.telegramBotToken)
       : null,
+    // ntfy (#2657): the topic URL is not a secret (its secret, if any, is the
+    // access token) and is returned as-is so the UI can show which topic a
+    // route targets; the optional token IS a bare secret, masked like the
+    // Telegram bot token.
+    ntfyUrl: route.ntfyUrl,
+    ntfyTokenMasked: route.ntfyToken ? maskRoutingKey(route.ntfyToken) : null,
   }
 }
 
@@ -83,7 +89,10 @@ interface CreateRouteBody {
   matchHost?: unknown
   channelUrl?: unknown
   enabled?: unknown
-  /** `'webhook'` (default), `'pagerduty'` (plan 34), or `'telegram'` (#2655). */
+  /**
+   * `'webhook'` (default), `'pagerduty'` (plan 34), `'telegram'` (#2655), or
+   * `'ntfy'` (#2657).
+   */
   provider?: unknown
   /** PagerDuty-only: display label for the service. */
   serviceName?: unknown
@@ -93,6 +102,10 @@ interface CreateRouteBody {
   telegramBotToken?: unknown
   /** Telegram-only: the target chat id. */
   telegramChatId?: unknown
+  /** ntfy-only: the topic URL (SSRF-validated, HTTPS-only). */
+  ntfyUrl?: unknown
+  /** ntfy-only: the optional access token (a secret). */
+  ntfyToken?: unknown
 }
 
 async function handlePost(request: Request): Promise<Response> {
@@ -113,7 +126,9 @@ async function handlePost(request: Request): Promise<Response> {
       ? 'pagerduty'
       : body.provider === 'telegram'
         ? 'telegram'
-        : 'webhook'
+        : body.provider === 'ntfy'
+          ? 'ntfy'
+          : 'webhook'
 
   const matchRule =
     typeof body.matchRule === 'string' && body.matchRule.trim()
@@ -191,6 +206,49 @@ async function handlePost(request: Request): Promise<Response> {
       provider: 'telegram',
       telegramBotToken,
       telegramChatId,
+    })
+
+    if (!created) {
+      return jsonError(
+        'Alert routing storage is not configured (no D1 binding) or the write failed.',
+        501
+      )
+    }
+
+    return Response.json(
+      { success: true, route: toPublicRoute(created) },
+      { status: 201 }
+    )
+  }
+
+  if (provider === 'ntfy') {
+    const ntfyUrl = typeof body.ntfyUrl === 'string' ? body.ntfyUrl.trim() : ''
+    const ntfyToken =
+      typeof body.ntfyToken === 'string' ? body.ntfyToken.trim() : ''
+    if (!ntfyUrl || !ntfyUrl.startsWith('https://')) {
+      return jsonError(
+        'Missing or invalid "ntfyUrl": expected an HTTPS ntfy topic URL',
+        400
+      )
+    }
+
+    // Unlike Telegram (fixed api.telegram.org host), an ntfy topic URL is
+    // caller-supplied — a real SSRF sink — so it goes through the same guard
+    // the generic webhook path uses (`validateHostUrl`) before being stored.
+    const ssrfError = await validateHostUrl(ntfyUrl)
+    if (ssrfError) {
+      return jsonError(ssrfError, 400)
+    }
+
+    const created = await createRoute({
+      ownerId,
+      matchRule,
+      matchHost,
+      channelUrl: '',
+      enabled,
+      provider: 'ntfy',
+      ntfyUrl,
+      ntfyToken: ntfyToken || null,
     })
 
     if (!created) {

--- a/docs/content/guide/features/health.mdx
+++ b/docs/content/guide/features/health.mdx
@@ -101,6 +101,8 @@ The health-sweep endpoint runs checks over all configured hosts and sends a webh
 | `HEALTH_ALERT_MIN_SEVERITY` | `warning` | Minimum severity that triggers a notification. Values: `warning` or `critical`. |
 | `HEALTH_ALERT_TELEGRAM_BOT_TOKEN` | (unset = Telegram disabled) | Telegram Bot API token. Server-only secret — never exposed to the browser. Set together with `HEALTH_ALERT_TELEGRAM_CHAT_ID` to enable the global Telegram channel; each finding is sent to the chat via the Bot API `sendMessage` endpoint. Per-rule/per-host Telegram routes (Routing tab) override this fallback. |
 | `HEALTH_ALERT_TELEGRAM_CHAT_ID` | (unset = Telegram disabled) | Target Telegram chat id (e.g. `-1001234567890`, or `@channelname`). Both this and `HEALTH_ALERT_TELEGRAM_BOT_TOKEN` must be set for the global Telegram channel to fire. |
+| `HEALTH_ALERT_NTFY_URL` | (unset = ntfy disabled) | Full [ntfy](https://ntfy.sh) topic URL (e.g. `https://ntfy.sh/my-topic`, or a self-hosted server). Each finding is published with `Title`/`Priority`/`Tags` headers + a plain-text body (severity → priority: critical `5`/urgent, warning `4`/high, recovery `3`/default). Per-rule/per-host ntfy routes (Routing tab) override this fallback. |
+| `HEALTH_ALERT_NTFY_TOKEN` | (unset = no auth) | Optional ntfy access token for a protected topic, sent as `Authorization: Bearer <token>`. Server-only secret — never exposed to the browser. |
 
 <Callout type="warn" title="CRON_SECRET is required">
 `CRON_SECRET` is **required** for the cron endpoints. When it is unset, `/api/cron/health-sweep` and `/api/cron/retention-prune` **fail closed and return HTTP 503** (they do not run) — `retention-prune` is destructive, so it must never be reachable unauthenticated. Set `CRON_SECRET` and pass it as `Authorization: Bearer <secret>` from your cron caller.
@@ -117,6 +119,8 @@ wrangler secret put CRON_SECRET
 wrangler secret put HEALTH_ALERT_WEBHOOK_URL
 # Optional: Telegram channel (bot token is a secret; chat id is a plain var)
 wrangler secret put HEALTH_ALERT_TELEGRAM_BOT_TOKEN
+# Optional: ntfy channel (topic URL is a plain var; access token is a secret)
+wrangler secret put HEALTH_ALERT_NTFY_TOKEN
 ```
 </Step>
 <Step>


### PR DESCRIPTION
## Summary

Adds **ntfy** ([ntfy.sh](https://ntfy.sh) / self-hosted) as a health-alert delivery channel — a natural fit for the OSS/self-hosted product. Mirrors the Telegram channel (#2670) end-to-end.

Alerts and recoveries publish to an ntfy topic with severity-mapped priority + tags; all secrets stay server-side.

## What's included

- **Transport** `lib/health/ntfy-dispatch.ts` — POSTs to the topic URL with `Title`/`Priority`/`Tags` headers + plain-text body, optional `Authorization: Bearer`. Injectable `fetch`, never throws (fail-open), 10s timeout.
- **Formatter** `lib/health/adapters/ntfy.ts` — pure builder. Severity → priority/tags: critical=`5`/🚨, warning=`4`/⚠️, recovery=`3`/✅. Header-safe `Title` sanitization (full UTF-8 detail lives in the body).
- **Env config** `getServerNtfyConfig()` — `HEALTH_ALERT_NTFY_URL` (required) + optional `HEALTH_ALERT_NTFY_TOKEN`; opt-in, fails open.
- **Routing** `'ntfy'` provider + `ntfy_url`/`ntfy_token` columns (migration `0021_alert_routes_ntfy.sql`), `resolveNtfyTargets()` with env fallback + cross-provider suppression, `routes.ts` create branch. ntfy topic URLs are **user-supplied**, so unlike Telegram they go through the same SSRF guard (`validateHostUrl`, HTTPS-only) as generic webhooks; the token is masked on read-back.
- **Sweep** ntfy dispatch block in `server-sweep.ts` (alert + recovery, history channel `'ntfy'`).
- **Test route + UI** `GET/POST /api/v1/health/ntfy-test`, Settings badge + Send-test button, routing-dialog `'ntfy'` option + fields + test.
- **Docs** env-var rows in `health.mdx`.

## Deviation from the Telegram template

Telegram's per-route "Send test" rides the generic `/health/webhook` proxy. ntfy needs `Title/Priority/Tags` **HTTP headers** the proxy can't emit, so the ntfy test route additionally accepts an ad-hoc `{ url, token }` body (SSRF-validated) — the routing-dialog test uses that path; the Settings button uses the env-global path. Same secret posture as the Telegram/PagerDuty tests (token only travels browser→our server at creation time, never echoed back).

## Verification

- `biome check` clean on all changed files
- `pnpm run type-check` passes
- bun tests (per-file): `adapters/ntfy` (13), `ntfy-dispatch` (5), `server-alert-config` (39), `alert-routing` (51), `ntfy-test` (9), plus telegram-test / adapters / server-sweep regression suites — all green

Closes #2657

https://claude.ai/code/session_015Mq6c6bQstbRwQnKt9htbE
