### PR TITLE
feat(alerts): quiet hours — recurring time-of-day silence windows

### DIFF
--- a/apps/dashboard/src/components/health/health-settings-dialog.tsx
+++ b/apps/dashboard/src/components/health/health-settings-dialog.tsx
@@ -6,6 +6,7 @@ import { AlertRoutingPanel } from './alert-routing-dialog'
 import { AlertSuggestionsPanel } from './alert-suggestions-panel'
 import { HEALTH_CHECKS } from './health-checks'
 import { MaintenanceWindowsPanel } from './maintenance-windows-panel'
+import { QuietHoursPanel } from './quiet-hours-panel'
 import { RecentAlertsCard } from './recent-alerts-card'
 import { RuleBuilderPanel } from './rule-builder'
 import { WebhookSubscriptionsPanel } from './webhook-subscriptions-panel'
@@ -274,6 +275,7 @@ export function HealthSettingsDialog() {
               <TabsTrigger value="routing">Routing</TabsTrigger>
               <TabsTrigger value="webhooks">Webhooks</TabsTrigger>
               <TabsTrigger value="maintenance">Maintenance</TabsTrigger>
+              <TabsTrigger value="quiet-hours">Quiet Hours</TabsTrigger>
               <TabsTrigger value="suggested">Suggested</TabsTrigger>
               <TabsTrigger value="custom-rules">Custom Rules</TabsTrigger>
             </TabsList>
@@ -629,6 +631,12 @@ export function HealthSettingsDialog() {
           <TabsContent value="maintenance" className="min-h-0 overflow-hidden">
             <ScrollArea className="h-full pr-3">
               <MaintenanceWindowsPanel />
+            </ScrollArea>
+          </TabsContent>
+
+          <TabsContent value="quiet-hours" className="min-h-0 overflow-hidden">
+            <ScrollArea className="h-full pr-3">
+              <QuietHoursPanel />
             </ScrollArea>
           </TabsContent>
 

--- a/apps/dashboard/src/components/health/quiet-hours-panel.tsx
+++ b/apps/dashboard/src/components/health/quiet-hours-panel.tsx
@@ -1,0 +1,288 @@
+/**
+ * Quiet hours panel (#2662).
+ *
+ * The recurring sibling of `MaintenanceWindowsPanel`: an operator declares a
+ * recurring weekday + time-of-day range (in an IANA timezone) during which the
+ * health sweep silences outbound alert delivery. Checks still run and findings
+ * are still recorded — only delivery is gated. `severityCap = critical` lets
+ * criticals keep paging; catch-up notifications fire for still-active criticals
+ * once the window closes. Lives as a tab in `HealthSettingsDialog`; every
+ * action is an immediate server call (create/delete), same as the maintenance
+ * panel. Free/OSS: no Clerk sign-in required.
+ */
+
+import { MoonStar } from 'lucide-react'
+import { toast } from 'sonner'
+
+import type { QuietHoursInfo } from '@/lib/hooks/use-quiet-hours'
+
+import { useState } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { EmptyState } from '@/components/ui/empty-state'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Switch } from '@/components/ui/switch'
+import {
+  useQuietHours,
+  useQuietHoursMutations,
+} from '@/lib/hooks/use-quiet-hours'
+import { cn } from '@/lib/utils'
+
+/** Sun-first labels; index is the 0–6 weekday number stored server-side. */
+const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const
+
+function browserTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+  } catch {
+    return 'UTC'
+  }
+}
+
+/** All IANA zones when the runtime supports it, else a small useful fallback. */
+function timezoneOptions(): string[] {
+  try {
+    const supported = (
+      Intl as unknown as { supportedValuesOf?: (k: string) => string[] }
+    ).supportedValuesOf?.('timeZone')
+    if (supported && supported.length > 0) return supported
+  } catch {
+    // fall through
+  }
+  const tz = browserTimezone()
+  return [...new Set(['UTC', tz])]
+}
+
+function formatDays(days: number[]): string {
+  if (days.length === 7) return 'Every day'
+  return [...days]
+    .sort((a, b) => a - b)
+    .map((d) => WEEKDAYS[d])
+    .join(', ')
+}
+
+function QuietHoursRow({
+  window,
+  onDeleted,
+}: {
+  window: QuietHoursInfo
+  onDeleted: () => void
+}) {
+  const [busy, setBusy] = useState(false)
+  const { deleteWindow } = useQuietHoursMutations()
+
+  const handleDelete = async () => {
+    setBusy(true)
+    try {
+      await deleteWindow(window.id)
+      onDeleted()
+    } catch {
+      toast.error('Failed to delete quiet-hours window')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-2 rounded-md border p-3">
+      <div className="flex min-w-0 flex-col gap-1">
+        <div className="flex items-center gap-2">
+          <Badge variant="secondary">{formatDays(window.days)}</Badge>
+          <span className="truncate text-sm font-medium">
+            {window.start} → {window.end}
+          </span>
+        </div>
+        <span className="truncate text-xs text-muted-foreground">
+          {window.timezone} ·{' '}
+          {window.severityCap === 'critical'
+            ? 'Criticals still page'
+            : 'Silences all alerts'}
+        </span>
+      </div>
+      <Button variant="ghost" size="sm" disabled={busy} onClick={handleDelete}>
+        Delete
+      </Button>
+    </div>
+  )
+}
+
+function AddQuietHoursForm({ onCreated }: { onCreated: () => void }) {
+  const [days, setDays] = useState<number[]>([1, 2, 3, 4, 5])
+  const [start, setStart] = useState('22:00')
+  const [end, setEnd] = useState('07:00')
+  const [timezone, setTimezone] = useState(browserTimezone)
+  const [allowCriticals, setAllowCriticals] = useState(true)
+  const [busy, setBusy] = useState(false)
+  const { createWindow } = useQuietHoursMutations()
+
+  const toggleDay = (day: number) => {
+    setDays((prev) =>
+      prev.includes(day) ? prev.filter((d) => d !== day) : [...prev, day]
+    )
+  }
+
+  const handleSubmit = async () => {
+    if (days.length === 0) {
+      toast.error('Pick at least one day')
+      return
+    }
+    if (start === end) {
+      toast.error('Start and end times must differ')
+      return
+    }
+    setBusy(true)
+    try {
+      await createWindow({
+        days: [...days].sort((a, b) => a - b),
+        start,
+        end,
+        timezone,
+        severityCap: allowCriticals ? 'critical' : null,
+      })
+      toast.success('Quiet hours added')
+      onCreated()
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : 'Failed to create quiet hours'
+      )
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-3 rounded-md border p-3">
+      <Label className="text-sm font-medium">Add quiet hours</Label>
+
+      <div className="flex flex-col gap-1.5">
+        <Label className="text-xs text-muted-foreground">Days</Label>
+        <div className="flex flex-wrap gap-1.5">
+          {WEEKDAYS.map((label, day) => (
+            <button
+              key={label}
+              type="button"
+              onClick={() => toggleDay(day)}
+              aria-pressed={days.includes(day)}
+              className={cn(
+                'h-8 min-w-10 rounded-md border px-2 text-xs font-medium transition-colors',
+                days.includes(day)
+                  ? 'border-primary bg-primary text-primary-foreground'
+                  : 'border-border text-muted-foreground hover:bg-muted'
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <div className="flex flex-col gap-1">
+          <Label className="text-xs text-muted-foreground">Start</Label>
+          <Input
+            type="time"
+            value={start}
+            onChange={(e) => setStart(e.target.value)}
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label className="text-xs text-muted-foreground">End</Label>
+          <Input
+            type="time"
+            value={end}
+            onChange={(e) => setEnd(e.target.value)}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <Label className="text-xs text-muted-foreground">Timezone</Label>
+        <Select
+          value={timezone}
+          onValueChange={(value) => {
+            if (value != null) setTimezone(value)
+          }}
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent className="max-h-64">
+            {timezoneOptions().map((tz) => (
+              <SelectItem key={tz} value={tz}>
+                {tz}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex flex-col">
+          <Label className="text-sm">Let criticals page</Label>
+          <span className="text-xs text-muted-foreground">
+            Only warnings are silenced; critical alerts still deliver.
+          </span>
+        </div>
+        <Switch checked={allowCriticals} onCheckedChange={setAllowCriticals} />
+      </div>
+
+      <Button
+        size="sm"
+        className="self-start"
+        disabled={busy}
+        onClick={handleSubmit}
+      >
+        Add
+      </Button>
+    </div>
+  )
+}
+
+export function QuietHoursPanel({ className }: { className?: string }) {
+  const { windows, isLoading, refetch } = useQuietHours()
+
+  return (
+    <div className={cn('flex flex-col gap-3', className)}>
+      <p className="text-xs text-muted-foreground">
+        On the chosen days and time range, the health sweep still runs every
+        check and records findings — it only silences the outbound alert. Set
+        “Let criticals page” to keep critical alerts flowing; still-active
+        criticals get a catch-up notification when the window ends.
+      </p>
+
+      {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+
+      {!isLoading && windows.length === 0 && (
+        <EmptyState
+          compact
+          icon={
+            <MoonStar
+              className="h-10 w-10 text-muted-foreground/60"
+              strokeWidth={1.5}
+            />
+          }
+          title="No quiet hours"
+          description="Add a recurring window to silence non-critical alerts overnight or on weekends."
+        />
+      )}
+
+      {windows.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {windows.map((w) => (
+            <QuietHoursRow key={w.id} window={w} onDeleted={refetch} />
+          ))}
+        </div>
+      )}
+
+      <AddQuietHoursForm onCreated={refetch} />
+    </div>
+  )
+}

--- a/apps/dashboard/src/db/conversations-migrations/0022_quiet_hours.sql
+++ b/apps/dashboard/src/db/conversations-migrations/0022_quiet_hours.sql
@@ -1,0 +1,26 @@
+-- Quiet hours (issue #2662): recurring time-of-day alert-delivery silence
+-- windows — the recurring sibling of maintenance_windows (0-oneshot). While
+-- `now` falls inside a window, server-sweep.ts skips the outbound
+-- notification for a finding (the check still runs, the finding is still
+-- recorded in alert_events with a `quiet-hours` marker). `days` is a JSON
+-- array of weekday numbers (0=Sun..6=Sat), `start_time`/`end_time` are 'HH:mm'
+-- wall-clock strings interpreted in `timezone` (IANA), and `severity_cap`
+-- (NULL = suppress all, 'critical' = let criticals page) tunes what still
+-- gets through. `owner_id` follows the maintenance_windows convention:
+-- '' (self-hosted / no Clerk) or the Clerk org/user id in cloud mode. The
+-- table is also created lazily by lib/health/quiet-hours.ts, so an OSS
+-- deployment that never runs migrations still works.
+CREATE TABLE IF NOT EXISTS quiet_hours (
+  id           TEXT NOT NULL PRIMARY KEY,
+  owner_id     TEXT NOT NULL,
+  days         TEXT NOT NULL DEFAULT '[]',
+  start_time   TEXT NOT NULL,
+  end_time     TEXT NOT NULL,
+  timezone     TEXT NOT NULL,
+  severity_cap TEXT,
+  created_by   TEXT NOT NULL DEFAULT '',
+  created_at   INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_quiet_hours_owner
+  ON quiet_hours (owner_id);

--- a/apps/dashboard/src/lib/health/quiet-hours.test.ts
+++ b/apps/dashboard/src/lib/health/quiet-hours.test.ts
@@ -1,0 +1,435 @@
+/**
+ * Tests for quiet hours (#2662).
+ *
+ * Three layers, mirroring maintenance-windows.test.ts:
+ *  1. Pure matchers (`isWithinQuietWindow` / `isQuietSuppressed` / timezone +
+ *     across-midnight handling + severityCap) — the logic the sweep's dispatch
+ *     gate depends on, unit-tested directly (no D1).
+ *  2. The catch-up tracker (`markQuietSuppression` / `takeDueCatchUp`) — the
+ *     bookkeeping that lets a suppressed critical get a labeled catch-up once
+ *     its window closes.
+ *  3. The D1-backed store (`listQuietHours`/`createQuietHours`/`deleteQuietHours`)
+ *     via a behavioral D1 fake, exercising the real SQL, owner scoping,
+ *     validation, and fail-open degrade.
+ */
+
+import type { QuietHours } from './quiet-hours'
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// --- behavioral D1 fake ------------------------------------------------------
+interface FakeRow {
+  id: string
+  owner_id: string
+  days: string
+  start_time: string
+  end_time: string
+  timezone: string
+  severity_cap: string | null
+  created_by: string
+  created_at: number
+}
+
+function makeFakeD1() {
+  const rows: FakeRow[] = []
+
+  function prepare(sql: string) {
+    const isInsert = /^\s*INSERT INTO/i.test(sql)
+    const isDelete = /^\s*DELETE FROM/i.test(sql)
+    const isSelect = /^\s*SELECT/i.test(sql)
+
+    return {
+      bind(...args: unknown[]) {
+        return {
+          async run(): Promise<{ meta: { changes: number } }> {
+            if (isInsert) {
+              const [
+                id,
+                ownerId,
+                days,
+                startTime,
+                endTime,
+                timezone,
+                severityCap,
+                createdBy,
+                createdAt,
+              ] = args as [
+                string,
+                string,
+                string,
+                string,
+                string,
+                string,
+                string | null,
+                string,
+                number,
+              ]
+              rows.push({
+                id,
+                owner_id: ownerId,
+                days,
+                start_time: startTime,
+                end_time: endTime,
+                timezone,
+                severity_cap: severityCap,
+                created_by: createdBy,
+                created_at: createdAt,
+              })
+              return { meta: { changes: 1 } }
+            }
+            if (isDelete) {
+              const [id, ownerId] = args as [string, string]
+              const idx = rows.findIndex(
+                (r) => r.id === id && r.owner_id === ownerId
+              )
+              if (idx >= 0) rows.splice(idx, 1)
+              return { meta: { changes: idx >= 0 ? 1 : 0 } }
+            }
+            throw new Error(`fake D1: run() called on unexpected SQL: ${sql}`)
+          },
+          async all<T>(): Promise<{ results: T[] }> {
+            if (!isSelect)
+              throw new Error(`fake D1: all() called on non-SELECT: ${sql}`)
+            const [ownerId] = args as [string]
+            const filtered = rows
+              .filter((r) => r.owner_id === ownerId)
+              .sort((a, b) => b.created_at - a.created_at)
+            return { results: filtered as unknown as T[] }
+          },
+        }
+      },
+    }
+  }
+
+  return {
+    rows,
+    prepare,
+    batch: async (stmts: unknown[]) =>
+      stmts.map(() => ({ meta: { changes: 0 } })),
+  }
+}
+
+let fakeDb: ReturnType<typeof makeFakeD1> | null
+
+mock.module('@chm/platform', () => ({
+  getPlatformBindings: () => ({
+    getD1Database: () => fakeDb,
+  }),
+}))
+
+const {
+  isWithinQuietWindow,
+  activeQuietWindow,
+  isQuietSuppressed,
+  quietWindowEndMs,
+  parseHmToMinutes,
+  markQuietSuppression,
+  takeDueCatchUp,
+  clearQuietSuppression,
+  _resetQuietCatchUpTracker,
+  listQuietHours,
+  createQuietHours,
+  deleteQuietHours,
+} = await import('./quiet-hours')
+
+function qh(over: Partial<QuietHours> = {}): QuietHours {
+  return {
+    id: 'q1',
+    ownerId: 'owner-a',
+    days: [1, 2, 3, 4, 5],
+    start: '22:00',
+    end: '07:00',
+    timezone: 'UTC',
+    severityCap: 'critical',
+    createdBy: 'user_1',
+    createdAt: 500,
+    ...over,
+  }
+}
+
+// A fixed instant: Monday 2026-01-05 23:30 UTC (Jan 1 2026 is a Thursday).
+const MON_2330_UTC = Date.UTC(2026, 0, 5, 23, 30)
+const TUE_0630_UTC = Date.UTC(2026, 0, 6, 6, 30)
+const TUE_0700_UTC = Date.UTC(2026, 0, 6, 7, 0)
+const TUE_0800_UTC = Date.UTC(2026, 0, 6, 8, 0)
+const MON_2100_UTC = Date.UTC(2026, 0, 5, 21, 0)
+const MON_1400_UTC = Date.UTC(2026, 0, 5, 14, 0)
+
+// ---------------------------------------------------------------------------
+// parseHmToMinutes
+// ---------------------------------------------------------------------------
+describe('parseHmToMinutes', () => {
+  test('parses valid HH:mm', () => {
+    expect(parseHmToMinutes('00:00')).toBe(0)
+    expect(parseHmToMinutes('07:30')).toBe(450)
+    expect(parseHmToMinutes('23:59')).toBe(1439)
+  })
+  test('rejects malformed / out-of-range', () => {
+    expect(parseHmToMinutes('24:00')).toBeNull()
+    expect(parseHmToMinutes('7:60')).toBeNull()
+    expect(parseHmToMinutes('nope')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isWithinQuietWindow — across midnight + day boundaries (UTC)
+// ---------------------------------------------------------------------------
+describe('isWithinQuietWindow (across midnight)', () => {
+  const w = qh({ days: [1], start: '22:00', end: '07:00', timezone: 'UTC' })
+
+  test('true in the evening portion on the start weekday', () => {
+    expect(isWithinQuietWindow(w, MON_2330_UTC)).toBe(true)
+  })
+  test('true in the morning portion (belongs to the start weekday)', () => {
+    expect(isWithinQuietWindow(w, TUE_0630_UTC)).toBe(true)
+  })
+  test('false after the window ends', () => {
+    expect(isWithinQuietWindow(w, TUE_0800_UTC)).toBe(false)
+  })
+  test('false before the window starts', () => {
+    expect(isWithinQuietWindow(w, MON_2100_UTC)).toBe(false)
+  })
+  test('false when the weekday is not selected', () => {
+    // Tuesday-only window does NOT cover Monday evening.
+    const tueOnly = qh({ days: [2], start: '22:00', end: '07:00' })
+    expect(isWithinQuietWindow(tueOnly, MON_2330_UTC)).toBe(false)
+  })
+})
+
+describe('isWithinQuietWindow (same day)', () => {
+  const w = qh({ days: [1], start: '09:00', end: '17:00' })
+
+  test('start is inclusive, end is exclusive', () => {
+    const mon0900 = Date.UTC(2026, 0, 5, 9, 0)
+    const mon1700 = Date.UTC(2026, 0, 5, 17, 0)
+    expect(isWithinQuietWindow(w, mon0900)).toBe(true)
+    expect(isWithinQuietWindow(w, mon1700)).toBe(false)
+  })
+  test('equal start/end never matches', () => {
+    expect(
+      isWithinQuietWindow(qh({ start: '09:00', end: '09:00' }), MON_1400_UTC)
+    ).toBe(false)
+  })
+  test('empty days never matches', () => {
+    expect(isWithinQuietWindow(qh({ days: [] }), MON_2330_UTC)).toBe(false)
+  })
+})
+
+describe('isWithinQuietWindow (timezone)', () => {
+  // Same instant, different zones → different local wall-clock.
+  const w = (tz: string) =>
+    qh({ days: [1], start: '09:00', end: '17:00', timezone: tz })
+
+  test('the same UTC instant matches or not depending on the window timezone', () => {
+    // Mon 14:00 UTC.
+    expect(isWithinQuietWindow(w('UTC'), MON_1400_UTC)).toBe(true) // 14:00 local
+    expect(isWithinQuietWindow(w('America/New_York'), MON_1400_UTC)).toBe(true) // 09:00 local
+    expect(isWithinQuietWindow(w('Asia/Tokyo'), MON_1400_UTC)).toBe(false) // 23:00 local
+  })
+
+  test('invalid timezone fails open (not in window)', () => {
+    expect(isWithinQuietWindow(w('Not/AZone'), MON_1400_UTC)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// activeQuietWindow + isQuietSuppressed — severityCap
+// ---------------------------------------------------------------------------
+describe('isQuietSuppressed (severityCap)', () => {
+  test('cap=null suppresses every severity while active', () => {
+    const windows = [qh({ days: [1], severityCap: null })]
+    expect(isQuietSuppressed(windows, 'warning', MON_2330_UTC)).toBe(true)
+    expect(isQuietSuppressed(windows, 'critical', MON_2330_UTC)).toBe(true)
+  })
+
+  test('cap=critical suppresses warnings but lets criticals page', () => {
+    const windows = [qh({ days: [1], severityCap: 'critical' })]
+    expect(isQuietSuppressed(windows, 'warning', MON_2330_UTC)).toBe(true)
+    expect(isQuietSuppressed(windows, 'critical', MON_2330_UTC)).toBe(false)
+  })
+
+  test('nothing suppressed when no window is active', () => {
+    const windows = [qh({ days: [1], severityCap: null })]
+    expect(isQuietSuppressed(windows, 'critical', TUE_0800_UTC)).toBe(false)
+    expect(isQuietSuppressed([], 'warning', MON_2330_UTC)).toBe(false)
+  })
+
+  test('activeQuietWindow returns the covering window or null', () => {
+    const windows = [qh({ days: [1] })]
+    expect(activeQuietWindow(windows, MON_2330_UTC)?.id).toBe('q1')
+    expect(activeQuietWindow(windows, TUE_0800_UTC)).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// quietWindowEndMs
+// ---------------------------------------------------------------------------
+describe('quietWindowEndMs', () => {
+  test('across-midnight evening portion ends at the next morning end time', () => {
+    const w = qh({ days: [1], start: '22:00', end: '07:00', timezone: 'UTC' })
+    // Mon 23:30 UTC → end is Tue 07:00 UTC.
+    expect(quietWindowEndMs(w, MON_2330_UTC)).toBe(TUE_0700_UTC)
+  })
+  test('across-midnight morning portion ends later today', () => {
+    const w = qh({ days: [1], start: '22:00', end: '07:00', timezone: 'UTC' })
+    // Tue 06:30 UTC → end is Tue 07:00 UTC.
+    expect(quietWindowEndMs(w, TUE_0630_UTC)).toBe(TUE_0700_UTC)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// catch-up tracker
+// ---------------------------------------------------------------------------
+describe('catch-up tracker', () => {
+  beforeEach(() => _resetQuietCatchUpTracker())
+
+  test('takeDueCatchUp is false while the window is still open, true once ended', () => {
+    markQuietSuppression(3, 'disk', 'critical', 2000)
+    expect(takeDueCatchUp(3, 'disk', 1500)).toBe(false) // before end
+    expect(takeDueCatchUp(3, 'disk', 2000)).toBe(true) // at end → due
+  })
+
+  test('a due catch-up is consumed exactly once', () => {
+    markQuietSuppression(3, 'disk', 'critical', 2000)
+    expect(takeDueCatchUp(3, 'disk', 2500)).toBe(true)
+    expect(takeDueCatchUp(3, 'disk', 2500)).toBe(false)
+  })
+
+  test('no marker → no catch-up', () => {
+    expect(takeDueCatchUp(9, 'nope', 9999)).toBe(false)
+  })
+
+  test('clearQuietSuppression drops a pending marker (e.g. recovery)', () => {
+    markQuietSuppression(3, 'disk', 'critical', 2000)
+    clearQuietSuppression(3, 'disk')
+    expect(takeDueCatchUp(3, 'disk', 2500)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// D1-backed store
+// ---------------------------------------------------------------------------
+describe('quiet-hours d1 store', () => {
+  beforeEach(() => {
+    fakeDb = makeFakeD1()
+  })
+
+  test('create then list round-trips every field', async () => {
+    const created = await createQuietHours({
+      ownerId: 'owner-roundtrip',
+      days: [5, 1, 1, 3], // dupes + unsorted → normalized
+      start: '22:00',
+      end: '07:00',
+      timezone: 'UTC',
+      severityCap: 'critical',
+      createdBy: 'user_1',
+    })
+
+    expect(created.days).toEqual([1, 3, 5])
+    const listed = await listQuietHours('owner-roundtrip')
+    expect(listed).toEqual([created])
+  })
+
+  test('createQuietHours rejects empty days', async () => {
+    await expect(
+      createQuietHours({
+        ownerId: 'owner-invalid-days',
+        days: [],
+        start: '22:00',
+        end: '07:00',
+        timezone: 'UTC',
+        severityCap: null,
+        createdBy: 'u',
+      })
+    ).rejects.toThrow()
+  })
+
+  test('createQuietHours rejects equal start/end and bad timezone', async () => {
+    await expect(
+      createQuietHours({
+        ownerId: 'owner-equal',
+        days: [1],
+        start: '09:00',
+        end: '09:00',
+        timezone: 'UTC',
+        severityCap: null,
+        createdBy: 'u',
+      })
+    ).rejects.toThrow()
+    await expect(
+      createQuietHours({
+        ownerId: 'owner-badtz',
+        days: [1],
+        start: '09:00',
+        end: '17:00',
+        timezone: 'Not/AZone',
+        severityCap: null,
+        createdBy: 'u',
+      })
+    ).rejects.toThrow()
+  })
+
+  test('listQuietHours only returns rows for the requested owner', async () => {
+    await createQuietHours({
+      ownerId: 'owner-scope-a',
+      days: [1],
+      start: '22:00',
+      end: '07:00',
+      timezone: 'UTC',
+      severityCap: null,
+      createdBy: 'u',
+    })
+    await createQuietHours({
+      ownerId: 'owner-scope-b',
+      days: [2],
+      start: '22:00',
+      end: '07:00',
+      timezone: 'UTC',
+      severityCap: null,
+      createdBy: 'u',
+    })
+    expect((await listQuietHours('owner-scope-a')).map((w) => w.days)).toEqual([
+      [1],
+    ])
+    expect((await listQuietHours('owner-scope-b')).map((w) => w.days)).toEqual([
+      [2],
+    ])
+  })
+
+  test("deleteQuietHours is owner-scoped: cannot delete another owner's window", async () => {
+    const created = await createQuietHours({
+      ownerId: 'owner-del-a',
+      days: [1],
+      start: '22:00',
+      end: '07:00',
+      timezone: 'UTC',
+      severityCap: null,
+      createdBy: 'u',
+    })
+    await deleteQuietHours('owner-del-b', created.id)
+    expect((await listQuietHours('owner-del-a')).map((w) => w.id)).toEqual([
+      created.id,
+    ])
+    await deleteQuietHours('owner-del-a', created.id)
+    expect(await listQuietHours('owner-del-a')).toEqual([])
+  })
+
+  test('degrades to [] / throws-on-create when no D1 binding is present', async () => {
+    fakeDb = null
+    expect(await listQuietHours('owner-no-binding')).toEqual([])
+    await expect(
+      createQuietHours({
+        ownerId: 'owner-no-binding',
+        days: [1],
+        start: '22:00',
+        end: '07:00',
+        timezone: 'UTC',
+        severityCap: null,
+        createdBy: 'u',
+      })
+    ).rejects.toThrow()
+    await expect(
+      deleteQuietHours('owner-no-binding', 'missing')
+    ).resolves.toBeUndefined()
+  })
+})

--- a/apps/dashboard/src/lib/health/quiet-hours.ts
+++ b/apps/dashboard/src/lib/health/quiet-hours.ts
@@ -1,0 +1,495 @@
+/**
+ * Quiet hours — recurring time-of-day alert-delivery silence windows (#2662).
+ *
+ * The recurring sibling of `maintenance-windows.ts`: instead of a one-shot
+ * absolute `[startsAt, endsAt)` range, a quiet-hours window recurs on chosen
+ * weekdays for a wall-clock time range in an operator-chosen IANA timezone
+ * ("don't page me 22:00–07:00 on weekdays"). While `now` falls inside a
+ * matching window, `server-sweep.ts` skips the outbound notification for an
+ * otherwise-notify-worthy finding — exactly like a maintenance window. The
+ * rule still runs, the finding is still reported in the sweep summary and the
+ * alert history (with a `quiet-hours` marker), and the dedup state store
+ * (`alert-state-store.ts`) is left untouched (we never `commit()` a suppressed
+ * decision), so the moment a window closes the next sweep re-evaluates fresh
+ * and notifies normally — the natural catch-up.
+ *
+ * `severityCap` lets criticals still page during a window: `null` suppresses
+ * everything; `'critical'` allows `>= critical` through and suppresses only
+ * warnings.
+ *
+ * Storage mirrors `maintenance-windows.ts` verbatim (dedicated `MAINTENANCE_D1`
+ * binding, then the shared `CHM_CLOUD_D1`; lazy single-flight migration; every
+ * failure caught/logged/swallowed → "no windows" OSS default). The pure
+ * matchers (`isWithinQuietWindow` / `activeQuietWindow` / `isQuietSuppressed`)
+ * and the catch-up tracker are D1-free so they are fully unit-testable without
+ * mocking D1.
+ */
+
+import { ErrorLogger } from '@chm/logger'
+import { getPlatformBindings } from '@chm/platform'
+
+const COMPONENT = 'quiet-hours'
+const warn = (msg: string) =>
+  ErrorLogger.logWarning(`[quiet-hours] ${msg}`, { component: COMPONENT })
+
+/** Preferred dedicated binding, then the shared cloud-mode D1 binding. */
+const D1_BINDING_NAMES = ['MAINTENANCE_D1', 'CHM_CLOUD_D1'] as const
+
+const TABLE = 'quiet_hours'
+
+const MIGRATION_SQL = `
+  CREATE TABLE IF NOT EXISTS ${TABLE} (
+    id TEXT NOT NULL PRIMARY KEY,
+    owner_id TEXT NOT NULL,
+    days TEXT NOT NULL DEFAULT '[]',
+    start_time TEXT NOT NULL,
+    end_time TEXT NOT NULL,
+    timezone TEXT NOT NULL,
+    severity_cap TEXT,
+    created_by TEXT NOT NULL DEFAULT '',
+    created_at INTEGER NOT NULL
+  )
+`
+const INDEX_SQL = `
+  CREATE INDEX IF NOT EXISTS idx_quiet_hours_owner
+    ON ${TABLE} (owner_id)
+`
+
+/** Only 'critical' is meaningful — the highest actionable severity. */
+export type SeverityCap = 'critical'
+
+/** Actionable severities the sweep may dispatch (never 'ok'). */
+export type QuietSeverity = 'warning' | 'critical'
+
+export interface QuietHours {
+  id: string
+  ownerId: string
+  /** Weekday numbers, 0 = Sunday … 6 = Saturday (JS `Date#getDay`). */
+  days: number[]
+  /** Local wall-clock start, `'HH:mm'`. */
+  start: string
+  /** Local wall-clock end, `'HH:mm'`. May be < start (across midnight). */
+  end: string
+  /** IANA timezone the wall-clock times are interpreted in. */
+  timezone: string
+  /** null => suppress all; 'critical' => allow criticals through. */
+  severityCap: SeverityCap | null
+  createdBy: string
+  /** unix ms */
+  createdAt: number
+}
+
+export interface CreateQuietHoursInput {
+  ownerId: string
+  days: number[]
+  start: string
+  end: string
+  timezone: string
+  severityCap: SeverityCap | null
+  createdBy: string
+}
+
+/** D1 row shape (snake_case columns). */
+interface D1QuietRow {
+  id: string
+  owner_id: string
+  days: string
+  start_time: string
+  end_time: string
+  timezone: string
+  severity_cap: string | null
+  created_by: string
+  created_at: number
+}
+
+function parseDays(raw: string): number[] {
+  try {
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter(
+      (d): d is number => Number.isInteger(d) && d >= 0 && d <= 6
+    )
+  } catch {
+    return []
+  }
+}
+
+function rowToQuietHours(row: D1QuietRow): QuietHours {
+  return {
+    id: row.id,
+    ownerId: row.owner_id,
+    days: parseDays(row.days),
+    start: row.start_time,
+    end: row.end_time,
+    timezone: row.timezone,
+    severityCap: row.severity_cap === 'critical' ? 'critical' : null,
+    createdBy: row.created_by,
+    createdAt: row.created_at,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure matchers — no I/O, no D1 (unit-tested directly).
+// ---------------------------------------------------------------------------
+
+/** `'HH:mm'` → minutes-of-day (0..1439), or null when malformed. */
+export function parseHmToMinutes(value: string): number | null {
+  const m = /^(\d{1,2}):(\d{2})$/.exec(value.trim())
+  if (!m) return null
+  const h = Number(m[1])
+  const min = Number(m[2])
+  if (h < 0 || h > 23 || min < 0 || min > 59) return null
+  return h * 60 + min
+}
+
+const WEEKDAY_INDEX: Record<string, number> = {
+  Sun: 0,
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+}
+
+/**
+ * Weekday (0=Sun..6=Sat) and minute-of-day for `now` in `timezone`, via
+ * `Intl.DateTimeFormat` (handles DST and offsets correctly). Returns null when
+ * the timezone is invalid so callers can fail-open ("not in window").
+ */
+export function zonedWeekdayMinutes(
+  now: number,
+  timezone: string
+): { weekday: number; minutes: number } | null {
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      weekday: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    }).formatToParts(new Date(now))
+
+    let weekday: number | undefined
+    let hour = 0
+    let minute = 0
+    for (const p of parts) {
+      if (p.type === 'weekday') weekday = WEEKDAY_INDEX[p.value]
+      else if (p.type === 'hour') hour = Number(p.value) % 24
+      else if (p.type === 'minute') minute = Number(p.value)
+    }
+    if (weekday === undefined) return null
+    return { weekday, minutes: hour * 60 + minute }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * True iff `now` falls inside this recurring window. `days` are keyed to the
+ * weekday the window STARTS on, so an across-midnight window (start > end) that
+ * lists Monday covers Mon 22:00→23:59 and Tue 00:00→06:59.
+ */
+export function isWithinQuietWindow(window: QuietHours, now: number): boolean {
+  const startMin = parseHmToMinutes(window.start)
+  const endMin = parseHmToMinutes(window.end)
+  if (startMin === null || endMin === null || startMin === endMin) return false
+  if (window.days.length === 0) return false
+
+  const zoned = zonedWeekdayMinutes(now, window.timezone)
+  if (!zoned) return false
+  const { weekday, minutes } = zoned
+  const prevWeekday = (weekday + 6) % 7
+
+  if (startMin < endMin) {
+    // Same-day window.
+    return (
+      window.days.includes(weekday) && minutes >= startMin && minutes < endMin
+    )
+  }
+  // Across-midnight window: the evening portion belongs to today's weekday,
+  // the morning portion to yesterday's (the day the window started).
+  const eveningPortion = window.days.includes(weekday) && minutes >= startMin
+  const morningPortion = window.days.includes(prevWeekday) && minutes < endMin
+  return eveningPortion || morningPortion
+}
+
+/** First window (in list order) that currently covers `now`, else null. */
+export function activeQuietWindow(
+  windows: QuietHours[],
+  now: number
+): QuietHours | null {
+  return windows.find((w) => isWithinQuietWindow(w, now)) ?? null
+}
+
+/**
+ * Whether delivery of a finding at `severity` should be silenced right now.
+ * Suppressed when a window is active AND its `severityCap` doesn't let this
+ * severity through: `null` suppresses everything; `'critical'` suppresses
+ * anything below critical (i.e. warnings) and lets criticals page.
+ */
+export function isQuietSuppressed(
+  windows: QuietHours[],
+  severity: QuietSeverity,
+  now: number
+): boolean {
+  const w = activeQuietWindow(windows, now)
+  if (!w) return false
+  if (w.severityCap === 'critical') return severity !== 'critical'
+  return true
+}
+
+/**
+ * Unix-ms instant at which the given active window's current occurrence ends.
+ * Computed as an offset from `now` (minutes until the end boundary) so it
+ * never has to reconstruct a wall-clock instant in an arbitrary timezone.
+ * Assumes `window` is active at `now` (callers pass `activeQuietWindow(...)`).
+ */
+export function quietWindowEndMs(window: QuietHours, now: number): number {
+  const startMin = parseHmToMinutes(window.start) ?? 0
+  const endMin = parseHmToMinutes(window.end) ?? 0
+  const zoned = zonedWeekdayMinutes(now, window.timezone)
+  const cur = zoned?.minutes ?? 0
+
+  let minutesUntilEnd: number
+  if (startMin < endMin) {
+    minutesUntilEnd = endMin - cur
+  } else if (cur >= startMin) {
+    // Evening portion of an across-midnight window — end is tomorrow morning.
+    minutesUntilEnd = 1440 - cur + endMin
+  } else {
+    // Morning portion — end is later today.
+    minutesUntilEnd = endMin - cur
+  }
+  if (minutesUntilEnd < 0) minutesUntilEnd = 0
+  return now + minutesUntilEnd * 60_000
+}
+
+// ---------------------------------------------------------------------------
+// Catch-up tracker — remembers criticals suppressed during a quiet window so
+// the sweep can label the (naturally re-delivered) notification once the
+// window closes. In-memory + module-level, like `alert-state-store.ts`; keyed
+// by `${hostId}:${ruleId}`.
+// ---------------------------------------------------------------------------
+interface CatchUpMarker {
+  severity: QuietSeverity
+  /** unix ms the covering window ends — catch-up is due once now >= this. */
+  windowEnd: number
+}
+const catchUpTracker = new Map<string, CatchUpMarker>()
+
+function catchUpKey(hostId: number, ruleId: string): string {
+  return `${hostId}:${ruleId}`
+}
+
+/** Record that a critical was suppressed by a window ending at `windowEnd`. */
+export function markQuietSuppression(
+  hostId: number,
+  ruleId: string,
+  severity: QuietSeverity,
+  windowEnd: number
+): void {
+  catchUpTracker.set(catchUpKey(hostId, ruleId), { severity, windowEnd })
+}
+
+/**
+ * If a suppressed critical is now due for catch-up (its window has ended),
+ * consume and return true; otherwise false. Consuming (delete-on-take) means a
+ * catch-up fires exactly once per suppression episode.
+ */
+export function takeDueCatchUp(
+  hostId: number,
+  ruleId: string,
+  now: number
+): boolean {
+  const key = catchUpKey(hostId, ruleId)
+  const marker = catchUpTracker.get(key)
+  if (!marker) return false
+  if (now >= marker.windowEnd) {
+    catchUpTracker.delete(key)
+    return true
+  }
+  return false
+}
+
+/** Drop any pending catch-up marker (e.g. the condition recovered). */
+export function clearQuietSuppression(hostId: number, ruleId: string): void {
+  catchUpTracker.delete(catchUpKey(hostId, ruleId))
+}
+
+/** Test-only: reset the module-level catch-up tracker between cases. */
+export function _resetQuietCatchUpTracker(): void {
+  catchUpTracker.clear()
+}
+
+// ---------------------------------------------------------------------------
+// D1-backed store — mirrors maintenance-windows.ts.
+// ---------------------------------------------------------------------------
+
+function getDb(): D1Database | null {
+  const bindings = getPlatformBindings()
+  for (const name of D1_BINDING_NAMES) {
+    const db = bindings.getD1Database(name)
+    if (db) return db
+  }
+  return null
+}
+
+// Single-flight migration: concurrent first calls share one promise so the
+// idempotent DDL runs at most once; a failure clears it so the next call retries.
+let migration: Promise<void> | null = null
+
+function ensureMigrated(db: D1Database): Promise<void> {
+  if (!migration) {
+    migration = (async () => {
+      try {
+        await db.batch([db.prepare(MIGRATION_SQL), db.prepare(INDEX_SQL)])
+      } catch (err) {
+        migration = null
+        throw err
+      }
+    })()
+  }
+  return migration
+}
+
+// Best-effort 30s per-owner cache, so a health sweep tick doesn't pay a D1 read
+// for every host/rule combination. A create/delete invalidates the owner's entry.
+const CACHE_TTL_MS = 30_000
+const cache = new Map<string, { windows: QuietHours[]; expiresAt: number }>()
+
+function invalidateCache(ownerId: string): void {
+  cache.delete(ownerId)
+}
+
+/** Validate + normalize create input; throws on malformed values. */
+function validateInput(input: CreateQuietHoursInput): void {
+  const days = input.days.filter((d) => Number.isInteger(d) && d >= 0 && d <= 6)
+  if (days.length === 0) {
+    throw new Error('days must contain at least one weekday (0–6)')
+  }
+  if (parseHmToMinutes(input.start) === null) {
+    throw new Error('start must be a valid HH:mm time')
+  }
+  if (parseHmToMinutes(input.end) === null) {
+    throw new Error('end must be a valid HH:mm time')
+  }
+  if (input.start === input.end) {
+    throw new Error('start and end must differ')
+  }
+  // Reject an invalid IANA timezone up front (Intl throws on a bad zone).
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: input.timezone })
+  } catch {
+    throw new Error(`invalid timezone: ${input.timezone}`)
+  }
+}
+
+/**
+ * List every quiet-hours window for an owner. Best-effort: degrades to `[]`
+ * when no D1 binding resolves or the read fails.
+ */
+export async function listQuietHours(ownerId: string): Promise<QuietHours[]> {
+  const cached = cache.get(ownerId)
+  if (cached && cached.expiresAt > Date.now()) return cached.windows
+
+  try {
+    const db = getDb()
+    if (!db) return []
+    await ensureMigrated(db)
+
+    const result = await db
+      .prepare(
+        `SELECT id, owner_id, days, start_time, end_time, timezone, severity_cap, created_by, created_at
+         FROM ${TABLE}
+         WHERE owner_id = ?1
+         ORDER BY created_at DESC`
+      )
+      .bind(ownerId)
+      .all<D1QuietRow>()
+
+    const windows = (result.results ?? []).map(rowToQuietHours)
+    cache.set(ownerId, { windows, expiresAt: Date.now() + CACHE_TTL_MS })
+    return windows
+  } catch (err) {
+    warn(`failed to list quiet hours for owner ${ownerId}: ${err}`)
+    return []
+  }
+}
+
+/**
+ * Create a quiet-hours window. Validates the input (throws → caller surfaces a
+ * 400); a D1/binding failure also throws so the CRUD route reports the write
+ * didn't happen (unlike the read/suppression paths, which fail open).
+ */
+export async function createQuietHours(
+  input: CreateQuietHoursInput
+): Promise<QuietHours> {
+  validateInput(input)
+
+  const db = getDb()
+  if (!db) {
+    throw new Error('No D1 binding (MAINTENANCE_D1 / CHM_CLOUD_D1) found')
+  }
+  await ensureMigrated(db)
+
+  const days = [...new Set(input.days)].sort((a, b) => a - b)
+  const window: QuietHours = {
+    id: crypto.randomUUID(),
+    ownerId: input.ownerId,
+    days,
+    start: input.start,
+    end: input.end,
+    timezone: input.timezone,
+    severityCap: input.severityCap,
+    createdBy: input.createdBy,
+    createdAt: Date.now(),
+  }
+
+  await db
+    .prepare(
+      `INSERT INTO ${TABLE}
+         (id, owner_id, days, start_time, end_time, timezone, severity_cap, created_by, created_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)`
+    )
+    .bind(
+      window.id,
+      window.ownerId,
+      JSON.stringify(window.days),
+      window.start,
+      window.end,
+      window.timezone,
+      window.severityCap,
+      window.createdBy,
+      window.createdAt
+    )
+    .run()
+
+  invalidateCache(input.ownerId)
+  return window
+}
+
+/**
+ * Delete a quiet-hours window, scoped to its owner. Best-effort: a D1 failure
+ * is swallowed (logged) rather than thrown, matching the read/suppression
+ * paths' fail-open posture.
+ */
+export async function deleteQuietHours(
+  ownerId: string,
+  id: string
+): Promise<void> {
+  try {
+    const db = getDb()
+    if (!db) return
+    await ensureMigrated(db)
+
+    await db
+      .prepare(`DELETE FROM ${TABLE} WHERE id = ?1 AND owner_id = ?2`)
+      .bind(id, ownerId)
+      .run()
+
+    invalidateCache(ownerId)
+  } catch (err) {
+    warn(`failed to delete quiet hours ${id} for owner ${ownerId}: ${err}`)
+  }
+}

--- a/apps/dashboard/src/lib/health/server-sweep.ts
+++ b/apps/dashboard/src/lib/health/server-sweep.ts
@@ -37,6 +37,14 @@ import {
   PAGERDUTY_EVENTS_API_URL,
 } from './pagerduty-config'
 import {
+  activeQuietWindow,
+  isQuietSuppressed,
+  listQuietHours,
+  markQuietSuppression,
+  quietWindowEndMs,
+  takeDueCatchUp,
+} from './quiet-hours'
+import {
   getServerAlertConfig,
   getServerAlertCooldownMs,
   getServerEmailConfig,
@@ -106,6 +114,8 @@ export interface SweepSummary {
   alertsSuppressed: number
   /** Of `alertsSuppressed`, how many were gated by an active maintenance window. */
   maintenanceSuppressed: number
+  /** Of `alertsSuppressed`, how many were gated by an active quiet-hours window. */
+  quietHoursSuppressed: number
   /** Notify-worthy alerts suppressed by an active operator ACK (plan 29). */
   ackedSuppressed: number
   /** Recovery notifications sent for conditions that returned to ok. */
@@ -401,12 +411,18 @@ export async function runHealthSweep(): Promise<SweepSummary> {
   // ('') is correct today; multi-tenant sweep scoping is a follow-up.
   const windows = await listWindows('')
 
+  // Quiet hours: recurring time-of-day silence windows (#2662), loaded once
+  // per sweep alongside maintenance windows. Same best-effort/OSS-single-tenant
+  // contract — `listQuietHours` degrades to [] on any D1/binding failure.
+  const quietHours = await listQuietHours('')
+
   const hosts: SweepHostSummary[] = []
   const findings: SweepFinding[] = []
   let insightsGenerated = 0
   let alertsDispatched = 0
   let alertsSuppressed = 0
   let maintenanceSuppressed = 0
+  let quietHoursSuppressed = 0
   let ackedSuppressed = 0
   let recoveries = 0
   let emailsDispatched = 0
@@ -504,6 +520,59 @@ export async function runHealthSweep(): Promise<SweepSummary> {
       return
     }
 
+    if (
+      decision.notify &&
+      decision.kind !== 'recovery' &&
+      (effective === 'warning' || effective === 'critical') &&
+      isQuietSuppressed(quietHours, effective, Date.now())
+    ) {
+      // A quiet-hours window (#2662) silences delivery right now — same
+      // dispatch-time gate as the maintenance-window block above, but recurring
+      // (weekday + time-of-day in an IANA timezone) and severity-aware
+      // (`severityCap` lets criticals through). Deliberately do NOT call
+      // `commit()`: leaving the dedup state untouched means the first sweep
+      // after the window closes re-evaluates fresh and delivers normally — the
+      // catch-up. A still-suppressed critical is remembered so that delivery is
+      // labeled a catch-up (warnings just resume, no catch-up).
+      const now = Date.now()
+      alertsSuppressed++
+      quietHoursSuppressed++
+      if (effective === 'critical') {
+        const w = activeQuietWindow(quietHours, now)
+        if (w) {
+          markQuietSuppression(
+            hostId,
+            ruleId,
+            effective,
+            quietWindowEndMs(w, now)
+          )
+        }
+      }
+      try {
+        await recordAlertEvent({
+          eventTime: new Date().toISOString(),
+          hostId,
+          hostLabel: name,
+          rule: ruleId,
+          severity: effective,
+          prevSeverity:
+            decision.previousSeverity === 'ok'
+              ? null
+              : decision.previousSeverity,
+          decisionKind: 'quiet-hours',
+          delivered: false,
+          value,
+          channel: 'quiet-hours',
+        })
+      } catch (err) {
+        debug(
+          `[health-sweep] alert-history record failed for host ${hostId} rule ${ruleId}`,
+          err instanceof Error ? err.message : String(err)
+        )
+      }
+      return
+    }
+
     if (decision.notify && decision.kind === 'recovery') {
       // A resolved condition should always reach the operator — never
       // suppress a recovery — and any active ACK for it is now moot.
@@ -523,10 +592,16 @@ export async function runHealthSweep(): Promise<SweepSummary> {
     }
 
     if (decision.notify) {
+      // Catch-up (#2662): a critical suppressed during a quiet-hours window
+      // whose window has now closed — label the (naturally re-delivered)
+      // notification so the operator knows it was held back. Consumed once.
+      const isQuietCatchUp =
+        decision.kind !== 'recovery' &&
+        takeDueCatchUp(hostId, ruleId, Date.now())
       const text =
         decision.kind === 'recovery'
           ? `[RECOVERY] ${ruleTitle} — resolved (host ${name})`
-          : `[${effective.toUpperCase()}] ${ruleTitle} — ${label} (host ${name})`
+          : `${isQuietCatchUp ? '[CATCH-UP] ' : ''}[${effective.toUpperCase()}] ${ruleTitle} — ${label} (host ${name})`
 
       // Fan out to every matched route's channel (plan 30), falling back to
       // the legacy global webhook when nothing matches (see `alert-routing.ts`).
@@ -1075,6 +1150,7 @@ export async function runHealthSweep(): Promise<SweepSummary> {
     alertsDispatched,
     alertsSuppressed,
     maintenanceSuppressed,
+    quietHoursSuppressed,
     ackedSuppressed,
     recoveries,
     emailsDispatched,

--- a/apps/dashboard/src/lib/hooks/use-quiet-hours.ts
+++ b/apps/dashboard/src/lib/hooks/use-quiet-hours.ts
@@ -1,0 +1,89 @@
+/**
+ * Quiet hours (#2662) — client hook for the /api/v1/health/quiet-hours CRUD
+ * endpoint. Like maintenance windows, this is a free/OSS feature that does NOT
+ * require Clerk sign-in: the server resolves the caller's owner and the global
+ * /api/v1 middleware gates the request per the deployment's auth posture — this
+ * hook just calls the endpoint and surfaces the result.
+ */
+
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { apiFetch } from '@/lib/swr/api-fetch'
+import { throwIfNotOk } from '@/lib/swr/fetch-error'
+
+export interface QuietHoursInfo {
+  id: string
+  ownerId: string
+  days: number[]
+  start: string
+  end: string
+  timezone: string
+  severityCap: 'critical' | null
+  createdBy: string
+  createdAt: number
+}
+
+export const QUIET_HOURS_QUERY_KEY = ['/api/v1/health/quiet-hours'] as const
+
+export function useQuietHours(enabled = true) {
+  const query = useQuery({
+    queryKey: QUIET_HOURS_QUERY_KEY,
+    queryFn: async () => {
+      const response = await apiFetch('/api/v1/health/quiet-hours')
+      await throwIfNotOk(response, 'Failed to load quiet hours')
+      const json = (await response.json()) as {
+        success: boolean
+        windows: QuietHoursInfo[]
+      }
+      return json.windows ?? []
+    },
+    enabled,
+    staleTime: 15_000,
+  })
+
+  return {
+    windows: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
+  }
+}
+
+export function useQuietHoursMutations() {
+  const queryClient = useQueryClient()
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: QUIET_HOURS_QUERY_KEY })
+
+  const createWindow = async (input: {
+    days: number[]
+    start: string
+    end: string
+    timezone: string
+    severityCap: 'critical' | null
+  }): Promise<QuietHoursInfo> => {
+    const response = await apiFetch('/api/v1/health/quiet-hours', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    })
+    await throwIfNotOk(response, 'Failed to create quiet-hours window')
+    invalidate()
+    const json = (await response.json()) as {
+      success: boolean
+      window: QuietHoursInfo
+    }
+    return json.window
+  }
+
+  const deleteWindow = async (id: string): Promise<void> => {
+    const response = await apiFetch(
+      `/api/v1/health/quiet-hours?id=${encodeURIComponent(id)}`,
+      { method: 'DELETE' }
+    )
+    await throwIfNotOk(response, 'Failed to delete quiet-hours window')
+    invalidate()
+  }
+
+  return { createWindow, deleteWindow, invalidate }
+}

--- a/apps/dashboard/src/routes/api/v1/health/quiet-hours.ts
+++ b/apps/dashboard/src/routes/api/v1/health/quiet-hours.ts
@@ -1,0 +1,136 @@
+/**
+ * Quiet hours CRUD (#2662)
+ * GET    /api/v1/health/quiet-hours        — list windows for the caller's owner
+ * POST   /api/v1/health/quiet-hours        — create a window
+ * DELETE /api/v1/health/quiet-hours?id=... — delete a window
+ *
+ * Auth mirrors the sibling maint-windows.ts route: GET rides the global
+ * /api/v1 middleware auth gate; POST/DELETE self-enforce a write gate
+ * (`authorizeFeatureRequest`, feature 'settings') because that middleware is a
+ * public passthrough under provider='none' / CHM_CLERK_PUBLIC_READ. Owner
+ * resolution falls back to the OSS single-tenant owner (`''`) when Clerk isn't
+ * configured, per the fail-open invariant.
+ */
+
+import { z } from 'zod'
+import { createFileRoute } from '@tanstack/react-router'
+
+import { resolveBillingOwnerId } from '@/lib/billing/billing-owner'
+import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
+import {
+  createQuietHours,
+  deleteQuietHours,
+  listQuietHours,
+} from '@/lib/health/quiet-hours'
+
+/** OSS single-tenant fallback when Clerk is not configured / no session. */
+async function resolveOwnerId(): Promise<string> {
+  try {
+    return await resolveBillingOwnerId()
+  } catch {
+    return ''
+  }
+}
+
+function jsonError(message: string, status: number): Response {
+  return Response.json(
+    { success: false, error: { type: 'validation', message } },
+    { status }
+  )
+}
+
+const CreateQuietHoursSchema = z.object({
+  days: z.array(z.number().int().min(0).max(6)).min(1),
+  start: z.string().regex(/^\d{1,2}:\d{2}$/, 'start must be HH:mm'),
+  end: z.string().regex(/^\d{1,2}:\d{2}$/, 'end must be HH:mm'),
+  timezone: z.string().min(1),
+  severityCap: z.literal('critical').nullable().optional().default(null),
+})
+
+async function handleGet(): Promise<Response> {
+  const ownerId = await resolveOwnerId()
+  const windows = await listQuietHours(ownerId)
+  return Response.json(
+    { success: true, windows },
+    {
+      headers: {
+        'Cache-Control': 'public, s-maxage=5, stale-while-revalidate=15',
+      },
+    }
+  )
+}
+
+async function handlePost(request: Request): Promise<Response> {
+  const permissionResponse = await authorizeFeatureRequest(
+    { feature: 'settings', defaultAccess: 'authenticated', operation: 'write' },
+    request,
+    { allowAgentBearerToken: true }
+  )
+  if (permissionResponse) return permissionResponse
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return jsonError('Request body must be valid JSON', 400)
+  }
+
+  const parsed = CreateQuietHoursSchema.safeParse(body)
+  if (!parsed.success) {
+    return jsonError(
+      `Invalid request body: ${parsed.error.issues.map((i) => i.message).join(', ')}`,
+      400
+    )
+  }
+  const { days, start, end, timezone, severityCap } = parsed.data
+
+  const ownerId = await resolveOwnerId()
+  try {
+    const window = await createQuietHours({
+      ownerId,
+      days,
+      start,
+      end,
+      timezone,
+      severityCap: severityCap ?? null,
+      createdBy: ownerId,
+    })
+    return Response.json({ success: true, window }, { status: 201 })
+  } catch (err) {
+    return jsonError(
+      err instanceof Error
+        ? err.message
+        : 'Failed to create quiet-hours window',
+      400
+    )
+  }
+}
+
+async function handleDelete(request: Request): Promise<Response> {
+  const permissionResponse = await authorizeFeatureRequest(
+    { feature: 'settings', defaultAccess: 'authenticated', operation: 'write' },
+    request,
+    { allowAgentBearerToken: true }
+  )
+  if (permissionResponse) return permissionResponse
+
+  const { searchParams } = new URL(request.url)
+  const id = searchParams.get('id')
+  if (!id) {
+    return jsonError('Missing "id" query parameter', 400)
+  }
+
+  const ownerId = await resolveOwnerId()
+  await deleteQuietHours(ownerId, id)
+  return Response.json({ success: true })
+}
+
+export const Route = createFileRoute('/api/v1/health/quiet-hours')({
+  server: {
+    handlers: {
+      GET: async () => handleGet(),
+      POST: async ({ request }) => handlePost(request),
+      DELETE: async ({ request }) => handleDelete(request),
+    },
+  },
+})


### PR DESCRIPTION
## What

Adds **quiet hours** (#2662): recurring weekday + time-of-day windows (in an operator-chosen IANA timezone) that silence outbound alert delivery — the recurring sibling of one-shot maintenance windows.

While `now` falls inside a matching window the health sweep still runs every check and still records findings in history (marked `quiet-hours`) and in Active alerts — **only delivery is silenced**. `severityCap` tunes what still gets through: `null` suppresses everything, `critical` lets criticals keep paging. Still-active criticals get a labeled **catch-up** notification once the window closes.

## How

- **`lib/health/quiet-hours.ts`** — pure, D1-free matchers (`isWithinQuietWindow` / `activeQuietWindow` / `isQuietSuppressed`) handling across-midnight ranges and timezones via `Intl.DateTimeFormat`, plus severityCap logic; an in-memory catch-up tracker (`markQuietSuppression` / `takeDueCatchUp`); and a D1 store that mirrors `maintenance-windows.ts` verbatim (dedicated `MAINTENANCE_D1` then shared `CHM_CLOUD_D1`, lazy single-flight migration, per-owner cache, fail-open to "no windows").
- **`db/conversations-migrations/0022_quiet_hours.sql`** — the `quiet_hours` D1 table (0020/0021 were taken).
- **`routes/api/v1/health/quiet-hours.ts`** — GET/POST/DELETE CRUD following the sibling `maint-windows.ts` auth + feature-guard style (write gate, OSS single-tenant owner fallback).
- **`server-sweep.ts`** — minimal additive diff: load windows once, one suppression gate right after the maintenance-window gate (deliberately no `commit()`, so the first post-window sweep re-delivers naturally = the catch-up), a catch-up text label, and a `quietHoursSuppressed` summary counter. All logic delegated to `quiet-hours.ts`.
- **Health Settings dialog** — new **Quiet Hours** tab: day-of-week picker + time range + timezone select + "let criticals page" toggle, `EmptyState` for zero windows, plus the `use-quiet-hours` client hook.

## Client dispatcher decision

Left unchanged. Maintenance windows are **server-authoritative and enforced only in the server sweep** (the client `alert-dispatcher.ts` does not consult them). Quiet hours follow the same posture — delivery suppression and the window-end catch-up both inherently live in the sweep — rather than inventing a new client path.

## Tests

`lib/health/quiet-hours.test.ts` (28 tests): across-midnight matching (evening/morning portions, day boundaries), timezone handling (same instant differing by zone), severityCap behavior, `quietWindowEndMs`, catch-up tracker bookkeeping, and D1 CRUD round-trip / owner-scoping / validation / fail-open.

Verified: `bun test` on new + adjacent suites (per-file — cross-file `@chm/platform` mock leak is the pre-existing #2672), `biome check`, `pnpm run type-check` (regenerated `routeTree.gen.ts`).

https://claude.ai/code/session_015Mq6c6bQstbRwQnKt9htbE

Closes #2662