### PR TITLE
fix(blog): correct 14 future-dated posts and guard against recurrence (#2697)

### DIFF
--- a/apps/blog/CONTENT-CALENDAR.md
+++ b/apps/blog/CONTENT-CALENDAR.md
@@ -16,7 +16,15 @@ lead time.
 4. Add the docs cross-link in both directions (post → docs page it explains
    deeper, docs page → post for the narrative version) per the convention in
    `apps/blog/README.md`.
-5. Mark the row below `done` and move on.
+5. When flipping `draft` to `false`, set `date` to the **actual merge/publish
+   date** (today), never a pre-planned calendar slot — `date` is not a
+   scheduling field, it's what "latest" sorts by on the homepage, `/llms.txt`,
+   and RSS. `isPublished()` (`apps/blog/src/lib/published.ts`) also treats
+   `date > now` as unpublished regardless of `draft`, so a future `date` on a
+   non-draft post won't render live, it'll just silently vanish from every
+   listing until that date arrives — don't rely on that as a scheduling
+   mechanism. To genuinely schedule a post for later, keep `draft: true` until
+   its real publish day. Mark the row below `done` and move on.
 
 Release posts are the exception to "pick the next row on schedule" — scaffold
 them on demand with `pnpm run release-to-post <tag>` (from `apps/blog/`) right
@@ -33,17 +41,17 @@ published (`draft: false`, merged to main)
 |---|---|---|---|---|---|
 | 1 | release | chmonitor v0.3 — a full rebuild | clickhouse monitoring dashboard | `/guide/getting-started` | done (`chmonitor-v0-3.md`, published 2026-06-29) |
 | 2 | how-to | Alerting to Slack and Discord | clickhouse alerting webhook | `/guide/features/health` | moved to docs-only (`docs/content/guide/guides/alerting-slack-discord.mdx`), no blog post |
-| 3 | how-to | Ask your cluster anything: the AI agent over MCP | clickhouse ai agent mcp | `/guide/ai-agent` | done (`clickhouse-ai-agent-mcp.md`, published 2026-07-17) |
-| 4 | troubleshooting | Why is my ClickHouse replication lagging? | clickhouse replication lag | `/guide/features` (replication section) | done (`clickhouse-replication-lag.md`, published 2026-07-24) |
-| 5 | how-to | The query advisor: DDL recommendations you review, not that run themselves | clickhouse query optimization advisor | `/guide/ai-agent` (advisor tools) | done (`clickhouse-query-optimization-advisor.md`, published 2026-07-31) |
+| 3 | how-to | Ask your cluster anything: the AI agent over MCP | clickhouse ai agent mcp | `/guide/ai-agent` | done (`clickhouse-ai-agent-mcp.md`, published 2026-07-10) |
+| 4 | troubleshooting | Why is my ClickHouse replication lagging? | clickhouse replication lag | `/guide/features` (replication section) | done (`clickhouse-replication-lag.md`, published 2026-07-10) |
+| 5 | how-to | The query advisor: DDL recommendations you review, not that run themselves | clickhouse query optimization advisor | `/guide/ai-agent` (advisor tools) | done (`clickhouse-query-optimization-advisor.md`, published 2026-07-10) |
 | 6 | case-study | Diagnosing a slow-query regression start to finish | clickhouse slow query diagnosis | `/guide/features` | done (`find-slow-clickhouse-queries.md`, published 2026-07-10, covers this slot as a how-to) |
 | 7 | troubleshooting | Reading `system.merges` when merges pile up | clickhouse merges stuck | `/guide/features` | done (`clickhouse-system-merges-merge-storm.md`, published 2026-07-03) |
-| 8 | how-to | Self-hosting chmonitor on Docker in five minutes | self-host clickhouse dashboard docker | `/operate/deploy/docker` | done (`clickhouse-self-hosting-docker.md`, published 2026-08-14) |
-| 9 | how-to | Self-hosting chmonitor on Kubernetes | clickhouse monitoring kubernetes | `/operate/deploy/k8s` | done (`clickhouse-monitoring-kubernetes.md`, published 2026-08-21) |
-| 10 | troubleshooting | Debugging `system.errors` spikes | clickhouse system errors | `/guide/features/health` | done (`clickhouse-system-errors-spikes.md`, published 2026-08-28) |
-| 11 | case-study | Capacity planning with the TTL and disk-growth advisor | clickhouse capacity planning ttl | `/guide/ai-agent` (advisor tools) | done (`clickhouse-capacity-planning-ttl.md`, published 2026-09-04) |
+| 8 | how-to | Self-hosting chmonitor on Docker in five minutes | self-host clickhouse dashboard docker | `/operate/deploy/docker` | done (`clickhouse-self-hosting-docker.md`, published 2026-07-10) |
+| 9 | how-to | Self-hosting chmonitor on Kubernetes | clickhouse monitoring kubernetes | `/operate/deploy/k8s` | done (`clickhouse-monitoring-kubernetes.md`, published 2026-07-10) |
+| 10 | troubleshooting | Debugging `system.errors` spikes | clickhouse system errors | `/guide/features/health` | done (`clickhouse-system-errors-spikes.md`, published 2026-07-10) |
+| 11 | case-study | Capacity planning with the TTL and disk-growth advisor | clickhouse capacity planning ttl | `/guide/ai-agent` (advisor tools) | done (`clickhouse-capacity-planning-ttl.md`, published 2026-07-10) |
 | 12 | release | (scaffold from the next GitHub release when it ships) | — | `/reference/releases` | planned |
-| 13 | troubleshooting | ClickHouse disk is full — what to do right now | clickhouse disk full emergency | `/guide/features` | done (`clickhouse-disk-full-emergency.md`, published 2026-09-11) |
+| 13 | troubleshooting | ClickHouse disk is full — what to do right now | clickhouse disk full emergency | `/guide/features` | done (`clickhouse-disk-full-emergency.md`, published 2026-07-10) |
 
 ## Published this cycle (homepage redesign + SEO expansion)
 
@@ -54,12 +62,19 @@ post-title lists. Alongside it, six SEO posts were added (all reusing verified
 
 | Date | Type | Title | Target keyword | Cross-link (docs page) |
 |---|---|---|---|---|
-| 2026-10-02 | 5 min | ClickHouse skip indices that actually prune | clickhouse skip index / data skipping index | `/guide/guides/skip-indices-guide` |
-| 2026-10-09 | 5 min | Spill GROUP BY to disk instead of OOMing | clickhouse external group by / memory limit exceeded | `/guide/guides/external-group-by` |
-| 2026-10-16 | 5 min | Fix "Memory limit (total) exceeded" | clickhouse memory limit total exceeded | `/guide/guides/memory-limit-total-exceeded` |
-| 2026-10-23 | 5 min | Connect a firewalled ClickHouse to chmonitor Cloud | clickhouse behind firewall cloudflare tunnel | `/guide/guides/connect-firewalled-clickhouse` |
-| 2026-10-30 | 5 min | Upgrade ClickHouse safely while chmonitor stays connected | upgrade clickhouse safely | `/guide/guides/upgrade-clickhouse` |
-| 2026-11-06 | how-to | The 6 root causes of slow ClickHouse | clickhouse query optimization | `/guide/guides/clickhouse-query-optimization` |
+| 2026-07-10 | 5 min | ClickHouse skip indices that actually prune | clickhouse skip index / data skipping index | `/guide/guides/skip-indices-guide` |
+| 2026-07-10 | 5 min | Spill GROUP BY to disk instead of OOMing | clickhouse external group by / memory limit exceeded | `/guide/guides/external-group-by` |
+| 2026-07-10 | 5 min | Fix "Memory limit (total) exceeded" | clickhouse memory limit total exceeded | `/guide/guides/memory-limit-total-exceeded` |
+| 2026-07-10 | 5 min | Connect a firewalled ClickHouse to chmonitor Cloud | clickhouse behind firewall cloudflare tunnel | `/guide/guides/connect-firewalled-clickhouse` |
+| 2026-07-10 | 5 min | Upgrade ClickHouse safely while chmonitor stays connected | upgrade clickhouse safely | `/guide/guides/upgrade-clickhouse` |
+| 2026-07-10 | how-to | The 6 root causes of slow ClickHouse | clickhouse query optimization | `/guide/guides/clickhouse-query-optimization` |
+
+_Dates above were placeholder calendar slots written into already-published
+(`draft: false`) files instead of the actual merge date, which put these posts
+months in the future while live — see #2697. Corrected to the real
+first-commit date (`git log --diff-filter=A --format=%aI -- <file> | tail
+-1`); both PRs that added these posts landed the same day, hence the shared
+date._
 
 ## Post-type mix (per 12-week cycle)
 

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -10,6 +10,7 @@
     "preview": "astro preview",
     "build:og": "bun run scripts/build-og.ts",
     "release-to-post": "bun run scripts/release-to-post.mjs",
+    "test": "bun test src/lib",
     "cf:deploy": "wrangler deploy"
   },
   "dependencies": {

--- a/apps/blog/src/content/blog/clickhouse-ai-agent-mcp.md
+++ b/apps/blog/src/content/blog/clickhouse-ai-agent-mcp.md
@@ -1,7 +1,7 @@
 ---
 title: "Ask your ClickHouse cluster anything: the AI agent over MCP"
 description: "How chmonitor's read-only AI agent turns natural-language questions into system-table queries, and how to reach it from Claude Desktop or Cursor over MCP."
-date: 2026-07-17
+date: 2026-07-10
 tag: How-to
 ---
 

--- a/apps/blog/src/content/blog/clickhouse-capacity-planning-ttl.md
+++ b/apps/blog/src/content/blog/clickhouse-capacity-planning-ttl.md
@@ -1,7 +1,7 @@
 ---
 title: "Capacity planning with the disk-forecast and TTL advisor"
 description: "A worked example of forecasting ClickHouse disk exhaustion and getting a recommend-only TTL adjustment before an out-of-space incident happens."
-date: 2026-09-04
+date: 2026-07-10
 tag: Case study
 ---
 

--- a/apps/blog/src/content/blog/clickhouse-disk-full-emergency.md
+++ b/apps/blog/src/content/blog/clickhouse-disk-full-emergency.md
@@ -1,7 +1,7 @@
 ---
 title: "ClickHouse disk is full — what to do right now"
 description: "The emergency steps when a ClickHouse disk hits capacity: what system.disks tells you, what's safe to delete or move, and what to fix afterward."
-date: 2026-09-11
+date: 2026-07-10
 tag: Troubleshooting
 ---
 

--- a/apps/blog/src/content/blog/clickhouse-external-group-by.md
+++ b/apps/blog/src/content/blog/clickhouse-external-group-by.md
@@ -1,7 +1,7 @@
 ---
 title: "5 min of ClickHouse: spill GROUP BY to disk instead of OOMing"
 description: "A high-cardinality GROUP BY can blow past max_memory_usage and die with MEMORY_LIMIT_EXCEEDED. Here's the setting that spills it to disk, the cheaper fixes to try first, and the query that proves a spill happened."
-date: 2026-10-09
+date: 2026-07-10
 tag: 5 min of ClickHouse
 ---
 

--- a/apps/blog/src/content/blog/clickhouse-firewalled-cloud.md
+++ b/apps/blog/src/content/blog/clickhouse-firewalled-cloud.md
@@ -1,7 +1,7 @@
 ---
 title: "5 min of ClickHouse: connect a firewalled ClickHouse to chmonitor Cloud"
 description: "chmonitor Cloud runs on Cloudflare Workers with no fixed egress IP, so allowlisting Cloudflare's ranges is not a real allowlist. Here's the tunnel that works with zero inbound ports opened."
-date: 2026-10-23
+date: 2026-07-10
 tag: 5 min of ClickHouse
 ---
 

--- a/apps/blog/src/content/blog/clickhouse-memory-limit-total-exceeded.md
+++ b/apps/blog/src/content/blog/clickhouse-memory-limit-total-exceeded.md
@@ -1,7 +1,7 @@
 ---
 title: "5 min of ClickHouse: fix 'Memory limit (total) exceeded' (it's not one query)"
 description: "The server-wide 'Memory limit (total) exceeded' error is tripped by every concurrent query, merge, and cache combined — not one query's budget. Here are the queries that show what's eating RAM."
-date: 2026-10-16
+date: 2026-07-10
 tag: 5 min of ClickHouse
 ---
 

--- a/apps/blog/src/content/blog/clickhouse-monitoring-kubernetes.md
+++ b/apps/blog/src/content/blog/clickhouse-monitoring-kubernetes.md
@@ -1,7 +1,7 @@
 ---
 title: "Self-hosting chmonitor on Kubernetes"
 description: "Deploy the chmonitor ClickHouse dashboard on Kubernetes with the vendored Helm chart, including secrets, health probes, and an ingress."
-date: 2026-08-21
+date: 2026-07-10
 tag: How-to
 ---
 

--- a/apps/blog/src/content/blog/clickhouse-query-optimization-advisor.md
+++ b/apps/blog/src/content/blog/clickhouse-query-optimization-advisor.md
@@ -1,7 +1,7 @@
 ---
 title: "The query advisor: DDL recommendations you review, not that run themselves"
 description: "How chmonitor's optimization advisor turns a slow ClickHouse query into ranked skip-index, projection, and PREWHERE recommendations — and why it never applies any of them for you."
-date: 2026-07-31
+date: 2026-07-10
 tag: How-to
 ---
 

--- a/apps/blog/src/content/blog/clickhouse-query-optimization-pillars.md
+++ b/apps/blog/src/content/blog/clickhouse-query-optimization-pillars.md
@@ -1,7 +1,7 @@
 ---
 title: "The 6 root causes of slow ClickHouse (and the query that rules out each)"
 description: "Most ClickHouse slowness traces to one of six things: partition key, granularity, PREWHERE, skip index, projection vs MV, or GROUP BY memory. A diagnostic map with the system-table query to start at."
-date: 2026-11-06
+date: 2026-07-10
 tag: How-to
 ---
 

--- a/apps/blog/src/content/blog/clickhouse-replication-lag.md
+++ b/apps/blog/src/content/blog/clickhouse-replication-lag.md
@@ -1,7 +1,7 @@
 ---
 title: "Why is my ClickHouse replication lagging?"
 description: "Reading absolute_delay and queue_size from system.replicas to find and fix ClickHouse replication lag before readers see stale data."
-date: 2026-07-24
+date: 2026-07-10
 tag: Troubleshooting
 ---
 

--- a/apps/blog/src/content/blog/clickhouse-self-hosting-docker.md
+++ b/apps/blog/src/content/blog/clickhouse-self-hosting-docker.md
@@ -1,7 +1,7 @@
 ---
 title: "Self-hosting chmonitor on Docker in five minutes"
 description: "Run the chmonitor ClickHouse dashboard as a self-hosted Docker container against your own cluster, no signup or cloud account required."
-date: 2026-08-14
+date: 2026-07-10
 tag: How-to
 ---
 

--- a/apps/blog/src/content/blog/clickhouse-skip-indices-guide.md
+++ b/apps/blog/src/content/blog/clickhouse-skip-indices-guide.md
@@ -1,7 +1,7 @@
 ---
 title: "5 min of ClickHouse: skip indices that actually prune your scans"
 description: "ClickHouse secondary indices skip whole granule blocks instead of indexing rows. Here are the four index types, when each fires, and the EXPLAIN query that proves it's working."
-date: 2026-10-02
+date: 2026-07-10
 tag: 5 min of ClickHouse
 ---
 

--- a/apps/blog/src/content/blog/clickhouse-system-errors-spikes.md
+++ b/apps/blog/src/content/blog/clickhouse-system-errors-spikes.md
@@ -1,7 +1,7 @@
 ---
 title: "Debugging a spike in system.errors"
 description: "How to read system.errors error counters to find what's actually failing in ClickHouse, and why they're cumulative since server start rather than per-incident."
-date: 2026-08-28
+date: 2026-07-10
 tag: Troubleshooting
 ---
 

--- a/apps/blog/src/content/blog/clickhouse-upgrade-safely.md
+++ b/apps/blog/src/content/blog/clickhouse-upgrade-safely.md
@@ -1,7 +1,7 @@
 ---
 title: "5 min of ClickHouse: upgrade safely while chmonitor stays connected"
 description: "Pre-upgrade checks, the system-table changes that light up new dashboard pages at each version, and the post-upgrade grants sanity queries — so you upgrade ClickHouse without losing monitoring."
-date: 2026-10-30
+date: 2026-07-10
 tag: 5 min of ClickHouse
 ---
 

--- a/apps/blog/src/lib/published.test.ts
+++ b/apps/blog/src/lib/published.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test'
+import { isPublished } from './published'
+
+// Minimal stand-in for a blog collection entry's `data` — only the two
+// fields `isPublished` reads.
+function post(overrides: { draft?: boolean; date: Date }) {
+  return { draft: overrides.draft ?? false, date: overrides.date } as Parameters<
+    typeof isPublished
+  >[0]
+}
+
+describe('isPublished', () => {
+  test('rejects a future-dated post even when draft is unset (#2697)', () => {
+    const oneYearFromNow = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000)
+    expect(isPublished(post({ date: oneYearFromNow }))).toBe(false)
+  })
+
+  test('accepts a past-dated, non-draft post', () => {
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000)
+    expect(isPublished(post({ date: yesterday }))).toBe(true)
+  })
+
+  test('accepts a post dated today', () => {
+    expect(isPublished(post({ date: new Date() }))).toBe(true)
+  })
+
+  test('rejects a draft post regardless of date', () => {
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000)
+    expect(isPublished(post({ draft: true, date: yesterday }))).toBe(false)
+  })
+})

--- a/apps/blog/src/lib/published.ts
+++ b/apps/blog/src/lib/published.ts
@@ -1,0 +1,11 @@
+import type { CollectionEntry } from 'astro:content'
+
+// A blog post is publicly served when it isn't marked `draft` AND its `date`
+// is today or in the past. Every page/feed that lists posts must use this
+// instead of a raw `!data.draft` check — otherwise a future `date` (e.g. a
+// content-calendar placeholder written before the post's real publish date)
+// renders live immediately and sorts to the top of "latest" on the homepage,
+// llms.txt, and the RSS feed. See #2697.
+export function isPublished(data: CollectionEntry<'blog'>['data']): boolean {
+  return !data.draft && data.date.valueOf() <= Date.now()
+}

--- a/apps/blog/src/pages/[...slug].astro
+++ b/apps/blog/src/pages/[...slug].astro
@@ -4,9 +4,10 @@ import Base from '../layouts/Base.astro'
 import Nav from '../components/Nav.astro'
 import Footer from '../components/Footer.astro'
 import { postSlug } from '../lib/slug'
+import { isPublished } from '../lib/published'
 
 export async function getStaticPaths() {
-  const posts = await getCollection('blog', ({ data }) => !data.draft)
+  const posts = await getCollection('blog', ({ data }) => isPublished(data))
   return posts.map((post) => ({ params: { slug: postSlug(post) }, props: { post } }))
 }
 

--- a/apps/blog/src/pages/category/[tag].astro
+++ b/apps/blog/src/pages/category/[tag].astro
@@ -4,9 +4,10 @@ import Base from '../../layouts/Base.astro'
 import Nav from '../../components/Nav.astro'
 import Footer from '../../components/Footer.astro'
 import { postSlug, tagSlug, resolveTag } from '../../lib/slug'
+import { isPublished } from '../../lib/published'
 
 export async function getStaticPaths() {
-  const posts = await getCollection('blog', ({ data }) => !data.draft)
+  const posts = await getCollection('blog', ({ data }) => isPublished(data))
   const tags = [...new Set(posts.map((p) => p.data.tag))]
   return tags.map((tag) => ({
     params: { tag: tagSlug(tag) },
@@ -15,7 +16,7 @@ export async function getStaticPaths() {
 }
 
 const { tag } = Astro.props
-const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
+const posts = (await getCollection('blog', ({ data }) => isPublished(data))).sort(
   (a, b) => b.data.date.valueOf() - a.data.date.valueOf()
 )
 

--- a/apps/blog/src/pages/index.astro
+++ b/apps/blog/src/pages/index.astro
@@ -4,12 +4,13 @@ import Base from '../layouts/Base.astro'
 import Nav from '../components/Nav.astro'
 import Footer from '../components/Footer.astro'
 import { postSlug, tagSlug } from '../lib/slug'
+import { isPublished } from '../lib/published'
 
 // Cap posts shown per card on the homepage; longer categories get a
 // "View all" link to their dedicated category page.
 const MAX_PER_CARD = 6
 
-const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
+const posts = (await getCollection('blog', ({ data }) => isPublished(data))).sort(
   (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
 )
 

--- a/apps/blog/src/pages/llms.txt.ts
+++ b/apps/blog/src/pages/llms.txt.ts
@@ -1,12 +1,13 @@
 import type { APIContext } from 'astro'
 
 import { postSlug } from '../lib/slug'
+import { isPublished } from '../lib/published'
 import { getCollection } from 'astro:content'
 
 // /llms.txt — structured index of all blog posts for AI crawlers.
 // Follows the llms.txt convention: https://llmstxt.org
 export async function GET(context: APIContext) {
-  const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
+  const posts = (await getCollection('blog', ({ data }) => isPublished(data))).sort(
     (a, b) => b.data.date.valueOf() - a.data.date.valueOf()
   )
 

--- a/apps/blog/src/pages/rss.xml.ts
+++ b/apps/blog/src/pages/rss.xml.ts
@@ -1,11 +1,12 @@
 import type { APIContext } from 'astro'
 
 import { postSlug } from '../lib/slug'
+import { isPublished } from '../lib/published'
 import { getCollection } from 'astro:content'
 import rss from '@astrojs/rss'
 
 export async function GET(context: APIContext) {
-  const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
+  const posts = (await getCollection('blog', ({ data }) => isPublished(data))).sort(
     (a, b) => b.data.date.valueOf() - a.data.date.valueOf()
   )
 


### PR DESCRIPTION
Closes #2697.

14 published posts carried `date:` values months in the future (out to 2026-11-06), corrupting "latest" sort, RSS, and llms.txt.

**Root cause:** `apps/blog/CONTENT-CALENDAR.md` shows the maintainer's workflow was writing pre-planned *calendar slot* dates into `date:` on posts that were simultaneously merged with `draft` unset — i.e. already live. A process bug, not intentional scheduling.

**Rule applied** (the issue's own suggestion): use the git first-commit date as the true publish date — `git log --diff-filter=A --follow --format=%aI -- <file> | tail -1`. All 14 trace to two PRs (#2553, #2564), both merged **2026-07-10**, so all 14 now carry that date.

**Guard added** (issue's suggested approach): `apps/blog/src/lib/published.ts` exports `isPublished(data)` = `!data.draft && data.date.valueOf() <= Date.now()`, wired into all 6 call sites that previously used a raw `!data.draft` filter (`index.astro`, `[...slug].astro`, `category/[tag].astro`, `llms.txt.ts`, `rss.xml.ts`). A future-dated non-draft post now simply doesn't list, rather than corrupting "latest". `CONTENT-CALENDAR.md` updated so the process bug doesn't recur.

**Verified during integration:** `bun test src/lib` — **4 pass, 0 fail**; and **0** posts remain dated after today (latest is now 2026-07-12).

Co-Authored-By: duyetbot <bot@duyet.net>