### PR TITLE
fix(a11y): accessible names for icon-only buttons

### DIFF
--- a/apps/dashboard/src/components/agents/agent-visualization/index.tsx
+++ b/apps/dashboard/src/components/agents/agent-visualization/index.tsx
@@ -364,6 +364,7 @@ export function AgentVisualization({
             className="size-7"
             onClick={handleDownload}
             title="Download CSV"
+            aria-label="Download CSV"
             disabled={!hasData}
           >
             <DownloadIcon className="size-3.5" />

--- a/apps/dashboard/src/components/data-table/cells/actions/inline-actions.tsx
+++ b/apps/dashboard/src/components/data-table/cells/actions/inline-actions.tsx
@@ -89,6 +89,7 @@ export function InlineActions<TData extends RowData>({
                       className="size-7 text-muted-foreground hover:text-destructive"
                       onClick={handleKill}
                       disabled={isKilling}
+                      aria-label={config.label}
                     />
                   }
                 >
@@ -122,6 +123,7 @@ export function InlineActions<TData extends RowData>({
                     size="icon"
                     className="size-7 text-muted-foreground hover:text-foreground"
                     render={<Link href={href} />}
+                    aria-label={config.label}
                   />
                 }
               >

--- a/apps/dashboard/src/components/query-favorites/query-favorites-panel.tsx
+++ b/apps/dashboard/src/components/query-favorites/query-favorites-panel.tsx
@@ -156,6 +156,7 @@ function FavoriteItem({
                   size="icon"
                   className="size-6"
                   title="Copy deep-link"
+                  aria-label="Copy deep-link"
                   onClick={copyLink}
                 >
                   {copied ? (
@@ -170,6 +171,7 @@ function FavoriteItem({
                 size="icon"
                 className="size-6"
                 title="Run"
+                aria-label="Run"
                 onClick={() => onSelect(fav.sql, true)}
               >
                 <Play className="size-3" />
@@ -179,6 +181,7 @@ function FavoriteItem({
                 size="icon"
                 className="size-6"
                 title="Edit name / tags"
+                aria-label="Edit name / tags"
                 onClick={startEdit}
               >
                 <Pencil className="size-3" />
@@ -188,6 +191,7 @@ function FavoriteItem({
                 size="icon"
                 className="size-6"
                 title="Remove"
+                aria-label="Remove"
                 onClick={() => onRemove(fav.id)}
               >
                 <Trash2 className="size-3" />

--- a/apps/dashboard/src/components/sql-console/query-history-panel.tsx
+++ b/apps/dashboard/src/components/sql-console/query-history-panel.tsx
@@ -145,6 +145,7 @@ export function QueryHistoryPanel({
                       size="icon"
                       className="size-6"
                       title="Run"
+                      aria-label="Run"
                       onClick={() => onSelect(e.sql, true)}
                     >
                       <Play className="size-3" />
@@ -154,6 +155,7 @@ export function QueryHistoryPanel({
                       size="icon"
                       className="size-6"
                       title={e.pinned ? 'Unpin' : 'Pin'}
+                      aria-label={e.pinned ? 'Unpin' : 'Pin'}
                       onClick={() => onTogglePin(e.id)}
                     >
                       {e.pinned ? (
@@ -167,6 +169,7 @@ export function QueryHistoryPanel({
                       size="icon"
                       className="size-6"
                       title="Remove"
+                      aria-label="Remove"
                       onClick={() => onRemove(e.id)}
                     >
                       <Trash2 className="size-3" />
@@ -220,6 +223,7 @@ export function QueryHistoryPanel({
                     size="icon"
                     className="size-6 opacity-0 transition-opacity group-hover:opacity-100"
                     title="Run"
+                    aria-label="Run"
                     onClick={() => onSelect(r.query, true)}
                   >
                     <Play className="size-3" />


### PR DESCRIPTION
## Summary

- Add `aria-label` to the kill-query icon button in `InlineActions` (data-table row actions), which previously had no accessible name at all — not even a `title` fallback — for one of the most consequential destructive actions in the dashboard.
- Sweep the sibling link-based action button in the same file (open-in-explorer / explain-query / analyze-with-ai) for the same gap, reusing the existing `config.label` already used for the adjacent tooltip.
- Add `aria-label` mirroring the existing `title` text on icon-only buttons in the SQL console history panel, query-favorites panel, and the agent-visualization download button — `title` alone is not a reliable accessibility mechanism (many screen readers ignore it, and it has no effect on touch/mobile).

Existing `title` attributes are kept for sighted mouse-hover tooltips; `aria-label` is added alongside so accessible names no longer depend on `title`.

## Files touched

- `apps/dashboard/src/components/data-table/cells/actions/inline-actions.tsx`
- `apps/dashboard/src/components/sql-console/query-history-panel.tsx`
- `apps/dashboard/src/components/query-favorites/query-favorites-panel.tsx`
- `apps/dashboard/src/components/agents/agent-visualization/index.tsx`

## Test plan

- [ ] CI: `dashboard` build + `unit-tests` (required checks)
- [ ] Manually inspect the accessible name of each button via browser devtools Accessibility tab on `/queries`, the SQL console history/favorites panels, and an agent chat visualization with results

Fixes #2683
Fixes #2684

https://claude.ai/code/session_012Gxih6GHqnzMKLRmbYC6vK