### PR TITLE
feat(telemetry): enhance privacy note and add disable-tracking instructions to landing page

### DIFF
--- a/apps/telemetry/index.html
+++ b/apps/telemetry/index.html
@@ -168,6 +168,73 @@
       line-height: 1.6;
     }
 
+    .opt-out-box {
+      border: none;
+      background: #f0f7ff;
+      padding: 28px;
+      margin-bottom: 40px;
+      border-radius: 14px;
+    }
+
+    .opt-out-box h3 {
+      font-size: 1.1rem;
+      font-weight: 700;
+      color: #1e3a8a;
+      margin-bottom: 12px;
+      letter-spacing: -0.02em;
+    }
+
+    .opt-out-box p {
+      font-size: 0.9rem;
+      color: #1e40af;
+      line-height: 1.6;
+      margin-bottom: 16px;
+    }
+
+    .opt-out-methods {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .opt-out-method {
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      padding: 12px 16px;
+      background: #ffffff;
+      border-radius: 10px;
+      font-size: 0.9rem;
+    }
+
+    .opt-out-method code {
+      font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, Consolas, monospace;
+      font-size: 0.85rem;
+      background: #eef2ff;
+      padding: 4px 10px;
+      border-radius: 6px;
+      color: #1e40af;
+      font-weight: 600;
+      white-space: nowrap;
+    }
+
+    .opt-out-method .desc {
+      color: var(--fg-muted);
+      font-size: 0.85rem;
+    }
+
+    .opt-out-footnote {
+      margin-top: 12px;
+      font-size: 0.8rem;
+      color: var(--fg-muted);
+    }
+
+    .opt-out-footnote a {
+      color: var(--accent);
+      text-decoration: underline;
+      text-underline-offset: 3px;
+    }
+
     .stats-grid {
       display: grid;
       grid-template-columns: 1fr 1fr;
@@ -423,9 +490,31 @@
       <div class="info-box">
         <h3>Privacy-First Analytics</h3>
         <p>
-          All data is 100% anonymous. No IPs, hostnames, or identifying information are recorded.
-          Only COUNT(DISTINCT) of SHA-256 hashed instance IDs are processed. Each install generates a unique
-          hash that cannot be reversed to identify the original instance.
+          chmonitor includes an anonymous, privacy-first telemetry system. It is <strong>on by default</strong>
+          and you can turn it off at any time. All data is 100% anonymous — no IPs, hostnames, or identifying
+          information are recorded. Only COUNT(DISTINCT) of SHA-256 hashed instance IDs are processed.
+        </p>
+      </div>
+
+      <div class="opt-out-box">
+        <h3>How to Disable Tracking</h3>
+        <p>Telemetry runs unless you explicitly turn it off. Any of the following methods disables it:</p>
+        <div class="opt-out-methods">
+          <div class="opt-out-method">
+            <code>CHM_TELEMETRY=off</code>
+            <span class="desc">Server runtime environment variable (also <code>0</code>, <code>false</code>, <code>no</code>)</span>
+          </div>
+          <div class="opt-out-method">
+            <code>DO_NOT_TRACK=1</code>
+            <span class="desc">Cross-tool <a href="https://consoledonottrack.com">opt-out standard</a> — hard override</span>
+          </div>
+          <div class="opt-out-method">
+            <code>CHM_TELEMETRY_ENDPOINT=""</code>
+            <span class="desc">Hard kill-switch — empty endpoint stops all network calls</span>
+          </div>
+        </div>
+        <p class="opt-out-footnote">
+          See <a href="https://docs.chmonitor.dev/operate/advanced/telemetry">the docs</a> for full details on telemetry, events, and retention.
         </p>
       </div>
 

--- a/apps/telemetry/src/index.ts
+++ b/apps/telemetry/src/index.ts
@@ -282,6 +282,79 @@ export default {
       line-height: 1.6;
     }
 
+    .opt-out-box {
+      border: none;
+      background: #f0f7ff;
+      padding: 28px;
+      margin-bottom: 40px;
+      border-radius: 14px;
+    }
+
+    .opt-out-box h3 {
+      font-size: 1.1rem;
+      font-weight: 700;
+      color: #1e3a8a;
+      margin-bottom: 12px;
+      letter-spacing: -0.02em;
+    }
+
+    .opt-out-box p {
+      font-size: 0.9rem;
+      color: #1e40af;
+      line-height: 1.6;
+      margin-bottom: 16px;
+    }
+
+    .opt-out-methods {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .opt-out-method {
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      padding: 12px 16px;
+      background: #ffffff;
+      border-radius: 10px;
+      font-size: 0.9rem;
+    }
+
+    .opt-out-method code {
+      font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, Consolas, monospace;
+      font-size: 0.85rem;
+      background: #eef2ff;
+      padding: 4px 10px;
+      border-radius: 6px;
+      color: #1e40af;
+      font-weight: 600;
+      white-space: nowrap;
+    }
+
+    .opt-out-method .desc {
+      color: #475569;
+      font-size: 0.85rem;
+    }
+
+    .opt-out-method .desc a {
+      color: #2563eb;
+      text-decoration: underline;
+      text-underline-offset: 3px;
+    }
+
+    .opt-out-footnote {
+      margin-top: 12px;
+      font-size: 0.8rem;
+      color: #475569;
+    }
+
+    .opt-out-footnote a {
+      color: #2563eb;
+      text-decoration: underline;
+      text-underline-offset: 3px;
+    }
+
     .stats-grid {
       display: grid;
       grid-template-columns: 1fr 1fr;
@@ -449,6 +522,40 @@ export default {
         opacity: 0.85;
       }
 
+      .opt-out-box {
+        background: #1e293b;
+      }
+
+      .opt-out-box h3 {
+        color: #93c5fd;
+      }
+
+      .opt-out-box p {
+        color: #bfdbfe;
+      }
+
+      .opt-out-method {
+        background: #0f172a;
+      }
+
+      .opt-out-method code {
+        background: #1e3a5f;
+        color: #93c5fd;
+      }
+
+      .opt-out-method .desc {
+        color: #94a3b8;
+      }
+
+      .opt-out-method .desc a,
+      .opt-out-footnote a {
+        color: #60a5fa;
+      }
+
+      .opt-out-footnote {
+        color: #94a3b8;
+      }
+
       .stat-card {
         background: #111827;
       }
@@ -537,9 +644,31 @@ export default {
       <div class="info-box">
         <h3>Privacy-First Analytics</h3>
         <p>
-          All data is 100% anonymous. No IPs, hostnames, or identifying information are recorded.
-          Only COUNT(DISTINCT) of SHA-256 hashed instance IDs are processed. Each install generates a unique
-          hash that cannot be reversed to identify the original instance.
+          chmonitor includes an anonymous, privacy-first telemetry system. It is <strong>on by default</strong>
+          and you can turn it off at any time. All data is 100% anonymous — no IPs, hostnames, or identifying
+          information are recorded. Only COUNT(DISTINCT) of SHA-256 hashed instance IDs are processed.
+        </p>
+      </div>
+
+      <div class="opt-out-box">
+        <h3>How to Disable Tracking</h3>
+        <p>Telemetry runs unless you explicitly turn it off. Any of the following methods disables it:</p>
+        <div class="opt-out-methods">
+          <div class="opt-out-method">
+            <code>CHM_TELEMETRY=off</code>
+            <span class="desc">Server runtime environment variable (also <code>0</code>, <code>false</code>, <code>no</code>)</span>
+          </div>
+          <div class="opt-out-method">
+            <code>DO_NOT_TRACK=1</code>
+            <span class="desc">Cross-tool <a href="https://consoledontrack.com">opt-out standard</a> — hard override</span>
+          </div>
+          <div class="opt-out-method">
+            <code>CHM_TELEMETRY_ENDPOINT=""</code>
+            <span class="desc">Hard kill-switch — empty endpoint stops all network calls</span>
+          </div>
+        </div>
+        <p class="opt-out-footnote">
+          See <a href="https://docs.chmonitor.dev/operate/advanced/telemetry">the docs</a> for full details on telemetry, events, and retention.
         </p>
       </div>
 


### PR DESCRIPTION
## Changes

Enhance the telemetry landing page (telemetry.chmonitor.dev) with two improvements:

1. **Privacy note enhancement** — clarifies telemetry is **on by default** with opt-out anytime, making the privacy stance transparent
2. **New 'How to Disable Tracking' section** — documents all three opt-out methods with examples:
   - `CHM_TELEMETRY=off` (env var)
   - `DO_NOT_TRACK=1` (cross-tool standard)
   - `CHM_TELEMETRY_ENDPOINT=""` (hard kill-switch)

Both `index.html` (static source) and `src/index.ts` (Cloudflare Worker template literal) are updated in sync.

## Preview

The opt-out section displays each method as a code block with a brief description, styled consistently with the existing info-box design.