### PR TITLE
fix(ux): surface clipboard copy failures instead of failing silently

### DIFF
--- a/apps/dashboard/src/components/charts/chart-error-dialog-content.tsx
+++ b/apps/dashboard/src/components/charts/chart-error-dialog-content.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/dialog'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { type CardError, getTableMissingInfo } from '@/lib/card-error-utils'
+import { describeError } from '@/lib/swr/fetch-error'
 import { cn } from '@/lib/utils'
 
 interface ChartErrorDialogContentProps {
@@ -38,8 +39,8 @@ export default function ChartErrorDialogContent({
     try {
       await navigator.clipboard.writeText(errorMarkdown)
       toast.success('Error details copied to clipboard')
-    } catch {
-      toast.error('Failed to copy error')
+    } catch (err) {
+      toast.error('Failed to copy error', { description: describeError(err) })
     }
   }
 
@@ -48,8 +49,8 @@ export default function ChartErrorDialogContent({
     try {
       await navigator.clipboard.writeText(prompt)
       toast.info('Prompt copied! Paste into your AI agent (Claude, etc.)')
-    } catch {
-      toast.error('Failed to copy prompt')
+    } catch (err) {
+      toast.error('Failed to copy prompt', { description: describeError(err) })
     }
   }
 
@@ -82,8 +83,10 @@ export default function ChartErrorDialogContent({
                     try {
                       await navigator.clipboard.writeText(sql)
                       toast.success('SQL query copied to clipboard')
-                    } catch {
-                      toast.error('Failed to copy SQL')
+                    } catch (err) {
+                      toast.error('Failed to copy SQL', {
+                        description: describeError(err),
+                      })
                     }
                   }}
                 >

--- a/apps/dashboard/src/components/charts/chart-zoom-dialog.tsx
+++ b/apps/dashboard/src/components/charts/chart-zoom-dialog.tsx
@@ -11,6 +11,7 @@ import {
   SparklesIcon,
   Zap,
 } from 'lucide-react'
+import { toast } from 'sonner'
 
 import type { CardToolbarMetadata } from '@/components/cards/card-toolbar'
 import type { DateRangeConfig, DateRangeValue } from '@/components/date-range'
@@ -41,6 +42,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { formatSql } from '@/lib/sql-format'
+import { describeError } from '@/lib/swr/fetch-error'
 import { cn, dedent } from '@/lib/utils'
 
 const BEAUTIFY_STORAGE_KEY = 'chart-zoom-sql-beautify'
@@ -162,10 +164,16 @@ export const ChartZoomDialog = function ChartZoomDialog({
 
   const handleQueryCopy = async () => {
     if (!sql) return
-    const text = isBeautified ? await formatSql(sql) : dedent(sql)
-    await navigator.clipboard.writeText(text)
-    setQueryCopied(true)
-    setTimeout(() => setQueryCopied(false), 2000)
+    try {
+      const text = isBeautified ? await formatSql(sql) : dedent(sql)
+      await navigator.clipboard.writeText(text)
+      setQueryCopied(true)
+      setTimeout(() => setQueryCopied(false), 2000)
+    } catch (err) {
+      // Previously an unhandled rejection — the user clicked Copy and nothing
+      // happened, with no feedback at all (#2729).
+      toast.error('Failed to copy SQL', { description: describeError(err) })
+    }
   }
 
   // Handle dialog resize via mouse drag

--- a/apps/dashboard/src/components/charts/system/top-memory-queries.tsx
+++ b/apps/dashboard/src/components/charts/system/top-memory-queries.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { ExternalLink, Lightbulb, MemoryStick } from 'lucide-react'
+import { toast } from 'sonner'
 
 import type { ChartProps } from '@/components/charts/chart-props'
 
@@ -17,6 +18,7 @@ import {
 } from '@/components/ui/dialog'
 import { buildExplorerQueryUrl } from '@/lib/explorer-url'
 import { REFRESH_INTERVAL, useChartData, useHostId } from '@/lib/swr'
+import { describeError } from '@/lib/swr/fetch-error'
 import { cn } from '@/lib/utils'
 
 type DataRow = {
@@ -63,8 +65,9 @@ function QueryDetailDialog({
       await navigator.clipboard.writeText(query)
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
-    } catch {
-      /* noop */
+    } catch (err) {
+      // Silent failure here left the user clicking Copy with no feedback (#2729).
+      toast.error('Failed to copy query', { description: describeError(err) })
     }
   }
 

--- a/apps/dashboard/src/components/query-detail/query-detail-view.tsx
+++ b/apps/dashboard/src/components/query-detail/query-detail-view.tsx
@@ -16,6 +16,7 @@ import {
   User as UserIcon,
   Wand2,
 } from 'lucide-react'
+import { toast } from 'sonner'
 
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { highlightCode } from '@/components/ai-elements/code-block'
@@ -32,6 +33,7 @@ import { formatReadableSize } from '@/lib/format-readable'
 import { deriveQueryInsights } from '@/lib/query/query-insights'
 import { useTableData } from '@/lib/query/use-table-data'
 import { formatSql } from '@/lib/sql-format'
+import { describeError } from '@/lib/swr/fetch-error'
 import { useHostId } from '@/lib/swr/use-host'
 import { buildUrl } from '@/lib/url/url-builder'
 import { cn } from '@/lib/utils'
@@ -330,8 +332,9 @@ function SqlBlock({ query }: { query: string }) {
       setCopied(true)
       if (copyTimer.current) clearTimeout(copyTimer.current)
       copyTimer.current = setTimeout(() => setCopied(false), 2000)
-    } catch {
-      /* noop */
+    } catch (err) {
+      // Silent failure here left the user clicking Copy with no feedback (#2729).
+      toast.error('Failed to copy query', { description: describeError(err) })
     }
   }
 

--- a/apps/dashboard/src/components/query-favorites/query-favorites-panel.tsx
+++ b/apps/dashboard/src/components/query-favorites/query-favorites-panel.tsx
@@ -1,4 +1,5 @@
 import { Check, Copy, Pencil, Play, Trash2, X } from 'lucide-react'
+import { toast } from 'sonner'
 
 import type { QueryFavorite } from '@/lib/stores/use-query-favorites'
 
@@ -8,6 +9,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { useQueryFavorites } from '@/lib/stores/use-query-favorites'
+import { describeError } from '@/lib/swr/fetch-error'
 import { cn } from '@/lib/utils'
 
 function relTime(ts: number): string {
@@ -72,8 +74,9 @@ function FavoriteItem({
       await navigator.clipboard.writeText(fav.shareUrl)
       setCopied(true)
       setTimeout(() => setCopied(false), 1500)
-    } catch {
-      // Clipboard unavailable — ignore silently.
+    } catch (err) {
+      // Silent failure here left the user clicking Copy with no feedback (#2729).
+      toast.error('Failed to copy link', { description: describeError(err) })
     }
   }
 


### PR DESCRIPTION
Refs #2729 (the user-visible cluster; follow-up to #2687)

## What
Five clipboard copy paths either swallowed the error with a bare `catch {}` (query-detail-view, top-memory-queries, query-favorites-panel) or had no try/catch at all (chart-zoom-dialog's `handleQueryCopy` — an unhandled rejection), so a failed Copy click gave the user zero feedback. `chart-error-dialog-content` (3 sites) had error toasts but no failure detail.

All now follow the #2687 convention: `toast.error('Failed to X', { description: describeError(err) })` — title says *what* failed, description says *why*.

## Deliberately not changed (read each site first, per the issue's own caution)
- localStorage pref catches (data-table ×3, chart-zoom ×2, query-detail ×2, chart-scale-context) — legitimate graceful fallbacks
- `highlightCode` fallback, `isValidUrl` parse guard
- clerk-nav sign-out catch — its fallback is a forced navigation, a real remediation, not a discard
- `connection-form.tsx:133` from the issue is actually `isValidUrl`'s parse guard, and the test-connection catches already capture `err` and feed `ConnectionErrorPanel`/`classifyConnectionError` — that issue item is stale on current main

## Verify
`pnpm run type-check` clean; Biome lint-staged passed.

https://claude.ai/code/session_015bMEPjo2wiRfzHj3APikzr