### PR TITLE
feat(health): predictive parts-pressure early warning

### DIFF
--- a/apps/dashboard/src/components/health/health-checks.ts
+++ b/apps/dashboard/src/components/health/health-checks.ts
@@ -8,10 +8,17 @@ import {
   ServerCrash,
   ShieldAlert,
   Timer,
+  TrendingUp,
   XCircle,
 } from 'lucide-react'
 
 import type { Thresholds } from '@/lib/health/thresholds-storage'
+
+import {
+  buildPartsPressurePercentSql,
+  PARTS_PRESSURE_PERCENT_CRITICAL,
+  PARTS_PRESSURE_PERCENT_WARNING,
+} from '@/lib/health/parts-pressure'
 
 export interface RelatedLink {
   label: string
@@ -199,6 +206,55 @@ WHERE active AND database NOT IN ('system', 'INFORMATION_SCHEMA', 'information_s
 GROUP BY database, table, partition
 ORDER BY part_count DESC
 LIMIT 1`,
+  },
+  {
+    id: 'parts-pressure',
+    title: 'Parts Pressure (predictive)',
+    icon: TrendingUp,
+    chartName: 'health-parts-pressure',
+    detailChartName: 'health-parts-pressure-detail',
+    detailTitle: 'Partitions by projected time-to-throw',
+    detailDescription:
+      'Per-partition active parts vs `parts_to_throw_insert` (respecting table overrides), with the net part-growth rate from `system.part_log` and the projected hours until inserts are rejected. Requires `system.part_log` for the projection.',
+    detailEmptyMessage:
+      'No partition is under parts pressure — or `system.part_log` is disabled, so the time projection is unavailable (see Max Parts / Partition for current counts).',
+    valueKey: 'pressure_percent',
+    defaults: {
+      warning: PARTS_PRESSURE_PERCENT_WARNING,
+      critical: PARTS_PRESSURE_PERCENT_CRITICAL,
+    },
+    formatLabel: (v) =>
+      `${(v ?? 0).toLocaleString()}% of parts_to_throw_insert`,
+    formatValue: (v) => `${(v ?? 0).toLocaleString()}%`,
+    description:
+      'Predictive "too many parts" early warning. Tracks the worst partition’s active parts as a percentage of `parts_to_throw_insert` and projects when inserts will be rejected from the recent part-creation vs merge rate. Warns before the MergeTree starts throttling then failing inserts.',
+    systemTables: [
+      'system.parts',
+      'system.part_log',
+      'system.merge_tree_settings',
+    ],
+    commonCauses: [
+      'Frequent small inserts producing parts faster than merges consume them',
+      'Background merges starved (low background_pool_size, slow disk)',
+      'Partition key too granular, spreading inserts across many partitions',
+      '`parts_to_throw_insert` / `parts_to_delay_insert` lowered per table',
+    ],
+    relatedLinks: [
+      { label: 'Merges', href: '/merges' },
+      { label: 'Tables Overview', href: '/tables-overview' },
+      { label: 'Merge Performance', href: '/merge-performance' },
+    ],
+    docsLinks: [
+      {
+        label: 'MergeTree settings (parts_to_throw_insert)',
+        url: 'https://clickhouse.com/docs/en/operations/settings/merge-tree-settings#parts-to-throw-insert',
+      },
+      {
+        label: 'system.part_log',
+        url: 'https://clickhouse.com/docs/en/operations/system-tables/part_log',
+      },
+    ],
+    sql: buildPartsPressurePercentSql(),
   },
   {
     id: 'long-running-queries',

--- a/apps/dashboard/src/lib/alerting/builtin-rules.ts
+++ b/apps/dashboard/src/lib/alerting/builtin-rules.ts
@@ -13,6 +13,11 @@
 import type { CompoundRuleDef } from './compound-rules'
 import type { AlertRuleDef } from './rule-registry'
 
+import {
+  buildPartsPressurePercentSql,
+  PARTS_PRESSURE_PERCENT_CRITICAL,
+  PARTS_PRESSURE_PERCENT_WARNING,
+} from '../health/parts-pressure'
 import { atLeast, compoundRuleRegistry } from './compound-rules'
 import { ruleRegistry } from './rule-registry'
 
@@ -243,6 +248,43 @@ FROM system.view_refreshes`,
     formatLabel: fmtCount('failed MV refresh'),
     optional: true,
     tableCheck: 'system.view_refreshes',
+  },
+
+  {
+    id: 'parts-pressure',
+    type: 'parts-pressure',
+    title: 'Parts Pressure',
+    description:
+      'Worst partition’s active parts as a percentage of parts_to_throw_insert. A predictive "too many parts" signal — sustained pressure leads to throttled then rejected inserts.',
+    sql: buildPartsPressurePercentSql(),
+    valueKey: 'pressure_percent',
+    defaults: {
+      warning: PARTS_PRESSURE_PERCENT_WARNING,
+      critical: PARTS_PRESSURE_PERCENT_CRITICAL,
+    },
+    formatLabel: (v) => `${v ?? 0}% of parts_to_throw_insert`,
+    optional: true,
+    tableCheck: 'system.parts',
+    remediationActions: [
+      {
+        id: 'parts-pressure-runbook',
+        label: 'Too many parts runbook',
+        kind: 'runbook',
+        url: 'https://docs.chmonitor.dev/guide/guides/max-parts-runbook',
+      },
+      {
+        id: 'parts-pressure-detail',
+        label: 'Get partitions near the throw limit',
+        kind: 'diagnostic',
+        description: 'Partitions with the most active parts, worst first.',
+        sql: `SELECT database, table, partition, count() AS parts
+FROM system.parts
+WHERE active
+GROUP BY database, table, partition
+ORDER BY parts DESC
+LIMIT 20`,
+      },
+    ],
   },
 
   {

--- a/apps/dashboard/src/lib/alerting/rule-registry.ts
+++ b/apps/dashboard/src/lib/alerting/rule-registry.ts
@@ -28,6 +28,7 @@ export type AlertRuleType =
   | 'keeper-unavailable'
   | 'mv-refresh-failures'
   | 'slow-query-regression'
+  | 'parts-pressure'
   | 'custom'
 
 /**

--- a/apps/dashboard/src/lib/api/charts/system-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/system-charts.ts
@@ -11,6 +11,10 @@ import {
   buildTimeFilter,
   buildTimeFilterInterval,
 } from './types'
+import {
+  buildPartsPressurePercentSql,
+  buildPartsPressureProjectionSql,
+} from '@/lib/health/parts-pressure'
 import { STUCK_THRESHOLD_SECONDS } from '@/lib/query-config/merges/mutations'
 
 const METRICS_PERMISSION = {
@@ -472,6 +476,15 @@ export const systemCharts: Record<string, ChartQueryBuilder> = {
   `,
   }),
 
+  // Predictive parts pressure: worst partition's fill vs parts_to_throw_insert
+  // (%). Higher-is-worse scalar for the health card + alert rule. No part_log
+  // dependency — always available.
+  'health-parts-pressure': () => ({
+    query: buildPartsPressurePercentSql(),
+    optional: true,
+    tableCheck: 'system.parts',
+  }),
+
   'health-long-running-queries': () => ({
     query: `
     SELECT count() AS long_running
@@ -645,6 +658,26 @@ export const systemCharts: Record<string, ChartQueryBuilder> = {
   `,
     optional: true,
     tableCheck: 'system.parts',
+  }),
+
+  // Parts-pressure evidence: per-partition current parts, effective throw/delay
+  // limits, net part-growth rate, and projected hours-to-throw. Requires
+  // system.part_log for the projection; when it is disabled the dialog shows the
+  // empty message (the max-parts breakdown still gives the current counts).
+  'health-parts-pressure-detail': () => ({
+    query: `
+    SELECT
+      concat(database, '.', table) AS table_path,
+      partition,
+      parts,
+      throw_limit,
+      delay_limit,
+      net_parts_per_hour,
+      if(is_delaying, 'delaying now', if(isNull(hours_to_throw), 'stable', concat('~', toString(hours_to_throw), 'h to throw'))) AS projection
+    FROM (${buildPartsPressureProjectionSql({ limit: 20 })})
+  `,
+    optional: true,
+    tableCheck: 'system.part_log',
   }),
 
   'health-long-running-queries-detail': () => ({

--- a/apps/dashboard/src/lib/health/parts-pressure.test.ts
+++ b/apps/dashboard/src/lib/health/parts-pressure.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for the parts-pressure projection math and SQL builders.
+ *
+ * The math functions are pure (no ClickHouse I/O), so they are exercised
+ * directly against boundary values. The SQL builders are asserted on the shape
+ * that matters — the tables they read, the optional part_log dependency, and the
+ * override/threshold precedence — rather than exact whitespace.
+ */
+
+import {
+  buildPartsPressureCurrentSql,
+  buildPartsPressurePercentSql,
+  buildPartsPressureProjectionSql,
+  classifyPartsPressure,
+  DEFAULT_PARTS_TO_DELAY_INSERT,
+  DEFAULT_PARTS_TO_THROW_INSERT,
+  PARTS_PRESSURE_CRITICAL_WINDOW_HOURS,
+  PARTS_PRESSURE_MIN_PARTS,
+  PARTS_PRESSURE_WARN_WINDOW_HOURS,
+  projectHoursToThreshold,
+} from './parts-pressure'
+import { describe, expect, test } from 'bun:test'
+
+describe('projectHoursToThreshold', () => {
+  test('projects linearly from a positive net rate', () => {
+    // 3000 - 1000 = 2000 remaining at 500/h -> 4h
+    expect(projectHoursToThreshold(1000, 3000, 500)).toBe(4)
+  })
+
+  test('returns null when the net rate is non-positive (merges keeping up)', () => {
+    expect(projectHoursToThreshold(1000, 3000, 0)).toBeNull()
+    expect(projectHoursToThreshold(1000, 3000, -50)).toBeNull()
+  })
+
+  test('returns null when part_log rate is unavailable', () => {
+    expect(projectHoursToThreshold(1000, 3000, null)).toBeNull()
+  })
+
+  test('returns 0 when already at or past the throw limit', () => {
+    expect(projectHoursToThreshold(3000, 3000, 100)).toBe(0)
+    expect(projectHoursToThreshold(3200, 3000, 100)).toBe(0)
+  })
+
+  test('guards invalid limits', () => {
+    expect(projectHoursToThreshold(1000, 0, 100)).toBeNull()
+    expect(projectHoursToThreshold(Number.NaN, 3000, 100)).toBeNull()
+  })
+})
+
+describe('classifyPartsPressure', () => {
+  const base = { parts: 100, throwLimit: 3000, delayLimit: 1000 }
+
+  test('already delaying is always critical', () => {
+    expect(
+      classifyPartsPressure({
+        ...base,
+        parts: 1000,
+        hoursToThrow: 999,
+      })
+    ).toBe('critical')
+  })
+
+  test('projected breach within the critical window is critical', () => {
+    expect(
+      classifyPartsPressure({
+        ...base,
+        hoursToThrow: PARTS_PRESSURE_CRITICAL_WINDOW_HOURS,
+      })
+    ).toBe('critical')
+  })
+
+  test('projected breach within the warn window is a warning', () => {
+    expect(
+      classifyPartsPressure({
+        ...base,
+        hoursToThrow: PARTS_PRESSURE_WARN_WINDOW_HOURS,
+      })
+    ).toBe('warning')
+  })
+
+  test('projected breach beyond the warn window is suppressed', () => {
+    expect(
+      classifyPartsPressure({
+        ...base,
+        hoursToThrow: PARTS_PRESSURE_WARN_WINDOW_HOURS + 1,
+      })
+    ).toBeNull()
+  })
+
+  test('falls back to fill percent when no projection (part_log off)', () => {
+    // delayLimit raised above parts so the delay-limit rule does not pre-empt
+    // the fill-percent fallback we are exercising here.
+    const noDelay = { parts: 0, throwLimit: 3000, delayLimit: 3000 }
+    // 95%+ of throw -> warning even without a rate
+    expect(
+      classifyPartsPressure({ ...noDelay, parts: 2850, hoursToThrow: null })
+    ).toBe('warning')
+    // 80%+ -> info
+    expect(
+      classifyPartsPressure({ ...noDelay, parts: 2400, hoursToThrow: null })
+    ).toBe('info')
+    // below the warn fill -> nothing
+    expect(
+      classifyPartsPressure({ ...noDelay, parts: 500, hoursToThrow: null })
+    ).toBeNull()
+  })
+
+  test('delay limit takes precedence over a benign projection', () => {
+    expect(
+      classifyPartsPressure({
+        ...base,
+        parts: 1200,
+        delayLimit: 1000,
+        hoursToThrow: null,
+      })
+    ).toBe('critical')
+  })
+})
+
+describe('buildPartsPressurePercentSql', () => {
+  const sql = buildPartsPressurePercentSql()
+
+  test('reads parts, tables, and merge_tree_settings; exposes pressure_percent', () => {
+    expect(sql).toContain('system.parts')
+    expect(sql).toContain('system.tables')
+    expect(sql).toContain('system.merge_tree_settings')
+    expect(sql).toContain('AS pressure_percent')
+  })
+
+  test('does not depend on part_log (always-available scalar)', () => {
+    expect(sql).not.toContain('system.part_log')
+  })
+
+  test('prefers per-table overrides then server default then compiled fallback', () => {
+    expect(sql).toContain('throw_override')
+    expect(sql).toContain(String(DEFAULT_PARTS_TO_THROW_INSERT))
+  })
+
+  test('ignores tiny partitions below the min-parts floor', () => {
+    expect(sql).toContain(`>= ${PARTS_PRESSURE_MIN_PARTS}`)
+  })
+})
+
+describe('buildPartsPressureProjectionSql', () => {
+  const sql = buildPartsPressureProjectionSql({ rateWindowHours: 6, limit: 10 })
+
+  test('measures the net rate from part_log NewPart vs RemovePart', () => {
+    expect(sql).toContain('system.part_log')
+    expect(sql).toContain("event_type = 'NewPart'")
+    expect(sql).toContain("event_type = 'RemovePart'")
+  })
+
+  test('exposes projection columns and orders worst-first', () => {
+    expect(sql).toContain('AS hours_to_throw')
+    expect(sql).toContain('AS is_delaying')
+    expect(sql).toContain('AS net_parts_per_hour')
+    expect(sql).toContain('ORDER BY is_delaying DESC')
+  })
+
+  test('interpolates a safe integer window and limit', () => {
+    const injected = buildPartsPressureProjectionSql({
+      rateWindowHours: Number.NaN,
+      limit: -5,
+    })
+    expect(injected).toContain('INTERVAL 6 HOUR')
+    expect(injected).toContain('LIMIT 20')
+  })
+})
+
+describe('buildPartsPressureCurrentSql', () => {
+  const sql = buildPartsPressureCurrentSql()
+
+  test('is the part_log-free fallback (no rate/projection columns)', () => {
+    expect(sql).not.toContain('system.part_log')
+    expect(sql).not.toContain('hours_to_throw')
+    expect(sql).toContain('system.parts')
+    expect(sql).toContain('AS is_delaying')
+  })
+
+  test('still resolves delay/throw limits from settings', () => {
+    expect(sql).toContain('system.merge_tree_settings')
+    expect(sql).toContain(String(DEFAULT_PARTS_TO_DELAY_INSERT))
+  })
+})

--- a/apps/dashboard/src/lib/health/parts-pressure.ts
+++ b/apps/dashboard/src/lib/health/parts-pressure.ts
@@ -1,0 +1,276 @@
+/**
+ * Predictive "too many parts" pressure — shared core.
+ *
+ * A MergeTree table rejects inserts once a single partition reaches
+ * `parts_to_throw_insert` active parts, and throttles them at
+ * `parts_to_delay_insert`. Those failures normally arrive without warning. This
+ * module projects *when* a partition will hit the throw threshold from its
+ * recent net part-growth rate (part creation vs merge consumption, read from
+ * `system.part_log`) so the health engine can warn ahead of time.
+ *
+ * Everything here is pure (SQL string builders + projection/classification math)
+ * so it is unit-tested directly. `system-charts.ts` (health card + evidence),
+ * `builtin-rules.ts` (alert channels) and the insight collector all consume it.
+ *
+ * Two surfaces, one metric family:
+ * - **Fill percent** (`current parts / parts_to_throw_insert`) is the headline
+ *   scalar for the /health card + alert rule — higher-is-worse, so it fits the
+ *   shared warning/critical threshold storage every other check uses.
+ * - **Time-to-threshold projection** (needs `system.part_log`) drives the card's
+ *   evidence drill-down and the AI-insight finding, which warns inside a
+ *   configurable window (default 6h) and escalates to critical inside 1h or when
+ *   the partition is already delaying. Falls back to fill-percent-only when
+ *   part_log is disabled.
+ */
+
+/** Warn when a partition is projected to breach parts_to_throw_insert within this many hours. */
+export const PARTS_PRESSURE_WARN_WINDOW_HOURS = 6
+/** Escalate to critical when the projected breach is within this many hours. */
+export const PARTS_PRESSURE_CRITICAL_WINDOW_HOURS = 1
+/** Lookback window (hours) over system.part_log used to measure the net part-growth rate. */
+export const PARTS_PRESSURE_RATE_WINDOW_HOURS = 6
+/** Ignore partitions smaller than this — tiny partitions are noise, never pressure. */
+export const PARTS_PRESSURE_MIN_PARTS = 20
+
+/**
+ * Fallback thresholds when `system.merge_tree_settings` cannot be read. These
+ * match modern ClickHouse defaults (parts_to_throw_insert=3000,
+ * parts_to_delay_insert=1000); the queries always prefer the live server value
+ * and any per-table override extracted from `create_table_query`.
+ */
+export const DEFAULT_PARTS_TO_THROW_INSERT = 3000
+export const DEFAULT_PARTS_TO_DELAY_INSERT = 1000
+
+/** Fill-percent thresholds for the /health card + alert rule (higher-is-worse). */
+export const PARTS_PRESSURE_PERCENT_WARNING = 80
+export const PARTS_PRESSURE_PERCENT_CRITICAL = 95
+
+/** Databases whose parts are internal and never surfaced. */
+const EXCLUDED_DATABASES =
+  "'system', 'INFORMATION_SCHEMA', 'information_schema'"
+
+/** Clamp an interpolated interval/limit to a safe positive integer for SQL. */
+function safeInt(value: number, fallback: number): number {
+  const n = Math.trunc(value)
+  return Number.isFinite(n) && n > 0 ? n : fallback
+}
+
+/**
+ * Per-partition effective throw/delay limits: the per-table override parsed from
+ * `create_table_query` when present, else the live server default from
+ * `system.merge_tree_settings`, else the compiled-in fallback. Emitted as a CTE
+ * body shared by the projection and scalar queries.
+ */
+function effectiveLimitsCte(): string {
+  return `parts_now AS (
+    SELECT database, table, partition, count() AS parts
+    FROM system.parts
+    WHERE active AND database NOT IN (${EXCLUDED_DATABASES})
+    GROUP BY database, table, partition
+  ),
+  table_overrides AS (
+    SELECT
+      database,
+      name AS table,
+      toInt64OrZero(extract(create_table_query, 'parts_to_throw_insert *= *([0-9]+)')) AS throw_override,
+      toInt64OrZero(extract(create_table_query, 'parts_to_delay_insert *= *([0-9]+)')) AS delay_override
+    FROM system.tables
+    WHERE database NOT IN (${EXCLUDED_DATABASES})
+  ),
+  server_defaults AS (
+    SELECT
+      coalesce((SELECT toInt64OrNull(value) FROM system.merge_tree_settings WHERE name = 'parts_to_throw_insert'), ${DEFAULT_PARTS_TO_THROW_INSERT}) AS throw_default,
+      coalesce((SELECT toInt64OrNull(value) FROM system.merge_tree_settings WHERE name = 'parts_to_delay_insert'), ${DEFAULT_PARTS_TO_DELAY_INSERT}) AS delay_default
+  ),
+  limits AS (
+    SELECT
+      p.database AS database,
+      p.table AS table,
+      p.partition AS partition,
+      p.parts AS parts,
+      if(o.throw_override > 0, o.throw_override, (SELECT throw_default FROM server_defaults)) AS throw_limit,
+      if(o.delay_override > 0, o.delay_override, (SELECT delay_default FROM server_defaults)) AS delay_limit
+    FROM parts_now p
+    LEFT JOIN table_overrides o ON p.database = o.database AND p.table = o.table
+    WHERE p.parts >= ${PARTS_PRESSURE_MIN_PARTS}
+  )`
+}
+
+/**
+ * Scalar query for the /health card + alert rule: the single worst partition's
+ * fill percent (`active parts / parts_to_throw_insert * 100`). Higher-is-worse,
+ * read via `valueKey: 'pressure_percent'`. Only needs `system.parts` /
+ * `system.tables` / `system.merge_tree_settings` — no part_log dependency, so it
+ * always works.
+ */
+export function buildPartsPressurePercentSql(): string {
+  return `WITH ${effectiveLimitsCte()}
+SELECT round(max(parts * 100.0 / nullIf(throw_limit, 0)), 1) AS pressure_percent
+FROM limits`
+}
+
+/**
+ * Projection query: per-partition current parts, effective throw/delay limits,
+ * net part-growth rate from `system.part_log`, and the projected hours until the
+ * partition breaches `parts_to_throw_insert`. Requires `system.part_log` (mark
+ * the chart/collector `optional` + `tableCheck: 'system.part_log'`); use
+ * {@link buildPartsPressureCurrentSql} as the graceful fallback.
+ *
+ * Net rate = (NewPart events − RemovePart events) over the rate window, per
+ * partition: a positive net means parts are accumulating faster than merges
+ * consume them. Rows are ordered worst-first — already-delaying partitions, then
+ * the soonest projected breach.
+ */
+export function buildPartsPressureProjectionSql(opts?: {
+  rateWindowHours?: number
+  limit?: number
+}): string {
+  const windowHours = safeInt(
+    opts?.rateWindowHours ?? PARTS_PRESSURE_RATE_WINDOW_HOURS,
+    PARTS_PRESSURE_RATE_WINDOW_HOURS
+  )
+  const limit = safeInt(opts?.limit ?? 20, 20)
+  return `WITH ${effectiveLimitsCte()},
+  part_rate AS (
+    SELECT
+      database,
+      table,
+      partition,
+      (countIf(event_type = 'NewPart') - countIf(event_type = 'RemovePart')) / ${windowHours}.0 AS net_parts_per_hour
+    FROM system.part_log
+    WHERE event_time > now() - INTERVAL ${windowHours} HOUR
+      AND database NOT IN (${EXCLUDED_DATABASES})
+    GROUP BY database, table, partition
+  )
+SELECT
+  l.database AS database,
+  l.table AS table,
+  l.partition AS partition,
+  l.parts AS parts,
+  l.throw_limit AS throw_limit,
+  l.delay_limit AS delay_limit,
+  round(coalesce(r.net_parts_per_hour, 0), 2) AS net_parts_per_hour,
+  l.parts >= l.delay_limit AS is_delaying,
+  if(
+    coalesce(r.net_parts_per_hour, 0) > 0 AND l.parts < l.throw_limit,
+    round((l.throw_limit - l.parts) / r.net_parts_per_hour, 2),
+    NULL
+  ) AS hours_to_throw
+FROM limits l
+LEFT JOIN part_rate r ON l.database = r.database AND l.table = r.table AND l.partition = r.partition
+ORDER BY is_delaying DESC, hours_to_throw ASC NULLS LAST, parts DESC
+LIMIT ${limit}`
+}
+
+/**
+ * Fallback query when `system.part_log` is disabled: per-partition current parts
+ * and effective limits, no rate/projection columns. Ordered by raw fill so the
+ * fullest partition leads.
+ */
+export function buildPartsPressureCurrentSql(opts?: {
+  limit?: number
+}): string {
+  const limit = safeInt(opts?.limit ?? 20, 20)
+  return `WITH ${effectiveLimitsCte()}
+SELECT
+  database,
+  table,
+  partition,
+  parts,
+  throw_limit,
+  delay_limit,
+  parts >= delay_limit AS is_delaying
+FROM limits
+ORDER BY parts * 1.0 / nullIf(throw_limit, 0) DESC
+LIMIT ${limit}`
+}
+
+/** A single partition's projected pressure, parsed from a projection query row. */
+export interface PartsPressureRow {
+  database: string
+  table: string
+  partition: string
+  parts: number
+  throwLimit: number
+  delayLimit: number
+  /** Net parts/hour from part_log; null when part_log is unavailable. */
+  netPartsPerHour: number | null
+  /** Projected hours until parts reaches throwLimit; null when not projectable. */
+  hoursToThrow: number | null
+  isDelaying: boolean
+}
+
+/**
+ * Project hours until a partition reaches its throw threshold. Returns null when
+ * the net rate is non-positive (parts stable/shrinking — merges keeping up) or
+ * inputs are invalid, and 0 when the partition has already reached the limit.
+ * Pure — the projection query computes the same thing in SQL; this mirror is
+ * what the fallback path and unit tests use.
+ */
+export function projectHoursToThreshold(
+  currentParts: number,
+  throwLimit: number,
+  netPartsPerHour: number | null
+): number | null {
+  if (
+    netPartsPerHour === null ||
+    !Number.isFinite(netPartsPerHour) ||
+    netPartsPerHour <= 0
+  )
+    return null
+  if (
+    !Number.isFinite(currentParts) ||
+    !Number.isFinite(throwLimit) ||
+    throwLimit <= 0
+  )
+    return null
+  const remaining = throwLimit - currentParts
+  if (remaining <= 0) return 0
+  return remaining / netPartsPerHour
+}
+
+export type PartsPressureSeverity = 'info' | 'warning' | 'critical'
+
+/**
+ * Classify a partition's parts pressure into a severity, or null when it is not
+ * worth surfacing. Encodes the PRD policy:
+ * - already delaying (parts ≥ parts_to_delay_insert) → critical
+ * - projected breach within the critical window (default 1h) → critical
+ * - projected breach within the warn window (default 6h) → warning
+ * - no projection (part_log off): fall back to raw fill — ≥ critical% → warning,
+ *   ≥ warning% → info, else null
+ * - projectable but breach is beyond the warn window → null (not imminent)
+ */
+export function classifyPartsPressure(input: {
+  parts: number
+  throwLimit: number
+  delayLimit: number
+  hoursToThrow: number | null
+  warnWindowHours?: number
+  criticalWindowHours?: number
+}): PartsPressureSeverity | null {
+  const {
+    parts,
+    throwLimit,
+    delayLimit,
+    hoursToThrow,
+    warnWindowHours = PARTS_PRESSURE_WARN_WINDOW_HOURS,
+    criticalWindowHours = PARTS_PRESSURE_CRITICAL_WINDOW_HOURS,
+  } = input
+
+  if (Number.isFinite(delayLimit) && delayLimit > 0 && parts >= delayLimit)
+    return 'critical'
+
+  if (hoursToThrow !== null && Number.isFinite(hoursToThrow)) {
+    if (hoursToThrow <= criticalWindowHours) return 'critical'
+    if (hoursToThrow <= warnWindowHours) return 'warning'
+    return null
+  }
+
+  // No projection (part_log unavailable) — fall back to raw fill percent.
+  const percent =
+    throwLimit > 0 ? (parts * 100) / throwLimit : Number.POSITIVE_INFINITY
+  if (percent >= PARTS_PRESSURE_PERCENT_CRITICAL) return 'warning'
+  if (percent >= PARTS_PRESSURE_PERCENT_WARNING) return 'info'
+  return null
+}

--- a/apps/dashboard/src/lib/insights/collectors.ts
+++ b/apps/dashboard/src/lib/insights/collectors.ts
@@ -13,9 +13,16 @@ import type { InsightCandidate, InsightSeverity } from './types'
 
 import { readOnlyQuery } from '../ai/agent/tools/helpers'
 import {
+  buildPartsPressureCurrentSql,
+  buildPartsPressureProjectionSql,
+  type PartsPressureRow,
+  projectHoursToThreshold,
+} from '../health/parts-pressure'
+import {
   checkDetachedParts,
   checkFailedDictionaries,
   checkLongRunningQuery,
+  checkPartsPressure,
   checkStuckMutations,
 } from './operational-checks'
 import {
@@ -425,7 +432,63 @@ async function collectOperational(hostId: number): Promise<InsightCandidate[]> {
     if (candidate) out.push(candidate)
   }
 
+  // Predictive parts pressure — project the worst partition's time-to-throw from
+  // system.part_log; fall back to fill-percent-only when part_log is disabled.
+  const pressure = await collectPartsPressure(hostId)
+  if (pressure) out.push(pressure)
+
   return out
+}
+
+/** Parse a projection/fallback query row into a typed PartsPressureRow. */
+function toPartsPressureRow(
+  raw: Record<string, unknown>,
+  hasProjection: boolean
+): PartsPressureRow {
+  const parts = Number(raw.parts) || 0
+  const throwLimit = Number(raw.throw_limit) || 0
+  const netRaw = raw.net_parts_per_hour
+  const netPartsPerHour = hasProjection
+    ? Number.isFinite(Number(netRaw))
+      ? Number(netRaw)
+      : null
+    : null
+  const hoursRaw = raw.hours_to_throw
+  const hoursToThrow = hasProjection
+    ? hoursRaw === null || hoursRaw === undefined || hoursRaw === ''
+      ? null
+      : Number.isFinite(Number(hoursRaw))
+        ? Number(hoursRaw)
+        : projectHoursToThreshold(parts, throwLimit, netPartsPerHour)
+    : null
+  return {
+    database: String(raw.database ?? ''),
+    table: String(raw.table ?? ''),
+    partition: String(raw.partition ?? ''),
+    parts,
+    throwLimit,
+    delayLimit: Number(raw.delay_limit) || 0,
+    netPartsPerHour,
+    hoursToThrow,
+    isDelaying: Number(raw.is_delaying) === 1 || raw.is_delaying === true,
+  }
+}
+
+/**
+ * Worst-partition parts-pressure candidate. Tries the part_log projection first;
+ * if that query fails (part_log disabled/missing) it retries the fill-percent
+ * fallback so the finding still fires — degraded to a current-count warning.
+ */
+async function collectPartsPressure(
+  hostId: number
+): Promise<InsightCandidate | null> {
+  const projected = await firstRow(buildPartsPressureProjectionSql(), hostId)
+  if (projected) return checkPartsPressure(toPartsPressureRow(projected, true))
+
+  const current = await firstRow(buildPartsPressureCurrentSql(), hostId)
+  if (current) return checkPartsPressure(toPartsPressureRow(current, false))
+
+  return null
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/dashboard/src/lib/insights/operational-checks.test.ts
+++ b/apps/dashboard/src/lib/insights/operational-checks.test.ts
@@ -13,10 +13,13 @@
  * two drift, insights silently lose their link after a reload.
  */
 
+import type { PartsPressureRow } from '../health/parts-pressure'
+
 import {
   checkDetachedParts,
   checkFailedDictionaries,
   checkLongRunningQuery,
+  checkPartsPressure,
   checkStuckMutations,
   DETACHED_PARTS_MIN,
   DETACHED_PARTS_WARN,
@@ -126,5 +129,61 @@ describe('checkFailedDictionaries', () => {
 
   test('several failures use plural copy', () => {
     expect(checkFailedDictionaries(3)?.title).toContain('3 dictionaries failed')
+  })
+})
+
+describe('checkPartsPressure', () => {
+  const row = (over: Partial<PartsPressureRow> = {}): PartsPressureRow => ({
+    database: 'app',
+    table: 'events',
+    partition: '202607',
+    parts: 100,
+    throwLimit: 3000,
+    delayLimit: 1000,
+    netPartsPerHour: null,
+    hoursToThrow: null,
+    isDelaying: false,
+    ...over,
+  })
+
+  test('a calm partition is not surfaced', () => {
+    expect(checkPartsPressure(row())).toBeNull()
+  })
+
+  test('an imminent projected breach surfaces as a storage finding', () => {
+    const c = checkPartsPressure(
+      row({ parts: 800, netPartsPerHour: 200, hoursToThrow: 5 })
+    )
+    expect(c?.severity).toBe('warning')
+    expect(c?.category).toBe('storage')
+    expect(c?.metric).toBe('parts_pressure')
+    expect(c?.title).toBe('app.events is approaching too many parts')
+    // Must match the deriveAction('parts_pressure') case in read-insights.ts.
+    expect(c?.action).toEqual({ label: 'View merges', href: '/merges' })
+  })
+
+  test('an already-delaying partition is critical', () => {
+    const c = checkPartsPressure(row({ parts: 1200, isDelaying: true }))
+    expect(c?.severity).toBe('critical')
+    expect(c?.detail).toContain('throttled')
+  })
+
+  test('title is stable across runs (no projected hours in the key surface)', () => {
+    const a = checkPartsPressure(
+      row({ parts: 800, netPartsPerHour: 200, hoursToThrow: 5 })
+    )
+    const b = checkPartsPressure(
+      row({ parts: 850, netPartsPerHour: 400, hoursToThrow: 2.25 })
+    )
+    expect(a?.title).toBe(b?.title ?? '')
+  })
+
+  test('degrades to a fill-percent finding when part_log is disabled', () => {
+    // delayLimit raised so the fill-percent fallback (not the delay rule) fires.
+    const c = checkPartsPressure(
+      row({ parts: 2900, delayLimit: 3000, hoursToThrow: null })
+    )
+    expect(c?.severity).toBe('warning')
+    expect(c?.detail).toContain('system.part_log')
   })
 })

--- a/apps/dashboard/src/lib/insights/operational-checks.ts
+++ b/apps/dashboard/src/lib/insights/operational-checks.ts
@@ -12,6 +12,11 @@
 
 import type { InsightCandidate } from './types'
 
+import {
+  classifyPartsPressure,
+  type PartsPressureRow,
+} from '../health/parts-pressure'
+
 /** Detached parts: below this many, don't surface at all. */
 export const DETACHED_PARTS_MIN = 10
 /** At/above this many detached parts, escalate from notice to warning. */
@@ -91,6 +96,60 @@ export function checkLongRunningQuery(
     detail: `The longest live query has been running for ${formatDuration(maxElapsedSeconds)}${others ? ` (${others} queries over a minute)` : ''}. Long-running queries hold locks and memory — check for a runaway scan or a missing filter, and cancel it if it is stuck.`,
     value: Math.round(maxElapsedSeconds),
     action: { label: 'Open running queries', href: '/running-queries' },
+  }
+}
+
+/**
+ * Predictive "too many parts" early warning. Given the worst partition's active
+ * parts, its effective throw/delay limits, and (when `system.part_log` is
+ * available) the projected hours until it hits `parts_to_throw_insert`, decide
+ * whether to surface a finding and at what severity. Severity policy lives in
+ * `classifyPartsPressure`; this wraps the winning partition into a candidate.
+ *
+ * The stable key is `host:storage:parts_pressure:<title>`, so the title carries
+ * only the partition identity (never the run-to-run projected hours) — a
+ * dismissal survives regeneration while the projected time keeps updating in the
+ * detail text.
+ */
+export function checkPartsPressure(
+  row: PartsPressureRow
+): InsightCandidate | null {
+  const severity = classifyPartsPressure({
+    parts: row.parts,
+    throwLimit: row.throwLimit,
+    delayLimit: row.delayLimit,
+    hoursToThrow: row.hoursToThrow,
+  })
+  if (!severity) return null
+
+  const target = `${row.database}.${row.table}`
+  const fillPercent =
+    row.throwLimit > 0 ? Math.round((row.parts * 100) / row.throwLimit) : 0
+
+  let projection: string
+  if (row.isDelaying) {
+    projection = `It has ${row.parts} active parts, at or past parts_to_delay_insert (${row.delayLimit}) — inserts are already being throttled and will be rejected at ${row.throwLimit}.`
+  } else if (row.hoursToThrow !== null) {
+    const when =
+      row.hoursToThrow <= 0
+        ? 'now'
+        : row.hoursToThrow < 1
+          ? `~${Math.round(row.hoursToThrow * 60)}m`
+          : `~${Math.round(row.hoursToThrow * 10) / 10}h`
+    projection = `At the current net rate of ${row.netPartsPerHour ?? 0} parts/hour it will reach parts_to_throw_insert (${row.throwLimit}) in ${when} — it now has ${row.parts} parts (${fillPercent}%).`
+  } else {
+    // part_log disabled — fill-percent-only fallback, no time projection.
+    projection = `It has ${row.parts} active parts (${fillPercent}% of parts_to_throw_insert ${row.throwLimit}). Enable system.part_log to project when inserts will be rejected.`
+  }
+
+  return {
+    severity,
+    category: 'storage',
+    metric: 'parts_pressure',
+    title: `${target} is approaching too many parts`,
+    detail: `Partition \`${row.partition}\` of ${target} is under parts pressure. ${projection} Increase insert batch sizes, speed up merges (background_pool_size / faster disk), or coarsen the partition key.`,
+    value: fillPercent,
+    action: { label: 'View merges', href: '/merges' },
   }
 }
 

--- a/apps/dashboard/src/lib/insights/read-insights.ts
+++ b/apps/dashboard/src/lib/insights/read-insights.ts
@@ -39,6 +39,8 @@ function deriveAction(
       return { label: 'View replicas', href: '/replicas' }
     case 'stuck_mutations':
       return { label: 'View mutations', href: '/mutations' }
+    case 'parts_pressure':
+      return { label: 'View merges', href: '/merges' }
     case 'longest_running_query':
       return { label: 'Open running queries', href: '/running-queries' }
     case 'failed_dictionaries':

--- a/docs/knowledge/ai-insights.md
+++ b/docs/knowledge/ai-insights.md
@@ -350,10 +350,17 @@ stay in sync) and the same card + severity styling:
   into the collect pipeline as the `optimization` category (see the
   schema-optimization collector above), reusing `analyzeQuery` rather than
   reimplementing schema analysis.
+- **Predictive parts pressure — done.** `checkPartsPressure`
+  (`operational-checks.ts`, metric `parts_pressure`, category `storage`) projects
+  when the worst partition will hit `parts_to_throw_insert` from the net
+  part-growth rate in `system.part_log` (warns inside 6h, critical inside 1h or
+  already delaying), degrading to a fill-percent-only finding when part_log is
+  off. The projection math + SQL builders live in `lib/health/parts-pressure.ts`
+  and are shared with the `/health` card (`parts-pressure`) and the
+  `parts-pressure` alert rule.
 - **More detectors.** The operational collectors are a starter set. Natural next
   detectors (each still a cheap single system-table read + a pure classifier in
-  `operational-checks.ts`): long-running merges (`system.merges`), high
-  `parts_to_throw_insert` pressure, growing `system.replication_queue`, dropped
-  connections / rejected inserts, and `cost`-category signals (e.g. cold-storage
-  candidates). Each new metric needs a matching `deriveAction` case and a
-  category in the board's `CATEGORY_META`.
+  `operational-checks.ts`): long-running merges (`system.merges`), growing
+  `system.replication_queue`, dropped connections / rejected inserts, and
+  `cost`-category signals (e.g. cold-storage candidates). Each new metric needs a
+  matching `deriveAction` case and a category in the board's `CATEGORY_META`.


### PR DESCRIPTION
Closes #2763

## What

A predictive "too many parts" health check. Instead of finding out about `parts_to_throw_insert` insert failures after they happen, this projects **when** a partition will hit the throw threshold and warns ahead of time.

### Shared core — `lib/health/parts-pressure.ts`
Pure SQL builders + projection/classification math (unit-tested):
- Active parts per partition (`system.parts`) vs **effective** `parts_to_throw_insert` / `parts_to_delay_insert` — server default from `system.merge_tree_settings`, overridden per-table by parsing `create_table_query`.
- Net part-growth rate (`NewPart` − `RemovePart`) from `system.part_log` → projected **hours-to-throw**.
- Graceful fallback to fill-percent-only when `system.part_log` is disabled.

### Three surfaces, one metric family
- **/health card `parts-pressure`** — headline = worst partition fill % of `parts_to_throw_insert` (higher-is-worse, fits the shared threshold storage every check uses). Evidence drill-down shows per-partition parts, limits, net rate, and projected time-to-throw. Threshold row appears automatically in **health-settings**.
- **`parts-pressure` alert rule** (`BUILTIN_RULES`) — delivered through the existing alert-settings channels like every other check, with a runbook link + read-only diagnostic.
- **AI Insights finding `parts_pressure`** — stable key `host:storage:parts_pressure:<title>` (projected hours kept out of the title so dismissals survive regeneration). Warns inside 6h, critical inside 1h or when the partition is already delaying.

### Design note
The time-window (6h/1h) projection policy lives in the alert rule + insight, where richer classification is available. The /health card uses fill-percent so it stays consistent with the shared warning/critical threshold UX; the projection is surfaced there as evidence.

## Verification
- `pnpm run lint` — clean
- `pnpm run build` (Vite + `tsc --noEmit`) — passes
- New unit tests for projection math, severity policy, and SQL builders (`parts-pressure.test.ts`, `operational-checks.test.ts`) — green; affected suites pass in isolation. (10 pre-existing cross-file `mock.module` failures in the insights suite are unrelated — identical on clean `main`.)

https://claude.ai/code/session_01EAzHsUVHPqCzE9M6o1yZZa