### PR TITLE
fix(mcp): rate-limit /api/mcp with the existing limiter (#2704)

### DIFF
--- a/apps/dashboard/src/lib/api/rate-limiter.ts
+++ b/apps/dashboard/src/lib/api/rate-limiter.ts
@@ -8,6 +8,7 @@
  * - Limits are env-configurable:
  *     RATE_LIMIT_AGENT_PER_MIN  (default 10)  — POST /api/v1/agent per identity
  *     RATE_LIMIT_API_PER_MIN    (default 100) — GET  data routes per IP
+ *     RATE_LIMIT_MCP_PER_MIN    (default 30)  — /api/mcp per IP
  * - Returns { allowed, retryAfterSec } so callers can build the 429 response.
  * - Safe for Workers: no Node-only APIs (no `process.hrtime`, no node timers).
  */
@@ -172,6 +173,7 @@ export function getRateLimitBinding(
 /** Binding names declared in wrangler.toml (`[[unsafe.bindings]]`). */
 export const RATE_LIMIT_BINDING_API = 'CHM_RATE_LIMIT_API'
 export const RATE_LIMIT_BINDING_AGENT = 'CHM_RATE_LIMIT_AGENT'
+export const RATE_LIMIT_BINDING_MCP = 'CHM_RATE_LIMIT_MCP'
 
 /**
  * Fleet-wide rate limit check with graceful fallback.
@@ -256,6 +258,19 @@ export function getAgentRateLimitPerMin(): number {
 
 export function getApiRateLimitPerMin(): number {
   return readIntEnv('RATE_LIMIT_API_PER_MIN', 100)
+}
+
+/**
+ * /api/mcp exposes the same class of capability as the agent's SQL-executing
+ * route (arbitrary read-only SQL via the `query` tool, plus 10 other
+ * ClickHouse-querying tools) over a differently-authenticated transport —
+ * see issue #2704. Default sits between the agent's per-turn budget (10,
+ * expensive multi-tool LLM turns) and the plain data-route budget (100,
+ * cheap single reads): a single MCP `tools/call` is one ClickHouse query,
+ * comparable in cost to one agent tool call.
+ */
+export function getMcpRateLimitPerMin(): number {
+  return readIntEnv('RATE_LIMIT_MCP_PER_MIN', 30)
 }
 
 /**

--- a/apps/dashboard/src/routes/api/__tests__/mcp-rate-limit.test.ts
+++ b/apps/dashboard/src/routes/api/__tests__/mcp-rate-limit.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for the rate-limit guard on /api/mcp (#2704).
+ *
+ * /api/mcp exposes arbitrary read-only SQL execution (the `query` tool, plus
+ * 10 other ClickHouse-querying tools) with no throttle before this change —
+ * this reuses the same `checkRateLimitDurable` in-memory token bucket already
+ * guarding the agent's SQL-executing route. Coverage: allowed under the
+ * configured limit, blocked (429 + Retry-After) once exhausted, and
+ * independent buckets per client IP.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { _resetBucketsForTest } from '@/lib/api/rate-limiter'
+
+const { __checkMcpRateLimitForTests: checkMcpRateLimit } = await import(
+  '../mcp'
+)
+
+const ORIGINAL_LIMIT = process.env.RATE_LIMIT_MCP_PER_MIN
+
+function makeRequest(ip = '203.0.113.1'): Request {
+  return new Request('https://dash.example.com/api/mcp', {
+    method: 'POST',
+    headers: { 'cf-connecting-ip': ip },
+  })
+}
+
+beforeEach(() => {
+  _resetBucketsForTest()
+  process.env.RATE_LIMIT_MCP_PER_MIN = '3'
+})
+
+afterEach(() => {
+  _resetBucketsForTest()
+  if (ORIGINAL_LIMIT === undefined) {
+    delete process.env.RATE_LIMIT_MCP_PER_MIN
+  } else {
+    process.env.RATE_LIMIT_MCP_PER_MIN = ORIGINAL_LIMIT
+  }
+})
+
+describe('checkMcpRateLimit', () => {
+  test('allows requests under the configured per-IP limit', async () => {
+    for (let i = 0; i < 3; i += 1) {
+      const result = await checkMcpRateLimit(makeRequest())
+      expect(result).toBeNull()
+    }
+  })
+
+  test('blocks the request once the limit is exhausted with a 429', async () => {
+    for (let i = 0; i < 3; i += 1) {
+      expect(await checkMcpRateLimit(makeRequest())).toBeNull()
+    }
+
+    const blocked = await checkMcpRateLimit(makeRequest())
+    expect(blocked).not.toBeNull()
+    expect(blocked?.status).toBe(429)
+    expect(blocked?.headers.get('Retry-After')).toBeTruthy()
+
+    const body = (await blocked?.json()) as {
+      success: boolean
+      error: { type: string }
+    }
+    expect(body.success).toBe(false)
+    expect(body.error.type).toBe('rate_limited')
+  })
+
+  test('429 response carries CORS headers so cross-origin MCP clients can read it', async () => {
+    for (let i = 0; i < 3; i += 1) {
+      await checkMcpRateLimit(makeRequest())
+    }
+    const blocked = await checkMcpRateLimit(makeRequest())
+    expect(blocked?.headers.get('Access-Control-Allow-Origin')).toBe('*')
+  })
+
+  test('different client IPs get independent buckets', async () => {
+    for (let i = 0; i < 3; i += 1) {
+      expect(await checkMcpRateLimit(makeRequest('203.0.113.1'))).toBeNull()
+    }
+    // IP 1 is now exhausted...
+    expect(await checkMcpRateLimit(makeRequest('203.0.113.1'))).not.toBeNull()
+    // ...but a different IP is untouched.
+    expect(await checkMcpRateLimit(makeRequest('203.0.113.2'))).toBeNull()
+  })
+})

--- a/apps/dashboard/src/routes/api/mcp.ts
+++ b/apps/dashboard/src/routes/api/mcp.ts
@@ -1,6 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router'
 
-import { corsPreflight, handleMcp } from '@chm/mcp-server/http'
+import { corsPreflight, handleMcp, withCors } from '@chm/mcp-server/http'
+import {
+  checkRateLimitDurable,
+  clientIpKey,
+  getMcpRateLimitPerMin,
+  RATE_LIMIT_BINDING_MCP,
+  rateLimitResponse,
+} from '@/lib/api/rate-limiter'
 import { requirePlanCapability } from '@/lib/billing/plan-capability'
 
 /**
@@ -14,22 +21,56 @@ import { requirePlanCapability } from '@/lib/billing/plan-capability'
  * Plan gate: POST and GET require the `api_mcp_access` capability (Max / Enterprise).
  * Self-hosted deployments are never gated — the capability check short-circuits to
  * null (allow) whenever billing context is unavailable. See lib/billing/plan-capability.ts.
+ *
+ * Rate limiting (#2704): reuses the same `checkRateLimitDurable` pattern already
+ * guarding the agent's SQL-executing route (routes/api/v1/agent.ts) — /api/mcp
+ * exposes the same class of capability (arbitrary read-only SQL via the `query`
+ * tool, plus 10 other ClickHouse-querying tools) over a differently-authenticated
+ * transport. Checked per-IP, before auth, on every verb: the resolved identity
+ * (API-key `sub` / Clerk user id) is only known inside `defaultAuthenticator`,
+ * which lives in the SDK-free `@chm/mcp-server` package (shared with the
+ * standalone apps/mcp Worker and forbidden by dependency-cruiser from depending
+ * on any apps/* package), so it cannot reuse this app's rate limiter. An
+ * IP-keyed check still bounds the exact abuse the issue calls out — unthrottled
+ * `tools/call` bursts, including the `CHM_MCP_PUBLIC=true` anonymous mode.
  */
+async function checkMcpRateLimit(request: Request): Promise<Response | null> {
+  const ip = clientIpKey(request)
+  const rl = await checkRateLimitDurable(
+    `mcp:ip:${ip}`,
+    getMcpRateLimitPerMin(),
+    RATE_LIMIT_BINDING_MCP
+  )
+  return rl.allowed ? null : withCors(rateLimitResponse(rl.retryAfterSec))
+}
+
 export const Route = createFileRoute('/api/mcp')({
   server: {
     handlers: {
       POST: async ({ request }) => {
+        const limited = await checkMcpRateLimit(request)
+        if (limited) return limited
         const denied = await requirePlanCapability('api_mcp_access', request)
         if (denied) return denied
         return handleMcp(request)
       },
       GET: async ({ request }) => {
+        const limited = await checkMcpRateLimit(request)
+        if (limited) return limited
         const denied = await requirePlanCapability('api_mcp_access', request)
         if (denied) return denied
         return handleMcp(request)
       },
-      DELETE: ({ request }) => handleMcp(request),
+      DELETE: async ({ request }) => {
+        const limited = await checkMcpRateLimit(request)
+        if (limited) return limited
+        return handleMcp(request)
+      },
       OPTIONS: () => corsPreflight(),
     },
   },
 })
+
+// Exported for unit tests (`__tests__/mcp-rate-limit.test.ts`), which exercise
+// this guard directly rather than routing through the TanStack Router.
+export { checkMcpRateLimit as __checkMcpRateLimitForTests }

--- a/apps/dashboard/wrangler.toml
+++ b/apps/dashboard/wrangler.toml
@@ -100,9 +100,10 @@ preview_id = "1f8ab0acc6114802bf5c14d883dae341"
 # ─────────────────────────────────────────────────────────────────────────────
 # Fleet-wide rate limiting (Cloudflare Rate Limiting API, "unsafe" binding).
 # Backs the public/anonymous abuse guards (share links, anon pageview inserts,
-# public chart GETs, agent burst guard). The in-memory token bucket in
-# lib/api/rate-limiter.ts is per-isolate, so Workers' isolate spread means
-# configured limits are not enforced fleet-wide — these edge counters are.
+# public chart GETs, agent burst guard, MCP tool-call burst guard). The
+# in-memory token bucket in lib/api/rate-limiter.ts is per-isolate, so Workers'
+# isolate spread means configured limits are not enforced fleet-wide — these
+# edge counters are.
 # checkRateLimitDurable() delegates to these bindings when present and falls
 # back to the in-memory limiter when absent, so self-hosted Docker/K8s/Node
 # (no binding) keeps working unchanged. namespace_id is a stable per-binding
@@ -119,6 +120,12 @@ name = "CHM_RATE_LIMIT_AGENT"
 type = "ratelimit"
 namespace_id = "2002"
 simple = { limit = 10, period = 60 }
+
+[[unsafe.bindings]]
+name = "CHM_RATE_LIMIT_MCP"
+type = "ratelimit"
+namespace_id = "2003"
+simple = { limit = 30, period = 60 }
 # ─────────────────────────────────────────────────────────────────────────────
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -259,6 +266,12 @@ name = "CHM_RATE_LIMIT_AGENT"
 type = "ratelimit"
 namespace_id = "2002"
 simple = { limit = 10, period = 60 }
+
+[[env.preview.unsafe.bindings]]
+name = "CHM_RATE_LIMIT_MCP"
+type = "ratelimit"
+namespace_id = "2003"
+simple = { limit = 30, period = 60 }
 
 # DO migrations are not inherited by named environments — repeat the chain that
 # drops the legacy preview worker's Durable Objects (see top-level note).

--- a/docs/content/reference/environment-variables.mdx
+++ b/docs/content/reference/environment-variables.mdx
@@ -214,6 +214,23 @@ CHM_DISABLED_FEATURES=settings,insights
 See [Feature permissions](/operate/advanced/feature-permissions) for config-file
 examples and precedence details.
 
+## Rate limiting
+
+Per-IP (and, for the agent, per-signed-in-identity) request throttling on the
+SQL-executing API surfaces. All three share one implementation
+(`lib/api/rate-limiter.ts`, `checkRateLimitDurable`): an in-memory token
+bucket everywhere, upgraded to a fleet-wide Cloudflare Rate Limiting binding
+on Workers deploys (`CHM_RATE_LIMIT_API` / `CHM_RATE_LIMIT_AGENT` /
+`CHM_RATE_LIMIT_MCP` in `wrangler.toml`) so the limit holds across isolates,
+not just per-isolate. Requests over the limit get `429` with a `Retry-After`
+header. None of these need to be set for the defaults to apply.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `RATE_LIMIT_API_PER_MIN` | `100` | GET data routes (e.g. `/api/v1/charts/$name`), per IP. |
+| `RATE_LIMIT_AGENT_PER_MIN` | `10` | `POST /api/v1/agent`, per IP then tightened per signed-in identity. |
+| `RATE_LIMIT_MCP_PER_MIN` | `30` | `/api/mcp` (POST/GET/DELETE), per IP. Same class of capability as the agent route — arbitrary read-only SQL via the `query` tool — over the MCP transport. |
+
 ## Authentication
 
 The active server-side auth provider is set by `CHM_AUTH_PROVIDER`. See

--- a/docs/knowledge/mcp-server.md
+++ b/docs/knowledge/mcp-server.md
@@ -63,6 +63,7 @@ curl -X POST https://your-deployment.example.com/api/mcp \
 
 - **Read-only**: All MCP tools execute read-only operations (`readonly: 1`)
 - **Secure by default**: The `/api/mcp` endpoint returns 401 when no auth scheme is configured. Anonymous access requires an explicit operator opt-in via `CHM_MCP_PUBLIC=true`.
+- **Rate limited** (#2704): Every verb (POST/GET/DELETE) is throttled per client IP via the same `checkRateLimitDurable` token-bucket pattern used by `POST /api/v1/agent` — 30 req/min by default, configurable with `RATE_LIMIT_MCP_PER_MIN` (see `docs/content/reference/environment-variables.mdx` → Rate limiting). Blocked requests get `429` + `Retry-After`. Checked in `apps/dashboard/src/routes/api/mcp.ts` (`checkMcpRateLimit`), *before* auth resolves — the dashboard app owns the check because the shared, SDK-free `@chm/mcp-server` package cannot depend on `apps/dashboard`'s rate limiter (dependency-cruiser `no-packages-to-apps`), so the standalone `apps/mcp` Worker is not yet covered (follow-up).
 - **Query limits**: Same `CLICKHOUSE_MAX_EXECUTION_TIME` timeout as dashboard
 - **No credential exposure**: Uses dashboard's configured ClickHouse credentials
 
@@ -87,7 +88,9 @@ exposure is visible in logs and cannot be silently forgotten.
 
 - `packages/mcp-server/src/http.ts` — auth gate (`defaultAuthenticator`)
 - `packages/mcp-server/src/auth/` — api-key + Clerk OAuth verifiers
-- Tests: `packages/mcp-server/src/__tests__/http.test.ts`
+- `apps/dashboard/src/routes/api/mcp.ts` — rate-limit guard (`checkMcpRateLimit`) + plan gate wired around `handleMcp`
+- `apps/dashboard/src/lib/api/rate-limiter.ts` — shared `checkRateLimitDurable` implementation (`getMcpRateLimitPerMin`, `RATE_LIMIT_BINDING_MCP`)
+- Tests: `packages/mcp-server/src/__tests__/http.test.ts`, `apps/dashboard/src/routes/api/__tests__/mcp-rate-limit.test.ts`
 
 ## Distribution: registry listing + one-command install
 


### PR DESCRIPTION
Closes #2704.

`/api/mcp` had no rate limiting despite an established limiter already guarding `POST /api/v1/agent`.

**Reuses** `checkRateLimitDurable` / `clientIpKey` / `rateLimitResponse` from `lib/api/rate-limiter.ts` — the same token-bucket (with the fleet-wide Cloudflare Rate Limiting binding upgrade). No new rate-limiting logic was written; that was the whole point of the issue.

- `getMcpRateLimitPerMin()` reads `RATE_LIMIT_MCP_PER_MIN` (default 30), mirroring the existing agent/API constants.
- Guard runs before auth/plan-gate on POST/GET/DELETE, keyed `mcp:ip:${ip}`; returns a CORS-wrapped 429 with `Retry-After`, consistent with the agent route.
- `wrangler.toml`: `CHM_RATE_LIMIT_MCP` binding, matching the `CHM_RATE_LIMIT_API`/`AGENT` pattern.
- Docs: new "Rate limiting" section covering all three vars — **none** were previously documented, so the pattern is no longer half-explained.

**Scope + known gaps (deliberate, flagged rather than hidden):**
- Only the in-process dashboard route is limited. `packages/mcp-server`'s `handleMcp` is untouched: that package cannot call into `apps/dashboard`'s limiter — dependency-cruiser's `no-packages-to-apps` rule forbids it. So **the standalone `apps/mcp` Worker is still unlimited** — filed as a follow-up.
- Guard is IP-only. Identity-based tightening (API-key `sub` / Clerk id, as in `agent.ts`) would require duplicating auth across the package boundary. IP still addresses the stated abuse case (unthrottled `tools/call` bursts under `CHM_MCP_PUBLIC=true`).

**Verified during integration:** rate-limit tests **4 pass, 0 fail**; `pnpm run type-check` clean.

Co-Authored-By: duyetbot <bot@duyet.net>