### PR TITLE
feat(landing): frameless hero shot and features list

### DIFF
--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -120,7 +120,7 @@ const githubSvg = `<svg class="size-3.5" viewBox="0 0 24 24" fill="currentColor"
         LCP element. Every shot after the first ships hidden so a slow network
         never shows them stacked while waiting for the first rotation tick. */}
     <div
-      class="mt-12 sm:mt-16 overflow-hidden rounded-xl border border-border bg-card p-1.5 sm:p-2 hero-shot-frame"
+      class="mt-12 sm:mt-16 overflow-hidden rounded-xl hero-shot-frame"
       data-hero-rotate
     >
       {
@@ -137,7 +137,7 @@ const githubSvg = `<svg class="size-3.5" viewBox="0 0 24 24" fill="currentColor"
     </div>
 
     <ul
-      class="mx-auto mt-12 sm:mt-16 grid max-w-3xl list-none gap-x-10 gap-y-3 sm:gap-y-3.5 sm:grid-cols-2 border-t border-border pt-8 sm:pt-10"
+      class="mx-auto mt-12 sm:mt-16 grid max-w-3xl list-none gap-x-10 gap-y-3 sm:gap-y-3.5 sm:grid-cols-2 pt-8 sm:pt-10"
       data-hero-features
     >
       {


### PR DESCRIPTION
Landing polish per screenshot feedback:

- Hero screenshot: remove the card frame (`border border-border bg-card p-1.5 sm:p-2`) so the shot sits frameless on the hero; keeps `rounded-xl overflow-hidden` and the scroll-settle animation.
- Hero feature checklist ("Real-time queries, merges and replication…"): remove the `border-t` hairline above it.
- Nav transparent-at-top → bg+border when scrolled was already implemented (`Base.astro` + `data-scrolled` in `Nav.astro`); ships with this deploy.

Verified: `pnpm run build` in apps/landing passes (26 pages, verify-landing-structure OK).

https://claude.ai/code/session_01NCvrJbUzzzA3Whh3tPJkZn