### PR TITLE
feat(metrics): memory & CPU deep-dive charts

### DIFF
--- a/apps/dashboard/src/components/charts/registry/chart-categories.ts
+++ b/apps/dashboard/src/components/charts/registry/chart-categories.ts
@@ -64,6 +64,10 @@ export const CHARTS_BY_CATEGORY: Record<ChartCategory, string[]> = {
     'memory-usage',
     'cpu-usage',
     'disk-usage-by-database',
+    'memory-breakdown',
+    'cpu-load-average',
+    'cpu-mode-split',
+    'thread-pool-utilization',
   ],
   [CHART_CATEGORIES.REPLICATION]: [
     'replication-queue-count',

--- a/apps/dashboard/src/components/charts/registry/imports/system-charts.ts
+++ b/apps/dashboard/src/components/charts/registry/imports/system-charts.ts
@@ -39,6 +39,26 @@ export const systemChartImports: ChartRegistryMap = {
       default: m.ChartCPUUsage,
     }))
   ),
+  'memory-breakdown': lazy(() =>
+    import('@/components/charts/system/memory-breakdown').then((m) => ({
+      default: m.ChartMemoryBreakdown,
+    }))
+  ),
+  'cpu-load-average': lazy(() =>
+    import('@/components/charts/system/cpu-load-average').then((m) => ({
+      default: m.ChartCpuLoadAverage,
+    }))
+  ),
+  'cpu-mode-split': lazy(() =>
+    import('@/components/charts/system/cpu-mode-split').then((m) => ({
+      default: m.ChartCpuModeSplit,
+    }))
+  ),
+  'thread-pool-utilization': lazy(() =>
+    import('@/components/charts/system/thread-pool-utilization').then((m) => ({
+      default: m.ChartThreadPoolUtilization,
+    }))
+  ),
   'disk-usage-by-database': lazy(() =>
     import('@/components/charts/system/disk-usage-by-database').then((m) => ({
       default: m.ChartDiskUsageByDatabase,

--- a/apps/dashboard/src/components/charts/registry/type-hints.ts
+++ b/apps/dashboard/src/components/charts/registry/type-hints.ts
@@ -58,6 +58,10 @@ export const CHART_TYPE_HINTS: Record<string, ChartSkeletonType> = {
   'memory-usage': 'area',
   'cpu-usage': 'area',
   'disk-usage-by-database': 'bar',
+  'memory-breakdown': 'area',
+  'cpu-load-average': 'area',
+  'cpu-mode-split': 'area',
+  'thread-pool-utilization': 'area',
 
   // Replication Charts
   'replication-queue-count': 'area',

--- a/apps/dashboard/src/components/charts/system/cpu-load-average.tsx
+++ b/apps/dashboard/src/components/charts/system/cpu-load-average.tsx
@@ -1,0 +1,34 @@
+import type { ChartProps } from '@/components/charts/chart-props'
+
+import { createAreaChart } from '@/components/charts/factory'
+import { chartTickFormatters } from '@/lib/utils'
+
+/**
+ * Load average (1m/5m/15m) plotted alongside the logical CPU core count, so
+ * "load above cores" reads as saturation at a glance.
+ */
+export const ChartCpuLoadAverage = createAreaChart({
+  chartName: 'cpu-load-average',
+  index: 'event_time',
+  categories: [
+    'load_average_1m',
+    'load_average_5m',
+    'load_average_15m',
+    'cpu_cores',
+  ],
+  defaultTitle: 'Load Average vs CPU Cores',
+  defaultInterval: 'toStartOfTenMinutes',
+  defaultLastHours: 24,
+  dataTestId: 'cpu-load-average-chart',
+  dateRangeConfig: 'system-metrics',
+  areaChartProps: {
+    stack: false,
+    showLegend: true,
+    colors: ['--chart-1', '--chart-2', '--chart-3', '--chart-5'],
+    yAxisTickFormatter: chartTickFormatters.count,
+  },
+})
+
+export type ChartCpuLoadAverageProps = ChartProps
+
+export default ChartCpuLoadAverage

--- a/apps/dashboard/src/components/charts/system/cpu-mode-split.tsx
+++ b/apps/dashboard/src/components/charts/system/cpu-mode-split.tsx
@@ -1,0 +1,30 @@
+import type { ChartProps } from '@/components/charts/chart-props'
+
+import { createAreaChart } from '@/components/charts/factory'
+import { chartTickFormatters } from '@/lib/utils'
+
+/**
+ * CPU mode split (user/system/iowait/idle), aggregated across all cores.
+ * Degrades to the chart's all-zero empty state on platforms that don't
+ * expose these OS-level asynchronous metrics.
+ */
+export const ChartCpuModeSplit = createAreaChart({
+  chartName: 'cpu-mode-split',
+  index: 'event_time',
+  categories: ['user_time', 'system_time', 'iowait_time', 'idle_time'],
+  defaultTitle: 'CPU Mode Split',
+  defaultInterval: 'toStartOfTenMinutes',
+  defaultLastHours: 24,
+  dataTestId: 'cpu-mode-split-chart',
+  dateRangeConfig: 'system-metrics',
+  areaChartProps: {
+    stack: true,
+    showLegend: true,
+    colors: ['--chart-1', '--chart-2', '--chart-yellow', '--chart-6'],
+    yAxisTickFormatter: chartTickFormatters.count,
+  },
+})
+
+export type ChartCpuModeSplitProps = ChartProps
+
+export default ChartCpuModeSplit

--- a/apps/dashboard/src/components/charts/system/memory-breakdown.tsx
+++ b/apps/dashboard/src/components/charts/system/memory-breakdown.tsx
@@ -1,0 +1,36 @@
+import type { ChartProps } from '@/components/charts/chart-props'
+
+import { createAreaChart } from '@/components/charts/factory'
+import { chartTickFormatters } from '@/lib/utils'
+
+/**
+ * RSS decomposition: memory tracked by queries/other, caches (mark +
+ * uncompressed + query cache), background merges/mutations, and primary
+ * keys/indexes. See `lib/api/charts/system-charts.ts` `'memory-breakdown'`
+ * for the approximation methodology.
+ */
+export const ChartMemoryBreakdown = createAreaChart({
+  chartName: 'memory-breakdown',
+  index: 'event_time',
+  categories: [
+    'queries_memory',
+    'caches_memory',
+    'merges_memory',
+    'primary_key_memory',
+  ],
+  defaultTitle: 'Memory Breakdown',
+  defaultInterval: 'toStartOfTenMinutes',
+  defaultLastHours: 24,
+  dataTestId: 'memory-breakdown-chart',
+  dateRangeConfig: 'system-metrics',
+  areaChartProps: {
+    stack: true,
+    showLegend: true,
+    colors: ['--chart-1', '--chart-2', '--chart-3', '--chart-4'],
+    yAxisTickFormatter: chartTickFormatters.bytes,
+  },
+})
+
+export type ChartMemoryBreakdownProps = ChartProps
+
+export default ChartMemoryBreakdown

--- a/apps/dashboard/src/components/charts/system/thread-pool-utilization.tsx
+++ b/apps/dashboard/src/components/charts/system/thread-pool-utilization.tsx
@@ -1,0 +1,29 @@
+import type { ChartProps } from '@/components/charts/chart-props'
+
+import { createAreaChart } from '@/components/charts/factory'
+import { chartTickFormatters } from '@/lib/utils'
+
+/**
+ * Global thread pool saturation: active vs total threads, from
+ * `system.metric_log`'s `CurrentMetric_GlobalThreadPool*` gauges.
+ */
+export const ChartThreadPoolUtilization = createAreaChart({
+  chartName: 'thread-pool-utilization',
+  index: 'event_time',
+  categories: ['active_threads', 'total_threads'],
+  defaultTitle: 'Thread Pool Utilization',
+  defaultInterval: 'toStartOfTenMinutes',
+  defaultLastHours: 24,
+  dataTestId: 'thread-pool-utilization-chart',
+  dateRangeConfig: 'system-metrics',
+  areaChartProps: {
+    stack: false,
+    showLegend: true,
+    colors: ['--chart-1', '--chart-3'],
+    yAxisTickFormatter: chartTickFormatters.count,
+  },
+})
+
+export type ChartThreadPoolUtilizationProps = ChartProps
+
+export default ChartThreadPoolUtilization

--- a/apps/dashboard/src/lib/api/__tests__/charts/system-charts.test.ts
+++ b/apps/dashboard/src/lib/api/__tests__/charts/system-charts.test.ts
@@ -58,6 +58,65 @@ describe('systemCharts', () => {
       })
     }
 
+    if (name === 'memory-breakdown') {
+      test('breaks memory down into queries/caches/merges/primary-key categories', () => {
+        const result = builder({
+          interval: 'toStartOfTenMinutes',
+          lastHours: 24,
+        })
+        if ('query' in result) {
+          expect(result.query).toContain('queries_memory')
+          expect(result.query).toContain('caches_memory')
+          expect(result.query).toContain('merges_memory')
+          expect(result.query).toContain('primary_key_memory')
+          // Row-based metric source: version-tolerant, no per-column errors.
+          expect(result.query).toContain(
+            "metric = 'CurrentMetric_MemoryTracking'"
+          )
+          expect(result.query).toContain('system.parts')
+        }
+      })
+    }
+
+    if (name === 'cpu-load-average') {
+      test('derives core count from per-core OSUserTimeCPU% gauges', () => {
+        const result = builder({})
+        if ('query' in result) {
+          expect(result.query).toContain('load_average_1m')
+          expect(result.query).toContain('load_average_5m')
+          expect(result.query).toContain('load_average_15m')
+          expect(result.query).toContain('cpu_cores')
+          expect(result.query).toContain("metric LIKE 'OSUserTimeCPU%'")
+        }
+      })
+    }
+
+    if (name === 'cpu-mode-split') {
+      test('splits CPU time into user/system/iowait/idle', () => {
+        const result = builder({})
+        if ('query' in result) {
+          expect(result.query).toContain('user_time')
+          expect(result.query).toContain('system_time')
+          expect(result.query).toContain('iowait_time')
+          expect(result.query).toContain('idle_time')
+        }
+      })
+    }
+
+    if (name === 'thread-pool-utilization') {
+      test('reads global thread pool active/total gauges from metric_log', () => {
+        const result = builder({})
+        if ('query' in result) {
+          expect(result.query).toContain(
+            'CurrentMetric_GlobalThreadPoolActiveThreads'
+          )
+          expect(result.query).toContain(
+            'CurrentMetric_GlobalThreadPoolThreads'
+          )
+        }
+      })
+    }
+
     if (name === 'disks-usage') {
       // Regression: the chart used to sumMap() over every async metric for
       // 30 days, materializing a hundreds-of-keys map per group and OOMing

--- a/apps/dashboard/src/lib/api/charts/system-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/system-charts.ts
@@ -56,6 +56,128 @@ export const systemCharts: Record<string, ChartQueryBuilder> = {
     }
   },
 
+  // Memory breakdown (RSS decomposition): approximates where the root memory
+  // tracker's bytes are going by subtracting the two biggest known background
+  // consumers (mark/uncompressed/query caches, background merges/mutations)
+  // from the total tracked memory; the remainder is attributed to
+  // queries/other. Primary-key/index memory has no historical time series in
+  // ClickHouse (system.parts is a live snapshot only), so it rides along as a
+  // constant "current" value repeated across every bucket via a scalar
+  // subquery wrapped in any() (required so it's valid alongside the GROUP BY).
+  // Row-based (metric, value) source ⇒ a metric name absent on an older
+  // ClickHouse version just yields no matching rows (ifNotFinite guards the
+  // resulting NaN from an empty avgIf) instead of a SQL error, so this needs
+  // no per-column `sql: VersionedSql[]` branching — only the table-existence
+  // check below.
+  'memory-breakdown': ({
+    interval = 'toStartOfTenMinutes',
+    lastHours = 24,
+  }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    return {
+      query: `
+    SELECT
+      ${applyInterval(interval, 'event_time')},
+      ifNotFinite(avgIf(value, metric = 'CurrentMetric_MemoryTracking'), 0) AS total_memory,
+      ifNotFinite(avgIf(value, metric = 'CurrentMetric_MergesMutationsMemoryTracking'), 0) AS merges_memory,
+      ifNotFinite(avgIf(value, metric = 'MarkCacheBytes'), 0)
+        + ifNotFinite(avgIf(value, metric = 'UncompressedCacheBytes'), 0)
+        + ifNotFinite(avgIf(value, metric = 'QueryCacheBytes'), 0) AS caches_memory,
+      greatest(total_memory - merges_memory - caches_memory, 0) AS queries_memory,
+      any((SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE active)) AS primary_key_memory
+    FROM merge('system', '^asynchronous_metric_log')
+    WHERE metric IN (
+      'CurrentMetric_MemoryTracking',
+      'CurrentMetric_MergesMutationsMemoryTracking',
+      'MarkCacheBytes',
+      'UncompressedCacheBytes',
+      'QueryCacheBytes'
+    )
+    ${timeFilter ? `AND ${timeFilter}` : ''}
+    GROUP BY 1
+    ORDER BY 1 ASC`,
+      optional: true,
+      tableCheck: 'system.asynchronous_metric_log',
+      permission: METRICS_PERMISSION,
+    }
+  },
+
+  // Load average (1m/5m/15m) vs core count. Core count is derived (not a
+  // single dedicated async metric) by counting the distinct per-core
+  // `OSUserTimeCPU{N}` gauges ClickHouse emits — one per logical core.
+  'cpu-load-average': ({
+    interval = 'toStartOfTenMinutes',
+    lastHours = 24,
+  }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    return {
+      query: `
+    SELECT
+      ${applyInterval(interval, 'event_time')},
+      ifNotFinite(avgIf(value, metric = 'LoadAverage1'), 0) AS load_average_1m,
+      ifNotFinite(avgIf(value, metric = 'LoadAverage5'), 0) AS load_average_5m,
+      ifNotFinite(avgIf(value, metric = 'LoadAverage15'), 0) AS load_average_15m,
+      uniqExactIf(metric, metric LIKE 'OSUserTimeCPU%') AS cpu_cores
+    FROM merge('system', '^asynchronous_metric_log')
+    WHERE metric IN ('LoadAverage1', 'LoadAverage5', 'LoadAverage15')
+       OR metric LIKE 'OSUserTimeCPU%'
+    ${timeFilter ? `AND ${timeFilter}` : ''}
+    GROUP BY 1
+    ORDER BY 1 ASC`,
+      optional: true,
+      tableCheck: 'system.asynchronous_metric_log',
+      permission: METRICS_PERMISSION,
+    }
+  },
+
+  // CPU mode split (user/system/iowait/idle), aggregated across all cores.
+  // Degrades gracefully (all-zero series → chart empty state) on platforms
+  // that don't expose these OS-level asynchronous metrics.
+  'cpu-mode-split': ({ interval = 'toStartOfTenMinutes', lastHours = 24 }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    return {
+      query: `
+    SELECT
+      ${applyInterval(interval, 'event_time')},
+      ifNotFinite(avgIf(value, metric = 'OSUserTime'), 0) AS user_time,
+      ifNotFinite(avgIf(value, metric = 'OSSystemTime'), 0) AS system_time,
+      ifNotFinite(avgIf(value, metric = 'OSIOWaitTime'), 0) AS iowait_time,
+      ifNotFinite(avgIf(value, metric = 'OSIdleTime'), 0) AS idle_time
+    FROM merge('system', '^asynchronous_metric_log')
+    WHERE metric IN ('OSUserTime', 'OSSystemTime', 'OSIOWaitTime', 'OSIdleTime')
+    ${timeFilter ? `AND ${timeFilter}` : ''}
+    GROUP BY 1
+    ORDER BY 1 ASC`,
+      optional: true,
+      tableCheck: 'system.asynchronous_metric_log',
+      permission: METRICS_PERMISSION,
+    }
+  },
+
+  // Global thread pool saturation (active vs total threads). Uses
+  // `system.metric_log`'s CurrentMetric_* columns, same source/convention as
+  // 'memory-usage'/'cpu-usage' above.
+  'thread-pool-utilization': ({
+    interval = 'toStartOfTenMinutes',
+    lastHours = 24,
+  }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    return {
+      query: `
+    SELECT
+      ${applyInterval(interval, 'event_time')},
+      avg(CurrentMetric_GlobalThreadPoolActiveThreads) AS active_threads,
+      avg(CurrentMetric_GlobalThreadPoolThreads) AS total_threads
+    FROM merge('system', '^metric_log')
+    ${timeFilter ? `WHERE ${timeFilter}` : ''}
+    GROUP BY 1
+    ORDER BY 1 ASC`,
+      optional: true,
+      tableCheck: 'system.metric_log',
+      permission: METRICS_PERMISSION,
+    }
+  },
+
   'disk-size': ({ params }) => {
     const name = params?.name as string | undefined
     // Sanitize disk name: allow only alphanumeric, underscore, hyphen

--- a/apps/dashboard/src/lib/query-config/index.ts
+++ b/apps/dashboard/src/lib/query-config/index.ts
@@ -77,6 +77,8 @@ import { slowQueriesConfig } from './queries/slow-queries'
 import { slowQueryPatternsConfig } from './queries/slow-query-patterns'
 // Thread Analysis
 import { threadAnalysisConfig } from './queries/thread-analysis'
+import { topCpuQueriesConfig } from './queries/top-cpu-queries'
+import { topMemoryQueriesLiveConfig } from './queries/top-memory-queries-live'
 import { loginAttemptsConfig } from './security/login-attempts'
 // Security
 import { sessionsConfig } from './security/sessions'
@@ -180,6 +182,8 @@ export const queries: Array<QueryConfig> = [
   commonErrorsConfig,
   expensiveQueriesConfig,
   expensiveQueriesByMemoryConfig,
+  topMemoryQueriesLiveConfig,
+  topCpuQueriesConfig,
   slowQueriesConfig,
   slowQueryPatternsConfig,
   userProcessesConfig,

--- a/apps/dashboard/src/lib/query-config/queries/top-cpu-queries.ts
+++ b/apps/dashboard/src/lib/query-config/queries/top-cpu-queries.ts
@@ -1,0 +1,123 @@
+import { CpuIcon, UserIcon } from 'lucide-react'
+
+import type { QueryConfig } from '@/types/query-config'
+
+import { createExpandedPanel } from '@/components/data-table/cells/expanded-panel'
+import { QUERY_LOG } from '@/lib/table-notes'
+import { ColumnFormat } from '@/types/column-format'
+
+/**
+ * Individual (non-grouped) queries — currently running (`system.processes`)
+ * unioned with recently finished (`system.query_log`) — ranked by total CPU
+ * time (`ProfileEvents['UserTimeMicroseconds'] +
+ * ProfileEvents['SystemTimeMicroseconds']`). Both source tables carry a
+ * `ProfileEvents` map, so the same expression works unmodified on running
+ * and finished queries.
+ */
+export const topCpuQueriesConfig: QueryConfig = {
+  name: 'top-cpu-queries',
+  defaultView: 'auto',
+  card: {
+    primary: 'query',
+    badges: ['status'],
+    metrics: ['user', 'elapsed'],
+  },
+  columnIcons: {
+    user: UserIcon,
+    readable_cpu_time_us: CpuIcon,
+  },
+  expandable: {
+    renderExpanded: createExpandedPanel({
+      sections: [
+        {
+          type: 'stats',
+          columns: [
+            {
+              key: 'cpu_time_us',
+              label: 'CPU time',
+              readableKey: 'readable_cpu_time_us',
+            },
+          ],
+        },
+        {
+          type: 'fields',
+          title: 'Details',
+          columns: ['user', 'status', 'elapsed'],
+        },
+        { type: 'code', title: 'Query', column: 'query' },
+      ],
+    }),
+  },
+  description:
+    'Currently running and recently finished queries, ranked by total CPU time (user + system)',
+  docs: QUERY_LOG,
+  tableCheck: 'system.query_log',
+  defaultParams: {
+    last_hours: '1',
+  },
+  filterParamPresets: [
+    { name: 'Last 1h', key: 'last_hours', value: '1' },
+    { name: 'Last 6h', key: 'last_hours', value: '6' },
+    { name: 'Last 24h', key: 'last_hours', value: '24' },
+    { name: 'Last 7d', key: 'last_hours', value: '168' },
+  ],
+  sql: `
+    WITH combined AS (
+      SELECT
+        query_id,
+        substr(query, 1, 500) AS query,
+        user,
+        'running' AS status,
+        elapsed,
+        (ProfileEvents['UserTimeMicroseconds'] + ProfileEvents['SystemTimeMicroseconds']) AS cpu_time_us
+      FROM system.processes
+      WHERE is_cancelled = 0 AND is_initial_query
+
+      UNION ALL
+
+      SELECT
+        query_id,
+        substr(query, 1, 500) AS query,
+        user,
+        'finished' AS status,
+        query_duration_ms / 1000 AS elapsed,
+        (ProfileEvents['UserTimeMicroseconds'] + ProfileEvents['SystemTimeMicroseconds']) AS cpu_time_us
+      FROM system.query_log
+      WHERE type = 'QueryFinish'
+        AND is_initial_query
+        AND event_time > (now() - interval {last_hours:UInt64} hour)
+    )
+    SELECT
+      query_id,
+      query,
+      user,
+      status,
+      round(elapsed, 1) AS elapsed,
+      cpu_time_us,
+      formatReadableTimeDelta(cpu_time_us / 1000000) AS readable_cpu_time_us,
+      round(100 * cpu_time_us / greatest(max(cpu_time_us) OVER (), 1)) AS pct_cpu_time_us
+    FROM combined
+    WHERE cpu_time_us > 0
+    ORDER BY cpu_time_us DESC
+    LIMIT 200
+  `,
+  columns: [
+    'action',
+    'query',
+    'status',
+    'user',
+    'elapsed',
+    'readable_cpu_time_us',
+  ],
+  columnFormats: {
+    action: [ColumnFormat.Action, ['explain-query', 'open-in-explorer']],
+    query: [
+      ColumnFormat.CodeDialog,
+      { max_truncate: 100, hide_query_comment: true },
+    ],
+    status: ColumnFormat.ColoredBadge,
+    user: ColumnFormat.Badge,
+    elapsed: ColumnFormat.Duration,
+    readable_cpu_time_us: ColumnFormat.BackgroundBar,
+  },
+}

--- a/apps/dashboard/src/lib/query-config/queries/top-memory-queries-live.ts
+++ b/apps/dashboard/src/lib/query-config/queries/top-memory-queries-live.ts
@@ -1,0 +1,122 @@
+import { MemoryStickIcon, UserIcon } from 'lucide-react'
+
+import type { QueryConfig } from '@/types/query-config'
+
+import { createExpandedPanel } from '@/components/data-table/cells/expanded-panel'
+import { QUERY_LOG } from '@/lib/table-notes'
+import { ColumnFormat } from '@/types/column-format'
+
+/**
+ * Individual (non-grouped) queries — currently running (`system.processes`)
+ * unioned with recently finished (`system.query_log`) — ranked by peak
+ * memory usage. Distinct from `expensiveQueriesByMemoryConfig`, which groups
+ * finished queries by normalized pattern; this table ranks single query
+ * executions and includes what's running right now.
+ */
+export const topMemoryQueriesLiveConfig: QueryConfig = {
+  name: 'top-memory-queries-live',
+  defaultView: 'auto',
+  card: {
+    primary: 'query',
+    badges: ['status'],
+    metrics: ['user', 'elapsed'],
+  },
+  columnIcons: {
+    user: UserIcon,
+    readable_memory_usage: MemoryStickIcon,
+  },
+  expandable: {
+    renderExpanded: createExpandedPanel({
+      sections: [
+        {
+          type: 'stats',
+          columns: [
+            {
+              key: 'memory_usage',
+              label: 'Peak memory',
+              readableKey: 'readable_memory_usage',
+            },
+          ],
+        },
+        {
+          type: 'fields',
+          title: 'Details',
+          columns: ['user', 'status', 'elapsed'],
+        },
+        { type: 'code', title: 'Query', column: 'query' },
+      ],
+    }),
+  },
+  description:
+    'Currently running and recently finished queries, ranked by peak memory usage',
+  docs: QUERY_LOG,
+  tableCheck: 'system.query_log',
+  defaultParams: {
+    last_hours: '1',
+  },
+  filterParamPresets: [
+    { name: 'Last 1h', key: 'last_hours', value: '1' },
+    { name: 'Last 6h', key: 'last_hours', value: '6' },
+    { name: 'Last 24h', key: 'last_hours', value: '24' },
+    { name: 'Last 7d', key: 'last_hours', value: '168' },
+  ],
+  sql: `
+    WITH combined AS (
+      SELECT
+        query_id,
+        substr(query, 1, 500) AS query,
+        user,
+        'running' AS status,
+        elapsed,
+        memory_usage
+      FROM system.processes
+      WHERE is_cancelled = 0 AND is_initial_query
+
+      UNION ALL
+
+      SELECT
+        query_id,
+        substr(query, 1, 500) AS query,
+        user,
+        'finished' AS status,
+        query_duration_ms / 1000 AS elapsed,
+        memory_usage
+      FROM system.query_log
+      WHERE type = 'QueryFinish'
+        AND is_initial_query
+        AND event_time > (now() - interval {last_hours:UInt64} hour)
+    )
+    SELECT
+      query_id,
+      query,
+      user,
+      status,
+      round(elapsed, 1) AS elapsed,
+      memory_usage,
+      formatReadableSize(memory_usage) AS readable_memory_usage,
+      round(100 * memory_usage / greatest(max(memory_usage) OVER (), 1)) AS pct_memory_usage
+    FROM combined
+    WHERE memory_usage > 0
+    ORDER BY memory_usage DESC
+    LIMIT 200
+  `,
+  columns: [
+    'action',
+    'query',
+    'status',
+    'user',
+    'elapsed',
+    'readable_memory_usage',
+  ],
+  columnFormats: {
+    action: [ColumnFormat.Action, ['explain-query', 'open-in-explorer']],
+    query: [
+      ColumnFormat.CodeDialog,
+      { max_truncate: 100, hide_query_comment: true },
+    ],
+    status: ColumnFormat.ColoredBadge,
+    user: ColumnFormat.Badge,
+    elapsed: ColumnFormat.Duration,
+    readable_memory_usage: ColumnFormat.BackgroundBar,
+  },
+}

--- a/apps/dashboard/src/routes/(dashboard)/-charts-config.ts
+++ b/apps/dashboard/src/routes/(dashboard)/-charts-config.ts
@@ -310,6 +310,26 @@ const ChartMemoryUsage = lazy(() =>
     default: mod.ChartMemoryUsage,
   }))
 )
+const ChartMemoryBreakdown = lazy(() =>
+  import('@/components/charts/system/memory-breakdown').then((mod) => ({
+    default: mod.ChartMemoryBreakdown,
+  }))
+)
+const ChartCpuLoadAverage = lazy(() =>
+  import('@/components/charts/system/cpu-load-average').then((mod) => ({
+    default: mod.ChartCpuLoadAverage,
+  }))
+)
+const ChartCpuModeSplit = lazy(() =>
+  import('@/components/charts/system/cpu-mode-split').then((mod) => ({
+    default: mod.ChartCpuModeSplit,
+  }))
+)
+const ChartThreadPoolUtilization = lazy(() =>
+  import('@/components/charts/system/thread-pool-utilization').then((mod) => ({
+    default: mod.ChartThreadPoolUtilization,
+  }))
+)
 const ChartMutationProgress = lazy(() =>
   import('@/components/charts/system/mutation-progress').then((mod) => ({
     default: mod.ChartMutationProgress,
@@ -539,6 +559,54 @@ export const OVERVIEW_TAB_CHARTS: OverviewChartConfig[] = [
     lastHours: 24,
     interval: 'toStartOfHour',
     className: 'w-full h-full',
+    type: 'area',
+    href: '/metrics',
+  },
+]
+
+/**
+ * Memory & CPU tab charts - deep-dive RSS decomposition, load average vs
+ * cores, CPU mode split, thread pool utilization, plus links through to the
+ * individual-query BackgroundBar tables ranked by peak memory / CPU time.
+ */
+export const MEMORY_CPU_TAB_CHARTS: OverviewChartConfig[] = [
+  {
+    id: 'memory-breakdown',
+    component: ChartMemoryBreakdown,
+    title: 'Memory Breakdown',
+    className: 'w-full h-full',
+    interval: 'toStartOfTenMinutes',
+    lastHours: 24,
+    type: 'area',
+    href: '/top-memory-queries',
+  },
+  {
+    id: 'cpu-load-average',
+    component: ChartCpuLoadAverage,
+    title: 'Load Average vs CPU Cores',
+    className: 'w-full h-full',
+    interval: 'toStartOfTenMinutes',
+    lastHours: 24,
+    type: 'area',
+    href: '/metrics',
+  },
+  {
+    id: 'cpu-mode-split',
+    component: ChartCpuModeSplit,
+    title: 'CPU Mode Split',
+    className: 'w-full h-full',
+    interval: 'toStartOfTenMinutes',
+    lastHours: 24,
+    type: 'area',
+    href: '/top-cpu-queries',
+  },
+  {
+    id: 'thread-pool-utilization',
+    component: ChartThreadPoolUtilization,
+    title: 'Thread Pool Utilization',
+    className: 'w-full h-full',
+    interval: 'toStartOfTenMinutes',
+    lastHours: 24,
     type: 'area',
     href: '/metrics',
   },
@@ -1010,6 +1078,12 @@ export const OVERVIEW_TABS: OverviewTabConfig[] = [
     label: 'Queries',
     gridClassName: GRID_LAYOUT_3_COL,
     charts: QUERIES_TAB_CHARTS,
+  },
+  {
+    value: 'memory-cpu',
+    label: 'Memory & CPU',
+    gridClassName: GRID_LAYOUT_2_COL,
+    charts: MEMORY_CPU_TAB_CHARTS,
   },
   {
     value: 'storage',

--- a/apps/dashboard/src/routes/(dashboard)/top-cpu-queries.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/top-cpu-queries.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { createPage } from '@/lib/create-page'
+import { topCpuQueriesConfig } from '@/lib/query-config/queries/top-cpu-queries'
+
+const TopCpuQueriesPage = createPage({
+  queryConfig: topCpuQueriesConfig,
+  title: 'Top CPU Queries',
+})
+
+export const Route = createFileRoute('/(dashboard)/top-cpu-queries')({
+  component: TopCpuQueriesPage,
+})

--- a/apps/dashboard/src/routes/(dashboard)/top-memory-queries.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/top-memory-queries.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { createPage } from '@/lib/create-page'
+import { topMemoryQueriesLiveConfig } from '@/lib/query-config/queries/top-memory-queries-live'
+
+const TopMemoryQueriesPage = createPage({
+  queryConfig: topMemoryQueriesLiveConfig,
+  title: 'Top Memory Queries',
+})
+
+export const Route = createFileRoute('/(dashboard)/top-memory-queries')({
+  component: TopMemoryQueriesPage,
+})


### PR DESCRIPTION
## Summary

Adds a **Memory & CPU** tab to the `/overview` page's existing tab set (no new top-level route), consolidating deep-dive charts + BackgroundBar detail tables per #2766.

- **Memory breakdown chart** (`memory-breakdown`): RSS decomposition into queries/other, caches (mark + uncompressed + query cache), background merges/mutations, and primary keys/indexes. Sourced from `system.asynchronous_metric_log` (row-based `metric`/`value`, so an absent metric name on an older ClickHouse version just yields no rows instead of a SQL error — no per-column version branching needed). Primary-key/index memory has no historical time series in ClickHouse, so it rides along as a constant "current" value (scalar subquery against `system.parts`).
- **Top memory queries table** (`/top-memory-queries`, `top-memory-queries-live` config): individual (non-grouped) queries — currently running (`system.processes`) unioned with recently finished (`system.query_log`) — ranked by peak memory, BackgroundBar-formatted. Distinct from the existing pattern-grouped `expensive-queries-by-memory`.
- **CPU section**:
  - `cpu-load-average` chart: load average (1m/5m/15m) vs CPU core count (derived by counting distinct `OSUserTimeCPU{N}` per-core gauges).
  - `cpu-mode-split` chart: user/system/iowait/idle CPU time, degrades gracefully (all-zero → chart empty state) where these OS metrics aren't exposed.
  - `thread-pool-utilization` chart: global thread pool active vs total threads (`system.metric_log` `CurrentMetric_GlobalThreadPool*`).
  - **Top CPU queries table** (`/top-cpu-queries`, `top-cpu-queries` config): same current+recent union, ranked by `ProfileEvents['UserTimeMicroseconds'] + ProfileEvents['SystemTimeMicroseconds']`, BackgroundBar-formatted.

All 4 new charts are `optional: true` with `tableCheck` against `system.asynchronous_metric_log` / `system.metric_log` for graceful degradation. The new tab reuses the existing Overview page's Radix `Tabs` (inactive tabs unmount, satisfying the project's "hidden auto-refresh charts must unmount, not CSS-hide" rule) — no new collapsible-section code needed.

## Files added/changed
- `lib/api/charts/system-charts.ts` — 4 new SQL builders (`memory-breakdown`, `cpu-load-average`, `cpu-mode-split`, `thread-pool-utilization`)
- `components/charts/system/{memory-breakdown,cpu-load-average,cpu-mode-split,thread-pool-utilization}.tsx` — new area-chart components
- `components/charts/registry/{imports/system-charts.ts,chart-categories.ts,type-hints.ts}` — registry wiring
- `lib/query-config/queries/{top-memory-queries-live,top-cpu-queries}.ts` — new BackgroundBar QueryConfigs
- `lib/query-config/index.ts` — registers the two new configs
- `routes/(dashboard)/{top-memory-queries,top-cpu-queries}.tsx` — new detail-table routes (leaf pages reached via chart `href`, matching the existing `/expensive-queries-by-memory` pattern)
- `routes/(dashboard)/-charts-config.ts` — new "Memory & CPU" tab on `/overview`
- `lib/api/__tests__/charts/system-charts.test.ts` — targeted unit tests for the 4 new SQL builders

## Test plan
- [x] `pnpm run lint` (Biome) — clean
- [x] `pnpm run build` (Vite build + `tsc --noEmit`) — passes, both new routes prerender (`/top-memory-queries`, `/top-cpu-queries`)
- [x] `pnpm run test:query-config` — 1156 pass / 0 fail
- [x] Full unit suite (`bun test src/ --isolate`) — 7203 pass / 0 fail (a transient 3-test flake unrelated to this change — `health-sweep` webhook bus + `cloudflare:workers` dual-runtime contract — was not reproducible on rerun or in isolation)
- [x] New targeted tests for the 4 chart SQL builders in `system-charts.test.ts`

Closes #2766