### PR TITLE
fix(mcp-server): cap get_running_queries rows with a limit param (#2705)

### DIFF
--- a/docs/knowledge/mcp-server.md
+++ b/docs/knowledge/mcp-server.md
@@ -26,7 +26,7 @@ The chmonitor exposes a [Model Context Protocol (MCP)](https://modelcontextproto
 | `list_tables` | List tables with row counts and sizes | `database` (string, required) |
 | `get_table_schema` | Show columns, types, defaults, comments | `database`, `table` (required) |
 | `get_metrics` | Server version, uptime, active connections | `hostId` (number, optional) |
-| `get_running_queries` | Currently executing queries by elapsed time | `hostId` (number, optional) |
+| `get_running_queries` | Currently executing queries by elapsed time | `limit` (number, optional, default 50, max 1000), `hostId` (number, optional) |
 | `get_slow_queries` | Slowest completed queries from query log | `limit` (number, optional) |
 | `get_merge_status` | Running merge operations with progress | `hostId` (number, optional) |
 | `explore_table_schema` | Schema exploration with relationship discovery (3 modes: databases, tables, full schema) | `database`, `table` (optional), `hostId` (optional) |

--- a/packages/mcp-server/src/data/mcp-tools-data.ts
+++ b/packages/mcp-server/src/data/mcp-tools-data.ts
@@ -174,6 +174,13 @@ export const MCP_TOOLS: McpTool[] = [
     category: 'system',
     params: [
       {
+        name: 'limit',
+        type: 'number',
+        required: false,
+        default: 50,
+        description: 'Max number of queries to return (default: 50)',
+      },
+      {
         name: 'hostId',
         type: 'number',
         required: false,

--- a/packages/mcp-server/src/tools/__tests__/queries.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/queries.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, mock, test } from 'bun:test'
+
+// Mock fetchData before importing the tool
+const mockFetchData = mock(() => Promise.resolve({ data: [], error: null }))
+
+mock.module('@chm/clickhouse-client', () => ({
+  fetchData: mockFetchData,
+}))
+
+import { registerQueryTools } from '../queries'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { z } from 'zod/v3'
+
+/** Helper to get the registered tool handler */
+function getToolHandler(server: McpServer, name: string) {
+  const tools = (server as any)._registeredTools
+  const tool = tools?.[name]
+  if (!tool?.handler) throw new Error(`Tool "${name}" not found`)
+  return (args: Record<string, unknown>) => tool.handler(args, {})
+}
+
+describe('registerQueryTools', () => {
+  test('registers without errors', () => {
+    const server = new McpServer({ name: 'test', version: '0.0.1' })
+    expect(() => registerQueryTools(server)).not.toThrow()
+  })
+})
+
+describe('get_running_queries limit param (#2705)', () => {
+  test('appends LIMIT {limit:UInt32} to the SQL and forwards limit via query_params', async () => {
+    const calls: any[] = []
+    mockFetchData.mockImplementation(async (params: any) => {
+      calls.push(params)
+      return { data: [], error: null }
+    })
+
+    const server = new McpServer({ name: 'test', version: '0.0.1' })
+    registerQueryTools(server)
+    const call = getToolHandler(server, 'get_running_queries')
+
+    // Explicit limit
+    await call({ limit: 5, hostId: 0 })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].query).toContain('LIMIT {limit:UInt32}')
+    expect(calls[0].query_params).toEqual({ limit: 5 })
+  })
+
+  test('forwards the schema-resolved default limit (50) via query_params', async () => {
+    const calls: any[] = []
+    mockFetchData.mockImplementation(async (params: any) => {
+      calls.push(params)
+      return { data: [], error: null }
+    })
+
+    const server = new McpServer({ name: 'test', version: '0.0.1' })
+    registerQueryTools(server)
+    const call = getToolHandler(server, 'get_running_queries')
+
+    // The MCP SDK resolves the zod `.default(50)` before invoking the
+    // handler; simulate that resolved value since this test calls the
+    // handler directly (bypassing the SDK's request-dispatch layer).
+    await call({ limit: 50 })
+
+    expect(calls[0].query_params).toEqual({ limit: 50 })
+  })
+})
+
+describe('get_running_queries limit schema (#2705)', () => {
+  // Mirrors the zod shape registered for `limit` in ../queries.ts
+  const limitSchema = z.number().int().min(1).max(1000).default(50)
+
+  test('defaults to 50 when omitted', () => {
+    expect(limitSchema.parse(undefined)).toBe(50)
+  })
+
+  test('accepts an explicit in-range value', () => {
+    expect(limitSchema.parse(5)).toBe(5)
+  })
+
+  test('rejects values above the hard max of 1000', () => {
+    expect(() => limitSchema.parse(5000)).toThrow()
+  })
+
+  test('rejects values below the min of 1', () => {
+    expect(() => limitSchema.parse(0)).toThrow()
+  })
+})

--- a/packages/mcp-server/src/tools/queries.ts
+++ b/packages/mcp-server/src/tools/queries.ts
@@ -17,12 +17,20 @@ export function registerQueryTools(server: McpServer) {
     'get_running_queries',
     'List currently running queries on the ClickHouse server, ordered by elapsed time.',
     {
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(1000)
+        .default(50)
+        .describe('Max number of queries to return (default: 50)'),
       hostId: hostIdSchema,
     },
-    async ({ hostId }) =>
+    async ({ limit, hostId }) =>
       runReadonlyQuery(
-        'SELECT query_id, user, elapsed, read_rows, memory_usage, substring(query, 1, 200) AS query FROM system.processes ORDER BY elapsed DESC',
-        hostId
+        'SELECT query_id, user, elapsed, read_rows, memory_usage, substring(query, 1, 200) AS query FROM system.processes ORDER BY elapsed DESC LIMIT {limit:UInt32}',
+        hostId,
+        { query_params: { limit } }
       )
   )
 


### PR DESCRIPTION
Closes #2705.

`get_running_queries` had no row cap — on a busy cluster it returned an unbounded result set, which can blow out an MCP client's context window.

- Adds an optional `limit` param mirroring the sibling `get_slow_queries` convention exactly (`z.number().int().min(1).max(1000).default(50)`) rather than inventing a new one.
- Cap is enforced in **SQL** (`LIMIT {limit:UInt32}` via `query_params`), not by slicing in JS.
- Updates the `MCP_TOOLS` catalog so the discovery endpoint / Playground / docs stay in sync — `mcp-tools-data-drift.test.ts` enforces this.
- New tests cover explicit limit, the resolved default, and rejection above max / below min.
- `docs/knowledge/mcp-server.md` param table updated (CLAUDE.md forbids docs drift).

**Verified:** `bun test` in `packages/mcp-server` — **141 pass, 0 fail** (the authoring agent could not run tests in its worktree; run in the main checkout during integration).

Co-Authored-By: duyetbot <bot@duyet.net>