### PR TITLE
fix(mcp-server): honour multi-host config in resources (#2707)

### DIFF
--- a/docs/content/reference/mcp-server.mdx
+++ b/docs/content/reference/mcp-server.mdx
@@ -137,14 +137,16 @@ All tools are read-only and respect the same `CLICKHOUSE_MAX_EXECUTION_TIME` tim
 
 The server exposes static and templated resources for context loading:
 
-| Resource | URI |
-|---|---|
-| System tables reference | `clickhouse://system-tables` |
-| Query examples | `clickhouse://query-examples` |
-| Database list | `clickhouse://databases` |
-| Tables in a database | `clickhouse://databases/{database}/tables` |
-| Table schema | `clickhouse://databases/{database}/tables/{table}/schema` |
-| Table parts | `clickhouse://databases/{database}/tables/{table}/parts` |
+| Resource | URI | Host-scoped equivalent |
+|---|---|---|
+| System tables reference | `clickhouse://system-tables` | — |
+| Query examples | `clickhouse://query-examples` | — |
+| Database list | `clickhouse://databases` | `clickhouse://hosts/{hostId}/databases` |
+| Tables in a database | `clickhouse://databases/{database}/tables` | `clickhouse://hosts/{hostId}/databases/{database}/tables` |
+| Table schema | `clickhouse://databases/{database}/tables/{table}/schema` | `clickhouse://hosts/{hostId}/databases/{database}/tables/{table}/schema` |
+| Table parts | `clickhouse://databases/{database}/tables/{table}/parts` | `clickhouse://hosts/{hostId}/databases/{database}/tables/{table}/parts` |
+
+On a multi-host deployment (comma-separated `CLICKHOUSE_HOST`), the plain `clickhouse://databases/...` resources always query host `0`, same as omitting `hostId` on a tool call. Use the `clickhouse://hosts/{hostId}/...` variant to target another host.
 
 Pre-built prompts for common workflows: `health-check`, `slow-query-analysis`, `storage-audit`, `replication-check`, `capacity-report`.
 

--- a/packages/mcp-server/src/__tests__/resources.test.ts
+++ b/packages/mcp-server/src/__tests__/resources.test.ts
@@ -1,16 +1,109 @@
 import { describe, expect, mock, test } from 'bun:test'
 
 // Mock fetchData before importing
+const mockFetchData = mock(() => Promise.resolve({ data: [], error: null }))
+
 mock.module('@chm/clickhouse-client', () => ({
-  fetchData: async () => ({ data: [], error: null }),
+  fetchData: mockFetchData,
 }))
 
 import { registerResources } from '../resources'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
+/**
+ * Resolves a resource URI the same way the SDK's internal
+ * `ReadResourceRequestSchema` handler does: an exact match against
+ * `_registeredResources`, falling back to the first `_registeredResourceTemplates`
+ * entry whose `uriTemplate` matches. See
+ * `@modelcontextprotocol/sdk`'s `server/mcp.js` `setResourceRequestHandlers`.
+ */
+async function readResource(server: McpServer, uriStr: string) {
+  const uri = new URL(uriStr)
+  const resources = (server as any)._registeredResources
+  const exact = resources?.[uri.toString()]
+  if (exact) return exact.readCallback(uri, {})
+
+  const templates = (server as any)._registeredResourceTemplates
+  for (const template of Object.values(templates ?? {}) as any[]) {
+    const variables = template.resourceTemplate.uriTemplate.match(
+      uri.toString()
+    )
+    if (variables) return template.readCallback(uri, variables, {})
+  }
+  throw new Error(`Resource ${uriStr} not found`)
+}
+
 describe('registerResources', () => {
   test('registers without errors', () => {
     const server = new McpServer({ name: 'test', version: '0.0.1' })
     expect(() => registerResources(server)).not.toThrow()
+  })
+
+  describe('hostId support', () => {
+    test('legacy URI without a hostId still resolves to host 0', async () => {
+      mockFetchData.mockClear()
+      const server = new McpServer({ name: 'test', version: '0.0.1' })
+      registerResources(server)
+
+      await readResource(server, 'clickhouse://databases/default/tables')
+
+      expect(mockFetchData).toHaveBeenCalledTimes(1)
+      expect(mockFetchData.mock.calls[0][0]).toMatchObject({ hostId: 0 })
+    })
+
+    test('clickhouse://databases (no template) also defaults to host 0', async () => {
+      mockFetchData.mockClear()
+      const server = new McpServer({ name: 'test', version: '0.0.1' })
+      registerResources(server)
+
+      await readResource(server, 'clickhouse://databases')
+
+      expect(mockFetchData).toHaveBeenCalledTimes(1)
+      expect(mockFetchData.mock.calls[0][0]).toMatchObject({ hostId: 0 })
+    })
+
+    test('clickhouse://hosts/{hostId}/databases/{database}/tables queries the requested host', async () => {
+      mockFetchData.mockClear()
+      const server = new McpServer({ name: 'test', version: '0.0.1' })
+      registerResources(server)
+
+      await readResource(
+        server,
+        'clickhouse://hosts/1/databases/default/tables'
+      )
+
+      expect(mockFetchData).toHaveBeenCalledTimes(1)
+      expect(mockFetchData.mock.calls[0][0]).toMatchObject({ hostId: 1 })
+    })
+
+    test('clickhouse://hosts/{hostId}/databases queries the requested host', async () => {
+      mockFetchData.mockClear()
+      const server = new McpServer({ name: 'test', version: '0.0.1' })
+      registerResources(server)
+
+      await readResource(server, 'clickhouse://hosts/2/databases')
+
+      expect(mockFetchData).toHaveBeenCalledTimes(1)
+      expect(mockFetchData.mock.calls[0][0]).toMatchObject({ hostId: 2 })
+    })
+
+    test('table schema and parts resources thread hostId through as well', async () => {
+      mockFetchData.mockClear()
+      const server = new McpServer({ name: 'test', version: '0.0.1' })
+      registerResources(server)
+
+      await readResource(
+        server,
+        'clickhouse://hosts/3/databases/default/tables/events/schema'
+      )
+      expect(mockFetchData.mock.calls[0][0]).toMatchObject({ hostId: 3 })
+
+      mockFetchData.mockClear()
+      await readResource(
+        server,
+        'clickhouse://hosts/3/databases/default/tables/events/parts'
+      )
+      expect(mockFetchData.mock.calls[0][0]).toMatchObject({ hostId: 3 })
+    })
   })
 })

--- a/packages/mcp-server/src/resources/index.ts
+++ b/packages/mcp-server/src/resources/index.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
-import { fetchData } from '@chm/clickhouse-client'
+import { runReadonlyFetch } from '../tools/helpers'
 import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js'
 
 const SYSTEM_TABLES_TEXT = `Key ClickHouse System Tables for Monitoring:
@@ -101,7 +101,8 @@ export function registerResources(server: McpServer) {
     'databases',
     'clickhouse://databases',
     {
-      description: 'List all ClickHouse databases',
+      description:
+        'List all ClickHouse databases on host 0. For a multi-host deployment, use clickhouse://hosts/{hostId}/databases to target a different host.',
       mimeType: 'application/json',
     },
     async () => {
@@ -118,7 +119,8 @@ export function registerResources(server: McpServer) {
       list: undefined,
     }),
     {
-      description: 'List tables in a ClickHouse database',
+      description:
+        'List tables in a ClickHouse database on host 0. For a multi-host deployment, use clickhouse://hosts/{hostId}/databases/{database}/tables to target a different host.',
       mimeType: 'application/json',
     },
     async (uri, variables) => {
@@ -138,7 +140,8 @@ export function registerResources(server: McpServer) {
       { list: undefined }
     ),
     {
-      description: 'Get column schema for a ClickHouse table',
+      description:
+        'Get column schema for a ClickHouse table on host 0. For a multi-host deployment, use clickhouse://hosts/{hostId}/databases/{database}/tables/{table}/schema to target a different host.',
       mimeType: 'application/json',
     },
     async (uri, variables) => {
@@ -159,7 +162,8 @@ export function registerResources(server: McpServer) {
       { list: undefined }
     ),
     {
-      description: 'Get active parts info for a ClickHouse table',
+      description:
+        'Get active parts info for a ClickHouse table on host 0. For a multi-host deployment, use clickhouse://hosts/{hostId}/databases/{database}/tables/{table}/parts to target a different host.',
       mimeType: 'application/json',
     },
     async (uri, variables) => {
@@ -168,6 +172,107 @@ export function registerResources(server: McpServer) {
       const data = await queryClickHouse(
         'SELECT partition, name, rows, formatReadableSize(bytes_on_disk) AS size, modification_time FROM system.parts WHERE database = {db:String} AND table = {tbl:String} AND active ORDER BY modification_time DESC LIMIT 50',
         { db: database, tbl: table }
+      )
+      return jsonResource(uri.href, data)
+    }
+  )
+
+  // Host-scoped variants: same data, but with an explicit {hostId} path segment
+  // so multi-host deployments can address a specific ClickHouse host, mirroring
+  // the `hostId` parameter every MCP tool already supports (see tools/helpers.ts).
+  //
+  // These are registered as a parallel `clickhouse://hosts/{hostId}/...`
+  // namespace rather than folding `{hostId}` into the existing templates above:
+  // the SDK's RFC 6570 `UriTemplate.match()` treats a `{?hostId}` query
+  // expression as a required literal, not an optional one, so a template like
+  // `clickhouse://databases{?hostId}` would fail to match the legacy
+  // (no-hostId) URI and break backward compatibility.
+
+  server.resource(
+    'databases-by-host',
+    new ResourceTemplate('clickhouse://hosts/{hostId}/databases', {
+      list: undefined,
+    }),
+    {
+      description: 'List all ClickHouse databases on a specific host',
+      mimeType: 'application/json',
+    },
+    async (uri, variables) => {
+      const hostId = parseHostId(variables.hostId)
+      const data = await queryClickHouse(
+        'SELECT name, engine, comment FROM system.databases ORDER BY name',
+        undefined,
+        hostId
+      )
+      return jsonResource(uri.href, data)
+    }
+  )
+
+  server.resource(
+    'database-tables-by-host',
+    new ResourceTemplate(
+      'clickhouse://hosts/{hostId}/databases/{database}/tables',
+      { list: undefined }
+    ),
+    {
+      description: 'List tables in a ClickHouse database on a specific host',
+      mimeType: 'application/json',
+    },
+    async (uri, variables) => {
+      const hostId = parseHostId(variables.hostId)
+      const database = String(variables.database)
+      const data = await queryClickHouse(
+        'SELECT name, engine, total_rows, formatReadableSize(total_bytes) AS size FROM system.tables WHERE database = {db:String} ORDER BY total_bytes DESC',
+        { db: database },
+        hostId
+      )
+      return jsonResource(uri.href, data)
+    }
+  )
+
+  server.resource(
+    'table-schema-by-host',
+    new ResourceTemplate(
+      'clickhouse://hosts/{hostId}/databases/{database}/tables/{table}/schema',
+      { list: undefined }
+    ),
+    {
+      description:
+        'Get column schema for a ClickHouse table on a specific host',
+      mimeType: 'application/json',
+    },
+    async (uri, variables) => {
+      const hostId = parseHostId(variables.hostId)
+      const database = String(variables.database)
+      const table = String(variables.table)
+      const data = await queryClickHouse(
+        'SELECT name, type, default_kind, default_expression, comment FROM system.columns WHERE database = {db:String} AND table = {tbl:String} ORDER BY position',
+        { db: database, tbl: table },
+        hostId
+      )
+      return jsonResource(uri.href, data)
+    }
+  )
+
+  server.resource(
+    'table-parts-by-host',
+    new ResourceTemplate(
+      'clickhouse://hosts/{hostId}/databases/{database}/tables/{table}/parts',
+      { list: undefined }
+    ),
+    {
+      description:
+        'Get active parts info for a ClickHouse table on a specific host',
+      mimeType: 'application/json',
+    },
+    async (uri, variables) => {
+      const hostId = parseHostId(variables.hostId)
+      const database = String(variables.database)
+      const table = String(variables.table)
+      const data = await queryClickHouse(
+        'SELECT partition, name, rows, formatReadableSize(bytes_on_disk) AS size, modification_time FROM system.parts WHERE database = {db:String} AND table = {tbl:String} AND active ORDER BY modification_time DESC LIMIT 50',
+        { db: database, tbl: table },
+        hostId
       )
       return jsonResource(uri.href, data)
     }
@@ -186,16 +291,33 @@ function jsonResource(uri: string, data: unknown[]) {
   }
 }
 
+/**
+ * Runs a read-only query via the same `runReadonlyFetch` helper every MCP
+ * tool uses (see tools/helpers.ts), so resources honour `hostId` the exact
+ * same way tools do — including the `?? 0` default when `hostId` is omitted.
+ */
 async function queryClickHouse(
   query: string,
-  query_params?: Record<string, string>
+  query_params?: Record<string, string>,
+  hostId?: number
 ): Promise<unknown[]> {
-  const { data } = await fetchData<unknown[]>({
+  const { data } = await runReadonlyFetch<unknown[]>({
     query,
     query_params,
-    format: 'JSONEachRow',
-    clickhouse_settings: { readonly: '1' },
-    hostId: 0,
+    hostId,
   })
   return data ?? []
+}
+
+/**
+ * Parses the `{hostId}` URI template variable into a number, falling back to
+ * `undefined` (which `runReadonlyFetch`/`queryClickHouse` then default to
+ * host 0) for a missing or non-numeric value — fail-safe like every other
+ * `hostId` entry point in this package.
+ */
+function parseHostId(value: string | string[] | undefined): number | undefined {
+  const raw = Array.isArray(value) ? value[0] : value
+  if (raw === undefined) return undefined
+  const parsed = Number(raw)
+  return Number.isFinite(parsed) ? parsed : undefined
 }


### PR DESCRIPTION
Closes #2707.

MCP resource templates always queried host 0, ignoring multi-host config — so on a multi-host deployment they silently read the wrong cluster, even though every *tool* already accepts `hostId`.

**Design note — the issue's suggestion #1 does not work, and it was verified rather than assumed.** The agent tested `UriTemplate` against the installed SDK (`@modelcontextprotocol/sdk@1.29.0`): `expand()` treats `{?hostId}` as optional, but `match()` — which is what the `ReadResourceRequestSchema` handler actually uses — compiles the `?` operator into a **required literal**. A legacy URI without `?hostId=` would stop matching, breaking every existing client. That's a real SDK limitation, not something to paper over with a regex hack.

So this takes the issue's suggestion #2 — a parallel host-scoped namespace:
- `clickhouse://hosts/{hostId}/databases`
- `clickhouse://hosts/{hostId}/databases/{database}/tables`
- `clickhouse://hosts/{hostId}/databases/{database}/tables/{table}/schema`
- `clickhouse://hosts/{hostId}/databases/{database}/tables/{table}/parts`

Original `clickhouse://databases/...` templates are untouched and still default to host 0 — **backward compatible**, matching the repo's fail-safe-default convention. Both old and new now route through the tools' own `runReadonlyFetch`, replacing the resources file's duplicated `fetchData` call, so resources and tools share one hostId mechanism.

Tests cover legacy URI → host 0, and host-scoped URIs → hosts 1/2/3.

**Verified during integration:** `bun test` in `packages/mcp-server` — **139 tests, 0 fail**.

Co-Authored-By: duyetbot <bot@duyet.net>