### PR TITLE
fix(health): keep the __digest__ sentinel out of channel-config reads; atomic digest buffering

### DIFF
--- a/apps/dashboard/src/lib/health/alert-channel-config-store.test.ts
+++ b/apps/dashboard/src/lib/health/alert-channel-config-store.test.ts
@@ -192,6 +192,31 @@ describe('alert-channel-config-store — round-trip', () => {
     expect(await listChannelConfigs('owner-1')).toEqual([])
   })
 
+  test('reserved sentinel rows (e.g. __digest__) never leak into listChannelConfigs', async () => {
+    const db = makeFakeD1()
+    currentDb = db
+    await upsertChannelConfig({
+      ownerId: 'o',
+      channel: 'webhook',
+      enabled: true,
+      target: { url: 'https://example.com/hook' },
+    })
+    // The digest settings store parks its config in the same table under a
+    // reserved channel key — it must never surface as a channel config (it
+    // would leak into GET /alert-config and the sweep's channel-settings map).
+    db._rows.push({
+      owner_id: 'o',
+      channel: '__digest__',
+      enabled: 1,
+      min_severity: null,
+      target_json: JSON.stringify({ windowMinutes: '15' }),
+      secret: null,
+      updated_at: 1,
+    })
+    const listed = await listChannelConfigs('o')
+    expect(listed.map((c) => c.channel)).toEqual(['webhook'])
+  })
+
   test('upsert drops empty/whitespace target fields', async () => {
     currentDb = makeFakeD1()
     const saved = await upsertChannelConfig({

--- a/apps/dashboard/src/lib/health/alert-channel-config-store.ts
+++ b/apps/dashboard/src/lib/health/alert-channel-config-store.ts
@@ -180,7 +180,13 @@ export async function listChannelConfigs(
       .prepare(D1_LIST_CHANNEL_CONFIG_SQL)
       .bind(ownerId)
       .all<D1ChannelConfigRow>()
-    return (result.results ?? []).map(rowToConfig)
+    // The table also holds reserved sentinel rows (e.g. the digest settings'
+    // '__digest__' key) that are NOT channel configs — without this filter they
+    // would leak into the public GET /alert-config response and pollute the
+    // sweep's mergeChannelSettings map with a bogus channel id.
+    return (result.results ?? [])
+      .filter((row) => isAlertConfigChannel(row.channel))
+      .map(rowToConfig)
   } catch (err) {
     warn(`failed to list channel configs for owner ${ownerId}: ${err}`)
     return []

--- a/apps/dashboard/src/lib/health/alert-digest-buffer-store.test.ts
+++ b/apps/dashboard/src/lib/health/alert-digest-buffer-store.test.ts
@@ -74,7 +74,10 @@ function makeFakeD1() {
       },
     }
   }
-  return { prepare, _rows: rows }
+  async function batch(stmts: { run(): Promise<unknown> }[]) {
+    return Promise.all(stmts.map((s) => s.run()))
+  }
+  return { prepare, batch, _rows: rows }
 }
 
 function makeThrowingD1() {

--- a/apps/dashboard/src/lib/health/alert-digest-buffer-store.ts
+++ b/apps/dashboard/src/lib/health/alert-digest-buffer-store.ts
@@ -92,17 +92,21 @@ export async function bufferDigestEntries(
       `INSERT INTO ${TABLE} (id, owner_id, flush_after, entry_json, created_at)
        VALUES (?1, ?2, ?3, ?4, ?5)`
     )
-    for (const entry of entries) {
-      await stmt
-        .bind(
+    // One atomic batch, not a loop of awaits: a mid-loop failure would leave
+    // earlier rows durably written while the caller (told `false`) re-sends
+    // the same entries via immediate grouping — a later sweep would then flush
+    // the orphaned rows too, delivering duplicates.
+    await db.batch(
+      entries.map((entry) =>
+        stmt.bind(
           crypto.randomUUID(),
           ownerId,
           flushAfter,
           JSON.stringify(entry),
           now
         )
-        .run()
-    }
+      )
+    )
     return true
   } catch (err) {
     warn(`failed to buffer ${entries.length} digest entries: ${err}`)

--- a/apps/dashboard/src/lib/health/server-sweep.test.ts
+++ b/apps/dashboard/src/lib/health/server-sweep.test.ts
@@ -136,8 +136,23 @@ function makeFakeD1(
     // `ensureMigrated`, which permanently caches the rejected migration
     // promise (the `migration = null` reset runs before the outer assignment)
     // and poisons those stores for every later suite in the same bun process.
+    // The digest buffer store inserts via `db.batch(boundStmts)` (atomic,
+    // all-or-nothing), so bound statements must actually execute; DDL/other
+    // statements the fake doesn't model still resolve to a no-op result.
     batch: async (stmts: unknown[]) =>
-      stmts.map(() => ({ meta: { changes: 0 } })),
+      Promise.all(
+        stmts.map(async (s) => {
+          const runnable = s as { run?: () => Promise<unknown> }
+          if (typeof runnable.run !== 'function') {
+            return { meta: { changes: 0 } }
+          }
+          try {
+            return await runnable.run()
+          } catch {
+            return { meta: { changes: 0 } }
+          }
+        })
+      ),
     prepare(sql: string) {
       const isRoutesSelect = /FROM alert_routes/i.test(sql)
       const isSubscriptionsSelect = /FROM webhook_subscriptions/i.test(sql)
@@ -145,6 +160,7 @@ function makeFakeD1(
       const isBufferInsert = /INTO alert_digest_buffer/i.test(sql)
       const isBufferSelect = /FROM alert_digest_buffer/i.test(sql)
       const isBufferDelete = /DELETE FROM alert_digest_buffer/i.test(sql)
+      const isEventsInsert = /INTO alert_events/i.test(sql)
 
       // Shared run()/all() so both the unbound statement (real D1 supports
       // calling `.run()`/`.all()` directly when the SQL has no `?`
@@ -215,6 +231,10 @@ function makeFakeD1(
           })
           return { meta: { changes: 1 } }
         }
+        // Anything else the fake doesn't model (e.g. lazy DDL migrations that
+        // now actually execute through `batch`) is a harmless no-op — only a
+        // real alert_events insert may write into `rows`.
+        if (!isEventsInsert) return { meta: { changes: 0 } }
         const [
           id,
           eventTime,


### PR DESCRIPTION
Follow-up to #2748 / #2747, from an adversarial post-merge review. Refs #2663 #2665.

## Bug 1 — sentinel leak (real, user-visible)
`alert-digest-settings-store` parks digest settings as a reserved `channel='__digest__'` row in the shared `alert_channel_config` table, but `listChannelConfigs()` had no channel filter — once an owner saved digest settings, `GET /api/v1/health/alert-config` returned a bogus `{ channel: '__digest__' }` entry and `mergeChannelSettings` polluted the sweep's channel-settings map with a non-`AlertChannelId` key. Fixed by filtering list results through `isAlertConfigChannel`; regression test seeds a sentinel row and asserts only real channels are listed.

## Bug 2 — duplicate delivery on partial buffer write (narrow edge)
`bufferDigestEntries` inserted per-entry in an awaited loop; a mid-loop D1 error returned `false` (caller falls back to immediate grouping) while earlier rows stayed durably written — a later sweep would flush those orphans too, double-delivering. Now a single `db.batch` (atomic all-or-nothing).

## Test-fake hardening
Fakes gain `batch`; the sweep fake's catch-all `run()` previously counted ANY unmodeled SQL as an `alert_events` insert — now only `INTO alert_events` writes rows, so DDL executed via batch is a no-op.

## Verified
`bun test .../lib/health` 622 pass / 0 fail across 3 consecutive runs; `type-check` + CI's `type-check:test` + lint clean.

https://claude.ai/code/session_015bMEPjo2wiRfzHj3APikzr