### PR TITLE
feat(cli): publish ch-monitor-cli to crates.io with a chm binary

### DIFF
--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'rust/ch-json/**'
       - 'rust/ch-pivot/**'
+      - 'rust/ch-monitor-cli/**'
       - '.github/workflows/cargo-publish.yml'
   workflow_dispatch:
 
@@ -44,6 +45,8 @@ jobs:
               - 'rust/ch-json/**'
             ch_pivot:
               - 'rust/ch-pivot/**'
+            ch_monitor_cli:
+              - 'rust/ch-monitor-cli/**'
 
       - name: Publish ch-json
         if: steps.filter.outputs.ch_json == 'true' || github.event_name == 'workflow_dispatch'
@@ -87,4 +90,29 @@ jobs:
             cargo publish
           else
             echo "ch-pivot v$VERSION already published or check inconclusive (HTTP $STATUS_CODE). Skipping publish."
+          fi
+
+      # The user-facing CLI (#2699): publishing it makes `cargo install
+      # ch-monitor-cli` work for Rust-toolchain users, complementing the
+      # binary install script (scripts/install.sh → chm-v* GitHub Releases).
+      - name: Publish ch-monitor-cli
+        if: steps.filter.outputs.ch_monitor_cli == 'true' || github.event_name == 'workflow_dispatch'
+        working-directory: rust/ch-monitor-cli
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          VERSION=$(grep -m 1 '^version = ' Cargo.toml | cut -d '"' -f 2)
+          echo "Checking ch-monitor-cli v$VERSION on crates.io..."
+
+          # crates.io API requires a User-Agent header (returns 403 otherwise).
+          # Publish ONLY on a definitive 404; treat 200/403/5xx as "skip" so a
+          # transient API quirk never triggers a doomed `cargo publish`.
+          STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "User-Agent: clickhouse-monitoring-ci (https://github.com/chmonitor/chmonitor)" \
+            "https://crates.io/api/v1/crates/ch-monitor-cli/$VERSION" || true)
+          if [ "$STATUS_CODE" = "404" ]; then
+            echo "ch-monitor-cli v$VERSION not found on crates.io. Publishing..."
+            cargo publish
+          else
+            echo "ch-monitor-cli v$VERSION already published or check inconclusive (HTTP $STATUS_CODE). Skipping publish."
           fi

--- a/.github/workflows/cli-rust-release.yml
+++ b/.github/workflows/cli-rust-release.yml
@@ -50,7 +50,8 @@ jobs:
       - name: Package
         run: |
           mkdir -p dist
-          cp rust/target/${{ matrix.target }}/release/ch-monitor-cli dist/${{ matrix.bin }}-${{ matrix.target }}
+          # The crate's [[bin]] is named `chm` (so `cargo install` matches the docs).
+          cp rust/target/${{ matrix.target }}/release/chm dist/${{ matrix.bin }}-${{ matrix.target }}
           cd dist
           shasum -a 256 ${{ matrix.bin }}-${{ matrix.target }} > ${{ matrix.bin }}-${{ matrix.target }}.sha256
       - uses: softprops/action-gh-release@v3

--- a/docs/content/guide/guides/diagnostics-cli.mdx
+++ b/docs/content/guide/guides/diagnostics-cli.mdx
@@ -21,6 +21,13 @@ script detects your OS/arch, downloads the matching binary from
 curl -sSf https://raw.githubusercontent.com/chmonitor/chmonitor/main/scripts/install.sh | bash
 ```
 
+Already have a Rust toolchain? `cargo install` works too and builds the same
+binary from [crates.io](https://crates.io/crates/ch-monitor-cli):
+
+```bash
+cargo install ch-monitor-cli
+```
+
 ```bash
 CLICKHOUSE_HOST=http://localhost:8123 CLICKHOUSE_USER=default chm diagnose
 ```
@@ -37,7 +44,7 @@ CLICKHOUSE_HOST=http://localhost:8123 CLICKHOUSE_USER=default \
 # or build once and reuse:
 cargo build --release --manifest-path rust/ch-monitor-cli/Cargo.toml
 CLICKHOUSE_HOST=http://localhost:8123 CLICKHOUSE_USER=default \
-  ./rust/target/release/ch-monitor-cli diagnose
+  ./rust/target/release/chm diagnose
 ```
 </Callout>
 

--- a/rust/ch-monitor-cli/Cargo.toml
+++ b/rust/ch-monitor-cli/Cargo.toml
@@ -11,6 +11,13 @@ keywords = ["clickhouse", "cli", "monitoring", "diagnostics"]
 categories = ["command-line-utilities"]
 exclude = ["/.github"]
 
+# The marketed command is `chm` (docs, install.sh, release assets) — without
+# this, `cargo install ch-monitor-cli` would drop a binary named
+# `ch-monitor-cli` that none of the documentation mentions.
+[[bin]]
+name = "chm"
+path = "src/main.rs"
+
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env"] }


### PR DESCRIPTION
Refs #2699 (issue closes fully once the maintainer pushes the first `chm-v*` tag — #2727)

## What
- `cargo-publish.yml`: adds `rust/ch-monitor-cli` to the path trigger + filter and a publish step identical in shape to ch-json/ch-pivot (404-gated, idempotent, skip-on-inconclusive).
- `rust/ch-monitor-cli/Cargo.toml`: `[[bin]] name = "chm"` — without it, `cargo install ch-monitor-cli` drops a binary named `ch-monitor-cli` that no docs mention. All marketing/docs/install.sh use `chm`.
- `cli-rust-release.yml`: package step copies `release/chm` (the new build output name).
- Docs: `cargo install ch-monitor-cli` added as the Rust-toolchain path; build-from-source path updated to the `chm` output name.

## Verified
- `cargo build --release` → `rust/target/release/chm`
- `cargo publish --dry-run --allow-dirty` packages + compiles cleanly (no path deps; the crate is workspace-member but self-contained)

https://claude.ai/code/session_015bMEPjo2wiRfzHj3APikzr