### PR TITLE
docs(mcp): tool tables, API-key example, plan gating, VS Code setup

### DIFF
--- a/docs/content/reference/mcp-clients.mdx
+++ b/docs/content/reference/mcp-clients.mdx
@@ -154,6 +154,8 @@ Once connected, your AI assistant can use these tools:
 | `get_slow_queries` | Slowest completed queries from the query log. |
 | `get_merge_status` | Running merge operations with progress. |
 | `explore_table_schema` | Schema exploration: list databases, summarize tables, or full schema with relationship discovery. |
+| `analyze_performance` | Structured health snapshot: slow queries, part counts, merge backlog, memory, and disk in one call. |
+| `get_optimization_recommendations` | Ranked query-optimization advice — skip-index, projection, partition key, or PREWHERE rewrite — for a query or `queryId`, with rationale and estimated savings. |
 
 All tools are read-only and respect the `CLICKHOUSE_MAX_EXECUTION_TIME` limit configured on the server.
 

--- a/docs/content/reference/mcp-server.mdx
+++ b/docs/content/reference/mcp-server.mdx
@@ -115,9 +115,7 @@ See [Authentication](/operate/authentication) for provider setup.
 
 ## Available tools
 
-The MCP server exposes the same read-only capabilities as the dashboard agent. For a full list of tools, see [AI Agent — Capabilities](/guide/ai-agent/capabilities).
-
-Quick summary of core tools:
+The MCP server exposes 11 read-only tools — a focused subset of the dashboard agent's capabilities. See [AI Agent — Capabilities](/guide/ai-agent/capabilities) for how these map to the broader agent toolset.
 
 | Tool | Description |
 |---|---|
@@ -131,6 +129,7 @@ Quick summary of core tools:
 | `get_merge_status` | Running merge operations with progress. |
 | `explore_table_schema` | Schema exploration with relationship discovery. |
 | `analyze_performance` | Combined health report: slow queries, parts, merges, memory, disk. |
+| `get_optimization_recommendations` | Ranked query-optimization advice — skip-index, projection, partition key, or PREWHERE rewrite — with rationale and estimated savings. |
 
 All tools are read-only and respect the same `CLICKHOUSE_MAX_EXECUTION_TIME` timeout as the dashboard.
 

--- a/docs/knowledge/mcp-server.md
+++ b/docs/knowledge/mcp-server.md
@@ -3,7 +3,7 @@ id: mcp-server
 title: MCP Server
 type: reference
 status: active
-updated: 2026-07-10
+updated: 2026-07-17
 tags:
   - mcp
   - api
@@ -29,6 +29,9 @@ The chmonitor exposes a [Model Context Protocol (MCP)](https://modelcontextproto
 | `get_running_queries` | Currently executing queries by elapsed time | `hostId` (number, optional) |
 | `get_slow_queries` | Slowest completed queries from query log | `limit` (number, optional) |
 | `get_merge_status` | Running merge operations with progress | `hostId` (number, optional) |
+| `explore_table_schema` | Schema exploration with relationship discovery (3 modes: databases, tables, full schema) | `database`, `table` (optional), `hostId` (optional) |
+| `analyze_performance` | Structured health snapshot: slow queries, parts, merges, memory, disk | `hostId` (optional), `lastHours` (optional) |
+| `get_optimization_recommendations` | Ranked optimization advice for a slow query — skip-index, projection, partition key, or PREWHERE rewrite | `sql` or `queryId` (one required), `database` (optional), `hostId` (optional) |
 
 ## Setup
 


### PR DESCRIPTION
Fixes 4 open MCP-documentation audit issues. Docs-only change (no server/component code touched — see notes below).

- **#2702** — the three customer-facing MCP tool tables (`docs/knowledge/mcp-server.md`, `docs/content/reference/mcp-server.mdx`, `docs/content/reference/mcp-clients.mdx`) each listed only 8-9 of the 11 tools the server actually registers (`packages/mcp-server/src/tools/index.ts`). Added the missing rows (`explore_table_schema`, `analyze_performance`, `get_optimization_recommendations` where absent) with descriptions sourced from each tool's real registration string.
- **#2689** — the API-key issuance curl example in `mcp-clients.mdx` was missing the required `Authorization: Bearer $CHM_API_KEY_SECRET` header and used the wrong JSON body field (`sub` instead of `label`/`days`), verified against `apps/dashboard/src/routes/api/v1/auth/api-key.ts`. Fixed the example and clarified that the bearer token for *this* request is the operator's own secret, not the token being minted. Also fixed the same class of bug (wrong response-shape comment) spotted in `docs/content/guide/features/mcp.mdx` while verifying every curl example against the route handler.
- **#2679** — documented Cloud plan gating: `/api/mcp` requires a Max or Enterprise plan (`api_mcp_access` capability, `apps/dashboard/src/routes/api/mcp.ts` + `packages/pricing/src/plans.ts`); Free/Pro get a `402 plan_capability_required` error. Added callouts with the exact 402 response shape to `mcp-server.mdx` and `features/mcp.mdx`. Self-hosted is never gated.
- **#2706** — added a VS Code tab to `mcp-clients.mdx`, matching the current VS Code MCP config schema (`.vscode/mcp.json`, top-level `servers` key, `type: "http"`) verified against the official VS Code docs. Also mentioned VS Code alongside the other clients in `docs/knowledge/mcp-server.md` and `README.md`.

**Note on #2706 scope**: this PR only covers the docs site. The in-app `/mcp` setup-guide component (`apps/dashboard/src/components/mcp/mcp-setup-guides.tsx`) still needs a matching VS Code entry — that's app code, out of scope for this docs-only PR per the task constraints. Flagged as a follow-up in a comment on #2706.

## Test plan
- [x] Verified all 11 tool names/descriptions against `packages/mcp-server/src/tools/*.ts` registration calls
- [x] Verified the API-key curl fix against `apps/dashboard/src/routes/api/v1/auth/api-key.ts` (header check, `label`/`days` fields, `{"data":{"apiKey":...}}` response shape)
- [x] Verified plan gating against `apps/dashboard/src/routes/api/mcp.ts`, `lib/billing/plan-capability.ts` (402 shape), and `packages/pricing/src/plans.ts` (Max/Enterprise only)
- [x] Verified VS Code's `.vscode/mcp.json` schema (`servers` key, `type: "http"`, `headers`) against code.visualstudio.com docs
- [ ] CI (docs build / link check)

Fixes #2702
Fixes #2689
Fixes #2679
Fixes #2706

https://claude.ai/code/session_012Gxih6GHqnzMKLRmbYC6vK