### PR TITLE
feat(menu): add Alert Settings to sidebar menu

### DIFF
--- a/apps/dashboard/src/components/health/health-settings-dialog.tsx
+++ b/apps/dashboard/src/components/health/health-settings-dialog.tsx
@@ -50,8 +50,13 @@ import {
 } from '@/lib/health/thresholds-storage'
 import { describeError } from '@/lib/swr/fetch-error'
 
-export function HealthSettingsDialog() {
-  const [open, setOpen] = useState(false)
+export function HealthSettingsDialog({
+  defaultOpen = false,
+}: {
+  /** Open the dialog on mount — used by the /health?settings=alerts deep link. */
+  defaultOpen?: boolean
+}) {
+  const [open, setOpen] = useState(defaultOpen)
   const [thresholds, setThresholdsState] = useState<ThresholdsMap>({})
   const [alerts, setAlerts] = useState<AlertSettings>(DEFAULT_ALERT_SETTINGS)
 

--- a/apps/dashboard/src/menu.ts
+++ b/apps/dashboard/src/menu.ts
@@ -164,11 +164,30 @@ export const menuItemsConfig: MenuItem[] = [
     ],
   },
   {
+    // Parent groups the health summary and the alert settings deep link —
+    // both land on /health; ?settings=alerts opens the settings dialog.
     title: 'Health',
-    href: '/health',
+    href: '',
     icon: HeartPulseIcon,
     section: 'main',
     permission: { feature: 'health' },
+    items: [
+      {
+        title: 'Health',
+        href: '/health',
+        description:
+          'Real-time health indicators for your ClickHouse cluster with active alerts',
+        icon: HeartPulseIcon,
+      },
+      {
+        title: 'Alert Settings',
+        href: '/health?settings=alerts',
+        description:
+          'Thresholds, alert channels, webhooks, quiet hours, digests and alert history',
+        icon: SlidersHorizontalIcon,
+        isNew: true,
+      },
+    ],
   },
   {
     title: 'Traffic',

--- a/apps/dashboard/src/routes/(dashboard)/health.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/health.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, useSearch } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { HealthGrid } from '@/components/health/health-grid'
@@ -7,12 +7,17 @@ import { PageHeader } from '@/components/layout'
 import { ChartsOnlyPageSkeleton } from '@/components/skeletons'
 
 function HealthPageContent() {
+  // Deep link from the sidebar's "Alert Settings" item: /health?settings=alerts
+  // mounts the page with the settings dialog already open.
+  const search = useSearch({ strict: false }) as { settings?: string }
   return (
     <div className="flex flex-col gap-3 sm:gap-4">
       <PageHeader
         title="Health Summary"
         description="Real-time health indicators for your ClickHouse cluster"
-        actions={<HealthSettingsDialog />}
+        actions={
+          <HealthSettingsDialog defaultOpen={search.settings === 'alerts'} />
+        }
       />
       <HealthGrid />
     </div>


### PR DESCRIPTION
## Changes

- Sidebar **Health** entry becomes a group (same pattern as Insights): **Health** and a new **Alert Settings** item.
- **Alert Settings** deep-links to `/health?settings=alerts`, which mounts the health page with the existing `HealthSettingsDialog` already open (new `defaultOpen` prop).
- Menu hrefs already support embedded query strings (`mergeHrefSearch`), so the deep link survives host-context merging.

Type-check passes.

https://claude.ai/code/session_01NCvrJbUzzzA3Whh3tPJkZn