### PR TITLE
fix(pricing): disclose beta-wide feature unlock on the landing pricing page

### DIFF
--- a/apps/landing/src/data/pricing.ts
+++ b/apps/landing/src/data/pricing.ts
@@ -203,6 +203,10 @@ export interface PricingFaq {
 
 export const pricingFaqs: PricingFaq[] = [
   {
+    q: 'Are Pro/Max features really exclusive right now?',
+    a: 'Not yet — during early access every plan feature (Fleet view, custom dashboards, webhook integrations, data export, anomaly detection, advanced alerting) is unlocked for all tiers, including Free. Only plan limits (hosts, seats, alert rules, history, AI usage) are enforced today. Per-tier feature gating begins at paid GA, and existing subscribers will be notified before anything changes. Paying now supports development and locks in your limits.',
+  },
+  {
     q: 'Is self-hosting really free?',
     a: 'Yes. chmonitor is open source under GPL-3.0. Run it on your own infrastructure (Docker, Cloudflare Workers, Kubernetes) with every feature, unlimited clusters, and your data never leaving your network — at no cost, forever.',
   },

--- a/apps/landing/src/pages/pricing.astro
+++ b/apps/landing/src/pages/pricing.astro
@@ -44,6 +44,7 @@ const breadcrumbJsonLd = {
           <span class="eyebrow">Pricing</span>
           <h1>Simple pricing that scales with your fleet</h1>
           <p>Self-hosting is always free under GPL-3.0. The hosted cloud connects a cluster in minutes — start free, upgrade when your team grows. <strong>Early access is free to try</strong> while in beta.</p>
+          <p><strong>During early access, every plan feature is unlocked for all tiers</strong> — paid plans currently differ by limits only (hosts, seats, alert rules, history, AI usage). Feature gating by tier arrives at paid GA, with advance notice to subscribers.</p>
           <p>Postgres source monitoring (beta) is available on every plan, including Free and self-hosted.</p>
         </div>
       </div>
@@ -59,6 +60,7 @@ const breadcrumbJsonLd = {
           <span class="eyebrow">Compare</span>
           <h2>Every plan, side by side</h2>
           <p>Limits and features across all {compareColumns.length} tiers. Self-hosting includes everything, with no caps.</p>
+          <p>Feature checkmarks show where each capability lands at paid GA — during early access they are unlocked for every tier, and only the Limits rows are enforced today.</p>
         </div>
 
         <div class="cmp-wrap reveal">


### PR DESCRIPTION
Closes #2678 — option (b) from the issue: explicit disclosure rather than premature gating.

## Why not gate (option a)?
Gating Fleet/dashboards/webhooks/export/anomaly/alerting mid-beta would pull access from Free users without notice and contradicts `plan-enforcement.ts`'s own stated intent ('Free during early access; gate when paid GA launches'). Enforcement remains a deliberate paid-GA product decision.

## What
The in-app billing page already discloses this — `plan-comparison.tsx` renders capabilities the enforcement registry marks `deferred` as a single 'beta — included for everyone' row, driven off `CAPABILITY_ENFORCEMENT` so it can't drift. The landing pricing page (which the issue shows never mentions the unlock) now says it in the three places a buyer looks:

- **Intro banner**: 'During early access, every plan feature is unlocked for all tiers — paid plans currently differ by limits only… Feature gating by tier arrives at paid GA, with advance notice to subscribers.'
- **Compare matrix note**: checkmarks show where capabilities land at paid GA; only Limits rows are enforced today.
- **Leading FAQ entry**: 'Are Pro/Max features really exclusive right now?' with the honest answer and the why-pay-now framing.

Landing can't import the dashboard's enforcement registry (apps→apps), so this is prose; if the registry ever moves into `packages/pricing`, the matrix note can become registry-driven like the in-app one.

## Verify
`apps/landing` astro build passes (25 pages).

https://claude.ai/code/session_015bMEPjo2wiRfzHj3APikzr