### PR TITLE
fix(ux): surface real error detail in Health panel toasts (#2687)

### DIFF
--- a/apps/dashboard/src/components/health/alert-routing-dialog.tsx
+++ b/apps/dashboard/src/components/health/alert-routing-dialog.tsx
@@ -44,6 +44,7 @@ import {
   useAlertRoutesMutations,
   usePagerDutyServices,
 } from '@/lib/hooks/use-alert-routes'
+import { describeError } from '@/lib/swr/fetch-error'
 import { cn } from '@/lib/utils'
 
 function RouteRow({
@@ -65,7 +66,7 @@ function RouteRow({
       await deleteRoute(route.id)
       onDeleted()
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to delete route')
+      toast.error('Failed to delete route', { description: describeError(err) })
     } finally {
       setBusy(false)
     }
@@ -245,7 +246,7 @@ function AddRouteForm({ onCreated }: { onCreated: () => void }) {
       reset()
       onCreated()
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to create route')
+      toast.error('Failed to create route', { description: describeError(err) })
     } finally {
       setBusy(false)
     }

--- a/apps/dashboard/src/components/health/alert-suggestions-panel.tsx
+++ b/apps/dashboard/src/components/health/alert-suggestions-panel.tsx
@@ -26,6 +26,7 @@ import {
   useAlertSuggestionMutations,
   useAlertSuggestions,
 } from '@/lib/hooks/use-alert-suggestions'
+import { describeError } from '@/lib/swr/fetch-error'
 import { cn } from '@/lib/utils'
 
 const SOURCE_LABELS: Record<SuggestionSource, string> = {
@@ -66,9 +67,9 @@ function SuggestionCard({
       toast.success('Rule created from suggestion')
       onChanged()
     } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : 'Failed to accept suggestion'
-      )
+      toast.error('Failed to accept suggestion', {
+        description: describeError(err),
+      })
     } finally {
       setBusy(null)
     }
@@ -80,9 +81,9 @@ function SuggestionCard({
       await dismissSuggestion(suggestion.key)
       onChanged()
     } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : 'Failed to dismiss suggestion'
-      )
+      toast.error('Failed to dismiss suggestion', {
+        description: describeError(err),
+      })
     } finally {
       setBusy(null)
     }

--- a/apps/dashboard/src/components/health/health-audit-prompt-dialog.tsx
+++ b/apps/dashboard/src/components/health/health-audit-prompt-dialog.tsx
@@ -22,6 +22,7 @@ import {
   DEFAULT_AUDIT_PROMPT_OPTIONS,
   estimateTokens,
 } from '@/lib/health/audit-prompt'
+import { describeError } from '@/lib/swr/fetch-error'
 
 interface HealthAuditPromptDialogProps {
   open: boolean
@@ -97,8 +98,10 @@ export function HealthAuditPromptDialog({
       setCopied(true)
       toast.success('Audit prompt copied to clipboard')
       setTimeout(() => setCopied(false), 2000)
-    } catch {
-      toast.error('Failed to copy prompt')
+    } catch (err) {
+      // Clipboard writes fail for reasons the user can act on (no permission,
+      // or a non-secure context), so surface the browser's own reason.
+      toast.error('Failed to copy prompt', { description: describeError(err) })
     }
   }
 

--- a/apps/dashboard/src/components/health/health-settings-dialog.tsx
+++ b/apps/dashboard/src/components/health/health-settings-dialog.tsx
@@ -44,6 +44,7 @@ import {
   saveThresholds,
   type ThresholdsMap,
 } from '@/lib/health/thresholds-storage'
+import { describeError } from '@/lib/swr/fetch-error'
 
 export function HealthSettingsDialog() {
   const [open, setOpen] = useState(false)
@@ -139,8 +140,10 @@ export function HealthSettingsDialog() {
             toast.error('Browser notifications were not granted')
             return
           }
-        } catch {
-          toast.error('Failed to request browser notification permission')
+        } catch (err) {
+          toast.error('Failed to request browser notification permission', {
+            description: describeError(err),
+          })
           return
         }
       } else if (Notification.permission === 'denied') {
@@ -192,13 +195,16 @@ export function HealthSettingsDialog() {
         toast.success('Opsgenie test alert sent')
       } else {
         const body = await res.json().catch(() => null)
-        toast.error(
-          (body as { error?: { message?: string } } | null)?.error?.message ??
-            'Opsgenie test alert failed'
-        )
+        toast.error('Opsgenie test alert failed', {
+          description:
+            (body as { error?: { message?: string } } | null)?.error?.message ??
+            `HTTP ${res.status}`,
+        })
       }
-    } catch {
-      toast.error('Opsgenie test alert failed')
+    } catch (err) {
+      toast.error('Opsgenie test alert failed', {
+        description: describeError(err),
+      })
     }
   }
 
@@ -211,13 +217,16 @@ export function HealthSettingsDialog() {
         toast.success('Telegram test message sent')
       } else {
         const body = await res.json().catch(() => null)
-        toast.error(
-          (body as { error?: { message?: string } } | null)?.error?.message ??
-            'Telegram test message failed'
-        )
+        toast.error('Telegram test message failed', {
+          description:
+            (body as { error?: { message?: string } } | null)?.error?.message ??
+            `HTTP ${res.status}`,
+        })
       }
-    } catch {
-      toast.error('Telegram test message failed')
+    } catch (err) {
+      toast.error('Telegram test message failed', {
+        description: describeError(err),
+      })
     }
   }
 
@@ -228,13 +237,16 @@ export function HealthSettingsDialog() {
         toast.success('ntfy test notification sent')
       } else {
         const body = await res.json().catch(() => null)
-        toast.error(
-          (body as { error?: { message?: string } } | null)?.error?.message ??
-            'ntfy test notification failed'
-        )
+        toast.error('ntfy test notification failed', {
+          description:
+            (body as { error?: { message?: string } } | null)?.error?.message ??
+            `HTTP ${res.status}`,
+        })
       }
-    } catch {
-      toast.error('ntfy test notification failed')
+    } catch (err) {
+      toast.error('ntfy test notification failed', {
+        description: describeError(err),
+      })
     }
   }
 
@@ -248,10 +260,14 @@ export function HealthSettingsDialog() {
       if (res.ok && data?.success) {
         toast.success('Test email sent')
       } else {
-        toast.error(data?.error?.message || 'Failed to send test email')
+        toast.error('Failed to send test email', {
+          description: data?.error?.message || `HTTP ${res.status}`,
+        })
       }
-    } catch {
-      toast.error('Failed to send test email')
+    } catch (err) {
+      toast.error('Failed to send test email', {
+        description: describeError(err),
+      })
     }
   }
 

--- a/apps/dashboard/src/components/health/maintenance-windows-panel.tsx
+++ b/apps/dashboard/src/components/health/maintenance-windows-panel.tsx
@@ -30,6 +30,7 @@ import {
   useMaintenanceWindows,
   useMaintenanceWindowsMutations,
 } from '@/lib/hooks/use-maintenance-windows'
+import { describeError } from '@/lib/swr/fetch-error'
 import { useHosts } from '@/lib/swr/use-hosts'
 import { cn } from '@/lib/utils'
 
@@ -76,8 +77,10 @@ function WindowRow({
     try {
       await deleteWindow(window.id)
       onDeleted()
-    } catch {
-      toast.error('Failed to delete maintenance window')
+    } catch (err) {
+      toast.error('Failed to delete maintenance window', {
+        description: describeError(err),
+      })
     } finally {
       setBusy(false)
     }
@@ -139,9 +142,9 @@ function AddWindowForm({ onCreated }: { onCreated: () => void }) {
       setReason('')
       onCreated()
     } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : 'Failed to create window'
-      )
+      toast.error('Failed to create maintenance window', {
+        description: describeError(err),
+      })
     } finally {
       setBusy(false)
     }

--- a/apps/dashboard/src/components/health/quiet-hours-panel.tsx
+++ b/apps/dashboard/src/components/health/quiet-hours-panel.tsx
@@ -34,6 +34,7 @@ import {
   useQuietHours,
   useQuietHoursMutations,
 } from '@/lib/hooks/use-quiet-hours'
+import { describeError } from '@/lib/swr/fetch-error'
 import { cn } from '@/lib/utils'
 
 /** Sun-first labels; index is the 0–6 weekday number stored server-side. */
@@ -84,8 +85,10 @@ function QuietHoursRow({
     try {
       await deleteWindow(window.id)
       onDeleted()
-    } catch {
-      toast.error('Failed to delete quiet-hours window')
+    } catch (err) {
+      toast.error('Failed to delete quiet-hours window', {
+        description: describeError(err),
+      })
     } finally {
       setBusy(false)
     }
@@ -150,9 +153,9 @@ function AddQuietHoursForm({ onCreated }: { onCreated: () => void }) {
       toast.success('Quiet hours added')
       onCreated()
     } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : 'Failed to create quiet hours'
-      )
+      toast.error('Failed to create quiet hours', {
+        description: describeError(err),
+      })
     } finally {
       setBusy(false)
     }

--- a/apps/dashboard/src/components/health/rule-builder.tsx
+++ b/apps/dashboard/src/components/health/rule-builder.tsx
@@ -33,6 +33,7 @@ import {
   useCustomAlertRulesMutations,
   useMetricCatalog,
 } from '@/lib/hooks/use-custom-alert-rules'
+import { describeError } from '@/lib/swr/fetch-error'
 import { cn } from '@/lib/utils'
 
 function RuleRow({
@@ -57,8 +58,10 @@ function RuleRow({
     try {
       await deleteRule(rule.id)
       onDeleted()
-    } catch {
-      toast.error('Failed to delete custom rule')
+    } catch (err) {
+      toast.error('Failed to delete custom rule', {
+        description: describeError(err),
+      })
     } finally {
       setBusy(false)
     }
@@ -145,9 +148,9 @@ function AddRuleForm({ onCreated }: { onCreated: () => void }) {
       setCritical('')
       onCreated()
     } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : 'Failed to save custom rule'
-      )
+      toast.error('Failed to save custom rule', {
+        description: describeError(err),
+      })
     } finally {
       setBusy(false)
     }

--- a/apps/dashboard/src/components/health/webhook-subscriptions-panel.tsx
+++ b/apps/dashboard/src/components/health/webhook-subscriptions-panel.tsx
@@ -29,6 +29,7 @@ import {
   useWebhookSubscriptions,
   useWebhookSubscriptionsMutations,
 } from '@/lib/hooks/use-webhook-subscriptions'
+import { describeError } from '@/lib/swr/fetch-error'
 import { cn } from '@/lib/utils'
 
 function deliveryStatusVariant(
@@ -94,8 +95,10 @@ function SubscriptionRow({
     try {
       await updateSubscription(subscription.id, { enabled: checked })
       onToggled()
-    } catch {
-      toast.error('Failed to update subscription')
+    } catch (err) {
+      toast.error('Failed to update subscription', {
+        description: describeError(err),
+      })
     } finally {
       setBusy(false)
     }
@@ -106,8 +109,10 @@ function SubscriptionRow({
     try {
       await deleteSubscription(subscription.id)
       onDeleted()
-    } catch {
-      toast.error('Failed to delete subscription')
+    } catch (err) {
+      toast.error('Failed to delete subscription', {
+        description: describeError(err),
+      })
     } finally {
       setBusy(false)
     }
@@ -120,12 +125,14 @@ function SubscriptionRow({
       if (outcome.status === 'delivered') {
         toast.success('Test webhook delivered')
       } else {
-        toast.error(
-          `Test webhook failed: ${outcome.lastError ?? `status ${outcome.status}`}`
-        )
+        toast.error('Test webhook failed', {
+          description: outcome.lastError ?? `status ${outcome.status}`,
+        })
       }
-    } catch {
-      toast.error('Failed to send test webhook')
+    } catch (err) {
+      toast.error('Failed to send test webhook', {
+        description: describeError(err),
+      })
     } finally {
       setBusy(false)
     }
@@ -222,9 +229,9 @@ function AddSubscriptionForm({ onCreated }: { onCreated: () => void }) {
       setSelected(new Set())
       onCreated()
     } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : 'Failed to create subscription'
-      )
+      toast.error('Failed to create subscription', {
+        description: describeError(err),
+      })
     } finally {
       setBusy(false)
     }

--- a/apps/dashboard/src/lib/swr/fetch-error.test.ts
+++ b/apps/dashboard/src/lib/swr/fetch-error.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for `describeError` (fetch-error.ts).
+ *
+ * These encode the reason the helper exists (issue #2687): a failed mutation
+ * must tell the user *why* it failed — a 403 must not look identical to a 500
+ * or to a dropped connection — while never rendering a toast description that
+ * adds nothing over the caller's own title.
+ */
+
+import { describe, expect, it } from 'bun:test'
+
+import type { FetchError } from './fetch-error'
+
+import { describeError, throwIfNotOk } from './fetch-error'
+
+function fetchError(message: string, status?: number): FetchError {
+  const err = new Error(message) as FetchError
+  if (status !== undefined) err.status = status
+  return err
+}
+
+describe('describeError', () => {
+  it("surfaces the server's message for a permission failure", () => {
+    expect(describeError(fetchError('Not enough privileges', 403))).toBe(
+      'Not enough privileges (HTTP 403)'
+    )
+  })
+
+  it('distinguishes a 500 from a 403 with the same message', () => {
+    const forbidden = describeError(fetchError('Request failed', 403))
+    const serverError = describeError(fetchError('Request failed', 500))
+    expect(forbidden).not.toBe(serverError)
+  })
+
+  it('describes a network drop, which carries no HTTP status', () => {
+    expect(describeError(new TypeError('Failed to fetch'))).toBe(
+      'Failed to fetch'
+    )
+  })
+
+  it('does not repeat a status the message already carries', () => {
+    // `throwIfNotOk` builds "<fallback>: <statusText>" messages, and some APIs
+    // put the code in the message itself — don't render "... 503 (HTTP 503)".
+    expect(describeError(fetchError('Upstream returned 503', 503))).toBe(
+      'Upstream returned 503'
+    )
+  })
+
+  it('falls back to the bare status when there is no message', () => {
+    expect(describeError(fetchError('', 502))).toBe('HTTP 502')
+  })
+
+  it('returns undefined when the error says nothing, so no empty description', () => {
+    expect(describeError(new Error(''))).toBeUndefined()
+    expect(describeError(undefined)).toBeUndefined()
+    expect(describeError(null)).toBeUndefined()
+    expect(describeError({})).toBeUndefined()
+  })
+
+  it('accepts a thrown string', () => {
+    expect(describeError('boom')).toBe('boom')
+  })
+
+  it('describes what throwIfNotOk actually throws', async () => {
+    const response = new Response(
+      JSON.stringify({ error: { message: 'Subscription not found' } }),
+      { status: 404, headers: { 'content-type': 'application/json' } }
+    )
+
+    const err = await throwIfNotOk(response, 'Failed to delete subscription')
+      .then(() => null)
+      .catch((e: unknown) => e)
+
+    expect(describeError(err)).toBe('Subscription not found (HTTP 404)')
+  })
+})

--- a/apps/dashboard/src/lib/swr/fetch-error.ts
+++ b/apps/dashboard/src/lib/swr/fetch-error.ts
@@ -24,6 +24,35 @@ export interface FetchError extends Error {
   metadata?: ApiErrorBody['metadata']
 }
 
+/**
+ * Human-readable detail for a failed request, for a toast `description`.
+ *
+ * The panels pair this with their own action-specific title ("Failed to delete
+ * subscription"), so the toast keeps saying *what* failed while this adds *why*
+ * — the server's message and/or the HTTP status, which is what distinguishes a
+ * 403 from a 500 from a dropped connection.
+ *
+ * Returns `undefined` when the error carries nothing beyond what the caller's
+ * title already says, so the toast renders clean rather than with an empty or
+ * meaningless second line.
+ */
+export function describeError(err: unknown): string | undefined {
+  const message =
+    err instanceof Error
+      ? err.message.trim()
+      : typeof err === 'string'
+        ? err.trim()
+        : ''
+  const status = err instanceof Error ? (err as FetchError).status : undefined
+
+  if (!message) return status ? `HTTP ${status}` : undefined
+  // `throwIfNotOk` already appends statusText to its fallback message, so only
+  // add the status when the message doesn't already carry it.
+  return status !== undefined && !message.includes(String(status))
+    ? `${message} (HTTP ${status})`
+    : message
+}
+
 export async function throwIfNotOk(
   response: Response,
   fallbackMessage = 'Request failed'


### PR DESCRIPTION
Partially addresses #2687 — fixes **19 sites across all of `components/health/`**. Remaining ~28 tracked in **#2729** (a 47-site sweep in one PR would be unreviewable).

## Key finding: the error detail already existed
The panels' mutation hooks **already** throw a `FetchError` carrying the server's message *and* HTTP status, built by `throwIfNotOk` (`lib/swr/fetch-error.ts:27`). The `catch {}` blocks were discarding data that was already right there — no new plumbing needed, just stop dropping it.

Adds `describeError(err)` (pure — `lib/` never imports sonner, so the toast call stays at the component) paired with each panel's existing action-specific string:
```ts
toast.error('Failed to delete subscription', { description: describeError(err) })
```

## Two deliberate deviations from the issue
1. **Title + description, not the issue's `toast.error(err.message ?? fallback)`.** That pattern *replaces* the title, so the user sees a bare `Code: 516` with no idea which action failed. Title+description keeps *what* and adds *why*. This also converged the 7 sites already using the issue's pattern onto one shape — otherwise the directory carries two competing conventions.
2. **Did not reuse `connection-errors.ts`.** Read it as instructed; it's a genuine misfit — its `fix` copy is all ClickHouse host URLs/ports ("Confirm the port… 8443 HTTPS"), which is *wrong advice* for a failed webhook delete. Forcing it here would produce confidently wrong guidance. It fits `connection-form.tsx:133` exactly, which is why #2729 names that the best next PR.

**Left alone (legitimate):** `quiet-hours-panel.tsx:46,58` — `Intl` feature-detection fallbacks. Self-evident from the code; no comment added rather than add noise.

Also note: the issue's count of 42 has drifted — the real number is **47**, and its `rg` scoped to `src/components`, missing `lib/` (a separate data-layer problem, out of scope).

**Verified during integration:** `bun test src/lib/swr/fetch-error.test.ts` — **8 pass, 0 fail**; `pnpm run type-check` clean.

Co-Authored-By: duyetbot <bot@duyet.net>