### PR TITLE
docs: add missing billing and peerdb feature ids (#2692)

### DIFF
--- a/docs/content/operate/advanced/feature-permissions.mdx
+++ b/docs/content/operate/advanced/feature-permissions.mdx
@@ -115,6 +115,7 @@ Use these ids in TOML/YAML (lowercase) or env vars (uppercase):
 | `security` | `/security` |
 | `logs` | `/logs` |
 | `settings` | `/settings` |
+| `billing` | `/billing`, `/organization` (Cloud only — subscription, usage, team management) |
 | `mcp` | MCP server feature area |
 | `docs` | `/docs` |
 | `about` | `/about` |

--- a/docs/content/operate/deploy/cloudflare.mdx
+++ b/docs/content/operate/deploy/cloudflare.mdx
@@ -187,7 +187,7 @@ CHM_FEATURE_SETTINGS_ENABLED = "false"
 
 **Via a mounted config file:** not directly supported in Workers — use env vars instead.
 
-Feature ids: `overview`, `agent`, `insights`, `health`, `queries`, `tables`, `metrics`, `dashboard`, `security`, `logs`, `settings`, `cluster`, `operations`, `actions`, `mcp`, `docs`, `about`.
+Feature ids: `overview`, `agent`, `insights`, `health`, `queries`, `tables`, `metrics`, `dashboard`, `security`, `logs`, `settings`, `billing`, `cluster`, `operations`, `actions`, `mcp`, `peerdb`, `docs`, `about`.
 
 ### Authentication
 

--- a/docs/content/operate/deploy/docker.mdx
+++ b/docs/content/operate/deploy/docker.mdx
@@ -177,7 +177,7 @@ access = "authenticated"
 </Tab>
 </Tabs>
 
-Feature ids: `overview`, `agent`, `insights`, `health`, `queries`, `tables`, `metrics`, `dashboard`, `security`, `logs`, `settings`, `cluster`, `operations`, `actions`, `mcp`, `docs`, `about`.
+Feature ids: `overview`, `agent`, `insights`, `health`, `queries`, `tables`, `metrics`, `dashboard`, `security`, `logs`, `settings`, `billing`, `cluster`, `operations`, `actions`, `mcp`, `peerdb`, `docs`, `about`.
 
 ### Authentication
 

--- a/docs/content/operate/deploy/k8s.mdx
+++ b/docs/content/operate/deploy/k8s.mdx
@@ -318,7 +318,7 @@ volumes:
 </Tab>
 </Tabs>
 
-Feature ids: `overview`, `agent`, `insights`, `health`, `queries`, `tables`, `metrics`, `dashboard`, `security`, `logs`, `settings`, `cluster`, `operations`, `actions`, `mcp`, `docs`, `about`.
+Feature ids: `overview`, `agent`, `insights`, `health`, `queries`, `tables`, `metrics`, `dashboard`, `security`, `logs`, `settings`, `billing`, `cluster`, `operations`, `actions`, `mcp`, `peerdb`, `docs`, `about`.
 
 ### Authentication
 

--- a/docs/content/operate/deploy/self-host.mdx
+++ b/docs/content/operate/deploy/self-host.mdx
@@ -137,7 +137,7 @@ access = "authenticated"
 </Tab>
 </Tabs>
 
-Feature ids: `overview`, `agent`, `insights`, `health`, `queries`, `tables`, `metrics`, `dashboard`, `security`, `logs`, `settings`, `cluster`, `operations`, `actions`, `mcp`, `docs`, `about`.
+Feature ids: `overview`, `agent`, `insights`, `health`, `queries`, `tables`, `metrics`, `dashboard`, `security`, `logs`, `settings`, `billing`, `cluster`, `operations`, `actions`, `mcp`, `peerdb`, `docs`, `about`.
 
 ### Authentication
 

--- a/docs/content/operate/deploy/vercel.mdx
+++ b/docs/content/operate/deploy/vercel.mdx
@@ -114,7 +114,7 @@ CHM_FEATURE_SETTINGS_ENABLED=false
 
 For a config file, set `CHM_CONFIG_FILE` to a path readable by the Vercel function runtime and include the file in the repo.
 
-Feature ids: `overview`, `agent`, `insights`, `health`, `queries`, `tables`, `metrics`, `dashboard`, `security`, `logs`, `settings`, `cluster`, `operations`, `actions`, `mcp`, `docs`, `about`.
+Feature ids: `overview`, `agent`, `insights`, `health`, `queries`, `tables`, `metrics`, `dashboard`, `security`, `logs`, `settings`, `billing`, `cluster`, `operations`, `actions`, `mcp`, `peerdb`, `docs`, `about`.
 
 #### Authentication
 

--- a/docs/content/reference/environment-variables.mdx
+++ b/docs/content/reference/environment-variables.mdx
@@ -203,7 +203,8 @@ different behavior.
 
 Replace `{ID}` with an uppercase feature id: `OVERVIEW`, `AGENT`, `INSIGHTS`,
 `HEALTH`, `QUERIES`, `TABLES`, `METRICS`, `DASHBOARD`, `SECURITY`, `LOGS`,
-`SETTINGS`, `CLUSTER`, `OPERATIONS`, `ACTIONS`, `MCP`, `DOCS`, `ABOUT`, `PEERDB`.
+`SETTINGS`, `BILLING`, `CLUSTER`, `OPERATIONS`, `ACTIONS`, `MCP`, `DOCS`,
+`ABOUT`, `PEERDB`.
 
 ```bash
 CHM_FEATURE_AGENT_ACCESS=authenticated


### PR DESCRIPTION
Salvaged from uncommitted work left in a stale agent worktree for #2692 — never shipped in #2717.

The `Feature ids:` list in every deploy guide (docker, k8s, cloudflare, vercel, self-host) advertised **17 ids while `FEATURE_IDS` defines 19** (`apps/dashboard/src/lib/feature-permissions/types.ts`). `billing` and `peerdb` were undocumented, so operators had no way to discover they could gate those surfaces.

- Adds `billing` + `peerdb` to all five deploy guides
- Documents the `billing` id in the feature-permissions reference table (Cloud-only: `/billing`, `/organization`)
- Syncs the environment-variables reference

Each list was verified against `FEATURE_IDS`; all five guides now carry one identical 19-id list. `catalog-contributing.mdx` already listed all 19 on main, so it's left untouched.

Docs-only; no runtime change.

Co-Authored-By: duyetbot <bot@duyet.net>