### PR TITLE
fix(landing): deduplicate version badges in changelog band

### DIFF
--- a/apps/landing/src/components/ChangelogBand.astro
+++ b/apps/landing/src/components/ChangelogBand.astro
@@ -1,11 +1,19 @@
 ---
+import type { ChangelogFeature } from '../lib/parse-changelog-features'
 import { loadChangelogFeatures } from '../data/changelog-features'
 
-// Newest features sit first in CHANGELOG.md, so the raw (file-order) list gives
-// us the latest four without re-sorting. Each card links to the real changelog
-// page (release notes), not an in-page anchor.
+// Newest features sit first in CHANGELOG.md. Take one feature per version so the
+// band never shows the same version badge on every card. Each card links to the
+// real changelog page (release notes), not an in-page anchor.
 const { features } = loadChangelogFeatures()
-const latest = features.slice(0, 4)
+const seenVersions = new Set<string>()
+const latest: ChangelogFeature[] = []
+for (const f of features) {
+  if (f.version && seenVersions.has(f.version)) continue
+  if (f.version) seenVersions.add(f.version)
+  latest.push(f)
+  if (latest.length >= 4) break
+}
 ---
 <section class="py-14 sm:py-18 border-t border-border bg-muted/30">
   <div class="mx-auto max-w-6xl px-4 sm:px-6">


### PR DESCRIPTION
## Problem

The landing page Changelog band () could show duplicate version badges — if multiple features from the same release happened to be among the latest 4, every card displayed an identical badge, making the band look redundant.

## Fix

Instead of , the component now iterates through features and picks one per version until 4 distinct-version cards are collected (or features are exhausted). Each card shows a unique version badge.

## Verification

- 
> chmonitor@0.2.9 build:landing /Users/duet/project/chmonitor/chmonitor
> cd apps/landing && pnpm install --frozen-lockfile && pnpm run build

Lockfile is up to date, resolution step is skipped
Already up to date

Done in 2.1s using pnpm v10.18.0

> landing@0.2.0 build /Users/duet/project/chmonitor/chmonitor/apps/landing
> node ../../scripts/sync-shared-assets.mjs && astro build

sync-shared-assets: 0 file(s) copied to /Users/duet/project/chmonitor/chmonitor/apps/landing/public/assets
19:57:06 [types] Generated 30ms
19:57:06 [build] output: "static"
19:57:06 [build] mode: "static"
19:57:06 [build] directory: /Users/duet/project/chmonitor/chmonitor/apps/landing/dist/
19:57:06 [build] Collecting build info...
19:57:06 [build] ✓ Completed in 54ms.
19:57:06 [build] Building static entrypoints...
19:57:06 [vite] ✓ built in 293ms
19:57:07 [vite] ✓ built in 256ms
19:57:07 [build] Rearranging server assets...

 generating static routes 
19:57:07   ├─ /404.html (+7ms) 
19:57:07   ├─ /brand/index.html (+2ms) 
19:57:07   ├─ /changelog/index.html (+1.73s) 
19:57:08   ├─ /clickhouse-vs-druid-pinot/index.html (+4ms) 
19:57:08   ├─ /clickhouse-vs-postgres/index.html (+2ms) 
19:57:08   ├─ /clickhouse-vs-timescaledb/index.html (+2ms) 
19:57:08   ├─ /cluster-health/index.html (+389ms) 
19:57:09   ├─ /features/ai-agent/index.html (+3ms) 
19:57:09   ├─ /features/queries/index.html (+1ms) 
19:57:09   ├─ /features/topology/index.html (+2ms) 
19:57:09   ├─ /features/alerting/index.html (+1ms) 
19:57:09   ├─ /features/data-explorer/index.html (+1ms) 
19:57:09   ├─ /features/insights/index.html (+1ms) 
19:57:09   ├─ /features/peerdb/index.html (+1ms) 
19:57:09   ├─ /features/postgres/index.html (+1ms) 
19:57:09   ├─ /features/overview/index.html (+1ms) 
19:57:09   ├─ /features/storage/index.html (+1ms) 
19:57:09   ├─ /monitor-queries/index.html (+1ms) 
19:57:09   ├─ /performance/index.html (+1ms) 
19:57:09   ├─ /pricing/index.html (+18ms) 
19:57:09   ├─ /replication/index.html (+3ms) 
19:57:09   ├─ /vs-clickhouse-cloud/index.html (+5ms) 
19:57:09   ├─ /vs-datadog/index.html (+8ms) 
19:57:09   ├─ /vs-grafana/index.html (+1ms) 
19:57:09   ├─ /index.html (+5ms) 
19:57:09 ✓ Completed in 2.25s.

19:57:09 [build] ✓ Completed in 2.82s.
19:57:09 [@astrojs/sitemap] `sitemap-index.xml` created at `dist`
19:57:09 [build] 25 page(s) built in 2.91s
19:57:09 [build] Complete! passes