### PR TITLE
feat(insights): percentile distributions + errors/hot-tables drill-downs

### DIFF
--- a/apps/dashboard/src/components/charts/query-performance/percentile-distribution.tsx
+++ b/apps/dashboard/src/components/charts/query-performance/percentile-distribution.tsx
@@ -1,0 +1,86 @@
+import { BarChart } from '@/components/charts/primitives/bar/bar'
+import { cn } from '@/lib/utils'
+
+/** A single row returned by the `*-distribution` chart builders: p10..p99 of one metric. */
+export interface PercentileRow {
+  p10: number
+  p25: number
+  p50: number
+  p75: number
+  p90: number
+  p95: number
+  p99: number
+}
+
+const PERCENTILE_KEYS = [
+  'p10',
+  'p25',
+  'p50',
+  'p75',
+  'p90',
+  'p95',
+  'p99',
+] as const
+
+function StatChip({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col items-center gap-0.5 rounded-md border bg-muted/40 px-3 py-1.5">
+      <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </span>
+      <span className="font-mono text-sm font-semibold tabular-nums">
+        {value}
+      </span>
+    </div>
+  )
+}
+
+/**
+ * Shared render body for the four Query Insights distribution tiles
+ * (duration, memory, read rows, read bytes): p50/p95/p99 stat chips above
+ * a bar chart of the p10/p25/p50/p75/p90/p95/p99 percentile curve.
+ */
+export function PercentileDistribution({
+  row,
+  formatValue,
+  barColor = '--chart-2',
+  className,
+  emptyMessage = 'No query activity recorded',
+}: {
+  row: PercentileRow | undefined
+  formatValue: (value: number) => string
+  barColor?: string
+  className?: string
+  emptyMessage?: string
+}) {
+  if (!row) {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-xs text-muted-foreground">
+        {emptyMessage}
+      </div>
+    )
+  }
+
+  const bars = PERCENTILE_KEYS.map((key) => ({
+    percentile: key.toUpperCase(),
+    value: row[key] ?? 0,
+  }))
+
+  return (
+    <div className={cn('flex h-full flex-col gap-3', className)}>
+      <div className="flex flex-wrap items-center gap-2 px-1">
+        <StatChip label="p50" value={formatValue(row.p50 ?? 0)} />
+        <StatChip label="p95" value={formatValue(row.p95 ?? 0)} />
+        <StatChip label="p99" value={formatValue(row.p99 ?? 0)} />
+      </div>
+      <BarChart
+        className="min-h-[120px] flex-1"
+        data={bars}
+        index="percentile"
+        categories={['value']}
+        colors={[barColor]}
+        yAxisTickFormatter={(v) => formatValue(Number(v))}
+      />
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/charts/query-performance/query-insights-duration-distribution.tsx
+++ b/apps/dashboard/src/components/charts/query-performance/query-insights-duration-distribution.tsx
@@ -1,0 +1,26 @@
+import type { PercentileRow } from './percentile-distribution'
+
+import { PercentileDistribution } from './percentile-distribution'
+import { createCustomChart } from '@/components/charts/factory'
+import { formatDuration } from '@/lib/utils'
+
+/** Histogram tile: p10..p99 distribution of query_duration_ms. */
+export const ChartQueryInsightsDurationDistribution = createCustomChart({
+  chartName: 'query-insights-duration-distribution',
+  defaultTitle: 'Duration Distribution',
+  defaultLastHours: 24,
+  dataTestId: 'query-insights-duration-distribution-chart',
+  dateRangeConfig: 'query-activity',
+  render: (dataArray) => {
+    const data = dataArray as PercentileRow[]
+    return (
+      <PercentileDistribution
+        row={data[0]}
+        formatValue={formatDuration}
+        barColor="--chart-1"
+      />
+    )
+  },
+})
+
+export default ChartQueryInsightsDurationDistribution

--- a/apps/dashboard/src/components/charts/query-performance/query-insights-errors-by-code.tsx
+++ b/apps/dashboard/src/components/charts/query-performance/query-insights-errors-by-code.tsx
@@ -1,0 +1,51 @@
+import { createCustomChart } from '@/components/charts/factory'
+import { formatCount } from '@/lib/utils'
+
+interface ErrorsByCodeData {
+  exception_code: number
+  count: number
+  sample: string
+  last_seen: string
+}
+
+/** Errors drill-down: failures grouped by exception code, with a sample message per code. */
+export const ChartQueryInsightsErrorsByCode = createCustomChart({
+  chartName: 'query-insights-errors-by-code',
+  defaultTitle: 'Errors by Exception Code',
+  defaultLastHours: 24,
+  dataTestId: 'query-insights-errors-by-code-chart',
+  dateRangeConfig: 'query-activity',
+  render: (dataArray) => {
+    const data = dataArray as ErrorsByCodeData[]
+
+    if (data.length === 0) {
+      return (
+        <div className="flex h-full items-center justify-center p-6 text-xs text-muted-foreground">
+          No errors recorded
+        </div>
+      )
+    }
+
+    return (
+      <div className="flex flex-col gap-3 overflow-y-auto">
+        {data.map((row) => (
+          <div key={row.exception_code} className="flex flex-col gap-0.5">
+            <div className="flex items-center justify-between text-[12.5px]">
+              <span className="truncate font-medium">
+                Code {row.exception_code}
+              </span>
+              <span className="shrink-0 font-mono tabular-nums text-muted-foreground">
+                {formatCount(row.count)}
+              </span>
+            </div>
+            <p className="truncate text-xs text-muted-foreground">
+              {row.sample || '—'}
+            </p>
+          </div>
+        ))}
+      </div>
+    )
+  },
+})
+
+export default ChartQueryInsightsErrorsByCode

--- a/apps/dashboard/src/components/charts/query-performance/query-insights-hot-tables.tsx
+++ b/apps/dashboard/src/components/charts/query-performance/query-insights-hot-tables.tsx
@@ -1,0 +1,43 @@
+import { createCustomChart } from '@/components/charts/factory'
+import { RankBars } from '@/components/charts/primitives/rank-bars'
+import { formatCount, formatDuration } from '@/lib/utils'
+
+interface HotTablesData {
+  table: string
+  query_count: number
+  avg_duration_ms: number
+}
+
+/** Hot tables drill-down: query volume + avg latency per referenced table (arrayJoin(tables)). */
+export const ChartQueryInsightsHotTables = createCustomChart({
+  chartName: 'query-insights-hot-tables',
+  defaultTitle: 'Hot Tables',
+  defaultLastHours: 24,
+  dataTestId: 'query-insights-hot-tables-chart',
+  dateRangeConfig: 'query-activity',
+  render: (dataArray) => {
+    const data = dataArray as HotTablesData[]
+
+    if (data.length === 0) {
+      return (
+        <div className="flex h-full items-center justify-center p-6 text-xs text-muted-foreground">
+          No table activity recorded
+        </div>
+      )
+    }
+
+    const maxCount = Math.max(...data.map((d) => d.query_count), 1)
+
+    return (
+      <RankBars
+        items={data.map((d) => ({
+          label: d.table,
+          value: `${formatCount(d.query_count)} · avg ${formatDuration(d.avg_duration_ms)}`,
+          pct: Math.max(4, (d.query_count / maxCount) * 100),
+        }))}
+      />
+    )
+  },
+})
+
+export default ChartQueryInsightsHotTables

--- a/apps/dashboard/src/components/charts/query-performance/query-insights-memory-distribution.tsx
+++ b/apps/dashboard/src/components/charts/query-performance/query-insights-memory-distribution.tsx
@@ -1,0 +1,26 @@
+import type { PercentileRow } from './percentile-distribution'
+
+import { PercentileDistribution } from './percentile-distribution'
+import { createCustomChart } from '@/components/charts/factory'
+import { formatBytes } from '@/lib/utils'
+
+/** Histogram tile: p10..p99 distribution of peak memory_usage. */
+export const ChartQueryInsightsMemoryDistribution = createCustomChart({
+  chartName: 'query-insights-memory-distribution',
+  defaultTitle: 'Memory Distribution',
+  defaultLastHours: 24,
+  dataTestId: 'query-insights-memory-distribution-chart',
+  dateRangeConfig: 'query-activity',
+  render: (dataArray) => {
+    const data = dataArray as PercentileRow[]
+    return (
+      <PercentileDistribution
+        row={data[0]}
+        formatValue={formatBytes}
+        barColor="--chart-3"
+      />
+    )
+  },
+})
+
+export default ChartQueryInsightsMemoryDistribution

--- a/apps/dashboard/src/components/charts/query-performance/query-insights-read-bytes-distribution.tsx
+++ b/apps/dashboard/src/components/charts/query-performance/query-insights-read-bytes-distribution.tsx
@@ -1,0 +1,26 @@
+import type { PercentileRow } from './percentile-distribution'
+
+import { PercentileDistribution } from './percentile-distribution'
+import { createCustomChart } from '@/components/charts/factory'
+import { formatBytes } from '@/lib/utils'
+
+/** Histogram tile: p10..p99 distribution of read_bytes per query. */
+export const ChartQueryInsightsReadBytesDistribution = createCustomChart({
+  chartName: 'query-insights-read-bytes-distribution',
+  defaultTitle: 'Read Bytes Distribution',
+  defaultLastHours: 24,
+  dataTestId: 'query-insights-read-bytes-distribution-chart',
+  dateRangeConfig: 'query-activity',
+  render: (dataArray) => {
+    const data = dataArray as PercentileRow[]
+    return (
+      <PercentileDistribution
+        row={data[0]}
+        formatValue={formatBytes}
+        barColor="--chart-2"
+      />
+    )
+  },
+})
+
+export default ChartQueryInsightsReadBytesDistribution

--- a/apps/dashboard/src/components/charts/query-performance/query-insights-read-rows-distribution.tsx
+++ b/apps/dashboard/src/components/charts/query-performance/query-insights-read-rows-distribution.tsx
@@ -1,0 +1,26 @@
+import type { PercentileRow } from './percentile-distribution'
+
+import { PercentileDistribution } from './percentile-distribution'
+import { createCustomChart } from '@/components/charts/factory'
+import { formatCount } from '@/lib/utils'
+
+/** Histogram tile: p10..p99 distribution of read_rows per query. */
+export const ChartQueryInsightsReadRowsDistribution = createCustomChart({
+  chartName: 'query-insights-read-rows-distribution',
+  defaultTitle: 'Read Rows Distribution',
+  defaultLastHours: 24,
+  dataTestId: 'query-insights-read-rows-distribution-chart',
+  dateRangeConfig: 'query-activity',
+  render: (dataArray) => {
+    const data = dataArray as PercentileRow[]
+    return (
+      <PercentileDistribution
+        row={data[0]}
+        formatValue={formatCount}
+        barColor="--chart-4"
+      />
+    )
+  },
+})
+
+export default ChartQueryInsightsReadRowsDistribution

--- a/apps/dashboard/src/lib/api/__tests__/charts/query-insights-charts.test.ts
+++ b/apps/dashboard/src/lib/api/__tests__/charts/query-insights-charts.test.ts
@@ -21,6 +21,12 @@ describe('queryInsightsCharts', () => {
     expect(names).toContain('query-insights-memory')
     expect(names).toContain('query-insights-read-throughput')
     expect(names).toContain('query-insights-top-users')
+    expect(names).toContain('query-insights-duration-distribution')
+    expect(names).toContain('query-insights-memory-distribution')
+    expect(names).toContain('query-insights-read-rows-distribution')
+    expect(names).toContain('query-insights-read-bytes-distribution')
+    expect(names).toContain('query-insights-errors-by-code')
+    expect(names).toContain('query-insights-hot-tables')
   })
 
   test.each(
@@ -98,5 +104,45 @@ describe('queryInsightsCharts', () => {
       defaultParams
     ) as any
     expect(result.query).toMatch(/GROUP BY user/)
+  })
+
+  test.each([
+    [
+      'query-insights-duration-distribution',
+      /quantile\(0\.50\)\(query_duration_ms\)/,
+    ],
+    ['query-insights-memory-distribution', /quantile\(0\.50\)\(memory_usage\)/],
+    ['query-insights-read-rows-distribution', /quantile\(0\.50\)\(read_rows\)/],
+    [
+      'query-insights-read-bytes-distribution',
+      /quantile\(0\.50\)\(read_bytes\)/,
+    ],
+  ])('"%s" tile computes p10..p99 percentiles for its metric', (name, expectedMetric) => {
+    const result = queryInsightsCharts[name](defaultParams) as any
+    expect(result.query).toMatch(expectedMetric)
+    expect(result.query).toMatch(/quantile\(0\.10\)/)
+    expect(result.query).toMatch(/quantile\(0\.25\)/)
+    expect(result.query).toMatch(/quantile\(0\.75\)/)
+    expect(result.query).toMatch(/quantile\(0\.90\)/)
+    expect(result.query).toMatch(/quantile\(0\.95\)/)
+    expect(result.query).toMatch(/quantile\(0\.99\)/)
+  })
+
+  test('errors-by-code tile groups by exception_code with a sample message', () => {
+    const result = queryInsightsCharts['query-insights-errors-by-code'](
+      defaultParams
+    ) as any
+    expect(result.query).toMatch(/exception_code\s*!=\s*0/)
+    expect(result.query).toMatch(/GROUP BY exception_code/)
+    expect(result.query).toMatch(/any\(exception\)/)
+  })
+
+  test('hot tables tile uses arrayJoin(tables) and orders by query volume', () => {
+    const result = queryInsightsCharts['query-insights-hot-tables'](
+      defaultParams
+    ) as any
+    expect(result.query).toMatch(/arrayJoin\(tables\)/)
+    expect(result.query).toMatch(/GROUP BY table/)
+    expect(result.query).toMatch(/ORDER BY query_count DESC/)
   })
 })

--- a/apps/dashboard/src/lib/api/charts/query-insights-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/query-insights-charts.ts
@@ -11,6 +11,32 @@ import type { ChartQueryBuilder } from './types'
 
 import { applyInterval, buildTimeFilter, fillStep, nowOrToday } from './types'
 
+/** Builds a p10/p25/p50/p75/p90/p95/p99 single-row distribution query for one metric column. */
+function percentileDistributionQuery(
+  column: string,
+  decimals: number,
+  timeFilter: string,
+  extraFilter = ''
+): string {
+  const round = (expr: string) =>
+    decimals > 0 ? `round(${expr}, ${decimals})` : `round(${expr})`
+  return `
+    SELECT
+      ${round(`quantile(0.10)(${column})`)} AS p10,
+      ${round(`quantile(0.25)(${column})`)} AS p25,
+      ${round(`quantile(0.50)(${column})`)} AS p50,
+      ${round(`quantile(0.75)(${column})`)} AS p75,
+      ${round(`quantile(0.90)(${column})`)} AS p90,
+      ${round(`quantile(0.95)(${column})`)} AS p95,
+      ${round(`quantile(0.99)(${column})`)} AS p99
+    FROM system.query_log
+    WHERE type = 'QueryFinish'
+          ${extraFilter}
+          ${timeFilter ? `AND ${timeFilter}` : ''}
+    SETTINGS max_execution_time = 25
+  `
+}
+
 /** Bucket width in seconds per interval, used to derive a queries/sec rate. */
 const INTERVAL_SECONDS: Record<string, number> = {
   toStartOfMinute: 60,
@@ -189,6 +215,78 @@ export const queryInsightsCharts: Record<string, ChartQueryBuilder> = {
     GROUP BY user
     ORDER BY query_count DESC
     LIMIT 8
+    SETTINGS max_execution_time = 25
+  `
+    return { query, sql: [{ since: '19.1', sql: query }] }
+  },
+
+  // Tile 10: Duration distribution — p10..p99 curve of query_duration_ms.
+  'query-insights-duration-distribution': ({ lastHours = 24 }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    const query = percentileDistributionQuery(
+      'query_duration_ms',
+      2,
+      timeFilter
+    )
+    return { query, sql: [{ since: '19.1', sql: query }] }
+  },
+
+  // Tile 11: Memory distribution — p10..p99 curve of peak memory_usage.
+  'query-insights-memory-distribution': ({ lastHours = 24 }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    const query = percentileDistributionQuery('memory_usage', 0, timeFilter)
+    return { query, sql: [{ since: '19.1', sql: query }] }
+  },
+
+  // Tile 12: Read rows distribution — p10..p99 curve of read_rows per query.
+  'query-insights-read-rows-distribution': ({ lastHours = 24 }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    const query = percentileDistributionQuery('read_rows', 0, timeFilter)
+    return { query, sql: [{ since: '19.1', sql: query }] }
+  },
+
+  // Tile 13: Read bytes distribution — p10..p99 curve of read_bytes per query.
+  'query-insights-read-bytes-distribution': ({ lastHours = 24 }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    const query = percentileDistributionQuery('read_bytes', 0, timeFilter)
+    return { query, sql: [{ since: '19.1', sql: query }] }
+  },
+
+  // Tile 14: Errors by exception code — count + a sample message per code.
+  'query-insights-errors-by-code': ({ lastHours = 24 }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    const query = `
+    SELECT
+      exception_code,
+      COUNT() AS count,
+      any(exception) AS sample,
+      max(event_time) AS last_seen
+    FROM system.query_log
+    WHERE exception_code != 0
+          ${timeFilter ? `AND ${timeFilter}` : ''}
+    GROUP BY exception_code
+    ORDER BY count DESC
+    LIMIT 10
+    SETTINGS max_execution_time = 25
+  `
+    return { query, sql: [{ since: '19.1', sql: query }] }
+  },
+
+  // Tile 15: Hot tables — query volume + avg latency per referenced table.
+  'query-insights-hot-tables': ({ lastHours = 24 }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    const query = `
+    SELECT
+      arrayJoin(tables) AS table,
+      COUNT() AS query_count,
+      round(avg(query_duration_ms), 2) AS avg_duration_ms
+    FROM system.query_log
+    WHERE type = 'QueryFinish'
+          AND notEmpty(tables)
+          ${timeFilter ? `AND ${timeFilter}` : ''}
+    GROUP BY table
+    ORDER BY query_count DESC
+    LIMIT 10
     SETTINGS max_execution_time = 25
   `
     return { query, sql: [{ since: '19.1', sql: query }] }

--- a/apps/dashboard/src/routes/(dashboard)/queries/insights.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/queries/insights.tsx
@@ -1,11 +1,17 @@
 import { createFileRoute } from '@tanstack/react-router'
 
 import { ChartQueryInsightsCacheHitRatio } from '@/components/charts/query-performance/query-insights-cache-hit-ratio'
+import { ChartQueryInsightsDurationDistribution } from '@/components/charts/query-performance/query-insights-duration-distribution'
 import { ChartQueryInsightsErrors } from '@/components/charts/query-performance/query-insights-errors'
+import { ChartQueryInsightsErrorsByCode } from '@/components/charts/query-performance/query-insights-errors-by-code'
+import { ChartQueryInsightsHotTables } from '@/components/charts/query-performance/query-insights-hot-tables'
 import { ChartQueryInsightsLatency } from '@/components/charts/query-performance/query-insights-latency'
 import { ChartQueryInsightsMemory } from '@/components/charts/query-performance/query-insights-memory'
+import { ChartQueryInsightsMemoryDistribution } from '@/components/charts/query-performance/query-insights-memory-distribution'
 import { ChartQueryInsightsOperations } from '@/components/charts/query-performance/query-insights-operations'
 import { ChartQueryInsightsQps } from '@/components/charts/query-performance/query-insights-qps'
+import { ChartQueryInsightsReadBytesDistribution } from '@/components/charts/query-performance/query-insights-read-bytes-distribution'
+import { ChartQueryInsightsReadRowsDistribution } from '@/components/charts/query-performance/query-insights-read-rows-distribution'
 import { ChartQueryInsightsReadThroughput } from '@/components/charts/query-performance/query-insights-read-throughput'
 import { ChartQueryInsightsRows } from '@/components/charts/query-performance/query-insights-rows'
 import { ChartQueryInsightsTopUsers } from '@/components/charts/query-performance/query-insights-top-users'
@@ -33,6 +39,32 @@ function QueryInsightsPage() {
         <ChartQueryInsightsMemory />
         <ChartQueryInsightsReadThroughput />
         <ChartQueryInsightsTopUsers />
+      </div>
+
+      <div>
+        <h2 className="text-lg font-semibold tracking-tight">Distributions</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          p10–p99 percentile curves, with p50/p95/p99 called out as chips
+        </p>
+      </div>
+
+      <div className="grid auto-rows-[320px] grid-cols-1 gap-3 lg:grid-cols-2 xl:grid-cols-3">
+        <ChartQueryInsightsDurationDistribution />
+        <ChartQueryInsightsMemoryDistribution />
+        <ChartQueryInsightsReadRowsDistribution />
+        <ChartQueryInsightsReadBytesDistribution />
+      </div>
+
+      <div>
+        <h2 className="text-lg font-semibold tracking-tight">Drill-downs</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Errors by exception code, and hot tables by query volume
+        </p>
+      </div>
+
+      <div className="grid auto-rows-[320px] grid-cols-1 gap-3 lg:grid-cols-2">
+        <ChartQueryInsightsErrorsByCode />
+        <ChartQueryInsightsHotTables />
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- Adds 4 new percentile-distribution tiles (duration, memory, read rows, read bytes) to `/queries/insights` — each shows p50/p95/p99 stat chips above a p10-p99 bar chart, computed with `quantile()` over `system.query_log`.
- Adds an errors-by-exception-code drill-down (count + latest sample message per code).
- Adds a hot-tables drill-down using `arrayJoin(tables)` (query volume + avg latency per table).
- Follows existing `createCustomChart` / `ChartCard` / `useChartData` patterns, versioned `sql: [{ since, sql }]` convention, and product-design chip/rank-bar styling. No new routes, nothing removed.

## Test plan
- [x] `pnpm run lint` — clean
- [x] `pnpm run build` (apps/dashboard) — Vite build + `tsc --noEmit` pass, `/queries/insights` prerenders
- [x] `pnpm run test:unit` — 7117 pass, 0 fail (added builder tests for all 6 new chart-registry entries)

Closes #2762