### PR TITLE
fix(landing): hero flash, nav polish, more recent releases

### DIFF
--- a/apps/landing/src/components/ChangelogBand.astro
+++ b/apps/landing/src/components/ChangelogBand.astro
@@ -12,7 +12,7 @@ for (const f of features) {
   if (f.version && seenVersions.has(f.version)) continue
   if (f.version) seenVersions.add(f.version)
   latest.push(f)
-  if (latest.length >= 4) break
+  if (latest.length >= 6) break
 }
 ---
 <section class="py-14 sm:py-18 border-t border-border bg-muted/30">
@@ -31,7 +31,7 @@ for (const f of features) {
         <svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
       </a>
     </div>
-    <div class="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+    <div class="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {
         latest.map((f) => (
           <a

--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -117,9 +117,10 @@ const githubSvg = `<svg class="size-3.5" viewBox="0 0 24 24" fill="currentColor"
 
     {/* Anchor screenshot(s). The hairline lives on THIS wrapper — see
         ScreenshotShot. The two overview shots rotate; the first is the eager
-        LCP element. */}
+        LCP element. Every shot after the first ships hidden so a slow network
+        never shows them stacked while waiting for the first rotation tick. */}
     <div
-      class="mt-12 sm:mt-16 overflow-hidden rounded-xl border border-border bg-card p-1.5 sm:p-2"
+      class="mt-12 sm:mt-16 overflow-hidden rounded-xl border border-border bg-card p-1.5 sm:p-2 hero-shot-frame"
       data-hero-rotate
     >
       {
@@ -129,6 +130,7 @@ const githubSvg = `<svg class="size-3.5" viewBox="0 0 24 24" fill="currentColor"
             src={shot.src}
             alt={shot.alt}
             eager={i === 0}
+            hidden={i > 0}
           />
         ))
       }
@@ -158,6 +160,15 @@ const githubSvg = `<svg class="size-3.5" viewBox="0 0 24 24" fill="currentColor"
       var idx = 0
       var reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches
       if (reduce) return
+      // Hidden slots carry loading=lazy and display:none, so the browser never
+      // fetched them — warm them after load so the first swap isn't blank.
+      window.addEventListener('load', function () {
+        shots.forEach(function (shot, i) {
+          if (i === 0) return
+          var img = shot.querySelector('img')
+          if (img) new Image().src = img.currentSrc || img.src
+        })
+      })
       setInterval(function () {
         shots[idx].style.display = 'none'
         idx = (idx + 1) % shots.length
@@ -165,4 +176,43 @@ const githubSvg = `<svg class="size-3.5" viewBox="0 0 24 24" fill="currentColor"
       }, 6000)
     })()
   </script>
+
+  {/* Scroll-linked settle: the shot frame starts a touch larger than rest size
+      and eases down to 1 over the first ~360px of scroll. Pure transform (no
+      layout/CLS); the section's overflow-hidden clips the enlarged edges. */}
+  <script is:inline>
+    (function () {
+      var frame = document.querySelector('[data-hero-rotate]')
+      if (!frame) return
+      if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+      var MAX = 0.045
+      var RANGE = 360
+      var ticking = false
+      var apply = function () {
+        ticking = false
+        var p = Math.min(Math.max(window.scrollY, 0) / RANGE, 1)
+        frame.style.setProperty('--hero-shot-scale', (1 + MAX * (1 - p)).toFixed(4))
+      }
+      window.addEventListener('scroll', function () {
+        if (!ticking) {
+          ticking = true
+          requestAnimationFrame(apply)
+        }
+      }, { passive: true })
+      apply()
+    })()
+  </script>
+
+  <style>
+    .hero-shot-frame {
+      transform: scale(var(--hero-shot-scale, 1.045));
+      transform-origin: 50% 0;
+      will-change: transform;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .hero-shot-frame {
+        transform: none;
+      }
+    }
+  </style>
 </section>

--- a/apps/landing/src/components/Nav.astro
+++ b/apps/landing/src/components/Nav.astro
@@ -25,8 +25,7 @@ import { btnOutline, btnOutlineBlock, btnPrimary, btnPrimaryBlock } from '../lib
             <a href="/features/data-explorer">Data Explorer<small>Tables, lineage and SQL console</small></a>
             <a href="/features/insights">Insights<small>AI findings and cluster vitals</small></a>
             <a href="/features/peerdb">PeerDB replication<small>Postgres → ClickHouse CDC</small></a>
-            <a href="/features/postgres">Postgres · Beta<small>Monitor Postgres alongside</small></a>
-            <a href="/#features">All features<small>Overview on the homepage</small></a>
+            <a href="/features/postgres"><span class="nav-item-label">Postgres<span class="nav-badge">Beta</span></span><small>Monitor Postgres alongside</small></a>
           </div>
         </div>
         <a href="https://github.com/chmonitor/chmonitor" target="_blank" rel="noopener">Open source</a>
@@ -78,25 +77,40 @@ import { btnOutline, btnOutlineBlock, btnPrimary, btnPrimaryBlock } from '../lib
         </button>
       </div>
       <div class="nav-drawer-body">
-        <span class="nav-drawer-label">Features</span>
-        <a href="/features/ai-agent">AI Agent</a>
-        <a href="/features/overview">Cluster overview</a>
-        <a href="/features/queries">Query monitoring</a>
-        <a href="/features/topology">Cluster topology</a>
-        <a href="/features/storage">Storage &amp; tables</a>
-        <a href="/features/alerting">Alerting</a>
-        <a href="/features/data-explorer">Data Explorer</a>
-        <a href="/features/insights">Insights</a>
-        <a href="/features/peerdb">PeerDB replication</a>
-        <a href="/features/postgres">Postgres · Beta</a>
-        <span class="nav-drawer-label">Explore</span>
+        {/* Groups with children collapse (closed by default) so the drawer
+            stays short; top-level destinations remain one-tap links. */}
+        <details class="nav-drawer-group">
+          <summary>
+            Features
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
+          </summary>
+          <div class="nav-drawer-group-body">
+            <a href="/features/ai-agent">AI Agent</a>
+            <a href="/features/overview">Cluster overview</a>
+            <a href="/features/queries">Query monitoring</a>
+            <a href="/features/topology">Cluster topology</a>
+            <a href="/features/storage">Storage &amp; tables</a>
+            <a href="/features/alerting">Alerting</a>
+            <a href="/features/data-explorer">Data Explorer</a>
+            <a href="/features/insights">Insights</a>
+            <a href="/features/peerdb">PeerDB replication</a>
+            <a href="/features/postgres">Postgres<span class="nav-badge">Beta</span></a>
+          </div>
+        </details>
         <a href="https://github.com/chmonitor/chmonitor" target="_blank" rel="noopener">Open source</a>
         <a href="/pricing">Pricing</a>
         <a href="https://docs.chmonitor.dev" target="_blank" rel="noopener">Docs</a>
-        <span class="nav-drawer-label">Resources</span>
-        <a href="https://blog.chmonitor.dev" target="_blank" rel="noopener">Blog</a>
-        <a href="/changelog">Changelog</a>
-        <a href="/brand">Brand</a>
+        <details class="nav-drawer-group">
+          <summary>
+            Resources
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
+          </summary>
+          <div class="nav-drawer-group-body">
+            <a href="https://blog.chmonitor.dev" target="_blank" rel="noopener">Blog</a>
+            <a href="/changelog">Changelog</a>
+            <a href="/brand">Brand</a>
+          </div>
+        </details>
       </div>
       <div class="nav-drawer-foot">
         <div class="nav-drawer-theme">

--- a/apps/landing/src/components/ScreenshotShot.astro
+++ b/apps/landing/src/components/ScreenshotShot.astro
@@ -6,6 +6,9 @@ interface Props {
   alt: string
   /** Hero shot only: it is the LCP element, so skip lazy-loading. */
   eager?: boolean
+  /** Rotation slots: render display:none so only the active shot is visible
+      before any script runs (a JS-only hide left both stacked on slow loads). */
+  hidden?: boolean
 }
 
 /*
@@ -17,7 +20,7 @@ interface Props {
  * the page, and that script counts raw string occurrences of the zoom
  * attribute. A comment naming it would pad the count and mask a regression.
  */
-const { id, src, srcDark, alt, eager = false } = Astro.props
+const { id, src, srcDark, alt, eager = false, hidden = false } = Astro.props
 ---
 
 <button
@@ -26,6 +29,7 @@ const { id, src, srcDark, alt, eager = false } = Astro.props
   data-zoom-src={src}
   data-zoom-src-dark={srcDark}
   data-zoom-alt={alt}
+  style={hidden ? 'display:none' : undefined}
   class="group relative block w-full cursor-zoom-in overflow-hidden rounded-lg bg-transparent p-0 leading-none outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:ring-offset-2 focus-visible:ring-offset-background"
   aria-label={`View full size: ${alt}`}
 >

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -277,6 +277,22 @@ const ogImage = new URL(image, Astro.site).toString()
     .nav-drawer-body a{display:flex;align-items:center;min-height:44px;padding:8px 10px;border-radius:var(--radius);
       font-size:15.5px;font-weight:500;color:var(--fg-soft);transition:background .14s,color .14s}
     .nav-drawer-body a:hover{background:var(--muted);color:var(--fg)}
+    /* Collapsible drawer groups: native <details> so collapse works pre-JS.
+       Summary rows mirror the plain link rows; children indent behind a
+       hairline like a tree level, not a second flat list. */
+    .nav-drawer-group summary{display:flex;align-items:center;justify-content:space-between;min-height:44px;
+      padding:8px 10px;border-radius:var(--radius);font-size:15.5px;font-weight:500;color:var(--fg-soft);
+      cursor:pointer;list-style:none;transition:background .14s,color .14s}
+    .nav-drawer-group summary::-webkit-details-marker{display:none}
+    .nav-drawer-group summary:hover{background:var(--muted);color:var(--fg)}
+    .nav-drawer-group summary svg{width:15px;height:15px;color:var(--muted-fg);
+      transition:transform .2s ease;flex:0 0 auto}
+    .nav-drawer-group[open] summary{color:var(--fg)}
+    .nav-drawer-group[open] summary svg{transform:rotate(180deg)}
+    .nav-drawer-group-body{display:flex;flex-direction:column;margin:2px 0 6px 10px;
+      padding-left:8px;border-left:1px solid var(--border-soft)}
+    .nav-drawer-group-body a{min-height:40px;font-size:14.5px;font-weight:450}
+    @media (prefers-reduced-motion:reduce){.nav-drawer-group summary svg{transition:none}}
     .nav-drawer-foot{display:flex;flex-direction:column;gap:10px;padding:16px 16px 22px;
       border-top:1px solid var(--border-soft);flex:0 0 auto}
     .nav-drawer-theme{display:flex;align-items:center;justify-content:space-between;
@@ -316,6 +332,15 @@ const ogImage = new URL(image, Astro.site).toString()
     .nav-menu a small{font-size:12px;font-weight:400;color:var(--muted-fg);
       display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:1;line-clamp:1;overflow:hidden}
     @media (prefers-reduced-motion:reduce){.nav-trigger svg,.nav-menu{transition:none}}
+    /* Status pill for nav items — e.g. "Beta". `--orange` is the small-text-safe
+       accent token; the tint uses color-mix so it stays legible in both themes
+       without a separate dark-mode override. */
+    .nav-item-label{display:inline-flex;align-items:center;gap:6px}
+    .nav-badge{display:inline-flex;align-items:center;height:16px;padding:0 6px;
+      border-radius:999px;font-size:10px;font-weight:700;letter-spacing:.03em;text-transform:uppercase;
+      color:var(--orange);background:color-mix(in srgb,var(--orange) 14%,transparent);
+      line-height:1}
+    .nav-drawer-group-body a .nav-badge{margin-left:auto}
 
     /* ── theme toggle ── */
     /* Matches .nav-toggle / .btn: 40px box, 8px radius, hairline border. */


### PR DESCRIPTION
## Summary
- Fix hero double-image flash on slow loads: non-first rotation shots now ship `display:none` (not just JS-hidden after the first 6s tick), so a slow network never shows two screenshots stacked.
- Add a scroll-settle effect: the hero shot frame starts slightly larger (1.045x) and eases to 1x over the first ~360px of scroll (`prefers-reduced-motion` respected).
- Nav: drop the redundant "All features" mega-menu link, add a "Beta" status pill next to Postgres (desktop + mobile), and fix the mobile drawer so Features/Resources collapse behind a tap instead of flattening every child into the top-level list.
- Changelog band: show 6 recent releases instead of 4 (3-col grid) so more recently shipped work is visible on the homepage.

## Test plan
- [x] `pnpm run build` — clean, 25 pages generated
- [x] `bun run verify:structure` — passes (one pre-existing unrelated failure on `/changelog`, confirmed present on `main` too)
- [x] Verified in Chrome DevTools at 1400px and 390px: only one hero shot renders on load, mega-menu shows Beta badge and no "All features" entry, mobile drawer collapses/expands Features and Resources with indented children, changelog band renders 6 cards in a 3×2 grid
- [x] Verified `--hero-shot-scale` CSS var eases 1.045 → 1.026 → 1.0 across scroll position