### PR TITLE
docs(mcp): fix broken API-key issuance curl example (#2689)

### DIFF
--- a/docs/content/guide/features/mcp.mdx
+++ b/docs/content/guide/features/mcp.mdx
@@ -72,7 +72,7 @@ Issue a token:
 ```bash
 curl -X POST https://your-chmonitor.example.com/api/v1/auth/api-key \
   -H "Authorization: Bearer $CHM_API_KEY_SECRET"
-# returns {"token":"chm_..."}
+# returns {"data":{"apiKey":"chm_..."}}
 ```
 
 Pass the token in MCP client requests:

--- a/docs/content/reference/mcp-clients.mdx
+++ b/docs/content/reference/mcp-clients.mdx
@@ -24,15 +24,18 @@ If `CHM_API_KEY_SECRET` is set on the server, every request must carry a bearer 
 <Step>
 ### Issue a token
 
-Run this once, on the server:
+Run this once, on the server. The `Authorization` header here is the server's
+own `CHM_API_KEY_SECRET` (the operator's shared secret) — not the token being
+minted; the two are easy to conflate:
 
 ```bash
 curl -X POST https://dash.example.com/api/v1/auth/api-key \
   -H "Content-Type: application/json" \
-  -d '{"sub": "my-mcp-client"}'
+  -H "Authorization: Bearer $CHM_API_KEY_SECRET" \
+  -d '{"label": "my-mcp-client", "days": 30}'
 ```
 
-The response returns a `chm_` prefixed token.
+The response is `{"data":{"apiKey":"chm_..."}}` — a `chm_` prefixed token.
 </Step>
 <Step>
 ### Pass it in the Authorization header


### PR DESCRIPTION
Closes #2689.

The MCP client setup guide's "Issue a token" curl example did not work as written:

- **Missing `Authorization` header** — `POST /api/v1/auth/api-key` requires `CHM_API_KEY_SECRET` as a Bearer token and returns 401 without it (`api-key.ts:47-52`).
- **Wrong body field** — the route reads `label` / `days` (`api-key.ts:74-75`); the documented `sub` was silently ignored.
- **Wrong response shape** — the route returns `{"data":{"apiKey":"chm_..."}}` (`api-key.ts:84`), not `{"token":"chm_..."}`.

Each claim was verified against the route handler. Also clarifies that the header carries the *operator's* shared secret, not the token being minted — the two are easy to conflate. The same response-shape mistake in `features/mcp.mdx`'s copy of the example is fixed too.

Docs-only; no runtime change.

Co-Authored-By: duyetbot <bot@duyet.net>