### PR TITLE
docs: record canonical GitHub repo metadata to stop SEO drift (#2698)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,7 @@ Developer-facing docs live in `docs/knowledge/` as a linked knowledge graph. Eac
 | Operations | [deployment.md](docs/knowledge/deployment.md) | Docker + Cloudflare Workers dual deployment |
 | Operations | [core-memory.md](docs/knowledge/core-memory.md) | Automation memory: code-smell scans, dead-code rules |
 | Operations | [secret-rotation.md](docs/knowledge/secret-rotation.md) | Redeploy after `wrangler secret put` |
+| Operations | [github-repo-metadata.md](docs/knowledge/github-repo-metadata.md) | Canonical repo description + topics (live outside version control, so they rot); banned `nextjs`/`vercel`; re-check when CLAUDE.md Project Overview or the README hero changes |
 | Operations | [observability-sentry.md](docs/knowledge/observability-sentry.md) | Sentry error tracking (OSS+Cloud): @sentry/react (browser) + @sentry/cloudflare (Worker, per-request middleware); DSN-gated off-by-default; source-map upload via SENTRY_AUTH_TOKEN |
 | Operations | [bug-handler-email-worker.md](docs/knowledge/bug-handler-email-worker.md) | apps/bug-handler: Cloudflare Email Worker turning inbound Sentry alert emails (bug@chmonitor.dev) into agent-friendly GitHub issues; fully env-configurable (address/repo/labels/assignees/token), own CI job |
 | Operations | [k8s-health-probes.md](docs/knowledge/k8s-health-probes.md) | /healthz (liveness, static) vs /api/healthz (readiness, CH-gated); startupProbe; :latest stale-image CrashLoop incident; non-helm manifest + migration prompt |

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -33,6 +33,7 @@ Agents discover knowledge in this order:
 | **Operations** | [monorepo-refactor.md](monorepo-refactor.md) | operations | Bun-workspaces + Turborepo migration: status, workflow, gotchas, Phase 5 TODO |
 | **Operations** | [core-memory.md](core-memory.md) | workflow | Automation core memory: code-smell scans, dead-code rules |
 | **Operations** | [secret-rotation.md](secret-rotation.md) | workflow | Cloudflare Workers secret rotation: redeploy after wrangler secret put |
+| **Operations** | [github-repo-metadata.md](github-repo-metadata.md) | workflow | Canonical GitHub repo description + topics; banned nextjs/vercel; re-check on stack/positioning change |
 | **Operations** | [k8s-health-probes.md](k8s-health-probes.md) | reference | /healthz (liveness, static) vs /api/healthz (readiness, CH-gated); startupProbe; :latest stale-image incident; non-helm manifest + migration prompt |
 | **Operations** | [workers-cache.md](workers-cache.md) | reference | Cloudflare Workers Cache: `[cache] enabled` per-worker; docs pages set `public, max-age=300, swr=86400` via start.ts middleware; landing/blog assets-only; dashboard/telemetry/mcp enabled-but-uncached (per-user/authed) |
 | **Operations** | [release-automation.md](release-automation.md) | workflow | release-please + release.yml pipeline: versioning rules, PR-title guard, labeler, CHANGELOG ownership, migration prompt |

--- a/docs/knowledge/github-repo-metadata.md
+++ b/docs/knowledge/github-repo-metadata.md
@@ -1,0 +1,82 @@
+---
+id: github-repo-metadata
+title: GitHub Repo Metadata (description + topics)
+type: workflow
+status: active
+updated: 2026-07-17
+tags:
+  - seo
+  - growth
+  - discoverability
+  - github
+related:
+  - release-automation
+  - conventions
+---
+
+# GitHub Repo Metadata (description + topics)
+
+The repo's `description` and `topics` are a first-class discoverability surface:
+they appear in GitHub search, org repo listings, and are scraped verbatim by
+"awesome-X" lists and directory sites. They also live **outside version
+control**, which is exactly why they rot silently — nothing in CI fails when the
+stack changes underneath them.
+
+This note is the versioned source of truth for what they should say.
+
+## Canonical values
+
+**Description** (keep under ~140 chars; GitHub truncates):
+
+```
+Open-source operational advisor for ClickHouse — real-time monitoring plus AI-driven index/partition/materialized-view recommendations. Self-host or use the cloud.
+```
+
+It mirrors the README hero line — chmonitor is an *operational advisor*, not
+just a metrics viewer. Lead with the AI-advisor differentiation, not dashboards.
+
+**Topics:**
+
+`chmonitor`, `clickhouse`, `duyet`, `monitoring`, `ai-agent`,
+`cloudflare-workers`, `database-monitoring`, `mcp`, `observability`,
+`open-source`, `self-hosted`, `tanstack-start`
+
+**Banned topics:** `nextjs`, `vercel`. Both were wrong and actively misleading —
+the Next.js migration is complete (TanStack Start replaced it) and the app
+deploys to Cloudflare Workers / Docker / Kubernetes. There is no Vercel
+deployment. A stack-detector or contributor reading those topics would set up
+the wrong dev environment before opening a file.
+
+## When to re-check
+
+Re-read this note whenever the stack or positioning changes — specifically when
+either of these changes, update the metadata in the same pass:
+
+- `CLAUDE.md` "Project Overview" (stack / deployment targets)
+- `README.md` hero line (positioning)
+
+## How to apply
+
+```bash
+gh repo edit chmonitor/chmonitor --description "<canonical description above>"
+gh repo edit chmonitor/chmonitor \
+  --add-topic tanstack-start --add-topic cloudflare-workers \
+  --add-topic observability --add-topic ai-agent --add-topic mcp \
+  --add-topic self-hosted --add-topic open-source \
+  --add-topic database-monitoring \
+  --remove-topic nextjs --remove-topic vercel
+```
+
+Verify:
+
+```bash
+gh api repos/chmonitor/chmonitor | jq '.description, .topics'
+```
+
+## Possible follow-up
+
+A CI job could assert the live metadata matches this note (read-only
+`gh api repos/...`, fail on a banned topic or a description mismatch), turning
+this from a convention into an enforced drift guard — the same move
+`packages/mcp-server/src/data/__tests__/mcp-tools-data-drift.test.ts` made for
+the MCP tool catalog. Not built yet; deliberately kept to a doc first.


### PR DESCRIPTION
Closes #2698.

**Steps 1 & 2 of the issue are already applied** — verified live via `gh api repos/chmonitor/chmonitor`: the description now matches the issue's suggestion and `nextjs`/`vercel` are gone, with all the new topics present.

This PR closes the loop on **step 3**, which is the part that actually prevents recurrence. That metadata lives *outside version control*, so nothing failed when it rotted — it advertised a Next.js/Vercel stack long after the TanStack Start migration completed and the app moved to Cloudflare Workers / Docker / K8s.

Adds `docs/knowledge/github-repo-metadata.md` recording:
- the canonical description + topic list
- the **banned** topics (`nextjs`, `vercel`) and why they were actively misleading
- the re-check trigger: CLAUDE.md "Project Overview" or the README hero line changing
- copy-pasteable `gh repo edit` apply + verify commands

Linked from both Knowledge Graph tables (CLAUDE.md + `docs/knowledge/README.md`), per CLAUDE.md's requirement that the table stay current.

A CI drift-guard (assert live metadata matches the note, like `mcp-tools-data-drift.test.ts` did for the MCP catalog) is noted as a follow-up rather than built — kept to a doc first.

Docs-only; no runtime change.

Co-Authored-By: duyetbot <bot@duyet.net>