### PR TITLE
fix(a11y): ARIA tree semantics and keyboard nav for the database explorer (#2686)

### DIFF
--- a/apps/dashboard/src/components/explorer/hooks/index.ts
+++ b/apps/dashboard/src/components/explorer/hooks/index.ts
@@ -1,4 +1,5 @@
 export type { ExplorerState, ExplorerTab } from './use-explorer-state'
 
 export { useExplorerState } from './use-explorer-state'
+export { useTreeKeyboardNav } from './use-tree-keyboard-nav'
 export { useTreeState } from './use-tree-state'

--- a/apps/dashboard/src/components/explorer/hooks/use-tree-keyboard-nav.ts
+++ b/apps/dashboard/src/components/explorer/hooks/use-tree-keyboard-nav.ts
@@ -1,0 +1,131 @@
+import { useCallback, useRef } from 'react'
+
+import type { FocusEvent, KeyboardEvent } from 'react'
+
+import {
+  getArrowLeftAction,
+  getArrowRightAction,
+  getNextFocusIndex,
+  type TreeArrowVerticalKey,
+  type TreeNavItem,
+} from '../tree/tree-keyboard-nav'
+
+const VERTICAL_KEYS: ReadonlySet<string> = new Set<TreeArrowVerticalKey>([
+  'ArrowDown',
+  'ArrowUp',
+  'Home',
+  'End',
+])
+
+/** Visible (not inside a collapsed ancestor) treeitems, in document order. */
+function getVisibleTreeItems(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>('[role="treeitem"]')
+  ).filter((el) => el.getClientRects().length > 0)
+}
+
+/** `aria-level` is 1-indexed; our internal level (and `TreeNode`'s `level`
+ * prop) is 0-indexed. */
+function getLevel(el: HTMLElement): number {
+  const raw = el.getAttribute('aria-level')
+  const parsed = raw ? Number(raw) : 1
+  return Number.isFinite(parsed) ? parsed - 1 : 0
+}
+
+function closestTreeItem(target: EventTarget | null): HTMLElement | null {
+  if (!(target instanceof HTMLElement)) return null
+  return target.closest<HTMLElement>('[role="treeitem"]')
+}
+
+/**
+ * Wires WAI-ARIA Tree View keyboard navigation + roving tabindex onto a
+ * `role="tree"` container: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
+ *
+ * - Up/Down/Home/End move focus between visible treeitems.
+ * - Right expands a closed node (or moves into its first child if already open).
+ * - Left collapses an open node (or moves focus to the parent).
+ * - Enter/Space activates the node (clicks its label, same as a mouse click).
+ *
+ * Operates on the live DOM (`querySelectorAll('[role="treeitem"]')`) rather
+ * than a React-side registry, since `DatabaseNode`/`TableNode`/`ColumnNode`
+ * mount, fetch, and expand independently of one another — there is no single
+ * place that owns the full flattened list of currently-visible nodes.
+ *
+ * Expand/collapse/activate are triggered by clicking the underlying
+ * `[data-tree-toggle]` / `[data-tree-label]` buttons so all existing
+ * mouse-click logic (fetch-on-expand, `expandOnSelect`, selection) is reused
+ * verbatim rather than duplicated here.
+ */
+export function useTreeKeyboardNav() {
+  // Tracks the roving-tabindex anchor without forcing a React re-render on
+  // every focus change — mirrors the standard "manual roving tabindex" recipe.
+  const lastActiveRef = useRef<HTMLElement | null>(null)
+
+  const handleFocus = useCallback((event: FocusEvent<HTMLElement>) => {
+    const treeItem = closestTreeItem(event.target)
+    if (!treeItem) return
+
+    if (lastActiveRef.current && lastActiveRef.current !== treeItem) {
+      lastActiveRef.current.tabIndex = -1
+    }
+    treeItem.tabIndex = 0
+    lastActiveRef.current = treeItem
+  }, [])
+
+  const handleKeyDown = useCallback((event: KeyboardEvent<HTMLElement>) => {
+    const treeItem = closestTreeItem(event.target)
+    if (!treeItem) return
+    const container = event.currentTarget
+
+    if (VERTICAL_KEYS.has(event.key)) {
+      const items = getVisibleTreeItems(container)
+      const currentIndex = items.indexOf(treeItem)
+      if (currentIndex === -1) return
+      event.preventDefault()
+      const nextIndex = getNextFocusIndex(
+        currentIndex,
+        items.length,
+        event.key as TreeArrowVerticalKey
+      )
+      items[nextIndex]?.focus()
+      return
+    }
+
+    if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
+      const items = getVisibleTreeItems(container)
+      const currentIndex = items.indexOf(treeItem)
+      if (currentIndex === -1) return
+      event.preventDefault()
+
+      const isExpanded = treeItem.getAttribute('aria-expanded') === 'true'
+      const hasChildren = treeItem.hasAttribute('aria-expanded')
+      const meta: TreeNavItem[] = items.map((el) => ({ level: getLevel(el) }))
+      const action =
+        event.key === 'ArrowRight'
+          ? getArrowRightAction(meta, currentIndex, isExpanded, hasChildren)
+          : getArrowLeftAction(meta, currentIndex, isExpanded, hasChildren)
+
+      if (action.type === 'expand' || action.type === 'collapse') {
+        // `treeItem`'s own toggle button is always rendered before its
+        // (possibly nested-treeitem-containing) children in the DOM, so the
+        // first descendant match is always this node's own toggle, never a
+        // descendant's.
+        treeItem
+          .querySelector<HTMLButtonElement>('[data-tree-toggle="true"]')
+          ?.click()
+      } else if (action.type === 'focus') {
+        items[action.index]?.focus()
+      }
+      return
+    }
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      treeItem
+        .querySelector<HTMLButtonElement>('[data-tree-label="true"]')
+        ?.click()
+    }
+  }, [])
+
+  return { handleKeyDown, handleFocus }
+}

--- a/apps/dashboard/src/components/explorer/tree/column-node.tsx
+++ b/apps/dashboard/src/components/explorer/tree/column-node.tsx
@@ -9,6 +9,10 @@ interface ColumnNodeProps {
   isInPrimaryKey?: boolean
   isInSortingKey?: boolean
   level: number
+  /** 1-indexed position among sibling columns, for `aria-posinset`. */
+  posInSet?: number
+  /** Total count of sibling columns, for `aria-setsize`. */
+  setSize?: number
 }
 
 export const ColumnNode = function ColumnNode({
@@ -17,6 +21,8 @@ export const ColumnNode = function ColumnNode({
   isInPrimaryKey,
   isInSortingKey,
   level,
+  posInSet,
+  setSize,
 }: ColumnNodeProps) {
   const icon = isInPrimaryKey || isInSortingKey ? KeyIcon : ColumnsIcon
 
@@ -25,6 +31,8 @@ export const ColumnNode = function ColumnNode({
       label={name}
       icon={icon}
       level={level}
+      posInSet={posInSet}
+      setSize={setSize}
       badge={
         <Badge variant="outline" className="text-xs">
           {type}

--- a/apps/dashboard/src/components/explorer/tree/database-node.tsx
+++ b/apps/dashboard/src/components/explorer/tree/database-node.tsx
@@ -26,6 +26,12 @@ interface DatabaseNodeProps {
   selectedTable: string | null
   selectedDatabase: string | null
   level: number
+  /** 1-indexed position among sibling databases, for `aria-posinset`. */
+  posInSet?: number
+  /** Total count of sibling databases, for `aria-setsize`. */
+  setSize?: number
+  /** Roving-tabindex fallback anchor — see `TreeNode`. */
+  isDefaultTabbable?: boolean
   searchFilter: string
   onToggleDatabase: (database: string) => void
   onToggleTable: (key: string) => void
@@ -48,6 +54,9 @@ export const DatabaseNode = function DatabaseNode({
   selectedTable,
   selectedDatabase,
   level,
+  posInSet,
+  setSize,
+  isDefaultTabbable = false,
   searchFilter,
   onToggleDatabase,
   onToggleTable,
@@ -105,6 +114,14 @@ export const DatabaseNode = function DatabaseNode({
 
   // Only highlight if this database is selected and no table is selected
   const isHighlighted = selectedDatabase === database && !selectedTable
+  // Fall back to this database as the roving-tabindex anchor while a table
+  // under it is selected but its table list hasn't loaded yet (so no deeper
+  // treeitem exists in the DOM yet to claim tabIndex=0). Once `tables` loads,
+  // the matching TableNode becomes tabbable and this fallback steps aside —
+  // otherwise both nodes would end up with tabIndex=0 at once.
+  const isTabbableFallback =
+    isDefaultTabbable ||
+    (selectedDatabase === database && Boolean(selectedTable) && !tables)
 
   return (
     <TreeNode
@@ -116,6 +133,9 @@ export const DatabaseNode = function DatabaseNode({
       isLoading={isLoading && isExpanded}
       hasChildren
       level={level}
+      posInSet={posInSet}
+      setSize={setSize}
+      isDefaultTabbable={isTabbableFallback}
       onToggle={handleToggle}
       onSelect={handleSelect}
     >
@@ -129,7 +149,7 @@ export const DatabaseNode = function DatabaseNode({
           ))}
         </div>
       ) : (
-        filteredTables.map((table) => {
+        filteredTables.map((table, index) => {
           const tableKey = `${database}.${table.name}`
           return (
             <TableNode
@@ -143,6 +163,8 @@ export const DatabaseNode = function DatabaseNode({
                 selectedDatabase === database && selectedTable === table.name
               }
               level={level + 1}
+              posInSet={index + 1}
+              setSize={filteredTables.length}
               onToggle={() => onToggleTable(tableKey)}
               onSelect={() => handleSelectTable(table.name, table.engine)}
             />

--- a/apps/dashboard/src/components/explorer/tree/database-tree.tsx
+++ b/apps/dashboard/src/components/explorer/tree/database-tree.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 
 import { useExplorerState } from '../hooks/use-explorer-state'
+import { useTreeKeyboardNav } from '../hooks/use-tree-keyboard-nav'
 import { useTreeState } from '../hooks/use-tree-state'
 import { DatabaseNode } from './database-node'
 import { TreeSearch } from './tree-search'
@@ -35,6 +36,7 @@ export function DatabaseTree() {
     useExplorerState()
   const { isDatabaseExpanded, isTableExpanded, toggleDatabase, toggleTable } =
     useTreeState(database, table)
+  const { handleKeyDown, handleFocus } = useTreeKeyboardNav()
 
   const queryKey = `/api/v1/explorer/databases?hostId=${hostId}`
   const {
@@ -82,12 +84,21 @@ export function DatabaseTree() {
     )
   }
 
+  // Fallback roving-tabindex anchor: when nothing is selected yet, the first
+  // database is the tree's single tabbable entry point.
+  const hasSelection = Boolean(database)
+
   return (
     <TooltipProvider>
       <div className="flex flex-col gap-2">
         <TreeSearch value={searchFilter} onChange={setSearchFilter} />
-        <SidebarMenu>
-          {databases.map((db) => (
+        <SidebarMenu
+          role="tree"
+          aria-label="Database explorer"
+          onKeyDown={handleKeyDown}
+          onFocus={handleFocus}
+        >
+          {databases.map((db, index) => (
             <DatabaseNode
               key={db.name}
               database={db.name}
@@ -96,6 +107,9 @@ export function DatabaseTree() {
               selectedTable={table}
               selectedDatabase={database}
               level={0}
+              posInSet={index + 1}
+              setSize={databases.length}
+              isDefaultTabbable={!hasSelection && index === 0}
               searchFilter={searchFilter}
               onToggleDatabase={toggleDatabase}
               onToggleTable={toggleTable}

--- a/apps/dashboard/src/components/explorer/tree/index.ts
+++ b/apps/dashboard/src/components/explorer/tree/index.ts
@@ -2,6 +2,16 @@ export { ColumnNode } from './column-node'
 export { DatabaseNode } from './database-node'
 export { DatabaseTree } from './database-tree'
 export { TableNode } from './table-node'
+export {
+  getArrowLeftAction,
+  getArrowRightAction,
+  getNextFocusIndex,
+} from './tree-keyboard-nav'
+export type {
+  TreeArrowVerticalKey,
+  TreeHorizontalAction,
+  TreeNavItem,
+} from './tree-keyboard-nav'
 export { TreeNode } from './tree-node'
 export { TreeSearch } from './tree-search'
 export { TreeSkeleton } from './tree-skeleton'

--- a/apps/dashboard/src/components/explorer/tree/table-node.tsx
+++ b/apps/dashboard/src/components/explorer/tree/table-node.tsx
@@ -29,6 +29,10 @@ interface TableNodeProps {
   isExpanded: boolean
   isSelected: boolean
   level: number
+  /** 1-indexed position among sibling tables, for `aria-posinset`. */
+  posInSet?: number
+  /** Total count of sibling tables, for `aria-setsize`. */
+  setSize?: number
   onToggle: () => void
   onSelect: () => void
 }
@@ -81,7 +85,6 @@ function RowCountBadge({ totalRows }: { totalRows: number }) {
 
   return (
     <span
-      role="presentation"
       className="ml-auto text-[10px] text-muted-foreground tabular-nums cursor-default overflow-hidden"
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
@@ -109,6 +112,8 @@ export const TableNode = function TableNode({
   isExpanded,
   isSelected,
   level,
+  posInSet,
+  setSize,
   onToggle,
   onSelect,
 }: TableNodeProps) {
@@ -154,6 +159,8 @@ export const TableNode = function TableNode({
       hasChildren
       expandOnSelect={false}
       level={level}
+      posInSet={posInSet}
+      setSize={setSize}
       badge={
         totalRows !== undefined && totalRows !== null ? (
           <RowCountBadge totalRows={totalRows} />
@@ -172,7 +179,7 @@ export const TableNode = function TableNode({
           ))}
         </div>
       ) : (
-        columns?.map((column) => (
+        columns?.map((column, index) => (
           <ColumnNode
             key={column.name}
             name={column.name}
@@ -180,6 +187,8 @@ export const TableNode = function TableNode({
             isInPrimaryKey={column.is_in_primary_key}
             isInSortingKey={column.is_in_sorting_key}
             level={level + 1}
+            posInSet={index + 1}
+            setSize={columns.length}
           />
         ))
       )}

--- a/apps/dashboard/src/components/explorer/tree/tree-keyboard-nav.test.ts
+++ b/apps/dashboard/src/components/explorer/tree/tree-keyboard-nav.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  getArrowLeftAction,
+  getArrowRightAction,
+  getNextFocusIndex,
+  type TreeNavItem,
+} from './tree-keyboard-nav'
+
+describe('getNextFocusIndex', () => {
+  it('ArrowDown moves to the next item', () => {
+    expect(getNextFocusIndex(1, 5, 'ArrowDown')).toBe(2)
+  })
+
+  it('ArrowDown clamps at the last item', () => {
+    expect(getNextFocusIndex(4, 5, 'ArrowDown')).toBe(4)
+  })
+
+  it('ArrowUp moves to the previous item', () => {
+    expect(getNextFocusIndex(2, 5, 'ArrowUp')).toBe(1)
+  })
+
+  it('ArrowUp clamps at the first item', () => {
+    expect(getNextFocusIndex(0, 5, 'ArrowUp')).toBe(0)
+  })
+
+  it('Home jumps to the first item', () => {
+    expect(getNextFocusIndex(3, 5, 'Home')).toBe(0)
+  })
+
+  it('End jumps to the last item', () => {
+    expect(getNextFocusIndex(1, 5, 'End')).toBe(4)
+  })
+
+  it('returns -1 when there are no items', () => {
+    expect(getNextFocusIndex(0, 0, 'ArrowDown')).toBe(-1)
+  })
+})
+
+describe('getArrowRightAction', () => {
+  // A tree shaped like:
+  // 0: db (level 0)
+  //   1: table (level 1)
+  //     2: column (level 2)
+  // 3: db2 (level 0, leaf-ish sibling with no children fetched yet)
+  const items: TreeNavItem[] = [
+    { level: 0 },
+    { level: 1 },
+    { level: 2 },
+    { level: 0 },
+  ]
+
+  it('expands a closed node with children, focus stays put', () => {
+    expect(getArrowRightAction(items, 0, false, true)).toEqual({
+      type: 'expand',
+    })
+  })
+
+  it('moves focus to the first child of an open node', () => {
+    expect(getArrowRightAction(items, 0, true, true)).toEqual({
+      type: 'focus',
+      index: 1,
+    })
+  })
+
+  it('does nothing on a leaf node', () => {
+    expect(getArrowRightAction(items, 2, false, false)).toEqual({
+      type: 'none',
+    })
+  })
+
+  it('does nothing on an open node whose next item is a sibling, not a child', () => {
+    // Index 1 (table, level 1) "open" but next item (index 2) is its own
+    // child in this fixture, so use an open leafless table with no children
+    // rendered yet (next item is a same-or-shallower-level sibling).
+    const flatItems: TreeNavItem[] = [{ level: 0 }, { level: 0 }]
+    expect(getArrowRightAction(flatItems, 0, true, true)).toEqual({
+      type: 'none',
+    })
+  })
+
+  it('does nothing on the last open node (no next item)', () => {
+    expect(getArrowRightAction(items, 3, true, true)).toEqual({
+      type: 'none',
+    })
+  })
+})
+
+describe('getArrowLeftAction', () => {
+  const items: TreeNavItem[] = [
+    { level: 0 },
+    { level: 1 },
+    { level: 2 },
+    { level: 0 },
+  ]
+
+  it('collapses an open node with children, focus stays put', () => {
+    expect(getArrowLeftAction(items, 0, true, true)).toEqual({
+      type: 'collapse',
+    })
+  })
+
+  it('moves focus to the parent of a closed node', () => {
+    expect(getArrowLeftAction(items, 1, false, true)).toEqual({
+      type: 'focus',
+      index: 0,
+    })
+  })
+
+  it('moves focus to the parent of a leaf node', () => {
+    expect(getArrowLeftAction(items, 2, false, false)).toEqual({
+      type: 'focus',
+      index: 1,
+    })
+  })
+
+  it('does nothing on a closed top-level (level 0) node', () => {
+    expect(getArrowLeftAction(items, 0, false, true)).toEqual({
+      type: 'none',
+    })
+  })
+
+  it('does nothing on a top-level leaf node', () => {
+    expect(getArrowLeftAction(items, 3, false, false)).toEqual({
+      type: 'none',
+    })
+  })
+
+  it('finds the nearest shallower ancestor, skipping same-level siblings', () => {
+    // db(0) > table(1) > column(2) > column(2) — second column should walk
+    // back to the table (level 1), not the first column (level 2).
+    const nested: TreeNavItem[] = [
+      { level: 0 },
+      { level: 1 },
+      { level: 2 },
+      { level: 2 },
+    ]
+    expect(getArrowLeftAction(nested, 3, false, false)).toEqual({
+      type: 'focus',
+      index: 1,
+    })
+  })
+})

--- a/apps/dashboard/src/components/explorer/tree/tree-keyboard-nav.ts
+++ b/apps/dashboard/src/components/explorer/tree/tree-keyboard-nav.ts
@@ -1,0 +1,95 @@
+/**
+ * Pure keyboard-navigation logic for the database explorer tree, implementing
+ * the WAI-ARIA Tree View pattern:
+ * https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
+ *
+ * These functions are intentionally framework/DOM-free (no React, no
+ * `document`) so they can be unit tested directly and reused by the DOM-glue
+ * hook (`hooks/use-tree-keyboard-nav.ts`), which queries the live
+ * `[role="treeitem"]` elements and hands their positions/levels in here.
+ */
+
+export type TreeArrowVerticalKey = 'ArrowDown' | 'ArrowUp' | 'Home' | 'End'
+
+/**
+ * Up/Down move focus to the previous/next visible item (clamped at the
+ * ends); Home/End jump to the first/last visible item.
+ */
+export function getNextFocusIndex(
+  currentIndex: number,
+  itemCount: number,
+  key: TreeArrowVerticalKey
+): number {
+  if (itemCount <= 0) return -1
+
+  switch (key) {
+    case 'ArrowDown':
+      return Math.min(currentIndex + 1, itemCount - 1)
+    case 'ArrowUp':
+      return Math.max(currentIndex - 1, 0)
+    case 'Home':
+      return 0
+    case 'End':
+      return itemCount - 1
+    default:
+      return currentIndex
+  }
+}
+
+export interface TreeNavItem {
+  /** 0-indexed nesting depth (database = 0, table = 1, column = 2). */
+  level: number
+}
+
+export type TreeHorizontalAction =
+  | { type: 'expand' }
+  | { type: 'collapse' }
+  | { type: 'focus'; index: number }
+  | { type: 'none' }
+
+/**
+ * Right Arrow: expands a closed node (focus stays put); on an already-open
+ * node, moves focus to its first child; does nothing on a leaf node.
+ */
+export function getArrowRightAction(
+  items: readonly TreeNavItem[],
+  currentIndex: number,
+  isExpanded: boolean,
+  hasChildren: boolean
+): TreeHorizontalAction {
+  if (!hasChildren) return { type: 'none' }
+  if (!isExpanded) return { type: 'expand' }
+
+  const current = items[currentIndex]
+  const next = items[currentIndex + 1]
+  if (current && next && next.level > current.level) {
+    return { type: 'focus', index: currentIndex + 1 }
+  }
+  return { type: 'none' }
+}
+
+/**
+ * Left Arrow: collapses an open node (focus stays put); on a closed node or
+ * leaf, moves focus to the parent node; does nothing on a top-level
+ * (level 0) closed/leaf node.
+ */
+export function getArrowLeftAction(
+  items: readonly TreeNavItem[],
+  currentIndex: number,
+  isExpanded: boolean,
+  hasChildren: boolean
+): TreeHorizontalAction {
+  const current = items[currentIndex]
+  if (!current) return { type: 'none' }
+
+  if (hasChildren && isExpanded) return { type: 'collapse' }
+  if (current.level === 0) return { type: 'none' }
+
+  for (let i = currentIndex - 1; i >= 0; i--) {
+    const item = items[i]
+    if (item && item.level < current.level) {
+      return { type: 'focus', index: i }
+    }
+  }
+  return { type: 'none' }
+}

--- a/apps/dashboard/src/components/explorer/tree/tree-node.tsx
+++ b/apps/dashboard/src/components/explorer/tree/tree-node.tsx
@@ -32,6 +32,16 @@ interface TreeNodeProps {
   hasChildren?: boolean
   expandOnSelect?: boolean // If true, clicking label expands node (default: true for backwards compat)
   level: number
+  /** 1-indexed position among visible siblings, for `aria-posinset`. */
+  posInSet?: number
+  /** Total count of visible siblings, for `aria-setsize`. */
+  setSize?: number
+  /**
+   * Marks this node as the roving-tabindex fallback entry point (used when
+   * nothing in the tree is selected, so the tree still has exactly one
+   * tabbable node). Actual selection (`isSelected`) always wins over this.
+   */
+  isDefaultTabbable?: boolean
   badge?: React.ReactNode
   onToggle?: () => void
   onSelect?: () => void
@@ -50,20 +60,37 @@ export const TreeNode = function TreeNode({
   hasChildren = false,
   expandOnSelect = true,
   level,
+  posInSet,
+  setSize,
+  isDefaultTabbable = false,
   badge,
   onToggle,
   onSelect,
   children,
 }: TreeNodeProps) {
   const paddingLeft = level * 12
+  const isSelectable = Boolean(onSelect)
+  // Roving tabindex: exactly one treeitem in the tree is a Tab stop at rest
+  // (the selected node, or a designated fallback). Arrow-key navigation then
+  // moves DOM focus + updates tabIndex directly (see use-tree-keyboard-nav).
+  const isTabbable = isSelected || isDefaultTabbable
 
   return (
     // SidebarMenuItem (<li>) must be the direct child of its SidebarMenu (<ul>),
     // so the Collapsible wrapper lives *inside* the <li> — which also gives the
     // tree its correct semantics (a node's nested <ul> sits within its <li>).
+    // WAI-ARIA Tree View pattern: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
     <SidebarMenuItem
+      role="treeitem"
+      aria-label={label}
+      aria-level={level + 1}
+      aria-posinset={posInSet}
+      aria-setsize={setSize}
+      aria-expanded={hasChildren ? isExpanded : undefined}
+      aria-selected={isSelectable ? isSelected : undefined}
+      tabIndex={isTabbable ? 0 : -1}
       className={cn(
-        'transition-colors',
+        'rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
         isHighlighted && !isSelected && 'bg-sidebar-accent/50'
       )}
     >
@@ -77,6 +104,8 @@ export const TreeNode = function TreeNode({
               render={
                 <button
                   type="button"
+                  tabIndex={-1}
+                  data-tree-toggle="true"
                   aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${label}`}
                   className="flex size-4 items-center justify-center rounded-sm hover:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
                   onClick={(e) => {
@@ -100,6 +129,8 @@ export const TreeNode = function TreeNode({
           {!hasChildren && <div className="size-4" />}
 
           <SidebarMenuButton
+            tabIndex={-1}
+            data-tree-label="true"
             onClick={() => {
               // If expandOnSelect is true and has children and not expanded, expand first
               if (expandOnSelect && hasChildren && !isExpanded) {
@@ -152,7 +183,7 @@ export const TreeNode = function TreeNode({
 
         {hasChildren && children && (
           <CollapsibleContent>
-            <SidebarMenuSub>{children}</SidebarMenuSub>
+            <SidebarMenuSub role="group">{children}</SidebarMenuSub>
           </CollapsibleContent>
         )}
       </Collapsible>


### PR DESCRIPTION
Closes #2686.

The Database explorer tree had no ARIA tree semantics and no arrow-key navigation — unusable with a screen reader or keyboard.

Implements the full WAI-ARIA APG treeview pattern:
- `role="tree"` / `"treeitem"` / `"group"`, `aria-expanded`, `aria-selected` (only on selectable nodes), `aria-level` (1-indexed), `aria-setsize` / `aria-posinset`
- **Roving tabindex** — exactly one Tab stop, not tabindex on every node
- Keys: Up/Down (prev/next visible), Right (expand-or-first-child), Left (collapse-or-parent), Home/End, Enter/Space (activate)
- Removes the stray `role="presentation"` the issue called out

**Design worth noting:** navigation logic is split into a **pure, DOM-free module** (`tree-keyboard-nav.ts` — `getNextFocusIndex`, `getArrowRightAction`, `getArrowLeftAction`) with the DOM glue in `use-tree-keyboard-nav.ts`. That's what makes it unit-testable at all — **18 bun:test cases, 18 pass**, covering clamping and the expand/collapse/move-to-parent/move-to-child model incl. the skip-same-level-siblings edge case.

Keyboard actions trigger the existing chevron/label buttons via `.click()`, so all current mouse logic (`expandOnSelect`, fetch-on-expand) is reused rather than duplicated. `components/ui/` untouched.

**Verified during integration:** 18/18 keyboard-nav tests pass; `pnpm run type-check` clean; `pnpm run lint` clean.

**Flagged for review:**
1. Nested `<button>`s (chevron, label) remain inside `role="treeitem"`, both `tabIndex={-1}` — the standard APG pattern for treeitems with embedded controls, and deliberate to avoid axe's `nested-interactive` rule. **The axe-core CI job on this PR is the real check.**
2. `getVisibleTreeItems` filters on `getClientRects().length > 0`, defending against Base UI's `Collapsible.Panel` either unmounting *or* hiding-in-place when collapsed — the agent couldn't determine which without `node_modules`.
3. No Cypress component test — there was no existing `.cy.tsx` harness for the explorer tree to extend. The extractable pure logic is covered by bun:test instead; a manual keyboard smoke test before merge is worthwhile.

Co-Authored-By: duyetbot <bot@duyet.net>