### PR TITLE
feat(traffic): insert performance chart — avg and p95 insert duration

### DIFF
--- a/apps/dashboard/src/components/charts/traffic/insert-performance-over-time.tsx
+++ b/apps/dashboard/src/components/charts/traffic/insert-performance-over-time.tsx
@@ -1,0 +1,28 @@
+import type { ChartProps } from '@/components/charts/chart-props'
+
+import { createAreaChart } from '@/components/charts/factory'
+import { chartTickFormatters } from '@/lib/utils'
+
+export const ChartInsertPerformanceOverTime = createAreaChart({
+  chartName: 'traffic-insert-performance',
+  index: 'event_time',
+  categories: ['avg_duration_ms', 'p95_duration_ms'],
+  defaultTitle: 'Insert Performance',
+  defaultInterval: 'toStartOfHour',
+  defaultLastHours: 24,
+  dataTestId: 'traffic-insert-performance-chart',
+  dateRangeConfig: 'operations',
+  areaChartProps: {
+    readable: 'duration',
+    showXAxis: true,
+    showCartesianGrid: true,
+    showLegend: true,
+    opacity: 0.25,
+    colors: ['--chart-2', '--chart-red'],
+    yAxisTickFormatter: chartTickFormatters.duration,
+  },
+})
+
+export type ChartInsertPerformanceOverTimeProps = ChartProps
+
+export default ChartInsertPerformanceOverTime

--- a/apps/dashboard/src/lib/api/charts/traffic-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/traffic-charts.ts
@@ -190,6 +190,34 @@ export const trafficCharts: Record<string, ChartQueryBuilder> = {
   },
 
   /**
+   * Insert (write) performance over time — average and p95 duration of
+   * successful insert queries, so slow-ingest regressions are visible next to
+   * the insert volume charts.
+   */
+  'traffic-insert-performance': ({
+    interval = 'toStartOfHour',
+    lastHours = 24,
+  }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    return {
+      query: `
+    SELECT ${applyInterval(interval, 'event_time')},
+           round(avg(query_duration_ms), 1) AS avg_duration_ms,
+           round(quantile(0.95)(query_duration_ms), 1) AS p95_duration_ms
+    FROM system.query_log
+    WHERE query_kind = 'Insert'
+      AND type = 'QueryFinish'
+      ${timeFilter ? `AND ${timeFilter}` : ''}
+    GROUP BY 1
+    ORDER BY 1
+    WITH FILL TO ${nowOrToday(interval)} STEP ${fillStep(interval)}
+  `,
+      optional: true,
+      tableCheck: 'system.query_log',
+    }
+  },
+
+  /**
    * Data merged over time — total on-disk size of parts produced by merges
    * (part_log MergeParts). High merge volume is background write work that
    * competes with ingestion for disk and CPU.

--- a/apps/dashboard/src/routes/(dashboard)/traffic.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/traffic.tsx
@@ -23,6 +23,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { ChartBytesOnDiskOverTime } from '@/components/charts/traffic/bytes-on-disk-over-time'
+import { ChartInsertPerformanceOverTime } from '@/components/charts/traffic/insert-performance-over-time'
 import { ChartInsertQueriesOverTime } from '@/components/charts/traffic/insert-queries-over-time'
 import { ChartInsertedBytesOverTime } from '@/components/charts/traffic/inserted-bytes-over-time'
 import { ChartInsertedRowsOverTime } from '@/components/charts/traffic/inserted-rows-over-time'
@@ -91,6 +92,10 @@ function TrafficPageContent() {
           chartCardContentClassName={CHART_CARD_CONTENT_CLASS}
         />
         <ChartInsertQueriesOverTime
+          chartClassName={CHART_CLASS}
+          chartCardContentClassName={CHART_CARD_CONTENT_CLASS}
+        />
+        <ChartInsertPerformanceOverTime
           chartClassName={CHART_CLASS}
           chartCardContentClassName={CHART_CARD_CONTENT_CLASS}
         />

--- a/docs/content/guide/features/traffic.mdx
+++ b/docs/content/guide/features/traffic.mdx
@@ -40,6 +40,7 @@ A grid of time-series charts. Every chart has its own **date-range selector** fo
 |---|---|---|
 | Inserted Rows over time | Rows ingested (uncompressed source of truth) | `system.query_log` |
 | Insert Queries over time | Insert-query count, split into successful and **failed** so ingestion incidents are visible | `system.query_log` |
+| Insert Performance over time | Average and p95 duration of successful insert queries — write/ingest latency regressions at a glance | `system.query_log` |
 | Inserted Bytes over time | Uncompressed bytes ingested | `system.query_log` |
 | Bytes on Disk over time | Compressed on-disk size of new parts — compare against Inserted Bytes to read effective compression | `system.part_log` |
 


### PR DESCRIPTION
Adds an **Insert Performance** chart to /traffic: avg + p95 duration of successful insert queries (system.query_log, QueryFinish, query_kind='Insert') per time bucket. Separate chart rather than a combo — insert volume already has its own chart, and duration axes don't share a scale with counts. Legend, duration tick/tooltip formatting, graceful empty state via the optional/tableCheck path. Docs chart table updated.

https://claude.ai/code/session_01NCvrJbUzzzA3Whh3tPJkZn