### PR TITLE
feat(alerts): Pushover delivery channel (#2659)

### DIFF
--- a/apps/dashboard/src/components/health/alert-routing-dialog.tsx
+++ b/apps/dashboard/src/components/health/alert-routing-dialog.tsx
@@ -36,6 +36,7 @@ import {
 import {
   fireNtfyTest,
   firePagerDutyTest,
+  firePushoverTest,
   fireTelegramTest,
   fireWebhook,
 } from '@/lib/health/alert-dispatcher'
@@ -58,6 +59,7 @@ function RouteRow({
   const isPagerDuty = route.provider === 'pagerduty'
   const isTelegram = route.provider === 'telegram'
   const isNtfy = route.provider === 'ntfy'
+  const isPushover = route.provider === 'pushover'
 
   const handleDelete = async () => {
     setBusy(true)
@@ -119,6 +121,16 @@ function RouteRow({
         else toast.error('ntfy request failed')
         return
       }
+      // Same tradeoff as PagerDuty/Telegram above: a Pushover route's
+      // application token is a masked secret never returned to the client
+      // after storage, so an existing route can only be re-tested by
+      // re-creating it.
+      if (isPushover) {
+        toast.info(
+          'Re-create the route to send another Pushover test notification (the token is never re-shown once saved).'
+        )
+        return
+      }
       const ok = await fireWebhook(testAlert, route.channelUrl)
       if (ok) toast.success('Test alert sent')
       else toast.error('Webhook request failed')
@@ -134,6 +146,7 @@ function RouteRow({
           {isPagerDuty && <Badge variant="default">PagerDuty</Badge>}
           {isTelegram && <Badge variant="default">Telegram</Badge>}
           {isNtfy && <Badge variant="default">ntfy</Badge>}
+          {isPushover && <Badge variant="default">Pushover</Badge>}
           <Badge variant="outline">rule: {route.matchRule}</Badge>
           <Badge variant="outline">host: {route.matchHost}</Badge>
           {!route.enabled && <Badge variant="secondary">disabled</Badge>}
@@ -145,7 +158,9 @@ function RouteRow({
               ? `chat ${route.telegramChatId} — bot ${route.telegramBotTokenMasked}`
               : isNtfy
                 ? `${route.ntfyUrl}${route.ntfyTokenMasked ? ` — token ${route.ntfyTokenMasked}` : ''}`
-                : route.channelUrl}
+                : isPushover
+                  ? `user ${route.pushoverUser} — token ${route.pushoverTokenMasked}`
+                  : route.channelUrl}
         </span>
       </div>
       <div className="flex shrink-0 items-center gap-2">
@@ -177,6 +192,8 @@ function AddRouteForm({ onCreated }: { onCreated: () => void }) {
   const [tgChatId, setTgChatId] = useState('')
   const [ntfyUrl, setNtfyUrl] = useState('')
   const [ntfyToken, setNtfyToken] = useState('')
+  const [poToken, setPoToken] = useState('')
+  const [poUser, setPoUser] = useState('')
   const [busy, setBusy] = useState(false)
   const { createRoute } = useAlertRoutesMutations()
   const { services: pdServices, isLoading: pdServicesLoading } =
@@ -193,6 +210,8 @@ function AddRouteForm({ onCreated }: { onCreated: () => void }) {
     setTgChatId('')
     setNtfyUrl('')
     setNtfyToken('')
+    setPoToken('')
+    setPoUser('')
   }
 
   const handleSubmit = async () => {
@@ -209,6 +228,11 @@ function AddRouteForm({ onCreated }: { onCreated: () => void }) {
     } else if (provider === 'ntfy') {
       if (!ntfyUrl.trim()) {
         toast.error('Enter the ntfy topic URL')
+        return
+      }
+    } else if (provider === 'pushover') {
+      if (!poToken.trim() || !poUser.trim()) {
+        toast.error('Enter the Pushover application token and user key')
         return
       }
     } else if (!channelUrl.trim()) {
@@ -239,7 +263,13 @@ function AddRouteForm({ onCreated }: { onCreated: () => void }) {
                   ntfyUrl: ntfyUrl.trim(),
                   ntfyToken: ntfyToken.trim() || undefined,
                 }
-              : { channelUrl: channelUrl.trim() }),
+              : provider === 'pushover'
+                ? {
+                    provider: 'pushover',
+                    pushoverToken: poToken.trim(),
+                    pushoverUser: poUser.trim(),
+                  }
+                : { channelUrl: channelUrl.trim() }),
       })
       toast.success('Route created')
       reset()
@@ -320,6 +350,21 @@ function AddRouteForm({ onCreated }: { onCreated: () => void }) {
     }
   }
 
+  const handleSendPushoverTest = async () => {
+    if (!poToken.trim() || !poUser.trim()) {
+      toast.error('Enter the Pushover application token and user key')
+      return
+    }
+    setBusy(true)
+    try {
+      const ok = await firePushoverTest(poToken.trim(), poUser.trim())
+      if (ok) toast.success('Test notification sent to Pushover')
+      else toast.error('Pushover request failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
   return (
     <div className="flex flex-col gap-2 rounded-md border p-3">
       <Label className="text-sm font-medium">Add route</Label>
@@ -339,6 +384,7 @@ function AddRouteForm({ onCreated }: { onCreated: () => void }) {
             <SelectItem value="pagerduty">PagerDuty service</SelectItem>
             <SelectItem value="telegram">Telegram chat</SelectItem>
             <SelectItem value="ntfy">ntfy topic</SelectItem>
+            <SelectItem value="pushover">Pushover user</SelectItem>
           </SelectContent>
         </Select>
       </div>
@@ -488,6 +534,42 @@ function AddRouteForm({ onCreated }: { onCreated: () => void }) {
             className="self-start"
             disabled={busy}
             onClick={handleSendNtfyTest}
+          >
+            Send test notification
+          </Button>
+        </>
+      ) : provider === 'pushover' ? (
+        <>
+          <Label
+            htmlFor="route-pushover-token"
+            className="text-xs text-muted-foreground"
+          >
+            Application API token
+          </Label>
+          <Input
+            id="route-pushover-token"
+            placeholder="a1b2c3..."
+            value={poToken}
+            onChange={(e) => setPoToken(e.target.value)}
+          />
+          <Label
+            htmlFor="route-pushover-user"
+            className="text-xs text-muted-foreground"
+          >
+            User (or group) key
+          </Label>
+          <Input
+            id="route-pushover-user"
+            placeholder="u1v2w3..."
+            value={poUser}
+            onChange={(e) => setPoUser(e.target.value)}
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            className="self-start"
+            disabled={busy}
+            onClick={handleSendPushoverTest}
           >
             Send test notification
           </Button>

--- a/apps/dashboard/src/components/health/health-settings-dialog.tsx
+++ b/apps/dashboard/src/components/health/health-settings-dialog.tsx
@@ -59,6 +59,9 @@ export function HealthSettingsDialog() {
   const [ntfyStatus, setNtfyStatus] = useState<{
     configured: boolean
   } | null>(null)
+  const [pushoverStatus, setPushoverStatus] = useState<{
+    configured: boolean
+  } | null>(null)
 
   useEffect(() => {
     if (!open) return
@@ -80,6 +83,12 @@ export function HealthSettingsDialog() {
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => setNtfyStatus(data as { configured: boolean } | null))
       .catch(() => setNtfyStatus(null))
+    fetch('/api/v1/health/pushover-test')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) =>
+        setPushoverStatus(data as { configured: boolean } | null)
+      )
+      .catch(() => setPushoverStatus(null))
   }, [open])
 
   const handleThresholdChange = (
@@ -235,6 +244,25 @@ export function HealthSettingsDialog() {
       }
     } catch {
       toast.error('ntfy test notification failed')
+    }
+  }
+
+  const handleTestPushover = async () => {
+    try {
+      const res = await fetch('/api/v1/health/pushover-test', {
+        method: 'POST',
+      })
+      if (res.ok) {
+        toast.success('Pushover test notification sent')
+      } else {
+        const body = await res.json().catch(() => null)
+        toast.error(
+          (body as { error?: { message?: string } } | null)?.error?.message ??
+            'Pushover test notification failed'
+        )
+      }
+    } catch {
+      toast.error('Pushover test notification failed')
     }
   }
 
@@ -605,6 +633,40 @@ export function HealthSettingsDialog() {
                     size="sm"
                     onClick={handleTestNtfy}
                     disabled={!ntfyStatus?.configured}
+                  >
+                    Send test
+                  </Button>
+                </div>
+
+                <Separator />
+
+                <div className="flex items-center justify-between rounded-md border p-3">
+                  <div className="flex flex-col">
+                    <div className="flex items-center gap-2">
+                      <Label className="text-sm font-medium">
+                        Pushover alerts
+                      </Label>
+                      <Badge
+                        variant={
+                          pushoverStatus?.configured ? 'default' : 'secondary'
+                        }
+                      >
+                        {pushoverStatus?.configured
+                          ? 'Configured'
+                          : 'Not configured'}
+                      </Badge>
+                    </div>
+                    <span className="text-xs text-muted-foreground">
+                      Set HEALTH_ALERT_PUSHOVER_TOKEN and
+                      HEALTH_ALERT_PUSHOVER_USER on the server to enable — the
+                      token is never exposed to the browser
+                    </span>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleTestPushover}
+                    disabled={!pushoverStatus?.configured}
                   >
                     Send test
                   </Button>

--- a/apps/dashboard/src/db/conversations-migrations/0024_alert_routes_pushover.sql
+++ b/apps/dashboard/src/db/conversations-migrations/0024_alert_routes_pushover.sql
@@ -1,0 +1,19 @@
+-- Pushover alert channel routing (feat #2659): extend the plan-30
+-- `alert_routes` table again rather than shipping a separate schema, exactly
+-- as plan 34 did for PagerDuty, 0019 did for Telegram, and 0021 did for ntfy.
+-- A route's `provider` may now also be `'pushover'` — delivering the finding
+-- to a Pushover user/group by POSTing to the fixed Messages API endpoint
+-- (https://api.pushover.net/1/messages.json) with `pushover_token` +
+-- `pushover_user`. Existing rows keep `provider = 'webhook'` so plan-30/34
+-- behavior is unchanged.
+--
+-- Unlike ntfy's operator-supplied topic URL, the Pushover Messages API host is
+-- fixed (mirrors the Telegram Bot API) — so `pushover_token`/`pushover_user`
+-- are not run through the SSRF guard the way `ntfy_url` is. `pushover_token`
+-- is a bare secret (an application API token), stored at rest the same way
+-- `telegram_bot_token` / `routing_key` are and masked (never returned in full)
+-- by the routes API; `pushover_user` (a user/group key) is not a secret on its
+-- own — like `telegram_chat_id`, it identifies the recipient but cannot be
+-- used to send messages without a valid app token — so it is returned as-is.
+ALTER TABLE alert_routes ADD COLUMN pushover_token TEXT;
+ALTER TABLE alert_routes ADD COLUMN pushover_user TEXT;

--- a/apps/dashboard/src/lib/health/adapters/__tests__/pushover.test.ts
+++ b/apps/dashboard/src/lib/health/adapters/__tests__/pushover.test.ts
@@ -1,0 +1,138 @@
+import type { AlertPayload } from '../types'
+
+import {
+  buildPushoverBody,
+  buildPushoverMessage,
+  pushoverAdapter,
+} from '../pushover'
+import { describe, expect, test } from 'bun:test'
+
+const CRITICAL: AlertPayload = {
+  severity: 'critical',
+  hostLabel: 'prod-1',
+  hostId: 2,
+  metric: 'failed-mutations',
+  value: 7,
+  warnThreshold: 1,
+  critThreshold: 5,
+  title: 'Failed mutations',
+  label: '7 failed mutations',
+  timestamp: '2026-07-02T10:00:00.000Z',
+}
+
+const WARNING: AlertPayload = { ...CRITICAL, severity: 'warning', value: 3 }
+const RECOVERY: AlertPayload = {
+  ...CRITICAL,
+  severity: 'recovery',
+  value: 0,
+  label: 'recovered',
+}
+
+describe('buildPushoverMessage — severity → priority', () => {
+  test('critical maps to priority 2 (emergency) with retry/expire', () => {
+    const msg = buildPushoverMessage(CRITICAL)
+    expect(msg.priority).toBe('2')
+    expect(msg.retry).toBe('60')
+    expect(msg.expire).toBe('3600')
+    expect(msg.title).toBe('[CRITICAL] Failed mutations')
+  })
+
+  test('warning maps to priority 0 (normal), no retry/expire', () => {
+    const msg = buildPushoverMessage(WARNING)
+    expect(msg.priority).toBe('0')
+    expect(msg.retry).toBeUndefined()
+    expect(msg.expire).toBeUndefined()
+    expect(msg.title).toBe('[WARNING] Failed mutations')
+  })
+
+  test('recovery maps to priority -1 (low, quiet) and RECOVERY heading', () => {
+    const msg = buildPushoverMessage(RECOVERY)
+    expect(msg.priority).toBe('-1')
+    expect(msg.retry).toBeUndefined()
+    expect(msg.expire).toBeUndefined()
+    expect(msg.title).toBe('[RECOVERY] Failed mutations')
+  })
+})
+
+describe('buildPushoverMessage — timestamp', () => {
+  test('converts the ISO timestamp to Unix seconds', () => {
+    const { timestamp } = buildPushoverMessage(CRITICAL)
+    expect(timestamp).toBe(
+      Math.floor(Date.parse('2026-07-02T10:00:00.000Z') / 1000)
+    )
+  })
+
+  test('falls back to "now" for an unparseable timestamp', () => {
+    const before = Math.floor(Date.now() / 1000)
+    const { timestamp } = buildPushoverMessage({
+      ...CRITICAL,
+      timestamp: 'not-a-date',
+    })
+    const after = Math.floor(Date.now() / 1000)
+    expect(timestamp).toBeGreaterThanOrEqual(before)
+    expect(timestamp).toBeLessThanOrEqual(after)
+  })
+})
+
+describe('buildPushoverMessage — message body', () => {
+  test('includes host, metric, value, thresholds, detail', () => {
+    const { message } = buildPushoverMessage(CRITICAL)
+    expect(message).toContain('Host: prod-1 (id 2)')
+    expect(message).toContain('Metric: failed-mutations')
+    expect(message).toContain('Value: 7')
+    expect(message).toContain('Thresholds: warn 1 | crit 5')
+    expect(message).toContain('Detail: 7 failed mutations')
+  })
+
+  test('renders n/a for a null value and omits absent thresholds', () => {
+    const { message } = buildPushoverMessage({
+      ...CRITICAL,
+      value: null,
+      warnThreshold: null,
+      critThreshold: null,
+    })
+    expect(message).toContain('Value: n/a')
+    expect(message).not.toContain('Thresholds:')
+  })
+
+  test('lists runbook urls when present, and sets url to the first one', () => {
+    const { message, url } = buildPushoverMessage({
+      ...CRITICAL,
+      runbookUrls: [
+        'https://runbook.example/mutations',
+        'https://runbook.example/other',
+      ],
+    })
+    expect(message).toContain('Runbooks:')
+    expect(message).toContain('- https://runbook.example/mutations')
+    expect(url).toBe('https://runbook.example/mutations')
+  })
+
+  test('omits url when there are no runbooks', () => {
+    const { url } = buildPushoverMessage(CRITICAL)
+    expect(url).toBeUndefined()
+  })
+})
+
+describe('buildPushoverBody', () => {
+  test('includes token + user alongside the message fields', () => {
+    const body = buildPushoverBody(CRITICAL, { token: 'app_tok', user: 'usr_key' })
+    expect(body.token).toBe('app_tok')
+    expect(body.user).toBe('usr_key')
+    expect(body.title).toBe('[CRITICAL] Failed mutations')
+    expect(body.priority).toBe('2')
+  })
+})
+
+describe('pushoverAdapter', () => {
+  test('buildBody returns the rendered message (no token/user)', () => {
+    expect(pushoverAdapter.id).toBe('pushover')
+    expect(pushoverAdapter.buildBody(CRITICAL)).toEqual(
+      buildPushoverMessage(CRITICAL)
+    )
+  })
+
+  test('has no URL detector (dispatched by config, not URL routing)', () => {
+    expect(pushoverAdapter.detect).toBeUndefined()
+  })
+})

--- a/apps/dashboard/src/lib/health/adapters/index.ts
+++ b/apps/dashboard/src/lib/health/adapters/index.ts
@@ -24,6 +24,11 @@ export type {
   PagerDutyEventBody,
   PagerDutySeverity,
 } from './pagerduty'
+export type {
+  PushoverConfig,
+  PushoverMessage,
+  PushoverMessageBody,
+} from './pushover'
 export type { SlackWebhookBody } from './slack'
 export type { TelegramConfig, TelegramSendMessageBody } from './telegram'
 export type {
@@ -48,6 +53,11 @@ export {
   pagerDutyAdapter,
   pagerDutyDedupKey,
 } from './pagerduty'
+export {
+  buildPushoverBody,
+  buildPushoverMessage,
+  pushoverAdapter,
+} from './pushover'
 export { buildSlackBody, slackAdapter } from './slack'
 export {
   buildTelegramBody,

--- a/apps/dashboard/src/lib/health/adapters/pushover.ts
+++ b/apps/dashboard/src/lib/health/adapters/pushover.ts
@@ -1,0 +1,151 @@
+/**
+ * Pushover notification adapter (pure formatter).
+ *
+ * Pushover (https://pushover.net) delivers a push notification by POSTing to
+ * the fixed Messages API endpoint
+ * (`https://api.pushover.net/1/messages.json`) with `token` (the application
+ * API token) and `user` (the target user/group key) plus the message fields.
+ * Pushover accepts either a form-encoded or a JSON-encoded body (see
+ * https://pushover.net/api) — this module uses JSON, mirroring
+ * `adapters/telegram.ts`.
+ *
+ * This module only SHAPES the message fields from an {@link AlertPayload};
+ * the caller (dispatch layer) owns `token`/`user` and the actual `fetch`.
+ * Pure — no network, no side effects — so it is trivially unit-tested,
+ * mirroring `adapters/ntfy.ts` / `adapters/telegram.ts`.
+ *
+ * Severity → priority mapping (per issue #2659):
+ *   critical → priority 2 (emergency — requires ack, retried until it expires)
+ *   warning  → priority 0 (normal)
+ *   recovery → priority -1 (low — quiet, no sound/vibration)
+ */
+
+import type { AlertPayload, AlertSeverity, NotificationAdapter } from './types'
+
+/** Severity → Pushover priority (`-1` low, `0` normal, `2` emergency). */
+const SEVERITY_PRIORITY: Record<AlertSeverity, '-1' | '0' | '2'> = {
+  critical: '2',
+  warning: '0',
+  recovery: '-1',
+}
+
+/**
+ * Emergency-priority (2) retry/expire, in seconds — REQUIRED by the Pushover
+ * API whenever `priority` is `2` (it 400s without them). Retries the
+ * notification every 60s, for up to 1 hour, until the operator acknowledges
+ * it — sane defaults for a monitoring alert (Pushover's own limits: `retry`
+ * >= 30s, `expire` <= 10800s/3h).
+ */
+const EMERGENCY_RETRY_SECONDS = '60'
+const EMERGENCY_EXPIRE_SECONDS = '3600'
+
+/** Caller-supplied Pushover transport config. */
+export interface PushoverConfig {
+  /** Application API token. */
+  token: string
+  /** Target user or group key. */
+  user: string
+}
+
+/** The rendered Pushover message fields (excludes `token`/`user`). */
+export interface PushoverMessage {
+  title: string
+  message: string
+  priority: '-1' | '0' | '2'
+  /** Unix timestamp (seconds), matching the Pushover API's `timestamp` field. */
+  timestamp: number
+  /** Required alongside `priority: '2'` — resend interval, in seconds. */
+  retry?: string
+  /** Required alongside `priority: '2'` — how long Pushover keeps retrying. */
+  expire?: string
+  /** Optional supplementary URL (first runbook link, when present). */
+  url?: string
+}
+
+/** Body shape for the Pushover Messages API (`token`/`user` + the message). */
+export interface PushoverMessageBody extends PushoverMessage {
+  token: string
+  user: string
+}
+
+/** `RECOVERY` for a resolved incident, otherwise the uppercased severity. */
+function heading(severity: AlertSeverity): string {
+  return severity === 'recovery' ? 'RECOVERY' : severity.toUpperCase()
+}
+
+/**
+ * Build the Pushover message fields (title/message/priority/…) for a
+ * payload. Exported so tests and the dispatch layer can assert the rendered
+ * shape independent of the `token`/`user` wrapper.
+ */
+export function buildPushoverMessage(payload: AlertPayload): PushoverMessage {
+  const lines: string[] = [
+    `Host: ${payload.hostLabel} (id ${payload.hostId})`,
+    `Metric: ${payload.metric}`,
+    `Value: ${payload.value === null ? 'n/a' : payload.value}`,
+  ]
+
+  const thresholds: string[] = []
+  if (payload.warnThreshold !== undefined && payload.warnThreshold !== null) {
+    thresholds.push(`warn ${payload.warnThreshold}`)
+  }
+  if (payload.critThreshold !== undefined && payload.critThreshold !== null) {
+    thresholds.push(`crit ${payload.critThreshold}`)
+  }
+  if (thresholds.length > 0) {
+    lines.push(`Thresholds: ${thresholds.join(' | ')}`)
+  }
+
+  lines.push(`Detail: ${payload.label}`)
+
+  if (payload.runbookUrls && payload.runbookUrls.length > 0) {
+    lines.push('')
+    lines.push('Runbooks:')
+    for (const url of payload.runbookUrls) lines.push(`- ${url}`)
+  }
+
+  const priority = SEVERITY_PRIORITY[payload.severity]
+  const parsedMs = Date.parse(payload.timestamp)
+  const timestamp = Number.isFinite(parsedMs)
+    ? Math.floor(parsedMs / 1000)
+    : Math.floor(Date.now() / 1000)
+
+  return {
+    title: `[${heading(payload.severity)}] ${payload.title}`,
+    message: lines.join('\n'),
+    priority,
+    timestamp,
+    ...(priority === '2'
+      ? { retry: EMERGENCY_RETRY_SECONDS, expire: EMERGENCY_EXPIRE_SECONDS }
+      : {}),
+    ...(payload.runbookUrls?.[0] ? { url: payload.runbookUrls[0] } : {}),
+  }
+}
+
+/**
+ * Build the full Pushover Messages API request body: `token` + `user` plus
+ * the rendered message fields.
+ */
+export function buildPushoverBody(
+  payload: AlertPayload,
+  config: PushoverConfig
+): PushoverMessageBody {
+  return {
+    token: config.token,
+    user: config.user,
+    ...buildPushoverMessage(payload),
+  }
+}
+
+/**
+ * Pushover adapter. `buildBody` returns the message fields only — `token`
+ * and `user` travel via {@link buildPushoverBody}, which the dispatch layer
+ * calls directly with its resolved config. Deliberately NOT registered in
+ * `ADAPTERS` (see `adapters/index.ts`) and has no `detect`: Pushover's
+ * endpoint is fixed (`api.pushover.net`), so it is selected by env/route
+ * config, not by detecting a webhook URL — same reasoning as `ntfyAdapter`.
+ */
+export const pushoverAdapter: NotificationAdapter = {
+  id: 'pushover',
+  buildBody: (payload: AlertPayload) => buildPushoverMessage(payload),
+}

--- a/apps/dashboard/src/lib/health/alert-dispatcher.ts
+++ b/apps/dashboard/src/lib/health/alert-dispatcher.ts
@@ -342,6 +342,38 @@ export async function fireNtfyTest(
   }
 }
 
+/**
+ * Send a test Pushover notification to a specific application token + user
+ * key, via the dedicated `/api/v1/health/pushover-test` route (#2659). The
+ * Pushover Messages API host is fixed (`api.pushover.net`), same as
+ * Telegram's Bot API — but unlike Telegram, this rides a dedicated route
+ * (like ntfy) rather than the generic `/health/webhook` proxy, since the
+ * `retry`/`expire` fields for an emergency-priority alert are easiest to
+ * build server-side alongside the env-global test path. The token is only
+ * ever sent to our own server at creation time (the user just typed it),
+ * never echoed back to the client after storage.
+ */
+export async function firePushoverTest(
+  token: string,
+  user: string
+): Promise<boolean> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 10_000)
+  try {
+    const res = await fetch('/api/v1/health/pushover-test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token, user }),
+      signal: controller.signal,
+    })
+    return res.ok
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
 export async function dispatchAlert(alert: HealthAlertEvent): Promise<void> {
   try {
     const settings = loadAlertSettings()

--- a/apps/dashboard/src/lib/health/alert-routing.test.ts
+++ b/apps/dashboard/src/lib/health/alert-routing.test.ts
@@ -31,6 +31,8 @@ interface FakeRow {
   telegram_chat_id?: string | null
   ntfy_url?: string | null
   ntfy_token?: string | null
+  pushover_token?: string | null
+  pushover_user?: string | null
 }
 
 function makeFakeD1() {
@@ -61,6 +63,8 @@ function makeFakeD1() {
                 telegram_chat_id,
                 ntfy_url,
                 ntfy_token,
+                pushover_token,
+                pushover_user,
               ] = params as [
                 string,
                 string,
@@ -70,6 +74,8 @@ function makeFakeD1() {
                 number,
                 number,
                 string,
+                string | null,
+                string | null,
                 string | null,
                 string | null,
                 string | null,
@@ -92,6 +98,8 @@ function makeFakeD1() {
                 telegram_chat_id,
                 ntfy_url,
                 ntfy_token,
+                pushover_token,
+                pushover_user,
               })
               return { meta: { changes: 1 } }
             }
@@ -148,6 +156,7 @@ const {
   matchRoutes,
   resolveNtfyTargets,
   resolvePagerDutyTargets,
+  resolvePushoverTargets,
   resolveTargets,
   resolveTelegramTargets,
 } = await import('./alert-routing')
@@ -170,6 +179,8 @@ function route(overrides: Partial<AlertRoute> = {}): AlertRoute {
     telegramChatId: null,
     ntfyUrl: null,
     ntfyToken: null,
+    pushoverToken: null,
+    pushoverUser: null,
     ...overrides,
   }
 }
@@ -552,6 +563,92 @@ describe('resolveNtfyTargets (pure) — #2657', () => {
   })
 })
 
+describe('resolvePushoverTargets (pure) — #2659', () => {
+  const ENV_FALLBACK = { token: 'env-tok', user: 'env-user' }
+
+  test('matches a pushover route and returns its token + user', () => {
+    const r = route({
+      matchRule: 'disk-usage',
+      provider: 'pushover',
+      pushoverToken: 'app_tok',
+      pushoverUser: 'usr_key',
+    })
+    expect(resolvePushoverTargets([r], TARGET, null)).toEqual([
+      { token: 'app_tok', user: 'usr_key' },
+    ])
+  })
+
+  test('matches a pushover route via glob and the * host wildcard', () => {
+    const r = route({
+      matchRule: 'disk-*',
+      matchHost: '*',
+      provider: 'pushover',
+      pushoverToken: 'app_tok',
+      pushoverUser: 'usr_key',
+    })
+    expect(resolvePushoverTargets([r], TARGET, null)).toEqual([
+      { token: 'app_tok', user: 'usr_key' },
+    ])
+  })
+
+  test('ignores webhook-provider routes even if matched', () => {
+    const r = route({ matchRule: 'disk-usage', provider: 'webhook' })
+    expect(resolvePushoverTargets([r], TARGET, ENV_FALLBACK)).toEqual([])
+  })
+
+  test('a matched webhook route suppresses the env Pushover fallback (no double-fire)', () => {
+    const webhook = route({ matchRule: 'disk-usage', provider: 'webhook' })
+    expect(resolvePushoverTargets([webhook], TARGET, ENV_FALLBACK)).toEqual([])
+  })
+
+  test('deduplicates matched routes sharing the same token + user', () => {
+    const r1 = route({
+      id: 'a',
+      matchRule: 'disk-usage',
+      provider: 'pushover',
+      pushoverToken: 'app_tok',
+      pushoverUser: 'usr_key',
+    })
+    const r2 = route({
+      id: 'b',
+      matchRule: '*',
+      provider: 'pushover',
+      pushoverToken: 'app_tok',
+      pushoverUser: 'usr_key',
+    })
+    expect(resolvePushoverTargets([r1, r2], TARGET, null)).toEqual([
+      { token: 'app_tok', user: 'usr_key' },
+    ])
+  })
+
+  test('a pushover route missing token or user never dispatches, and still suppresses the env fallback', () => {
+    const r = route({
+      matchRule: 'disk-usage',
+      provider: 'pushover',
+      pushoverToken: 'app_tok',
+      pushoverUser: null,
+    })
+    expect(resolvePushoverTargets([r], TARGET, ENV_FALLBACK)).toEqual([])
+  })
+
+  test('falls back to the env config when nothing matches', () => {
+    const r = route({ matchRule: 'replication-*', provider: 'pushover' })
+    expect(resolvePushoverTargets([r], TARGET, ENV_FALLBACK)).toEqual([
+      ENV_FALLBACK,
+    ])
+  })
+
+  test('empty route list falls back to the env config', () => {
+    expect(resolvePushoverTargets([], TARGET, ENV_FALLBACK)).toEqual([
+      ENV_FALLBACK,
+    ])
+  })
+
+  test('no match and no env config -> empty (no Pushover dispatch)', () => {
+    expect(resolvePushoverTargets([], TARGET, null)).toEqual([])
+  })
+})
+
 describe('D1-backed alert-routing CRUD', () => {
   test('listRoutes returns [] when D1 binding is missing (self-hosted/OSS)', async () => {
     currentDb = null
@@ -670,6 +767,29 @@ describe('D1-backed alert-routing CRUD', () => {
     expect(listed.provider).toBe('ntfy')
     expect(listed.ntfyUrl).toBe('https://ntfy.sh/my-topic')
     expect(listed.ntfyToken).toBe('tk_secret')
+  })
+
+  test('create -> list round-trip persists pushover provider fields', async () => {
+    const fakeDb = makeFakeD1()
+    currentDb = fakeDb
+
+    const created = await createRoute({
+      ownerId: 'owner-1',
+      matchRule: 'disk-*',
+      matchHost: '*',
+      channelUrl: '',
+      provider: 'pushover',
+      pushoverToken: 'app_tok',
+      pushoverUser: 'usr_key',
+    })
+    expect(created?.provider).toBe('pushover')
+    expect(created?.pushoverToken).toBe('app_tok')
+    expect(created?.pushoverUser).toBe('usr_key')
+
+    const [listed] = await listRoutes('owner-1')
+    expect(listed.provider).toBe('pushover')
+    expect(listed.pushoverToken).toBe('app_tok')
+    expect(listed.pushoverUser).toBe('usr_key')
   })
 
   test('legacy row with no provider column value defaults to webhook', async () => {

--- a/apps/dashboard/src/lib/health/alert-routing.ts
+++ b/apps/dashboard/src/lib/health/alert-routing.ts
@@ -40,8 +40,15 @@ const TABLE = 'alert_routes'
  * service's own escalation policy + on-call schedule. `'telegram'` (#2655)
  * routes to a Telegram chat via a bot token + chat id. `'ntfy'` (#2657)
  * routes to an ntfy topic URL (self-hostable) with an optional access token.
+ * `'pushover'` (#2659) routes to a Pushover user/group via an application
+ * token + user key.
  */
-export type AlertRouteProvider = 'webhook' | 'pagerduty' | 'telegram' | 'ntfy'
+export type AlertRouteProvider =
+  | 'webhook'
+  | 'pagerduty'
+  | 'telegram'
+  | 'ntfy'
+  | 'pushover'
 
 /** A configured alert route: match criteria → destination channel. */
 export interface AlertRoute {
@@ -68,6 +75,10 @@ export interface AlertRoute {
   ntfyUrl: string | null
   /** ntfy access token — a secret (provider `'ntfy'` only). */
   ntfyToken: string | null
+  /** Pushover application API token — a secret (provider `'pushover'` only). */
+  pushoverToken: string | null
+  /** Pushover target user/group key (provider `'pushover'` only). */
+  pushoverUser: string | null
 }
 
 interface D1AlertRouteRow {
@@ -85,6 +96,8 @@ interface D1AlertRouteRow {
   telegram_chat_id: string | null
   ntfy_url: string | null
   ntfy_token: string | null
+  pushover_token: string | null
+  pushover_user: string | null
 }
 
 function getDb(): D1Database | null {
@@ -110,13 +123,17 @@ function rowToRoute(row: D1AlertRouteRow): AlertRoute {
           ? 'telegram'
           : row.provider === 'ntfy'
             ? 'ntfy'
-            : 'webhook',
+            : row.provider === 'pushover'
+              ? 'pushover'
+              : 'webhook',
     serviceName: row.service_name ?? null,
     routingKey: row.routing_key ?? null,
     telegramBotToken: row.telegram_bot_token ?? null,
     telegramChatId: row.telegram_chat_id ?? null,
     ntfyUrl: row.ntfy_url ?? null,
     ntfyToken: row.ntfy_token ?? null,
+    pushoverToken: row.pushover_token ?? null,
+    pushoverUser: row.pushover_user ?? null,
   }
 }
 
@@ -135,7 +152,7 @@ export async function listRoutes(ownerId: string): Promise<AlertRoute[]> {
       .prepare(
         `SELECT id, owner_id, match_rule, match_host, channel_url, enabled, created_at,
                 provider, service_name, routing_key, telegram_bot_token, telegram_chat_id,
-                ntfy_url, ntfy_token
+                ntfy_url, ntfy_token, pushover_token, pushover_user
          FROM ${TABLE}
          WHERE owner_id = ?1
          ORDER BY created_at DESC`
@@ -170,6 +187,10 @@ export interface CreateRouteInput {
   ntfyUrl?: string | null
   /** ntfy access token — a secret (provider `'ntfy'` only). */
   ntfyToken?: string | null
+  /** Pushover application API token — a secret (provider `'pushover'` only). */
+  pushoverToken?: string | null
+  /** Pushover target user/group key (provider `'pushover'` only). */
+  pushoverUser?: string | null
 }
 
 /**
@@ -199,6 +220,8 @@ export async function createRoute(
       telegramChatId: input.telegramChatId?.trim() || null,
       ntfyUrl: input.ntfyUrl?.trim() || null,
       ntfyToken: input.ntfyToken?.trim() || null,
+      pushoverToken: input.pushoverToken?.trim() || null,
+      pushoverUser: input.pushoverUser?.trim() || null,
     }
 
     await db
@@ -206,8 +229,8 @@ export async function createRoute(
         `INSERT INTO ${TABLE}
            (id, owner_id, match_rule, match_host, channel_url, enabled, created_at,
             provider, service_name, routing_key, telegram_bot_token, telegram_chat_id,
-            ntfy_url, ntfy_token)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)`
+            ntfy_url, ntfy_token, pushover_token, pushover_user)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)`
       )
       .bind(
         route.id,
@@ -223,7 +246,9 @@ export async function createRoute(
         route.telegramBotToken,
         route.telegramChatId,
         route.ntfyUrl,
-        route.ntfyToken
+        route.ntfyToken,
+        route.pushoverToken,
+        route.pushoverUser
       )
       .run()
 
@@ -491,6 +516,57 @@ export function resolveNtfyTargets(
           ? { url: r.ntfyUrl, token: r.ntfyToken }
           : { url: r.ntfyUrl }
       )
+    }
+    return out
+  }
+
+  if (matched.length > 0) return []
+
+  return envFallback ? [envFallback] : []
+}
+
+/** One Pushover dispatch target: an application token + the user/group key. */
+export interface PushoverTarget {
+  token: string
+  user: string
+}
+
+/**
+ * Resolve the Pushover recipients a finding should notify (#2659 — extends
+ * the plan-30/34 routing model, mirroring {@link resolveTelegramTargets}):
+ * every ENABLED, matched route with `provider === 'pushover'` that carries
+ * both an application token and a user/group key, deduplicated by
+ * `token:user`. When NO route matched at all (any provider), falls back to
+ * `[envFallback]` when the env-configured global Pushover config is present —
+ * preserving the single-destination behavior for deployments that never
+ * configure a route. Returns `[]` when there is no env fallback, OR when a
+ * route of a different provider matched instead — the same cross-provider
+ * suppression {@link resolveTargets} / {@link resolvePagerDutyTargets} /
+ * {@link resolveTelegramTargets} / {@link resolveNtfyTargets} apply, so an
+ * operator who explicitly routed a rule elsewhere is not ALSO notified on the
+ * env-configured Pushover recipient. Pure — no I/O.
+ */
+export function resolvePushoverTargets(
+  routes: readonly AlertRoute[],
+  target: RouteMatchTarget,
+  envFallback: PushoverTarget | null
+): PushoverTarget[] {
+  const matched = matchRoutes(routes, target)
+  const pushoverMatched = matched.filter(
+    (r): r is AlertRoute & { pushoverToken: string; pushoverUser: string } =>
+      r.provider === 'pushover' &&
+      Boolean(r.pushoverToken) &&
+      Boolean(r.pushoverUser)
+  )
+
+  if (pushoverMatched.length > 0) {
+    const seen = new Set<string>()
+    const out: PushoverTarget[] = []
+    for (const r of pushoverMatched) {
+      const key = `${r.pushoverToken}:${r.pushoverUser}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      out.push({ token: r.pushoverToken, user: r.pushoverUser })
     }
     return out
   }

--- a/apps/dashboard/src/lib/health/pushover-dispatch.test.ts
+++ b/apps/dashboard/src/lib/health/pushover-dispatch.test.ts
@@ -1,0 +1,85 @@
+import type { AlertPayload } from './adapters/types'
+
+import { buildPushoverBody } from './adapters/pushover'
+import { dispatchPushover, PUSHOVER_MESSAGES_API_URL } from './pushover-dispatch'
+import { describe, expect, test } from 'bun:test'
+
+/** A fetch stub that records the request it was called with. */
+function stubFetch(response: Response = new Response('ok', { status: 200 })) {
+  const calls: { url: string; init: RequestInit }[] = []
+  const fetchImpl = (async (input: unknown, init?: RequestInit) => {
+    calls.push({ url: String(input), init: init ?? {} })
+    return response
+  }) as unknown as typeof fetch
+  return { calls, fetchImpl }
+}
+
+function throwingFetch(err: unknown) {
+  return (async () => {
+    throw err
+  }) as unknown as typeof fetch
+}
+
+const CONFIG = { token: 'app_tok', user: 'usr_key' }
+
+const CRITICAL: AlertPayload = {
+  severity: 'critical',
+  hostLabel: 'prod-1',
+  hostId: 2,
+  metric: 'failed-mutations',
+  value: 7,
+  warnThreshold: 1,
+  critThreshold: 5,
+  title: 'Failed mutations',
+  label: '7 failed mutations',
+  timestamp: '2026-07-02T10:00:00.000Z',
+}
+
+const RECOVERY: AlertPayload = {
+  ...CRITICAL,
+  severity: 'recovery',
+  value: 0,
+  label: 'recovered',
+}
+
+describe('dispatchPushover — send', () => {
+  test('POSTs the built JSON body to the Messages API', async () => {
+    const { calls, fetchImpl } = stubFetch()
+    const ok = await dispatchPushover(CRITICAL, CONFIG, { fetchImpl })
+
+    expect(ok).toBe(true)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toBe(PUSHOVER_MESSAGES_API_URL)
+    expect(calls[0].init.method).toBe('POST')
+    expect(
+      (calls[0].init.headers as Record<string, string>)['Content-Type']
+    ).toBe('application/json')
+    expect(JSON.parse(String(calls[0].init.body))).toEqual(
+      buildPushoverBody(CRITICAL, CONFIG)
+    )
+  })
+
+  test('sends a recovery with priority -1', async () => {
+    const { calls, fetchImpl } = stubFetch()
+    const ok = await dispatchPushover(RECOVERY, CONFIG, { fetchImpl })
+
+    expect(ok).toBe(true)
+    const body = JSON.parse(String(calls[0].init.body)) as { priority: string }
+    expect(body.priority).toBe('-1')
+  })
+
+  test('returns false when Pushover responds non-OK, without throwing', async () => {
+    const { fetchImpl } = stubFetch(new Response('nope', { status: 400 }))
+    const ok = await dispatchPushover(CRITICAL, CONFIG, { fetchImpl })
+    expect(ok).toBe(false)
+  })
+})
+
+describe('dispatchPushover — fail-open', () => {
+  test('returns false, never throws, when the fetch itself rejects', async () => {
+    const fetchImpl = throwingFetch(new Error('network down'))
+    await expect(
+      dispatchPushover(CRITICAL, CONFIG, { fetchImpl })
+    ).resolves.toBe(false)
+  })
+})

--- a/apps/dashboard/src/lib/health/pushover-dispatch.ts
+++ b/apps/dashboard/src/lib/health/pushover-dispatch.ts
@@ -1,0 +1,71 @@
+/**
+ * Pushover dispatch (transport layer).
+ *
+ * Builds the JSON body with the pure formatter (`adapters/pushover.ts`) and
+ * POSTs it to the fixed Pushover Messages API endpoint
+ * (`https://api.pushover.net/1/messages.json`). This module is the only
+ * place that actually talks to Pushover — mirrors the auth/transport
+ * separation Telegram/ntfy document (the adapter stays network-free).
+ *
+ * The endpoint host is fixed — only `token`/`user` in the body vary — so
+ * there is no caller-controlled SSRF sink here (unlike `webhook.ts` / the
+ * ntfy topic URL, both of which fetch an arbitrary operator-supplied
+ * destination). Same reasoning as `dispatchTelegram`.
+ *
+ * Never throws: a delivery failure must not abort the health sweep loop
+ * (fail-open, matching `dispatchTelegram` / `dispatchNtfy` / `postWebhook`).
+ */
+
+import type { AlertPayload } from './adapters/types'
+import type { ServerPushoverConfig } from './server-alert-config'
+
+import { buildPushoverBody } from './adapters/pushover'
+import { error } from '@chm/logger'
+
+/** Fixed Pushover Messages API endpoint. */
+export const PUSHOVER_MESSAGES_API_URL =
+  'https://api.pushover.net/1/messages.json'
+
+/** Injectable dependencies (tests override fetch). */
+export interface PushoverDispatchDeps {
+  fetchImpl?: typeof fetch
+}
+
+/**
+ * Dispatch one alert to Pushover: renders the payload as a JSON body and
+ * POSTs it to the Messages API. Returns whether the request succeeded;
+ * never throws.
+ */
+export async function dispatchPushover(
+  payload: AlertPayload,
+  config: ServerPushoverConfig,
+  deps: PushoverDispatchDeps = {}
+): Promise<boolean> {
+  const doFetch = deps.fetchImpl ?? fetch
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 10_000)
+  try {
+    const body = buildPushoverBody(payload, {
+      token: config.token,
+      user: config.user,
+    })
+    const res = await doFetch(PUSHOVER_MESSAGES_API_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    })
+    if (!res.ok) {
+      error(
+        '[health] Pushover dispatch returned non-OK status',
+        new Error(`Status ${res.status}`)
+      )
+    }
+    return res.ok
+  } catch (err) {
+    error('[health] Pushover dispatch failed', err as Error)
+    return false
+  } finally {
+    clearTimeout(timeout)
+  }
+}

--- a/apps/dashboard/src/lib/health/server-alert-config.test.ts
+++ b/apps/dashboard/src/lib/health/server-alert-config.test.ts
@@ -3,6 +3,7 @@ import {
   getServerEmailConfig,
   getServerNtfyConfig,
   getServerOpsgenieConfig,
+  getServerPushoverConfig,
   getServerTelegramConfig,
 } from './server-alert-config'
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
@@ -456,6 +457,58 @@ describe('getServerNtfyConfig', () => {
     expect(getServerNtfyConfig()).toEqual({
       url: 'https://ntfy.sh/my-topic',
       token: 'tk_secret',
+    })
+  })
+})
+
+const PUSHOVER_ENV_KEYS = [
+  'HEALTH_ALERT_PUSHOVER_TOKEN',
+  'HEALTH_ALERT_PUSHOVER_USER',
+] as const
+
+describe('getServerPushoverConfig', () => {
+  const original: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    for (const key of PUSHOVER_ENV_KEYS) {
+      original[key] = process.env[key]
+      delete process.env[key]
+    }
+  })
+
+  afterEach(() => {
+    for (const key of PUSHOVER_ENV_KEYS) {
+      if (original[key] === undefined) delete process.env[key]
+      else process.env[key] = original[key]
+    }
+  })
+
+  it('returns null when neither var is set', () => {
+    expect(getServerPushoverConfig()).toBeNull()
+  })
+
+  it('returns null when only the token is set', () => {
+    process.env.HEALTH_ALERT_PUSHOVER_TOKEN = 'app_tok'
+    expect(getServerPushoverConfig()).toBeNull()
+  })
+
+  it('returns null when only the user key is set', () => {
+    process.env.HEALTH_ALERT_PUSHOVER_USER = 'usr_key'
+    expect(getServerPushoverConfig()).toBeNull()
+  })
+
+  it('returns null when a var is whitespace-only', () => {
+    process.env.HEALTH_ALERT_PUSHOVER_TOKEN = '   '
+    process.env.HEALTH_ALERT_PUSHOVER_USER = 'usr_key'
+    expect(getServerPushoverConfig()).toBeNull()
+  })
+
+  it('trims and returns both values when set', () => {
+    process.env.HEALTH_ALERT_PUSHOVER_TOKEN = '  app_tok  '
+    process.env.HEALTH_ALERT_PUSHOVER_USER = '  usr_key  '
+    expect(getServerPushoverConfig()).toEqual({
+      token: 'app_tok',
+      user: 'usr_key',
     })
   })
 })

--- a/apps/dashboard/src/lib/health/server-alert-config.ts
+++ b/apps/dashboard/src/lib/health/server-alert-config.ts
@@ -245,6 +245,36 @@ export function getServerNtfyConfig(): ServerNtfyConfig | null {
   return token ? { url, token } : { url }
 }
 
+/** Resolved server-side Pushover config: the app token plus the target user/group key. */
+export interface ServerPushoverConfig {
+  token: string
+  user: string
+}
+
+/**
+ * Server-side Pushover config, sourced from environment variables:
+ *
+ *   - HEALTH_ALERT_PUSHOVER_TOKEN → token (application API token, default '')
+ *   - HEALTH_ALERT_PUSHOVER_USER  → user  (target user/group key, default '')
+ *
+ * Returns null unless BOTH are configured — Pushover delivery is opt-in and
+ * fails open (either value missing ⇒ the sweep skips the Pushover dispatch
+ * entirely). This is the global fallback used when no per-rule/per-host
+ * Pushover route matches, mirroring the Telegram fallback (#2655, #2659).
+ *
+ * NOTE: exposed as a companion function (matching
+ * {@link getServerTelegramConfig}) rather than folded into
+ * {@link getServerAlertConfig}'s return value — that shape is shared with the
+ * client's localStorage settings and asserted deeply by its tests, and the
+ * app token is a server-only secret that must never round-trip through it.
+ */
+export function getServerPushoverConfig(): ServerPushoverConfig | null {
+  const token = process.env.HEALTH_ALERT_PUSHOVER_TOKEN?.trim() || ''
+  const user = process.env.HEALTH_ALERT_PUSHOVER_USER?.trim() || ''
+  if (!token || !user) return null
+  return { token, user }
+}
+
 /** Default cron re-notify cooldown, in minutes, when the env var is unset. */
 export const DEFAULT_ALERT_COOLDOWN_MINUTES = 60
 

--- a/apps/dashboard/src/lib/health/server-sweep.ts
+++ b/apps/dashboard/src/lib/health/server-sweep.ts
@@ -25,6 +25,7 @@ import {
   listRoutes,
   resolveNtfyTargets,
   resolvePagerDutyTargets,
+  resolvePushoverTargets,
   resolveTargets,
   resolveTelegramTargets,
 } from './alert-routing'
@@ -38,6 +39,7 @@ import {
   getPagerDutyFallbackRoutingKey,
   PAGERDUTY_EVENTS_API_URL,
 } from './pagerduty-config'
+import { dispatchPushover } from './pushover-dispatch'
 import {
   activeQuietWindow,
   isQuietSuppressed,
@@ -52,6 +54,7 @@ import {
   getServerEmailConfig,
   getServerNtfyConfig,
   getServerOpsgenieConfig,
+  getServerPushoverConfig,
   getServerTelegramConfig,
   getServerThresholdOverrides,
 } from './server-alert-config'
@@ -371,6 +374,7 @@ export async function runHealthSweep(): Promise<SweepSummary> {
   const emailConfig = getServerEmailConfig()
   const telegramFallback = getServerTelegramConfig()
   const ntfyFallback = getServerNtfyConfig()
+  const pushoverFallback = getServerPushoverConfig()
   const canDispatch =
     settings.webhookEnabled &&
     (webhookConfigured ||
@@ -379,7 +383,8 @@ export async function runHealthSweep(): Promise<SweepSummary> {
       Boolean(opsgenieConfig) ||
       Boolean(emailConfig) ||
       Boolean(telegramFallback) ||
-      Boolean(ntfyFallback))
+      Boolean(ntfyFallback) ||
+      Boolean(pushoverFallback))
   const minRank = SEVERITY_ORDER[settings.minSeverity]
   const cooldownMs = getServerAlertCooldownMs()
 
@@ -652,6 +657,17 @@ export async function runHealthSweep(): Promise<SweepSummary> {
         routes,
         { ruleId, ruleType, hostId, hostName: name },
         ntfyFallback
+      )
+
+      // Pushover recipients (#2659): resolved separately from the generic
+      // webhook fan-out — a Pushover target needs the Messages API's
+      // token/user/priority body, not the `{ text, content }` wrapper. Falls
+      // back to the env-configured global recipient when no route matches,
+      // same fail-open contract as the webhook/PagerDuty/Telegram/ntfy paths.
+      const pushoverTargets = resolvePushoverTargets(
+        routes,
+        { ruleId, ruleType, hostId, hostName: name },
+        pushoverFallback
       )
 
       // Normalized payload shared by every per-URL body builder below (Discord
@@ -989,6 +1005,53 @@ export async function runHealthSweep(): Promise<SweepSummary> {
         }
       }
 
+      // Pushover (#2659): every resolved recipient (matched routes, or the
+      // env-configured global recipient when nothing matched).
+      // `dispatchPushover` renders the JSON body and never throws (fails
+      // open), matching every other channel here.
+      for (const target of pushoverTargets) {
+        const alertSeverity: AlertSeverity =
+          decision.kind === 'recovery'
+            ? 'recovery'
+            : (effective as 'warning' | 'critical')
+        const ok = await dispatchPushover(
+          {
+            severity: alertSeverity,
+            hostLabel: name,
+            hostId,
+            metric: ruleId,
+            value,
+            warnThreshold,
+            critThreshold,
+            title: ruleTitle,
+            label,
+            timestamp: new Date().toISOString(),
+          },
+          { token: target.token, user: target.user }
+        )
+        if (ok) anyDelivered = true
+
+        try {
+          await recordAlertEvent(
+            buildAlertEventRecord({
+              hostId,
+              hostLabel: name,
+              ruleId,
+              decision,
+              value,
+              delivered: ok,
+              error: ok ? undefined : 'Pushover dispatch failed',
+              channel: 'pushover',
+            })
+          )
+        } catch (err) {
+          debug(
+            `[health-sweep] alert-history record failed for host ${hostId} rule ${ruleId}`,
+            err instanceof Error ? err.message : String(err)
+          )
+        }
+      }
+
       // Persist "notified" only when there was nothing to deliver (no
       // targets at all across every channel — not a failure) or at least one
       // channel succeeded. A failed delivery with no successes leaves no
@@ -998,6 +1061,7 @@ export async function runHealthSweep(): Promise<SweepSummary> {
           pagerDutyTargets.length +
           telegramTargets.length +
           ntfyTargets.length +
+          pushoverTargets.length +
           (opsgenieConfig ? 1 : 0) +
           (emailConfig ? 1 : 0) ===
           0 ||

--- a/apps/dashboard/src/lib/hooks/use-alert-routes.ts
+++ b/apps/dashboard/src/lib/hooks/use-alert-routes.ts
@@ -14,9 +14,14 @@ import { throwIfNotOk } from '@/lib/swr/fetch-error'
 
 /**
  * Destination provider: `'webhook'` (plan 30), `'pagerduty'` (plan 34),
- * `'telegram'` (#2655), or `'ntfy'` (#2657).
+ * `'telegram'` (#2655), `'ntfy'` (#2657), or `'pushover'` (#2659).
  */
-export type AlertRouteProvider = 'webhook' | 'pagerduty' | 'telegram' | 'ntfy'
+export type AlertRouteProvider =
+  | 'webhook'
+  | 'pagerduty'
+  | 'telegram'
+  | 'ntfy'
+  | 'pushover'
 
 export interface AlertRouteInfo {
   id: string
@@ -37,6 +42,10 @@ export interface AlertRouteInfo {
   ntfyUrl: string | null
   /** Masked ntfy access token (last 4 chars only) — never the raw secret. */
   ntfyTokenMasked: string | null
+  /** Pushover target user/group key (not a secret). */
+  pushoverUser: string | null
+  /** Masked Pushover application token (last 4 chars only) — never the raw secret. */
+  pushoverTokenMasked: string | null
 }
 
 export const ALERT_ROUTES_QUERY_KEY = ['/api/v1/health/routes'] as const
@@ -82,6 +91,8 @@ export function useAlertRoutesMutations() {
     telegramChatId?: string
     ntfyUrl?: string
     ntfyToken?: string
+    pushoverToken?: string
+    pushoverUser?: string
   }): Promise<AlertRouteInfo> => {
     const response = await apiFetch('/api/v1/health/routes', {
       method: 'POST',

--- a/apps/dashboard/src/routes/api/v1/health/pushover-test.test.ts
+++ b/apps/dashboard/src/routes/api/v1/health/pushover-test.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// Same auth-gate mock pattern as ntfy-test.test.ts / telegram-test.test.ts.
+let authorizeFeatureRequest = mock(
+  async (
+    _permission: unknown,
+    _request: Request,
+    _options?: { allowAgentBearerToken?: boolean }
+  ): Promise<Response | null> => null
+)
+mock.module('@/lib/feature-permissions/server', () => ({
+  getAppConfig: () => ({ authProvider: 'none' as const, features: {} }),
+  _resetAppConfigCache: () => {},
+  publicReadEnabled: () => true,
+  authorizeFeatureRequest: (
+    permission: unknown,
+    request: Request,
+    options?: { allowAgentBearerToken?: boolean }
+  ) => authorizeFeatureRequest(permission, request, options),
+}))
+
+const PUSHOVER_ENV_KEYS = [
+  'HEALTH_ALERT_PUSHOVER_TOKEN',
+  'HEALTH_ALERT_PUSHOVER_USER',
+] as const
+
+const { __handleGetForTests: handleGet, __handlePostForTests: handlePost } =
+  await import('./pushover-test')
+
+const originalEnv: Record<string, string | undefined> = {}
+for (const key of PUSHOVER_ENV_KEYS) originalEnv[key] = process.env[key]
+
+beforeEach(() => {
+  authorizeFeatureRequest = mock(async () => null)
+  for (const key of PUSHOVER_ENV_KEYS) delete process.env[key]
+})
+
+function makeRequest(body?: unknown): Request {
+  return new Request('https://dash.example.com/api/v1/health/pushover-test', {
+    method: 'POST',
+    ...(body === undefined
+      ? {}
+      : {
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        }),
+  })
+}
+
+describe('GET /api/v1/health/pushover-test', () => {
+  test('reports not configured when neither var is set', async () => {
+    const res = await handleGet()
+    const body = (await res.json()) as { configured: boolean }
+    expect(body).toEqual({ configured: false })
+  })
+
+  test('reports not configured when only the token is set', async () => {
+    process.env.HEALTH_ALERT_PUSHOVER_TOKEN = 'app_tok'
+    const res = await handleGet()
+    const body = (await res.json()) as { configured: boolean }
+    expect(body).toEqual({ configured: false })
+  })
+
+  test('reports configured when both token and user are set', async () => {
+    process.env.HEALTH_ALERT_PUSHOVER_TOKEN = 'app_tok'
+    process.env.HEALTH_ALERT_PUSHOVER_USER = 'usr_key'
+    const res = await handleGet()
+    const body = (await res.json()) as { configured: boolean }
+    expect(body).toEqual({ configured: true })
+  })
+})
+
+describe('POST /api/v1/health/pushover-test — auth gate', () => {
+  test('anonymous is blocked, no egress', async () => {
+    process.env.HEALTH_ALERT_PUSHOVER_TOKEN = 'app_tok'
+    process.env.HEALTH_ALERT_PUSHOVER_USER = 'usr_key'
+    authorizeFeatureRequest = mock(
+      async () => new Response(null, { status: 401 })
+    )
+    const fetchImpl = mock(
+      async (_url: string, _init?: RequestInit) =>
+        new Response('ok', { status: 200 })
+    )
+    const res = await handlePost(makeRequest(), {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })
+
+    expect(res.status).toBe(401)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/v1/health/pushover-test — env-global mode', () => {
+  test('400s when Pushover is not configured', async () => {
+    const fetchImpl = mock(
+      async (_url: string, _init?: RequestInit) =>
+        new Response('ok', { status: 200 })
+    )
+    const res = await handlePost(makeRequest(), {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })
+
+    expect(res.status).toBe(400)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  test('sends a real test dispatch to the env recipient when configured', async () => {
+    process.env.HEALTH_ALERT_PUSHOVER_TOKEN = 'app_tok'
+    process.env.HEALTH_ALERT_PUSHOVER_USER = 'usr_key'
+    const fetchImpl = mock(
+      async (_url: string, _init?: RequestInit) =>
+        new Response('ok', { status: 200 })
+    )
+    const res = await handlePost(makeRequest(), {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })
+
+    expect(res.status).toBe(200)
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchImpl.mock.calls[0]
+    expect(url).toBe('https://api.pushover.net/1/messages.json')
+    const parsed = JSON.parse(String((init as RequestInit).body)) as {
+      token: string
+      user: string
+    }
+    expect(parsed.token).toBe('app_tok')
+    expect(parsed.user).toBe('usr_key')
+  })
+
+  test('502s when the Pushover request fails', async () => {
+    process.env.HEALTH_ALERT_PUSHOVER_TOKEN = 'app_tok'
+    process.env.HEALTH_ALERT_PUSHOVER_USER = 'usr_key'
+    const fetchImpl = mock(
+      async (_url: string, _init?: RequestInit) =>
+        new Response('nope', { status: 403 })
+    )
+    const res = await handlePost(makeRequest(), {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })
+
+    expect(res.status).toBe(502)
+  })
+})
+
+describe('POST /api/v1/health/pushover-test — ad-hoc mode', () => {
+  test('dispatches to a caller-supplied token + user', async () => {
+    const fetchImpl = mock(
+      async (_url: string, _init?: RequestInit) =>
+        new Response('ok', { status: 200 })
+    )
+    const res = await handlePost(
+      makeRequest({ token: 'ad_hoc_tok', user: 'ad_hoc_usr' }),
+      { fetchImpl: fetchImpl as unknown as typeof fetch }
+    )
+
+    expect(res.status).toBe(200)
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    const [, init] = fetchImpl.mock.calls[0]
+    const parsed = JSON.parse(String((init as RequestInit).body)) as {
+      token: string
+      user: string
+    }
+    expect(parsed.token).toBe('ad_hoc_tok')
+    expect(parsed.user).toBe('ad_hoc_usr')
+  })
+
+  test('rejects an ad-hoc token without a user, no egress', async () => {
+    const fetchImpl = mock(
+      async (_url: string, _init?: RequestInit) =>
+        new Response('ok', { status: 200 })
+    )
+    const res = await handlePost(makeRequest({ token: 'ad_hoc_tok' }), {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })
+
+    expect(res.status).toBe(400)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+})

--- a/apps/dashboard/src/routes/api/v1/health/pushover-test.ts
+++ b/apps/dashboard/src/routes/api/v1/health/pushover-test.ts
@@ -1,0 +1,154 @@
+/**
+ * Pushover Test-Message Endpoint
+ * GET  /api/v1/health/pushover-test  — is Pushover configured server-side (env global)?
+ * POST /api/v1/health/pushover-test  — send a synthetic test notification
+ *
+ * Two POST modes:
+ *   - No body (or `{}`)          → test the env-configured global recipient
+ *     (`HEALTH_ALERT_PUSHOVER_TOKEN` / `_USER`). Used by the Health Settings
+ *     button.
+ *   - `{ token, user }`          → test an ad-hoc recipient the operator just
+ *     typed into the routing dialog, before saving it as a route.
+ *
+ * The Pushover Messages API host is fixed (`api.pushover.net`) — unlike
+ * ntfy's operator-supplied topic URL, there is no caller-controlled SSRF sink
+ * here, so (unlike `ntfy-test.ts`) no `validateHostUrl` guard is needed.
+ *
+ * The Pushover application token is a server-side secret (never
+ * round-tripped to the browser after storage); in the ad-hoc mode the
+ * operator just typed it, same posture as the Telegram/ntfy routing-key
+ * tests (#2659).
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { PushoverDispatchDeps } from '@/lib/health/pushover-dispatch'
+import type { ServerPushoverConfig } from '@/lib/health/server-alert-config'
+
+import { debug } from '@chm/logger'
+import { createErrorResponse } from '@/lib/api/shared/response-builder'
+import { ApiErrorType } from '@/lib/api/types'
+import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
+import { dispatchPushover } from '@/lib/health/pushover-dispatch'
+import { getServerPushoverConfig } from '@/lib/health/server-alert-config'
+
+const ROUTE_CONTEXT = {
+  route: '/api/v1/health/pushover-test',
+  method: 'POST',
+} as const
+
+interface PushoverTestBody {
+  token?: unknown
+  user?: unknown
+}
+
+async function handleGet(): Promise<Response> {
+  const config = getServerPushoverConfig()
+  return Response.json({ configured: config !== null })
+}
+
+async function handlePost(
+  request: Request,
+  deps: PushoverDispatchDeps = {}
+): Promise<Response> {
+  // Write gate, same posture as /api/v1/health/webhook — this triggers a real
+  // outbound Pushover dispatch, so anonymous callers must not reach it.
+  const permissionResponse = await authorizeFeatureRequest(
+    { feature: 'settings', defaultAccess: 'authenticated', operation: 'write' },
+    request,
+    { allowAgentBearerToken: true }
+  )
+  if (permissionResponse) return permissionResponse
+
+  // Body is optional: absent → env-global test. A supplied `token`/`user`
+  // switches to the ad-hoc mode.
+  let body: PushoverTestBody = {}
+  try {
+    const text = await request.text()
+    if (text.trim()) body = JSON.parse(text) as PushoverTestBody
+  } catch {
+    return createErrorResponse(
+      {
+        type: ApiErrorType.ValidationError,
+        message: 'Request body must be valid JSON',
+      },
+      400,
+      ROUTE_CONTEXT
+    )
+  }
+
+  const adHocToken = typeof body.token === 'string' ? body.token.trim() : ''
+  const adHocUser = typeof body.user === 'string' ? body.user.trim() : ''
+
+  let config: ServerPushoverConfig | null
+  if (adHocToken || adHocUser) {
+    if (!adHocToken || !adHocUser) {
+      return createErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: 'Both "token" and "user" are required for an ad-hoc test',
+        },
+        400,
+        ROUTE_CONTEXT
+      )
+    }
+    config = { token: adHocToken, user: adHocUser }
+  } else {
+    config = getServerPushoverConfig()
+    if (!config) {
+      return createErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message:
+            'Pushover is not configured. Set HEALTH_ALERT_PUSHOVER_TOKEN and HEALTH_ALERT_PUSHOVER_USER on the server, or pass a token + user.',
+        },
+        400,
+        ROUTE_CONTEXT
+      )
+    }
+  }
+
+  debug('[POST /api/v1/health/pushover-test] Sending test notification')
+
+  const ok = await dispatchPushover(
+    {
+      severity: 'warning',
+      hostLabel: 'test-host',
+      hostId: 0,
+      metric: 'test',
+      value: 0,
+      warnThreshold: null,
+      critThreshold: null,
+      title: 'Test Alert',
+      label: 'This is a test alert from chmonitor',
+      timestamp: new Date().toISOString(),
+    },
+    config,
+    deps
+  )
+
+  if (!ok) {
+    return createErrorResponse(
+      {
+        type: ApiErrorType.NetworkError,
+        message: 'Pushover test notification failed. Check the server logs.',
+      },
+      502,
+      ROUTE_CONTEXT
+    )
+  }
+
+  return Response.json({ success: true }, { status: 200 })
+}
+
+export const Route = createFileRoute('/api/v1/health/pushover-test')({
+  server: {
+    handlers: {
+      GET: async () => handleGet(),
+      POST: async ({ request }) => handlePost(request),
+    },
+  },
+})
+
+// Exported for unit tests only.
+export { handleGet as __handleGetForTests, handlePost as __handlePostForTests }

--- a/apps/dashboard/src/routes/api/v1/health/routes.ts
+++ b/apps/dashboard/src/routes/api/v1/health/routes.ts
@@ -72,6 +72,14 @@ function toPublicRoute(route: Awaited<ReturnType<typeof listRoutes>>[number]) {
     // Telegram bot token.
     ntfyUrl: route.ntfyUrl,
     ntfyTokenMasked: route.ntfyToken ? maskRoutingKey(route.ntfyToken) : null,
+    // Pushover (#2659): the application token is a bare secret (like the
+    // Telegram bot token), never returned in full once stored. The user/group
+    // key is not a secret on its own — like the Telegram chat id — and is
+    // returned as-is so the UI can show which recipient a route targets.
+    pushoverUser: route.pushoverUser,
+    pushoverTokenMasked: route.pushoverToken
+      ? maskRoutingKey(route.pushoverToken)
+      : null,
   }
 }
 
@@ -90,8 +98,8 @@ interface CreateRouteBody {
   channelUrl?: unknown
   enabled?: unknown
   /**
-   * `'webhook'` (default), `'pagerduty'` (plan 34), `'telegram'` (#2655), or
-   * `'ntfy'` (#2657).
+   * `'webhook'` (default), `'pagerduty'` (plan 34), `'telegram'` (#2655),
+   * `'ntfy'` (#2657), or `'pushover'` (#2659).
    */
   provider?: unknown
   /** PagerDuty-only: display label for the service. */
@@ -106,6 +114,10 @@ interface CreateRouteBody {
   ntfyUrl?: unknown
   /** ntfy-only: the optional access token (a secret). */
   ntfyToken?: unknown
+  /** Pushover-only: the application API token (a secret). */
+  pushoverToken?: unknown
+  /** Pushover-only: the target user/group key. */
+  pushoverUser?: unknown
 }
 
 async function handlePost(request: Request): Promise<Response> {
@@ -128,7 +140,9 @@ async function handlePost(request: Request): Promise<Response> {
         ? 'telegram'
         : body.provider === 'ntfy'
           ? 'ntfy'
-          : 'webhook'
+          : body.provider === 'pushover'
+            ? 'pushover'
+            : 'webhook'
 
   const matchRule =
     typeof body.matchRule === 'string' && body.matchRule.trim()
@@ -249,6 +263,46 @@ async function handlePost(request: Request): Promise<Response> {
       provider: 'ntfy',
       ntfyUrl,
       ntfyToken: ntfyToken || null,
+    })
+
+    if (!created) {
+      return jsonError(
+        'Alert routing storage is not configured (no D1 binding) or the write failed.',
+        501
+      )
+    }
+
+    return Response.json(
+      { success: true, route: toPublicRoute(created) },
+      { status: 201 }
+    )
+  }
+
+  if (provider === 'pushover') {
+    const pushoverToken =
+      typeof body.pushoverToken === 'string' ? body.pushoverToken.trim() : ''
+    const pushoverUser =
+      typeof body.pushoverUser === 'string' ? body.pushoverUser.trim() : ''
+    if (!pushoverToken || !pushoverUser) {
+      return jsonError(
+        'Missing required "pushoverToken" and/or "pushoverUser" for a Pushover route',
+        400
+      )
+    }
+
+    // The Pushover Messages API endpoint is fixed (`api.pushover.net`) —
+    // token/user travel in the body, not the URL — so there is no
+    // caller-supplied SSRF sink here (unlike the webhook path below).
+    // `channelUrl` stays empty; the sweep posts to the fixed endpoint.
+    const created = await createRoute({
+      ownerId,
+      matchRule,
+      matchHost,
+      channelUrl: '',
+      enabled,
+      provider: 'pushover',
+      pushoverToken,
+      pushoverUser,
     })
 
     if (!created) {

--- a/docs/content/guide/features/health.mdx
+++ b/docs/content/guide/features/health.mdx
@@ -103,6 +103,8 @@ The health-sweep endpoint runs checks over all configured hosts and sends a webh
 | `HEALTH_ALERT_TELEGRAM_CHAT_ID` | (unset = Telegram disabled) | Target Telegram chat id (e.g. `-1001234567890`, or `@channelname`). Both this and `HEALTH_ALERT_TELEGRAM_BOT_TOKEN` must be set for the global Telegram channel to fire. |
 | `HEALTH_ALERT_NTFY_URL` | (unset = ntfy disabled) | Full [ntfy](https://ntfy.sh) topic URL (e.g. `https://ntfy.sh/my-topic`, or a self-hosted server). Each finding is published with `Title`/`Priority`/`Tags` headers + a plain-text body (severity → priority: critical `5`/urgent, warning `4`/high, recovery `3`/default). Per-rule/per-host ntfy routes (Routing tab) override this fallback. |
 | `HEALTH_ALERT_NTFY_TOKEN` | (unset = no auth) | Optional ntfy access token for a protected topic, sent as `Authorization: Bearer <token>`. Server-only secret — never exposed to the browser. |
+| `HEALTH_ALERT_PUSHOVER_TOKEN` | (unset = Pushover disabled) | [Pushover](https://pushover.net) application API token. Server-only secret — never exposed to the browser. Set together with `HEALTH_ALERT_PUSHOVER_USER` to enable the global Pushover channel; each finding is POSTed to the Messages API (severity → priority: critical `2`/emergency with retry+expire, warning `0`/normal, recovery `-1`/low-quiet). Per-rule/per-host Pushover routes (Routing tab) override this fallback. |
+| `HEALTH_ALERT_PUSHOVER_USER` | (unset = Pushover disabled) | Target Pushover user or group key. Both this and `HEALTH_ALERT_PUSHOVER_TOKEN` must be set for the global Pushover channel to fire. |
 
 <Callout type="warn" title="CRON_SECRET is required">
 `CRON_SECRET` is **required** for the cron endpoints. When it is unset, `/api/cron/health-sweep` and `/api/cron/retention-prune` **fail closed and return HTTP 503** (they do not run) — `retention-prune` is destructive, so it must never be reachable unauthenticated. Set `CRON_SECRET` and pass it as `Authorization: Bearer <secret>` from your cron caller.
@@ -121,6 +123,8 @@ wrangler secret put HEALTH_ALERT_WEBHOOK_URL
 wrangler secret put HEALTH_ALERT_TELEGRAM_BOT_TOKEN
 # Optional: ntfy channel (topic URL is a plain var; access token is a secret)
 wrangler secret put HEALTH_ALERT_NTFY_TOKEN
+# Optional: Pushover channel (app token is a secret; user key is a plain var)
+wrangler secret put HEALTH_ALERT_PUSHOVER_TOKEN
 ```
 </Step>
 <Step>


### PR DESCRIPTION
Closes #2659.

Adds Pushover as an alert delivery channel, mirroring **Telegram** (#2670) for wiring and **ntfy** (#2681) for the dedicated test-route template (the issue explicitly asked for `/api/v1/health/pushover-test`).

Like Telegram's Bot API, Pushover's Messages API host is fixed (`api.pushover.net`), so no SSRF guard is needed on `token`/`user` — unlike ntfy's operator-supplied topic URL.

**Severity → Pushover priority:** critical = 2 (emergency, with retry/expire), warning = 0 (normal), recovery = -1 (low/quiet).

Includes migration `0024_alert_routes_pushover.sql` (verified: `0024` is genuinely the next free number, no collision with the parallel work), routing CRUD, dialog wiring, and docs.

Env: `HEALTH_ALERT_PUSHOVER_TOKEN` (secret) + `HEALTH_ALERT_PUSHOVER_USER`, fails open when either is missing.

**Verified during integration:** `bun test src/lib/health/ src/routes/api/v1/health/` — **555 pass, 0 fail**; `pnpm run type-check` clean.

Type-check initially failed on the new route (`'/api/v1/health/pushover-test' is not assignable to keyof FileRoutesByPath`) — the known `routeTree.gen.ts` gotcha: that file is gitignored, so `tsc` can't see a new route until `vite dev` regenerates it. Regenerated, then clean.

**Two judgment calls worth a maintainer's eye:**
1. Priority-2 `retry`/`expire` defaults (60s / 3600s) are within Pushover's documented limits (retry ≥30s, expire ≤10800s) but weren't specified in the issue — sanity-check against product intent.
2. `pushover_user` is stored/returned **unmasked** (mirroring Telegram's `chat_id`) while `pushover_token` is masked. Confirm that asymmetry matches the posture you want for Pushover.

Co-Authored-By: duyetbot <bot@duyet.net>