### PR TITLE
feat(landing): hero bg to top under nav, feature-menu icons, footer tidy

### DIFF
--- a/apps/landing/src/components/Footer.astro
+++ b/apps/landing/src/components/Footer.astro
@@ -22,19 +22,15 @@ const latestVersion = loadLatestChangelogVersion()
             <div class="mt-3 flex flex-col gap-2.5">
               <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="/#top">Overview</a>
               <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="/#features">Features</a>
-              <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="/#feature-ai-agent">AI Agent</a>
-              <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="/#feature-topology">Cluster topology</a>
               <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="/pricing">Pricing</a>
               <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="https://dash.chmonitor.dev" target="_blank" rel="noopener">Dashboard</a>
               <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="https://blog.chmonitor.dev" target="_blank" rel="noopener">Blog</a>
-              <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href={latestVersion ? `/changelog#v${latestVersion}` : '/changelog'}>
-                Changelog{latestVersion && <span class="font-mono text-xs"> · v{latestVersion}</span>}
-              </a>
             </div>
           </div>
           <div class="min-w-0 sm:min-w-36">
             <h5 class="text-xs font-medium uppercase tracking-wider text-muted-foreground">Use cases</h5>
             <div class="mt-3 flex flex-col gap-2.5">
+              <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="/features/ai-agent">AI Agent</a>
               {useCases.map((u) => (
                 <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href={`/${u.slug}`}>{u.eyebrow}</a>
               ))}
@@ -47,6 +43,9 @@ const latestVersion = loadLatestChangelogVersion()
               <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="https://docs.chmonitor.dev" target="_blank" rel="noopener">Documentation</a>
               <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="https://github.com/chmonitor/chmonitor/issues" target="_blank" rel="noopener">Issues</a>
               <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href="https://github.com/chmonitor/chmonitor/releases" target="_blank" rel="noopener">Releases</a>
+              <a class="text-sm text-muted-foreground transition-colors hover:text-foreground" href={latestVersion ? `/changelog#v${latestVersion}` : '/changelog'}>
+                Changelog{latestVersion && <span class="font-mono text-xs"> · v{latestVersion}</span>}
+              </a>
             </div>
           </div>
           <div class="min-w-0 sm:min-w-36">

--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -42,7 +42,10 @@ const starSvg = `<svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="cur
 const githubSvg = `<svg class="size-3.5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49l-.01-1.9c-2.78.62-3.37-1.2-3.37-1.2-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.36-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.4 9.4 0 0 1 5 0c1.91-1.32 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.35 4.8-4.58 5.06.36.32.68.94.68 1.9l-.01 2.82c0 .27.18.6.69.49A10.03 10.03 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"/></svg>`
 ---
 
-<section class="relative isolate overflow-hidden pb-14 sm:pb-16 md:pb-[56px]" data-hero>
+<section class="relative isolate overflow-hidden -mt-16 pt-16 pb-14 sm:pb-16 md:pb-[56px]" data-hero>
+  {/* Pull the section up under the 64px sticky, transparent nav (-mt-16) and add
+      an equal pt-16 so the CONTENT stays put — this lets the ambient wash below
+      (absolute inset-0) reach the very top edge, behind the nav. */}
   {/* Ambient field: a single brand wash off the top edge. No grid, no second
       hue — the canvas carries the page. */}
   <div

--- a/apps/landing/src/components/Nav.astro
+++ b/apps/landing/src/components/Nav.astro
@@ -1,5 +1,24 @@
 ---
 import { btnOutline, btnOutlineBlock, btnPrimary, btnPrimaryBlock } from '../lib/button-classes'
+
+// Lucide glyphs (inner paths only) for the Features dropdown — one per child so
+// the mega-menu scans visually. Rendered inside `.nav-ico > svg` via set:html.
+const featureIcons = {
+  aiAgent: '<path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z"/>',
+  overview: '<rect width="7" height="9" x="3" y="3" rx="1"/><rect width="7" height="5" x="14" y="3" rx="1"/><rect width="7" height="9" x="14" y="12" rx="1"/><rect width="7" height="5" x="3" y="16" rx="1"/>',
+  queries: '<path d="M22 12h-4l-3 9L9 3l-3 9H2"/>',
+  topology: '<rect x="16" y="16" width="6" height="6" rx="1"/><rect x="2" y="16" width="6" height="6" rx="1"/><rect x="9" y="2" width="6" height="6" rx="1"/><path d="M5 16v-3a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1v3"/><path d="M12 12V8"/>',
+  storage: '<ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5V19A9 3 0 0 0 21 19V5"/><path d="M3 12A9 3 0 0 0 21 12"/>',
+  traffic: '<path d="m12 14 4-4"/><path d="M3.34 19a10 10 0 1 1 17.32 0"/>',
+  alerting: '<path d="M10.268 21a2 2 0 0 0 3.464 0"/><path d="M3.262 15.326A1 1 0 0 0 4 17h16a1 1 0 0 0 .74-1.673C19.41 13.956 18 12.499 18 8A6 6 0 0 0 6 8c0 4.499-1.411 5.956-2.738 7.326"/>',
+  explorer: '<path d="M12 3v18"/><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M3 9h18"/><path d="M3 15h18"/>',
+  insights: '<path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/><path d="M9 18h6"/><path d="M10 22h4"/>',
+  peerdb: '<path d="M8 3 4 7l4 4"/><path d="M4 7h16"/><path d="M16 21l4-4-4-4"/><path d="M20 17H4"/>',
+  postgres: '<rect width="20" height="8" x="2" y="2" rx="2" ry="2"/><rect width="20" height="8" x="2" y="14" rx="2" ry="2"/><line x1="6" x2="6.01" y1="6" y2="6"/><line x1="6" x2="6.01" y1="18" y2="18"/>',
+} as const
+
+const featureIco = (d: string) =>
+  `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${d}</svg>`
 ---
   <header class="nav">
     <div class="wrap nav-row">
@@ -16,20 +35,19 @@ import { btnOutline, btnOutlineBlock, btnPrimary, btnPrimaryBlock } from '../lib
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
           </button>
           <div class="nav-menu nav-menu-grid">
-            <a href="/features/ai-agent">AI Agent<small>Schema-aware recommendations &amp; MCP</small></a>
-            <a href="/features/overview">Cluster overview<small>Live charts the moment you connect</small></a>
-            <a href="/features/queries">Query monitoring<small>Running, slow, failed &amp; expensive</small></a>
-            <a href="/features/topology">Cluster topology<small>Nodes, shards, replicas &amp; Keeper</small></a>
-            <a href="/features/storage">Storage &amp; tables<small>Sizes, compression and disk headroom</small></a>
-            <a href="/features/traffic">Traffic<small>Ingestion, compression &amp; write amplification</small></a>
-            <a href="/features/alerting">Alerting<small>Health checks with webhooks</small></a>
-            <a href="/features/data-explorer">Data Explorer<small>Tables, lineage and SQL console</small></a>
-            <a href="/features/insights">Insights<small>AI findings and cluster vitals</small></a>
-            <a href="/features/peerdb">PeerDB replication<small>Postgres → ClickHouse CDC</small></a>
-            <a href="/features/postgres"><span class="nav-item-label">Postgres<span class="nav-badge">Beta</span></span><small>Monitor Postgres alongside</small></a>
+            <a href="/features/ai-agent"><span class="nav-ico" set:html={featureIco(featureIcons.aiAgent)} /><span class="nav-txt">AI Agent<small>Schema-aware recommendations &amp; MCP</small></span></a>
+            <a href="/features/overview"><span class="nav-ico" set:html={featureIco(featureIcons.overview)} /><span class="nav-txt">Cluster overview<small>Live charts the moment you connect</small></span></a>
+            <a href="/features/queries"><span class="nav-ico" set:html={featureIco(featureIcons.queries)} /><span class="nav-txt">Query monitoring<small>Running, slow, failed &amp; expensive</small></span></a>
+            <a href="/features/topology"><span class="nav-ico" set:html={featureIco(featureIcons.topology)} /><span class="nav-txt">Cluster topology<small>Nodes, shards, replicas &amp; Keeper</small></span></a>
+            <a href="/features/storage"><span class="nav-ico" set:html={featureIco(featureIcons.storage)} /><span class="nav-txt">Storage &amp; tables<small>Sizes, compression and disk headroom</small></span></a>
+            <a href="/features/traffic"><span class="nav-ico" set:html={featureIco(featureIcons.traffic)} /><span class="nav-txt">Traffic<small>Ingestion, compression &amp; write amplification</small></span></a>
+            <a href="/features/alerting"><span class="nav-ico" set:html={featureIco(featureIcons.alerting)} /><span class="nav-txt">Alerting<small>Health checks with webhooks</small></span></a>
+            <a href="/features/data-explorer"><span class="nav-ico" set:html={featureIco(featureIcons.explorer)} /><span class="nav-txt">Data Explorer<small>Tables, lineage and SQL console</small></span></a>
+            <a href="/features/insights"><span class="nav-ico" set:html={featureIco(featureIcons.insights)} /><span class="nav-txt">Insights<small>AI findings and cluster vitals</small></span></a>
+            <a href="/features/peerdb"><span class="nav-ico" set:html={featureIco(featureIcons.peerdb)} /><span class="nav-txt">PeerDB replication<small>Postgres → ClickHouse CDC</small></span></a>
+            <a href="/features/postgres"><span class="nav-ico" set:html={featureIco(featureIcons.postgres)} /><span class="nav-txt"><span class="nav-item-label">Postgres<span class="nav-badge">Beta</span></span><small>Monitor Postgres alongside</small></span></a>
           </div>
         </div>
-        <a href="https://github.com/chmonitor/chmonitor" target="_blank" rel="noopener">Open source</a>
         <a href="/pricing">Pricing</a>
         <a href="https://docs.chmonitor.dev" target="_blank" rel="noopener">Docs</a>
         <div class="nav-group">
@@ -98,7 +116,6 @@ import { btnOutline, btnOutlineBlock, btnPrimary, btnPrimaryBlock } from '../lib
             <a href="/features/postgres">Postgres<span class="nav-badge">Beta</span></a>
           </div>
         </details>
-        <a href="https://github.com/chmonitor/chmonitor" target="_blank" rel="noopener">Open source</a>
         <a href="/pricing">Pricing</a>
         <a href="https://docs.chmonitor.dev" target="_blank" rel="noopener">Docs</a>
         <details class="nav-drawer-group">

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -338,6 +338,14 @@ const ogImage = new URL(image, Astro.site).toString()
        matter how long the copy is — the panel height must not jump per item. */
     .nav-menu a small{font-size:12px;font-weight:400;color:var(--muted-fg);
       display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:1;line-clamp:1;overflow:hidden}
+    /* Features mega-menu: an icon rail to the left of each title+desc block.
+       Scoped to .nav-menu-grid so the (icon-less) Resources menu keeps its
+       simpler flex-column layout. */
+    .nav-menu-grid a{flex-direction:row;align-items:flex-start;gap:10px}
+    .nav-menu-grid .nav-ico{flex:0 0 auto;display:inline-flex;width:16px;height:16px;margin-top:1px;color:var(--muted-fg);transition:color .14s}
+    .nav-menu-grid .nav-ico svg{width:16px;height:16px}
+    .nav-menu-grid a:hover .nav-ico{color:var(--brand)}
+    .nav-menu-grid .nav-txt{display:flex;flex-direction:column;gap:2px;min-width:0}
     @media (prefers-reduced-motion:reduce){.nav-trigger svg,.nav-menu{transition:none}}
     /* Status pill for nav items — e.g. "Beta". `--orange` is the small-text-safe
        accent token; the tint uses color-mix so it stays legible in both themes


### PR DESCRIPTION
## What

Landing-page polish across the hero, nav, and footer.

### Hero
- Pull the hero section up under the transparent 64px sticky nav (`-mt-16 pt-16`) so the ambient brand wash reaches the very top edge, behind the nav. Content position is unchanged (equal padding compensates).

### Nav (Features dropdown)
- Added a lucide icon to each of the 11 Features child items, on an icon rail scoped to `.nav-menu-grid` (Resources dropdown untouched).
- Removed the top-level **Open source** link from both the desktop nav and the mobile drawer.

### Footer
- **Product**: removed *AI Agent* and *Cluster topology*.
- **Use cases**: added *AI Agent* (→ `/features/ai-agent`) as the first link.
- **Open source**: moved *Changelog* here from Product.

## Verify
- `pnpm run build` — 26 pages built, no type errors.
- `pnpm run test:unit` (7105 pass / 0 fail) + `pnpm run test:packages` (0 fail).
- Built-HTML inspection confirms hero `-mt-16 pt-16`, 11 nav icons, and final footer column ordering.

Co-Authored-By: duyetbot <bot@duyet.net>