### PR TITLE
fix(cloud-hooks): add fleet tier to PLAN_RANK

### DIFF
--- a/apps/cloud-hooks/src/polar-notify.ts
+++ b/apps/cloud-hooks/src/polar-notify.ts
@@ -15,12 +15,13 @@ import { BILLING_PLANS, monthlyEquivalentUsd, type PlanId } from '@chm/pricing'
 
 type Period = 'monthly' | 'yearly' | null
 
-/** Tier ranking for upgrade/downgrade detection. */
+/** Tier ranking for upgrade/downgrade detection, ordered by monthly value. */
 const PLAN_RANK: Record<PlanId, number> = {
   free: 0,
   pro: 1,
   max: 2,
-  enterprise: 3,
+  fleet: 3,
+  enterprise: 4,
 }
 
 export type TransitionCase =


### PR DESCRIPTION
PlanId gained `'fleet'` (B4 experiment tier, #2381) in `packages/pricing`, but `polar-notify.ts`'s `PLAN_RANK: Record<PlanId, number>` was never updated — `tsc --noEmit` fails on any PR touching cloud-hooks paths (surfaced by dependabot #2708's cloudflare.yml edit matching every filter).

- Adds `fleet: 3`, shifts `enterprise` to 4 — ranked by monthly value (free $0 < pro $29 < max $99 < fleet $199 < enterprise custom)
- `PLAN_RANK` is only compared relatively in `classifyTransition`, so renumbering is safe; local `pnpm run type-check` passes

Fixes #2709

https://claude.ai/code/session_012Gxih6GHqnzMKLRmbYC6vK