### PR TITLE
feat(landing): sticky frameless nav, compact capability grid, comparison rows

### DIFF
--- a/apps/dashboard/src/components/health/webhook-subscriptions-panel.tsx
+++ b/apps/dashboard/src/components/health/webhook-subscriptions-panel.tsx
@@ -315,9 +315,8 @@ function AddSubscriptionForm({ onCreated }: { onCreated: () => void }) {
           checked={instanceScoped}
           onCheckedChange={(checked) => setInstanceScoped(checked === true)}
         />
-        Instance-scoped (required for alert.fired / alert.resolved — these
-        come from the operator&apos;s env-configured hosts, not your own
-        connections)
+        Instance-scoped (required for alert.fired / alert.resolved — these come
+        from the operator&apos;s env-configured hosts, not your own connections)
       </label>
       <Button
         size="sm"

--- a/apps/dashboard/src/lib/events/event-types.ts
+++ b/apps/dashboard/src/lib/events/event-types.ts
@@ -46,9 +46,7 @@ export const INSTANCE_SCOPED_EVENT_TYPES = [
   'alert.resolved',
 ] as const satisfies readonly EmittableEventType[]
 
-export function isInstanceScopedEventType(
-  value: EmittableEventType
-): boolean {
+export function isInstanceScopedEventType(value: EmittableEventType): boolean {
   return (INSTANCE_SCOPED_EVENT_TYPES as readonly string[]).includes(value)
 }
 

--- a/apps/dashboard/src/lib/events/subscription-store.ts
+++ b/apps/dashboard/src/lib/events/subscription-store.ts
@@ -271,7 +271,8 @@ export async function createSubscription(
   const now = Date.now()
   const id = crypto.randomUUID()
   const secret = generateSubscriptionSecret()
-  const scope: SubscriptionScope = input.scope === 'instance' ? 'instance' : 'user'
+  const scope: SubscriptionScope =
+    input.scope === 'instance' ? 'instance' : 'user'
 
   try {
     await db

--- a/apps/dashboard/src/lib/health/alert-webhook-events.test.ts
+++ b/apps/dashboard/src/lib/health/alert-webhook-events.test.ts
@@ -73,7 +73,11 @@ describe('buildAlertWebhookEvent', () => {
   test('a NEW alert builds alert.fired with the current severity and resolved:false', () => {
     const evt = buildAlertWebhookEvent({
       ...baseParams,
-      decision: decision({ kind: 'new', severity: 'critical', previousSeverity: 'ok' }),
+      decision: decision({
+        kind: 'new',
+        severity: 'critical',
+        previousSeverity: 'ok',
+      }),
     })
     expect(evt).not.toBeNull()
     expect(evt).toMatchObject({

--- a/apps/dashboard/src/lib/health/alert-webhook-events.ts
+++ b/apps/dashboard/src/lib/health/alert-webhook-events.ts
@@ -19,8 +19,8 @@
  * decision, regardless of how many (if any) legacy channels are configured.
  */
 
-import type { AlertDecision } from './alert-state-store'
 import type { AlertEventData, EventPayload } from '@/lib/events/event-types'
+import type { AlertDecision } from './alert-state-store'
 
 import { debug } from '@chm/logger'
 import { emitInstanceEvent } from '@/lib/events/outbound-bus'

--- a/apps/dashboard/src/routes/api/v1/webhooks/subscriptions.ts
+++ b/apps/dashboard/src/routes/api/v1/webhooks/subscriptions.ts
@@ -14,7 +14,10 @@ import { ApiErrorType } from '@/lib/api/types'
 import { validateHostUrl } from '@/lib/browser-connections/host-url'
 import { mapSubscriptionApiError } from '@/lib/events/api-errors'
 import { resolveSubscriptionUserId } from '@/lib/events/auth'
-import { isInstanceScopedEventType, parseEventTypes } from '@/lib/events/event-types'
+import {
+  isInstanceScopedEventType,
+  parseEventTypes,
+} from '@/lib/events/event-types'
 import { getWebhookSubscriptionsServerConfig } from '@/lib/events/server-feature'
 import {
   createSubscription,
@@ -111,7 +114,11 @@ async function handlePost(request: Request): Promise<Response> {
     )
   }
 
-  if (body.scope !== undefined && body.scope !== 'user' && body.scope !== 'instance') {
+  if (
+    body.scope !== undefined &&
+    body.scope !== 'user' &&
+    body.scope !== 'instance'
+  ) {
     return createApiErrorResponse(
       {
         type: ApiErrorType.ValidationError,

--- a/apps/dashboard/src/routes/api/v1/webhooks/subscriptions/$id.ts
+++ b/apps/dashboard/src/routes/api/v1/webhooks/subscriptions/$id.ts
@@ -12,7 +12,10 @@ import { ApiErrorType } from '@/lib/api/types'
 import { validateHostUrl } from '@/lib/browser-connections/host-url'
 import { mapSubscriptionApiError } from '@/lib/events/api-errors'
 import { resolveSubscriptionUserId } from '@/lib/events/auth'
-import { isInstanceScopedEventType, parseEventTypes } from '@/lib/events/event-types'
+import {
+  isInstanceScopedEventType,
+  parseEventTypes,
+} from '@/lib/events/event-types'
 import { getWebhookSubscriptionsServerConfig } from '@/lib/events/server-feature'
 import {
   deleteSubscription,

--- a/apps/landing/src/components/Capabilities.astro
+++ b/apps/landing/src/components/Capabilities.astro
@@ -1,3 +1,69 @@
+---
+// Compact capability grid: icon + title on one row, short copy, 4-up on wide
+// screens so the section shows the breadth of coverage without scrolling far.
+const items = [
+  {
+    title: 'Overview & health',
+    desc: 'CPU, memory, connections and replication status at a glance, with cluster-wide health checks.',
+    icon: '<path d="M3 11.5 12 4l9 7.5"/><path d="M5 10v10h14V10"/>',
+  },
+  {
+    title: 'Query monitoring',
+    desc: 'Running, slow, failed and most-expensive queries with full query detail and kill actions.',
+    icon: '<circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/>',
+  },
+  {
+    title: 'Cluster insights',
+    desc: 'Record-breaking scans, busiest days and totals, surfaced automatically from query history.',
+    icon: '<path d="m3 17 6-6 4 4 8-8"/><path d="M14 7h7v7"/>',
+  },
+  {
+    title: 'Traffic & ingestion',
+    desc: 'Insert throughput, compression ratios, write amplification and disk write speed over time.',
+    icon: '<path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M4 21h16"/>',
+  },
+  {
+    title: 'Storage & tables',
+    desc: 'Table sizes, compression and disk headroom, down to part-size distribution.',
+    icon: '<ellipse cx="12" cy="5" rx="8" ry="3"/><path d="M4 5v14c0 1.7 3.6 3 8 3s8-1.3 8-3V5"/><path d="M4 12c0 1.7 3.6 3 8 3s8-1.3 8-3"/>',
+  },
+  {
+    title: 'Merges & parts',
+    desc: 'A live part-lifecycle timeline with merges, mutations and moves by table.',
+    icon: '<path d="M6 3v6a6 6 0 0 0 6 6h6"/><path d="m15 12 3 3-3 3"/><path d="M18 3v3"/>',
+  },
+  {
+    title: 'Cluster topology',
+    desc: 'Nodes, shards, replicas and Keeper drawn as a live topology map.',
+    icon: '<circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="12" cy="18" r="2"/><path d="M6 8v3a3 3 0 0 0 3 3h6a3 3 0 0 0 3-3V8"/><path d="M12 14v2"/>',
+  },
+  {
+    title: 'PeerDB replication',
+    desc: 'Mirrors and peers with live status, rows-synced trend, CDC batches and slot health.',
+    icon: '<path d="M17 2v6h-6"/><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M7 22v-6h6"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/>',
+  },
+  {
+    title: 'Advisor',
+    desc: 'Recommend-only tuning: skip indexes, projections, PREWHERE and TTL advice, ranked by impact.',
+    icon: '<path d="M12 2 13.5 9.5 21 11l-7.5 1.5L12 20l-1.5-7.5L3 11l7.5-1.5z"/>',
+  },
+  {
+    title: 'Alerting',
+    desc: 'Health checks with editable thresholds, webhooks to Slack or Discord, full alert history.',
+    icon: '<path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/><path d="M10.3 21a1.94 1.94 0 0 0 3.4 0"/>',
+  },
+  {
+    title: 'Security & access',
+    desc: 'Users, roles, grants and quotas, review who can touch what from one place.',
+    icon: '<path d="M12 2 4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/>',
+  },
+  {
+    title: 'Logs & system',
+    desc: 'Query, error, trace and ZooKeeper logs plus settings and metrics, searchable and time-ranged.',
+    icon: '<path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><path d="M14 3v6h6"/><path d="M8 13h8M8 17h6"/>',
+  },
+]
+---
   <section id="capabilities" class="py-14 sm:py-18">
     <div class="mx-auto max-w-6xl px-6">
       <div class="reveal mx-auto max-w-2xl text-center">
@@ -5,63 +71,18 @@
         <h2 class="mt-3 text-balance font-normal text-[clamp(1.75rem,4vw,2.25rem)] leading-[1.2] tracking-[-0.02em]">One dashboard for the whole cluster</h2>
         <p class="mt-4 text-pretty text-muted-foreground">From a high-level overview down to ZooKeeper logs and replication mirrors, every system table you reach for, already laid out.</p>
       </div>
-      <div class="mt-13 grid gap-[18px] min-[561px]:grid-cols-2 min-[881px]:grid-cols-3">
-        <div class="reveal rounded-xl border border-border bg-card p-6 shadow-sm transition-colors hover:border-ring/40">
-          <span class="inline-flex size-9 items-center justify-center rounded-lg bg-muted">
-            <svg class="size-4 text-muted-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M3 11.5 12 4l9 7.5"/><path d="M5 10v10h14V10"/></svg>
-          </span>
-          <h4 class="mt-4 font-semibold tracking-tight">Overview &amp; health</h4>
-          <p class="mt-2 text-sm text-muted-foreground">CPU, memory, connections and replication status at a glance, with health checks across the cluster.</p>
-        </div>
-        <div class="reveal rounded-xl border border-border bg-card p-6 shadow-sm transition-colors hover:border-ring/40">
-          <span class="inline-flex size-9 items-center justify-center rounded-lg bg-muted">
-            <svg class="size-4 text-muted-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="m3 17 6-6 4 4 8-8"/><path d="M14 7h7v7"/></svg>
-          </span>
-          <h4 class="mt-4 font-semibold tracking-tight">Cluster insights</h4>
-          <p class="mt-2 text-sm text-muted-foreground">Record-breaking scans, busiest days, total rows read and storage, surfaced automatically from your query history.</p>
-        </div>
-        <div class="reveal rounded-xl border border-border bg-card p-6 shadow-sm transition-colors hover:border-ring/40">
-          <span class="inline-flex size-9 items-center justify-center rounded-lg bg-muted">
-            <svg class="size-4 text-muted-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="12" cy="18" r="2"/><path d="M6 8v3a3 3 0 0 0 3 3h6a3 3 0 0 0 3-3V8"/><path d="M12 14v2"/></svg>
-          </span>
-          <h4 class="mt-4 font-semibold tracking-tight">PeerDB replication</h4>
-          <p class="mt-2 text-sm text-muted-foreground">Watch mirrors and peers with live status, rows-synced trend and routing, plus snapshot progress, CDC batch history and replication-slot health, failures surface immediately.</p>
-        </div>
-        <div class="reveal rounded-xl border border-border bg-card p-6 shadow-sm transition-colors hover:border-ring/40">
-          <span class="inline-flex size-9 items-center justify-center rounded-lg bg-muted">
-            <svg class="size-4 text-muted-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3v6a6 6 0 0 0 6 6h6"/><path d="m15 12 3 3-3 3"/><path d="M18 3v3"/></svg>
-          </span>
-          <h4 class="mt-4 font-semibold tracking-tight">Merges &amp; parts</h4>
-          <p class="mt-2 text-sm text-muted-foreground">A live part-lifecycle timeline with merges, mutations, moves and part-size distribution by table.</p>
-        </div>
-        <div class="reveal rounded-xl border border-border bg-card p-6 shadow-sm transition-colors hover:border-ring/40">
-          <span class="inline-flex size-9 items-center justify-center rounded-lg bg-muted">
-            <svg class="size-4 text-muted-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M12 2 4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/></svg>
-          </span>
-          <h4 class="mt-4 font-semibold tracking-tight">Security &amp; access</h4>
-          <p class="mt-2 text-sm text-muted-foreground">Users, roles, grants and quotas, review who can touch what, all from the same place.</p>
-        </div>
-        <div class="reveal rounded-xl border border-border bg-card p-6 shadow-sm transition-colors hover:border-ring/40">
-          <span class="inline-flex size-9 items-center justify-center rounded-lg bg-muted">
-            <svg class="size-4 text-muted-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><path d="M14 3v6h6"/><path d="M8 13h8M8 17h6"/></svg>
-          </span>
-          <h4 class="mt-4 font-semibold tracking-tight">Logs &amp; system</h4>
-          <p class="mt-2 text-sm text-muted-foreground">Query, error, trace and ZooKeeper logs alongside settings and metrics, searchable and time-ranged.</p>
-        </div>
-        <div class="reveal rounded-xl border border-border bg-card p-6 shadow-sm transition-colors hover:border-ring/40">
-          <span class="inline-flex size-9 items-center justify-center rounded-lg bg-muted">
-            <svg class="size-4 text-muted-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2 13.5 9.5 21 11l-7.5 1.5L12 20l-1.5-7.5L3 11l7.5-1.5z"/></svg>
-          </span>
-          <h4 class="mt-4 font-semibold tracking-tight">Advisor</h4>
-          <p class="mt-2 text-sm text-muted-foreground">Recommend-only tuning: skip indexes, projections, PREWHERE rewrites, materialized-view designs and TTL advice, ranked by impact. Nothing is applied automatically.</p>
-        </div>
-        <div class="reveal rounded-xl border border-border bg-card p-6 shadow-sm transition-colors hover:border-ring/40">
-          <span class="inline-flex size-9 items-center justify-center rounded-lg bg-muted">
-            <svg class="size-4 text-muted-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/><path d="M10.3 21a1.94 1.94 0 0 0 3.4 0"/></svg>
-          </span>
-          <h4 class="mt-4 font-semibold tracking-tight">Alerting</h4>
-          <p class="mt-2 text-sm text-muted-foreground">Built-in health checks with editable warning/critical thresholds, one webhook out to Slack or Discord, and a full alert history of every fire and recovery.</p>
-        </div>
+      <div class="mt-13 grid gap-3.5 min-[561px]:grid-cols-2 min-[881px]:grid-cols-3 min-[1101px]:grid-cols-4">
+        {items.map((item) => (
+          <div class="reveal rounded-xl border border-border bg-card p-4 shadow-sm transition-colors hover:border-ring/40">
+            <div class="flex items-center gap-2.5">
+              <span class="inline-flex size-7 shrink-0 items-center justify-center rounded-md bg-muted">
+                <svg class="size-3.5 text-muted-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" set:html={item.icon} />
+              </span>
+              <h4 class="text-sm font-semibold tracking-tight">{item.title}</h4>
+            </div>
+            <p class="mt-2.5 text-[13px] leading-relaxed text-muted-foreground">{item.desc}</p>
+          </div>
+        ))}
       </div>
     </div>
   </section>

--- a/apps/landing/src/components/Comparison.astro
+++ b/apps/landing/src/components/Comparison.astro
@@ -57,6 +57,20 @@ const partialSvg = `<svg class="inline-block size-[18px] shrink-0 align-middle t
               <td class="px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={crossSvg} /> none</span></td>
             </tr>
             <tr class="border-t border-border">
+              <td class="whitespace-nowrap px-5 py-3.5 font-medium text-foreground">Traffic &amp; ingestion insights</td>
+              <td class="bg-[var(--brand-soft)] px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={checkSvg} /> insert performance, compression, write amplification, disk write speed</span></td>
+              <td class="px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={partialSvg} /> possible, you build every panel</span></td>
+              <td class="px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={partialSvg} /> generic throughput metrics only</span></td>
+              <td class="px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={crossSvg} /> none</span></td>
+            </tr>
+            <tr class="border-t border-border">
+              <td class="whitespace-nowrap px-5 py-3.5 font-medium text-foreground">CDC &amp; Postgres monitoring</td>
+              <td class="bg-[var(--brand-soft)] px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={checkSvg} /> PeerDB mirrors, snapshot &amp; slot health; Postgres source (beta)</span></td>
+              <td class="px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={partialSvg} /> separate datasources, manual dashboards</span></td>
+              <td class="px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={partialSvg} /> Postgres integration, no PeerDB</span></td>
+              <td class="px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={crossSvg} /> none</span></td>
+            </tr>
+            <tr class="border-t border-border">
               <td class="whitespace-nowrap px-5 py-3.5 font-medium text-foreground">Alert rules &amp; channels</td>
               <td class="bg-[var(--brand-soft)] px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={checkSvg} /> Built-in health checks, editable thresholds; one webhook &rarr; Slack or Discord + full alert history</span></td>
               <td class="px-5 py-3.5 text-pretty text-muted-foreground"><span class="inline-flex items-start gap-2"><Fragment set:html={checkSvg} /> Grafana Alerting: many channels and routing rules, once you've built the CH panels</span></td>

--- a/apps/landing/src/components/Nav.astro
+++ b/apps/landing/src/components/Nav.astro
@@ -133,6 +133,18 @@ import { btnOutline, btnOutlineBlock, btnPrimary, btnPrimaryBlock } from '../lib
     </nav>
   </div>
   <script is:inline>
+    // Sticky-nav scroll state: frameless (transparent, no border) while at the
+    // very top; [data-scrolled] adds the blurred background + bottom border.
+    var navEl = document.querySelector('header.nav')
+    if (navEl) {
+      var syncNavScrolled = function () {
+        if (window.scrollY > 8) navEl.setAttribute('data-scrolled', '')
+        else navEl.removeAttribute('data-scrolled')
+      }
+      window.addEventListener('scroll', syncNavScrolled, { passive: true })
+      syncNavScrolled()
+    }
+
     // Reflect dropdown open/close state in aria-expanded (CSS handles the
     // hover/focus-within reveal; this keeps screen readers in sync).
     document.querySelectorAll('.nav-group').forEach(function (group) {
@@ -205,9 +217,9 @@ import { btnOutline, btnOutlineBlock, btnPrimary, btnPrimaryBlock } from '../lib
     // Use window.scrollTo with behavior:'instant', not el.scrollIntoView or CSS
     // smooth: an overflow-x:hidden wrapper makes scrollIntoView hit the wrong
     // scroll container, and behavior:'auto' defers to scroll-behavior:smooth
-    // which that wrapper silently cancels. The nav is static, so this is just
-    // breathing room and must match :target scroll-margin-top.
-    var NAV_OFFSET = 24
+    // which that wrapper silently cancels. The nav is sticky (64px tall), so
+    // the offset clears it plus breathing room; must match :target scroll-margin-top.
+    var NAV_OFFSET = 88
     var scrollToHash = function (hash) {
       if (!hash || hash === '#') return false
       var el = document.getElementById(decodeURIComponent(hash.slice(1)))

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -190,7 +190,8 @@ const ogImage = new URL(image, Astro.site).toString()
     button{border:0 solid transparent}
     html{scroll-behavior:smooth}
     /* breathing room above jump targets (the nav no longer overlaps) */
-    :target{scroll-margin-top:24px}
+    /* 64px sticky nav + breathing room; must match NAV_OFFSET in Nav.astro */
+    :target{scroll-margin-top:88px}
     body{
       background:var(--bg);
       color:var(--fg);
@@ -228,10 +229,16 @@ const ogImage = new URL(image, Astro.site).toString()
     .mark-lg svg{width:22px;height:22px}
 
     /* ── nav ──
-       Static, not sticky: the header scrolls away and gives the viewport back
-       to the content. No backdrop blur is needed once it never overlaps. */
-    header.nav{position:relative;z-index:50;background:var(--bg);
-      border-bottom:1px solid var(--border-soft)}
+       Sticky, frameless at rest: at the top of the page the header is fully
+       transparent (no background, no border) so it sits on the hero. Once the
+       page scrolls, [data-scrolled] (set in Nav.astro) fades in a translucent
+       blurred background + bottom border so links stay legible over content. */
+    header.nav{position:sticky;top:0;z-index:50;background:transparent;
+      border-bottom:1px solid transparent;
+      transition:background-color .18s ease,border-color .18s ease}
+    header.nav[data-scrolled]{background:color-mix(in oklab,var(--bg) 86%,transparent);
+      -webkit-backdrop-filter:blur(10px);backdrop-filter:blur(10px);
+      border-bottom-color:var(--border-soft)}
     .nav-row{display:flex;align-items:center;justify-content:space-between;gap:24px;height:64px}
     .brand{display:flex;align-items:center;gap:10px;flex:0 0 auto;font-weight:600;font-size:15px;letter-spacing:-.02em}
     .nav-links{display:flex;align-items:center;gap:4px}


### PR DESCRIPTION
## Changes

- **Nav**: sticky header, frameless (no background, no border) at the top of the page; scrolling adds a translucent blurred background + bottom border. In-page anchor offsets (`:target scroll-margin-top` + `NAV_OFFSET`) updated to 88px to clear the now-overlapping nav.
- **Capabilities ("Full coverage")**: compact cards — icon inline with title, tighter padding/copy, 4 columns on wide screens — expanded from 8 to 12 items (adds Query monitoring, Traffic & ingestion, Storage & tables, Cluster topology).
- **Comparison ("Why chmonitor")**: two new rows for recently shipped features — Traffic & ingestion insights, and CDC & Postgres monitoring (PeerDB + Postgres beta).
- **Chore**: biome formatting fixes on webhook subscription files (pre-existing on main, blocked pre-push hook).

Landing build passes (26 pages).

https://claude.ai/code/session_01NCvrJbUzzzA3Whh3tPJkZn