### PR TITLE
feat(mcp): rate-limit the standalone MCP worker

### DIFF
--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -23,6 +23,15 @@ import {
   normalizePath,
   withCors,
 } from '@chm/mcp-server/http'
+import { createIpRateLimitCheck } from '@chm/mcp-server/rate-limit'
+
+// Per-IP guard (#2728) — parity with the dashboard route's #2704 limiter, which
+// this Worker bypassed entirely (Workers Routes deliver /api/mcp* here first).
+// The CHM_RATE_LIMIT_MCP unsafe binding (wrangler.toml) is authoritative when
+// present; otherwise a per-isolate bucket enforces RATE_LIMIT_MCP_PER_MIN.
+const checkMcpRateLimit = createIpRateLimitCheck({
+  bindingName: 'CHM_RATE_LIMIT_MCP',
+})
 
 export default {
   async fetch(request: Request): Promise<Response> {
@@ -32,12 +41,19 @@ export default {
       // CORS preflight: respond before auth so browsers can complete the dance.
       if (request.method === 'OPTIONS') return corsPreflight()
 
-      if (pathname === '/api/mcp') return await handleMcp(request)
+      // Rate limit (#2728): injected per-IP guard, checked inside the handlers
+      // before auth — parity with the dashboard route's #2704 guard, which this
+      // Worker bypassed entirely (Workers Routes deliver /api/mcp* here first).
+      if (pathname === '/api/mcp') {
+        return await handleMcp(request, { rateLimitCheck: checkMcpRateLimit })
+      }
       if (pathname === '/api/v1/mcp/info') {
         if (request.method !== 'GET') {
           return withCors(new Response('Method Not Allowed', { status: 405 }))
         }
-        return await handleMcpInfo(request)
+        return await handleMcpInfo(request, {
+          rateLimitCheck: checkMcpRateLimit,
+        })
       }
       // OAuth discovery (RFC 9728). In production dash.chmonitor.dev/.well-known/*
       // is served by the dashboard worker; this keeps the MCP worker

--- a/apps/mcp/wrangler.toml
+++ b/apps/mcp/wrangler.toml
@@ -50,6 +50,18 @@ compatibility_flags = [
 [observability]
 enabled = true
 
+# Fleet-wide rate limiting (#2728) — same Cloudflare Rate Limiting binding
+# pattern as the dashboard worker's CHM_RATE_LIMIT_MCP. The edge counter is
+# authoritative across isolates; src/rate-limit.ts falls back to a per-isolate
+# token bucket when the binding is absent (wrangler dev / forks without it).
+# namespace_id is scoped to this worker script; 3001 avoids implying any link
+# to the dashboard worker's 2xxx ids.
+[[unsafe.bindings]]
+name = "CHM_RATE_LIMIT_MCP"
+type = "ratelimit"
+namespace_id = "3001"
+simple = { limit = 30, period = 60 }
+
 # Workers Cache (launched 2026-07-06): safe to enable — MCP requests are authed
 # and carry an `Authorization` bearer (auto-bypassed by Workers Cache), and no
 # response here sets a public `Cache-Control`, so nothing is cached. Enabled for
@@ -102,6 +114,14 @@ zone_name = "chmonitor.dev"
 [[env.preview.routes]]
 pattern = "preview.dash.chmonitor.dev/api/v1/mcp/info*"
 zone_name = "chmonitor.dev"
+
+# Preview shares the top-level rate-limit posture (wrangler does not inherit
+# top-level unsafe bindings into named envs, so it is redeclared here).
+[[env.preview.unsafe.bindings]]
+name = "CHM_RATE_LIMIT_MCP"
+type = "ratelimit"
+namespace_id = "3001"
+simple = { limit = 30, period = 60 }
 
 # Generic placeholders (see [vars] above) — real preview topology + pk_test are
 # injected at deploy from CI (CHM_CLERK_PUBLISHABLE_KEY_TEST + host secrets).

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -9,6 +9,7 @@
     ".": "./src/index.ts",
     "./server": "./src/server.ts",
     "./http": "./src/http.ts",
+    "./rate-limit": "./src/rate-limit.ts",
     "./cors": "./src/cors.ts",
     "./auth": "./src/auth/index.ts",
     "./data": "./src/data/mcp-tools-data.ts"

--- a/packages/mcp-server/src/__tests__/http.test.ts
+++ b/packages/mcp-server/src/__tests__/http.test.ts
@@ -150,6 +150,52 @@ describe('mcp http', () => {
     })
   })
 
+  describe('handleMcp rate-limit gate (#2728)', () => {
+    it('short-circuits with the rate-limit response before auth runs', async () => {
+      let authRan = false
+      const res = await handleMcp(req(), {
+        rateLimitCheck: async () => new Response('slow down', { status: 429 }),
+        authenticate: async () => {
+          authRan = true
+          return null
+        },
+      })
+      expect(res.status).toBe(429)
+      // rate-limit responses are CORS-wrapped so browser clients can read them
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*')
+      // cheap counter runs first; network-touching auth never fires
+      expect(authRan).toBe(false)
+    })
+
+    it('proceeds to auth when the rate-limit check allows', async () => {
+      const sentinel = new Response('nope', { status: 403 })
+      const res = await handleMcp(req(), {
+        rateLimitCheck: async () => null,
+        authenticate: async () => sentinel,
+      })
+      expect(res.status).toBe(403)
+    })
+
+    it('gates handleMcpInfo through the same option', async () => {
+      const res = await handleMcpInfo(
+        new Request('https://example.com/api/v1/mcp/info'),
+        { rateLimitCheck: async () => new Response('', { status: 429 }) }
+      )
+      expect(res.status).toBe(429)
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*')
+    })
+
+    it('returns a CORS-wrapped 500 when the rate-limit check throws', async () => {
+      const res = await handleMcp(req(), {
+        rateLimitCheck: async () => {
+          throw new Error('boom')
+        },
+      })
+      expect(res.status).toBe(500)
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*')
+    })
+  })
+
   describe('buildServerInfo / handleMcpInfo', () => {
     it('builds the expected server info payload', () => {
       const info = buildServerInfo()

--- a/packages/mcp-server/src/__tests__/rate-limit.test.ts
+++ b/packages/mcp-server/src/__tests__/rate-limit.test.ts
@@ -1,0 +1,96 @@
+import { _resetBucketsForTest, createIpRateLimitCheck } from '../rate-limit'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+
+function req(ip: string): Request {
+  return new Request('https://example.com/api/mcp', {
+    method: 'POST',
+    headers: { 'cf-connecting-ip': ip },
+  })
+}
+
+describe('createIpRateLimitCheck', () => {
+  const originalLimit = process.env.RATE_LIMIT_MCP_PER_MIN
+
+  beforeEach(() => {
+    _resetBucketsForTest()
+  })
+
+  afterEach(() => {
+    if (originalLimit !== undefined) {
+      process.env.RATE_LIMIT_MCP_PER_MIN = originalLimit
+    } else {
+      delete process.env.RATE_LIMIT_MCP_PER_MIN
+    }
+    delete (globalThis as Record<string, unknown>).TEST_RATE_LIMIT_BINDING
+  })
+
+  it('allows requests under the limit', async () => {
+    process.env.RATE_LIMIT_MCP_PER_MIN = '3'
+    const check = createIpRateLimitCheck()
+    expect(await check(req('1.1.1.1'))).toBeNull()
+    expect(await check(req('1.1.1.1'))).toBeNull()
+    expect(await check(req('1.1.1.1'))).toBeNull()
+  })
+
+  it('429s once the per-IP budget is exhausted, with Retry-After', async () => {
+    process.env.RATE_LIMIT_MCP_PER_MIN = '2'
+    const check = createIpRateLimitCheck()
+    await check(req('2.2.2.2'))
+    await check(req('2.2.2.2'))
+    const res = await check(req('2.2.2.2'))
+    expect(res?.status).toBe(429)
+    expect(Number(res?.headers.get('Retry-After'))).toBeGreaterThan(0)
+    const body = (await res?.json()) as {
+      error: { type: string; retryAfterSec: number }
+    }
+    expect(body.error.type).toBe('rate_limited')
+  })
+
+  it('tracks each client IP independently', async () => {
+    process.env.RATE_LIMIT_MCP_PER_MIN = '1'
+    const check = createIpRateLimitCheck()
+    await check(req('3.3.3.3'))
+    expect((await check(req('3.3.3.3')))?.status).toBe(429)
+    // a different IP still has a full bucket
+    expect(await check(req('4.4.4.4'))).toBeNull()
+  })
+
+  it('falls back to the default limit on junk env values', async () => {
+    process.env.RATE_LIMIT_MCP_PER_MIN = 'not-a-number'
+    const check = createIpRateLimitCheck()
+    // default is 30 — well above the two calls made here
+    expect(await check(req('5.5.5.5'))).toBeNull()
+    expect(await check(req('5.5.5.5'))).toBeNull()
+  })
+
+  it('uses the Cloudflare binding when present and 429s on { success: false }', async () => {
+    const seenKeys: string[] = []
+    ;(globalThis as Record<string, unknown>).TEST_RATE_LIMIT_BINDING = {
+      limit: async ({ key }: { key: string }) => {
+        seenKeys.push(key)
+        return { success: false }
+      },
+    }
+    const check = createIpRateLimitCheck({
+      bindingName: 'TEST_RATE_LIMIT_BINDING',
+    })
+    const res = await check(req('6.6.6.6'))
+    expect(res?.status).toBe(429)
+    expect(seenKeys).toEqual(['mcp:ip:6.6.6.6'])
+  })
+
+  it('fails open to the in-memory bucket when the binding throws', async () => {
+    ;(globalThis as Record<string, unknown>).TEST_RATE_LIMIT_BINDING = {
+      limit: async () => {
+        throw new Error('edge unavailable')
+      },
+    }
+    process.env.RATE_LIMIT_MCP_PER_MIN = '1'
+    const check = createIpRateLimitCheck({
+      bindingName: 'TEST_RATE_LIMIT_BINDING',
+    })
+    // first request passes via the fallback bucket; second exhausts it
+    expect(await check(req('7.7.7.7'))).toBeNull()
+    expect((await check(req('7.7.7.7')))?.status).toBe(429)
+  })
+})

--- a/packages/mcp-server/src/http.ts
+++ b/packages/mcp-server/src/http.ts
@@ -172,9 +172,26 @@ export const defaultAuthenticator: Authenticator = async (req) => {
   return unauthorized(req)
 }
 
+/**
+ * Resolves a request to a Response (rate limited, typically 429) or null
+ * (allowed). Injectable for the same reason as `Authenticator`: this package is
+ * forbidden (dependency-cruiser `no-packages-to-apps`) from importing any
+ * app's rate limiter, so each caller supplies its own — the dashboard route
+ * keeps its `checkMcpRateLimit` at the route layer (it must run before the
+ * plan-capability gate), and the standalone Worker (apps/mcp) passes one here.
+ */
+export type RateLimitCheck = (req: Request) => Promise<Response | null>
+
 interface HandleMcpOptions {
   /** Override the auth check. Defaults to defaultAuthenticator. */
   authenticate?: Authenticator
+  /**
+   * Optional pre-auth rate-limit gate (#2728). Runs before `authenticate` —
+   * cheap counter first, network-touching auth (Clerk REST) second — and its
+   * Response is returned with CORS headers applied. No default: callers that
+   * already guard at their route layer simply omit it.
+   */
+  rateLimitCheck?: RateLimitCheck
 }
 
 /**
@@ -186,9 +203,13 @@ interface HandleMcpOptions {
  */
 export async function handleMcp(
   req: Request,
-  { authenticate = defaultAuthenticator }: HandleMcpOptions = {}
+  { authenticate = defaultAuthenticator, rateLimitCheck }: HandleMcpOptions = {}
 ): Promise<Response> {
   try {
+    if (rateLimitCheck) {
+      const limited = await rateLimitCheck(req)
+      if (limited) return withCors(limited)
+    }
     // withCors even on the auth failure: a custom authenticator may return a
     // bare Response, and browser MCP clients need the CORS headers to read it.
     const fail = await authenticate(req)
@@ -269,9 +290,13 @@ export function buildServerInfo(): McpServerInfoResponse {
  */
 export async function handleMcpInfo(
   req: Request,
-  { authenticate = defaultAuthenticator }: HandleMcpOptions = {}
+  { authenticate = defaultAuthenticator, rateLimitCheck }: HandleMcpOptions = {}
 ): Promise<Response> {
   try {
+    if (rateLimitCheck) {
+      const limited = await rateLimitCheck(req)
+      if (limited) return withCors(limited)
+    }
     const fail = await authenticate(req)
     if (fail) return withCors(fail)
     return withCors(Response.json(buildServerInfo()))

--- a/packages/mcp-server/src/rate-limit.ts
+++ b/packages/mcp-server/src/rate-limit.ts
@@ -1,0 +1,172 @@
+/**
+ * Reusable per-IP rate-limit check for MCP endpoints (#2728).
+ *
+ * The dashboard's in-process /api/mcp route gained an IP-keyed guard in #2704,
+ * but the standalone Worker (apps/mcp) serves the same `handleMcp` and remained
+ * unlimited — and this package cannot import the dashboard's limiter
+ * (dependency-cruiser `no-packages-to-apps`, correctly). So `handleMcp` takes
+ * an injectable `rateLimitCheck` (see http.ts), and this module provides a
+ * dependency-free implementation callers can wire in.
+ *
+ * Semantics mirror `apps/dashboard/src/lib/api/rate-limiter.ts`:
+ * - When a Cloudflare Rate Limiting binding (`[[unsafe.bindings]]` type
+ *   "ratelimit") is present on `globalThis` under `bindingName`, its fleet-wide
+ *   edge counter is authoritative.
+ * - Otherwise a per-isolate token bucket enforces `limitPerMin` (covers
+ *   `wrangler dev`, forks without the binding, and non-Workers runtimes).
+ * - Binding errors fail open to the in-memory bucket rather than hard-blocking.
+ */
+
+/** Cloudflare Rate Limiting binding surface (the "unsafe" ratelimit binding). */
+export interface RateLimitBinding {
+  limit(options: { key: string }): Promise<{ success: boolean }>
+}
+
+/** The bindings we declare use a 60s period; blocked callers back off a full one. */
+const BINDING_PERIOD_SEC = 60
+const WINDOW_MS = 60_000
+
+interface Bucket {
+  tokens: number
+  lastRefillMs: number
+}
+
+/** Per-isolate fallback store; capped so hostile IP churn cannot grow it unbounded. */
+const buckets = new Map<string, Bucket>()
+const MAX_BUCKETS = 5_000
+
+function getBinding(name: string): RateLimitBinding | undefined {
+  const candidate = (globalThis as Record<string, unknown>)[name]
+  if (
+    candidate &&
+    typeof (candidate as RateLimitBinding).limit === 'function'
+  ) {
+    return candidate as RateLimitBinding
+  }
+  return undefined
+}
+
+/**
+ * Stable client identity: prefer Cloudflare's CF-Connecting-IP, fall back to
+ * X-Real-IP, then the first X-Forwarded-For hop, then "unknown".
+ */
+export function clientIpKey(request: Request): string {
+  return (
+    request.headers.get('cf-connecting-ip') ??
+    request.headers.get('x-real-ip') ??
+    ((request.headers.get('x-forwarded-for') ?? '').split(',')[0].trim() ||
+      'unknown')
+  )
+}
+
+/** In-memory token bucket; returns seconds to wait, or 0 when allowed. */
+function checkBucket(key: string, limit: number): number {
+  const nowMs = Date.now()
+  let bucket = buckets.get(key)
+  if (!bucket) {
+    if (buckets.size >= MAX_BUCKETS) {
+      const oldest = buckets.keys().next().value
+      if (oldest !== undefined) buckets.delete(oldest)
+    }
+    bucket = { tokens: limit, lastRefillMs: nowMs }
+  } else {
+    // Re-insert on touch so Map order approximates LRU for the cap eviction.
+    buckets.delete(key)
+  }
+  buckets.set(key, bucket)
+
+  const elapsedMs = nowMs - bucket.lastRefillMs
+  if (elapsedMs > 0) {
+    bucket.tokens = Math.min(
+      limit,
+      bucket.tokens + (elapsedMs / WINDOW_MS) * limit
+    )
+    bucket.lastRefillMs = nowMs
+  }
+  if (bucket.tokens >= 1) {
+    bucket.tokens -= 1
+    return 0
+  }
+  return Math.ceil((((1 - bucket.tokens) / limit) * WINDOW_MS) / 1000)
+}
+
+/** 429 with Retry-After — same JSON shape as the dashboard's rateLimitResponse. */
+function rateLimitResponse(retryAfterSec: number): Response {
+  return new Response(
+    JSON.stringify({
+      success: false,
+      error: {
+        type: 'rate_limited',
+        message: `Too many requests. Retry after ${retryAfterSec} second(s).`,
+        retryAfterSec,
+      },
+    }),
+    {
+      status: 429,
+      headers: {
+        'Content-Type': 'application/json',
+        'Retry-After': String(retryAfterSec),
+      },
+    }
+  )
+}
+
+export interface IpRateLimitOptions {
+  /**
+   * Name of a Cloudflare rate-limit binding on `globalThis` (e.g.
+   * "CHM_RATE_LIMIT_MCP"). When present it is authoritative; omit or absent →
+   * in-memory bucket only.
+   */
+  bindingName?: string
+  /**
+   * Env var read (lazily, per request) for the in-memory limit. Junk or unset
+   * values fall back to `defaultLimitPerMin`.
+   */
+  limitEnvVar?: string
+  /** Fallback per-60s limit when the env var is unset/invalid. Default 30. */
+  defaultLimitPerMin?: number
+  /** Bucket-key namespace prefix. Default "mcp". */
+  keyPrefix?: string
+}
+
+/**
+ * Build a `rateLimitCheck` (see http.ts `HandleMcpOptions`) that limits by
+ * client IP. Returns a 429 Response when over budget, null otherwise.
+ */
+export function createIpRateLimitCheck({
+  bindingName,
+  limitEnvVar = 'RATE_LIMIT_MCP_PER_MIN',
+  defaultLimitPerMin = 30,
+  keyPrefix = 'mcp',
+}: IpRateLimitOptions = {}): (req: Request) => Promise<Response | null> {
+  return async (request: Request) => {
+    const key = `${keyPrefix}:ip:${clientIpKey(request)}`
+    const binding = bindingName ? getBinding(bindingName) : undefined
+    if (binding) {
+      try {
+        const { success } = await binding.limit({ key })
+        return success ? null : rateLimitResponse(BINDING_PERIOD_SEC)
+      } catch {
+        // Fail open to the in-memory bucket rather than blocking legitimate
+        // traffic when the edge counter is unavailable.
+      }
+    }
+    // Read via globalThis so this stays type-clean under Workers-only tsconfigs
+    // (apps/mcp has no Node types; nodejs_compat provides process at runtime).
+    const raw = (
+      globalThis as {
+        process?: { env?: Record<string, string | undefined> }
+      }
+    ).process?.env?.[limitEnvVar]
+    const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN
+    const limit =
+      Number.isFinite(parsed) && parsed > 0 ? parsed : defaultLimitPerMin
+    const retryAfterSec = checkBucket(key, limit)
+    return retryAfterSec === 0 ? null : rateLimitResponse(retryAfterSec)
+  }
+}
+
+/** Test-only: reset the fallback store between cases. */
+export function _resetBucketsForTest(): void {
+  buckets.clear()
+}


### PR DESCRIPTION
Closes #2728

## Problem
#2704 rate-limited the in-process `dash.chmonitor.dev/api/mcp` route, but the standalone `apps/mcp` Worker serves the same `handleMcp` and remained unlimited — Workers Routes deliver `/api/mcp*` to it first in production, so the dashboard guard never sees that traffic.

## Approach (as suggested in the issue)
- `handleMcp` / `handleMcpInfo` gain an optional injectable `rateLimitCheck`, mirroring the existing `authenticate` injection — `packages/mcp-server` stays free of `apps/*` imports (dependency-cruiser `no-packages-to-apps`).
- New dependency-free `@chm/mcp-server/rate-limit` module: `createIpRateLimitCheck()` uses a Cloudflare Rate Limiting binding when present (fleet-wide edge counter), falls back to a per-isolate token bucket (`RATE_LIMIT_MCP_PER_MIN`, default 30 — same rationale as the dashboard), and fails open on binding errors. Lives in the package so `bun test packages` actually runs its tests in CI.
- `apps/mcp` wires it for both `/api/mcp` and `/api/v1/mcp/info`; wrangler.toml declares the `CHM_RATE_LIMIT_MCP` unsafe binding (30/60s, production + preview).
- Dashboard route intentionally unchanged: its route-layer check must stay ahead of the plan-capability gate (ordering documented in http.ts).

## Tests
- Injection: 429 short-circuits before auth, CORS-wrapped, throw → 500 (http.test.ts)
- Limiter: budget exhaustion + Retry-After, per-IP isolation, junk env fallback, binding authoritative path, fail-open on binding throw (rate-limit.test.ts)
- `bun test packages/mcp-server`: 158 pass

https://claude.ai/code/session_015bMEPjo2wiRfzHj3APikzr