### PR TITLE
feat(alerts): hysteresis + transition-based delivery (anti-flap)

### DIFF
--- a/apps/dashboard/src/components/health/alert-state-card.tsx
+++ b/apps/dashboard/src/components/health/alert-state-card.tsx
@@ -1,0 +1,155 @@
+import { RefreshCw } from 'lucide-react'
+
+import type { AlertRuleSeverity } from '@/lib/alerting/rule-registry'
+import type { AlertStateRow } from '@/lib/health/alert-state-persist'
+
+import { HEALTH_CHECKS } from './health-checks'
+import { useAlertState } from './use-alert-state'
+import { useMemo } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { EmptyState } from '@/components/ui/empty-state'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { useHostId } from '@/lib/swr/use-host'
+import { cn, formatDuration } from '@/lib/utils'
+import { formatRelativeTime } from '@/lib/utils/format-relative-time'
+
+/** Badge tint per confirmed state — 'ok' reuses the brand's health emerald. */
+const STATE_BADGE_CLASS: Record<AlertRuleSeverity, string> = {
+  ok: 'border-transparent bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300',
+  warning:
+    'border-transparent bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300',
+  critical:
+    'border-transparent bg-destructive/15 text-destructive dark:bg-destructive/25',
+}
+
+const STATE_LABEL: Record<AlertRuleSeverity, string> = {
+  ok: 'OK',
+  warning: 'Warning',
+  critical: 'Critical',
+}
+
+function checkTitle(ruleId: string): string {
+  const match = HEALTH_CHECKS.find((c) => c.id === ruleId)
+  return match?.title ?? ruleId
+}
+
+function StateRow({ row, now }: { row: AlertStateRow; now: number }) {
+  const firing = row.severity !== 'ok'
+  return (
+    <TableRow>
+      <TableCell className="font-medium">{checkTitle(row.ruleId)}</TableCell>
+      <TableCell>
+        <Badge className={cn('font-normal', STATE_BADGE_CLASS[row.severity])}>
+          {STATE_LABEL[row.severity]}
+        </Badge>
+        {row.pendingSeverity && row.pendingSeverity !== row.severity && (
+          <span className="ml-2 text-xs text-muted-foreground">
+            {/* An in-flight hysteresis streak awaiting confirmation. */}
+            {row.pendingSeverity === 'ok' ? 'clearing' : 'rising'} (
+            {row.pendingCount ?? 1})
+          </span>
+        )}
+      </TableCell>
+      <TableCell className="text-muted-foreground">
+        {formatRelativeTime(row.updatedAt)}
+      </TableCell>
+      <TableCell className="text-muted-foreground">
+        {firing && row.firstFiredAt !== undefined
+          ? formatDuration(now - row.firstFiredAt)
+          : '—'}
+      </TableCell>
+    </TableRow>
+  )
+}
+
+/**
+ * "Current alert state" card (#2767) — the health sweep's persisted last-known
+ * state per check for the currently-selected host: confirmed severity, when it
+ * last transitioned, any in-flight hysteresis streak, and (for a firing
+ * condition) how long the incident has been open. Best-effort: on a deployment
+ * without D1 configured (self-hosted/OSS default) this shows the empty state.
+ */
+export function AlertStateCard() {
+  const hostId = useHostId()
+  const { states, isLoading, isFetching, error, refetch } =
+    useAlertState(hostId)
+  const now = Date.now()
+
+  // Firing conditions first, then most-recently-transitioned.
+  const sorted = useMemo(
+    () =>
+      [...states].sort((a, b) => {
+        const af = a.severity === 'ok' ? 0 : 1
+        const bf = b.severity === 'ok' ? 0 : 1
+        if (af !== bf) return bf - af
+        return b.updatedAt - a.updatedAt
+      }),
+    [states]
+  )
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="font-medium text-sm">Current alert state</h3>
+          <p className="text-muted-foreground text-xs">
+            Last-known state and transition per check, with hysteresis damping.
+          </p>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={refetch}
+          disabled={isFetching}
+        >
+          <RefreshCw className={cn('size-4', isFetching && 'animate-spin')} />
+        </Button>
+      </div>
+
+      {error ? (
+        <EmptyState
+          title="Couldn't load alert state"
+          description={error.message}
+        />
+      ) : isLoading ? (
+        <EmptyState title="Loading…" description="Fetching current state." />
+      ) : sorted.length === 0 ? (
+        <EmptyState
+          title="No tracked state yet"
+          description="Once the health sweep runs (and D1 is configured) each check's current state and last transition appear here."
+        />
+      ) : (
+        <ScrollArea className="max-h-80">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Check</TableHead>
+                <TableHead>State</TableHead>
+                <TableHead>Last transition</TableHead>
+                <TableHead>Firing for</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {sorted.map((row) => (
+                <StateRow
+                  key={`${row.hostId}:${row.ruleId}`}
+                  row={row}
+                  now={now}
+                />
+              ))}
+            </TableBody>
+          </Table>
+        </ScrollArea>
+      )}
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/health/health-settings-panel.tsx
+++ b/apps/dashboard/src/components/health/health-settings-panel.tsx
@@ -16,6 +16,7 @@ import type { AlertChannelId } from '@/lib/health/alert-channel-settings'
 
 import { ActiveAlertsPanel } from './active-alerts-panel'
 import { AlertRoutingPanel } from './alert-routing-dialog'
+import { AlertStateCard } from './alert-state-card'
 import { AlertSuggestionsPanel } from './alert-suggestions-panel'
 import { ChannelSeverityToggle } from './channel-severity-toggle'
 import { DigestSettingsPanel } from './digest-settings-panel'
@@ -564,7 +565,13 @@ export function HealthSettingsPanel({
           </div>
         )}
 
-        {pane('active', <ActiveAlertsPanel />)}
+        {pane(
+          'active',
+          <div className="space-y-6">
+            <AlertStateCard />
+            <ActiveAlertsPanel />
+          </div>
+        )}
 
         {pane('history', <RecentAlertsCard />)}
 

--- a/apps/dashboard/src/components/health/use-alert-state.ts
+++ b/apps/dashboard/src/components/health/use-alert-state.ts
@@ -1,0 +1,60 @@
+/**
+ * Data hook for the "Current alert state" card (#2767).
+ *
+ * Thin TanStack Query wrapper around GET /api/v1/health/alert-state — mirrors
+ * the conventions of `use-alert-history.ts`.
+ */
+import { useQuery } from '@tanstack/react-query'
+
+import type { AlertStateRow } from '@/lib/health/alert-state-persist'
+
+import { apiFetch } from '@/lib/swr/api-fetch'
+import { throwIfNotOk } from '@/lib/swr/fetch-error'
+
+const REFRESH_INTERVAL_MS = 30_000
+
+interface AlertStateResponse {
+  success: boolean
+  states: AlertStateRow[]
+}
+
+export interface UseAlertStateResult {
+  states: AlertStateRow[]
+  isLoading: boolean
+  isFetching: boolean
+  error: Error | null
+  refetch: () => void
+}
+
+export function useAlertState(hostId?: number): UseAlertStateResult {
+  const queryKey = ['/api/v1/health/alert-state', hostId] as const
+
+  const { data, error, isPending, isFetching, refetch } = useQuery<
+    AlertStateResponse,
+    Error
+  >({
+    queryKey,
+    queryFn: async () => {
+      const qs = hostId === undefined ? '' : `?hostId=${hostId}`
+      const response = await apiFetch(`/api/v1/health/alert-state${qs}`)
+      await throwIfNotOk(response, 'Failed to fetch alert state')
+      return response.json() as Promise<AlertStateResponse>
+    },
+    staleTime: REFRESH_INTERVAL_MS * 0.9,
+    refetchInterval: () =>
+      typeof document !== 'undefined' && document.hidden
+        ? false
+        : REFRESH_INTERVAL_MS,
+    placeholderData: (prev) => prev,
+  })
+
+  return {
+    states: data?.states ?? [],
+    isLoading: isPending && isFetching,
+    isFetching,
+    error,
+    refetch: () => {
+      void refetch()
+    },
+  }
+}

--- a/apps/dashboard/src/db/conversations-migrations/0028_alert_state.sql
+++ b/apps/dashboard/src/db/conversations-migrations/0028_alert_state.sql
@@ -1,0 +1,28 @@
+-- Durable alert state machine (feat #2767).
+--
+-- Persists the last-known state per (check, host) for the health sweep's
+-- transition/hysteresis engine (`lib/health/alert-state-store.ts`). The engine
+-- keeps its working set in memory; the sweep hydrates from this table at the
+-- start of a tick and flushes back at the end (`alert-state-persist.ts`) so
+-- hysteresis streaks and incident timers survive worker restarts.
+--
+-- Fail-open: with no CHM_CLOUD_D1 binding the table simply never exists and the
+-- engine degrades to ephemeral in-memory state (the pre-#2767 behavior). No
+-- owner_id column — host_id already scopes every row to the operator's
+-- env-configured CLICKHOUSE_* hosts, same as alert_events.
+--
+-- `pending_severity`/`pending_count` hold an in-flight hysteresis streak
+-- awaiting confirmation; `first_fired_at` marks when the current incident began
+-- firing so a recovery can report its duration.
+
+CREATE TABLE IF NOT EXISTS alert_state (
+  host_id          INTEGER NOT NULL,
+  rule_id          TEXT    NOT NULL,
+  severity         TEXT    NOT NULL,
+  updated_at       INTEGER NOT NULL,
+  notified_at      INTEGER NOT NULL,
+  first_fired_at   INTEGER,
+  pending_severity TEXT,
+  pending_count    INTEGER,
+  PRIMARY KEY (host_id, rule_id)
+);

--- a/apps/dashboard/src/lib/health/alert-state-persist.ts
+++ b/apps/dashboard/src/lib/health/alert-state-persist.ts
@@ -1,0 +1,222 @@
+/**
+ * D1-backed persistence for the alert state machine (#2767).
+ *
+ * The transition/hysteresis engine in `alert-state-store.ts` keeps its working
+ * set in an in-memory singleton. That is lost on every worker restart, which
+ * would reset hysteresis streaks and incident timers mid-incident. To make the
+ * last-known state per (check, host) durable, the sweep HYDRATES the memory
+ * store from D1 at the start of a tick and FLUSHES it back at the end — the same
+ * `CHM_CLOUD_D1` binding and lazy `CREATE TABLE IF NOT EXISTS` migration pattern
+ * as `alert-ack-store.ts` / `alert-history-store.ts`.
+ *
+ * Best-effort like every other health D1 backend: a missing binding (the
+ * self-hosted/OSS default), an unmigrated table, or any D1 error is caught,
+ * logged, and swallowed — hydrate becomes a no-op and flush is dropped, so the
+ * sweep degrades to the pre-#2767 ephemeral-memory behavior rather than
+ * throwing. There is no owner/tenant column: `host_id` already scopes every row
+ * to the operator's env-configured hosts (see `alert-history-store.ts`).
+ */
+
+import type { AlertRuleSeverity } from '@/lib/alerting/rule-registry'
+import type { AlertStateRecord, AlertStateStore } from './alert-state-store'
+
+import { alertStateKey } from './alert-state-store'
+import { ErrorLogger } from '@chm/logger'
+import { getPlatformBindings } from '@chm/platform'
+
+const COMPONENT = 'alert-state-persist'
+const warn = (msg: string) =>
+  ErrorLogger.logWarning(`[alert-state-persist] ${msg}`, {
+    component: COMPONENT,
+  })
+
+const TABLE = 'alert_state'
+
+const MIGRATION_SQL = `
+  CREATE TABLE IF NOT EXISTS ${TABLE} (
+    host_id          INTEGER NOT NULL,
+    rule_id          TEXT    NOT NULL,
+    severity         TEXT    NOT NULL,
+    updated_at       INTEGER NOT NULL,
+    notified_at      INTEGER NOT NULL,
+    first_fired_at   INTEGER,
+    pending_severity TEXT,
+    pending_count    INTEGER,
+    PRIMARY KEY (host_id, rule_id)
+  )
+`
+
+/** Current alert state for one (host, rule) — the hydrated row shape for the UI. */
+export interface AlertStateRow extends AlertStateRecord {
+  hostId: number
+  ruleId: string
+}
+
+interface D1AlertStateRow {
+  host_id: number
+  rule_id: string
+  severity: string
+  updated_at: number
+  notified_at: number
+  first_fired_at: number | null
+  pending_severity: string | null
+  pending_count: number | null
+}
+
+let migration: Promise<void> | null = null
+
+function getDb(): D1Database | null {
+  return getPlatformBindings().getD1Database('CHM_CLOUD_D1')
+}
+
+function ensureMigrated(db: D1Database): Promise<void> {
+  if (!migration) {
+    migration = (async () => {
+      try {
+        await db.prepare(MIGRATION_SQL).run()
+      } catch (err) {
+        migration = null
+        throw err
+      }
+    })()
+  }
+  return migration
+}
+
+function rowToRecord(row: D1AlertStateRow): AlertStateRecord {
+  const rec: AlertStateRecord = {
+    severity: row.severity as AlertRuleSeverity,
+    updatedAt: row.updated_at,
+    notifiedAt: row.notified_at,
+  }
+  if (row.first_fired_at !== null) rec.firstFiredAt = row.first_fired_at
+  if (row.pending_severity !== null) {
+    rec.pendingSeverity = row.pending_severity as AlertRuleSeverity
+  }
+  if (row.pending_count !== null) rec.pendingCount = row.pending_count
+  return rec
+}
+
+/**
+ * Overlay every persisted state row onto `store` (D1 is authoritative for any
+ * key it holds). Deliberately does NOT clear the store first: on a real restart
+ * the in-memory store is already empty so an overlay == a full load, while on a
+ * warm worker this refreshes from D1 without discarding a just-committed record
+ * that a best-effort flush may not have persisted. Best-effort — a no-op when
+ * D1 is unavailable, leaving the store as-is.
+ */
+export async function hydrateAlertState(store: AlertStateStore): Promise<void> {
+  try {
+    const db = getDb()
+    if (!db) return
+    await ensureMigrated(db)
+    const result = await db
+      .prepare(
+        `SELECT host_id, rule_id, severity, updated_at, notified_at, first_fired_at, pending_severity, pending_count
+         FROM ${TABLE}`
+      )
+      .all<D1AlertStateRow>()
+    for (const row of result.results ?? []) {
+      store.set(alertStateKey(row.host_id, row.rule_id), rowToRecord(row))
+    }
+  } catch (err) {
+    warn(`failed to hydrate alert state: ${err}`)
+  }
+}
+
+/**
+ * Persist the store's current contents to D1: upsert every live record and
+ * delete rows for keys no longer present (recovered conditions clear their
+ * record). Best-effort — dropped entirely on any D1 error.
+ */
+export async function flushAlertState(store: AlertStateStore): Promise<void> {
+  try {
+    const db = getDb()
+    if (!db) return
+    await ensureMigrated(db)
+
+    const live = new Set<string>()
+    const statements: D1PreparedStatement[] = []
+    for (const [key, rec] of store.entries()) {
+      live.add(key)
+      const [hostIdRaw, ...ruleParts] = key.split(':')
+      const hostId = Number(hostIdRaw)
+      const ruleId = ruleParts.join(':')
+      if (!Number.isFinite(hostId) || ruleId === '') continue
+      statements.push(
+        db
+          .prepare(
+            `INSERT INTO ${TABLE}
+               (host_id, rule_id, severity, updated_at, notified_at, first_fired_at, pending_severity, pending_count)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+             ON CONFLICT(host_id, rule_id) DO UPDATE SET
+               severity = excluded.severity,
+               updated_at = excluded.updated_at,
+               notified_at = excluded.notified_at,
+               first_fired_at = excluded.first_fired_at,
+               pending_severity = excluded.pending_severity,
+               pending_count = excluded.pending_count`
+          )
+          .bind(
+            hostId,
+            ruleId,
+            rec.severity,
+            rec.updatedAt,
+            rec.notifiedAt,
+            rec.firstFiredAt ?? null,
+            rec.pendingSeverity ?? null,
+            rec.pendingCount ?? null
+          )
+      )
+    }
+
+    // Delete any persisted rows whose key is no longer live (recovered).
+    const existing = await db
+      .prepare(`SELECT host_id, rule_id FROM ${TABLE}`)
+      .all<{ host_id: number; rule_id: string }>()
+    for (const row of existing.results ?? []) {
+      if (!live.has(alertStateKey(row.host_id, row.rule_id))) {
+        statements.push(
+          db
+            .prepare(`DELETE FROM ${TABLE} WHERE host_id = ?1 AND rule_id = ?2`)
+            .bind(row.host_id, row.rule_id)
+        )
+      }
+    }
+
+    if (statements.length > 0) await db.batch(statements)
+  } catch (err) {
+    warn(`failed to flush alert state: ${err}`)
+  }
+}
+
+/**
+ * Read the current persisted alert state, newest transition first, optionally
+ * filtered by host. Best-effort — returns `[]` when D1 is unavailable. Powers
+ * the alert-settings "current state" UI (#2767).
+ */
+export async function readAlertStates(
+  hostId?: number
+): Promise<AlertStateRow[]> {
+  try {
+    const db = getDb()
+    if (!db) return []
+    await ensureMigrated(db)
+    const base = `SELECT host_id, rule_id, severity, updated_at, notified_at, first_fired_at, pending_severity, pending_count FROM ${TABLE}`
+    const stmt =
+      hostId === undefined
+        ? db.prepare(`${base} ORDER BY updated_at DESC`)
+        : db
+            .prepare(`${base} WHERE host_id = ?1 ORDER BY updated_at DESC`)
+            .bind(hostId)
+    const result = await stmt.all<D1AlertStateRow>()
+    return (result.results ?? []).map((row) => ({
+      hostId: row.host_id,
+      ruleId: row.rule_id,
+      ...rowToRecord(row),
+    }))
+  } catch (err) {
+    warn(`failed to read alert states: ${err}`)
+    return []
+  }
+}

--- a/apps/dashboard/src/lib/health/alert-state-store.test.ts
+++ b/apps/dashboard/src/lib/health/alert-state-store.test.ts
@@ -5,6 +5,7 @@
  * cooldown), and recovery.
  */
 
+import type { AlertRuleSeverity } from '@/lib/alerting/rule-registry'
 import type { AlertStateRecord } from './alert-state-store'
 
 import {
@@ -35,6 +36,8 @@ describe('decideNotification', () => {
       severity: 'warning',
       updatedAt: 5_000,
       notifiedAt: 5_000,
+      // A newly-firing condition stamps the incident start for duration reporting.
+      firstFiredAt: 5_000,
     })
   })
 
@@ -109,6 +112,149 @@ describe('decideNotification', () => {
     expect(next?.severity).toBe('warning')
     // Cooldown timer is not reset on a downgrade.
     expect(next?.notifiedAt).toBe(4_000)
+  })
+})
+
+describe('hysteresis (#2767)', () => {
+  test('breach hysteresis: a lone blip is held, not fired', () => {
+    // minConsecutiveBreaches=2 → first warning is a pending hold, no notify.
+    const first = decideNotification(undefined, 'warning', {
+      now: 1_000,
+      minConsecutiveBreaches: 2,
+    })
+    expect(first.decision.notify).toBe(false)
+    expect(first.decision.kind).toBe('suppressed')
+    expect(first.next).toMatchObject({
+      severity: 'ok',
+      pendingSeverity: 'warning',
+      pendingCount: 1,
+    })
+
+    // A single ok read clears the pending streak — the blip is forgotten.
+    const cleared = decideNotification(first.next ?? undefined, 'ok', {
+      now: 2_000,
+      minConsecutiveBreaches: 2,
+    })
+    expect(cleared.decision.notify).toBe(false)
+    expect(cleared.next).toBeNull()
+  })
+
+  test('breach hysteresis: fires only after N consecutive breaches', () => {
+    const a = decideNotification(undefined, 'critical', {
+      now: 1_000,
+      minConsecutiveBreaches: 3,
+    })
+    expect(a.decision.notify).toBe(false)
+    expect(a.next?.pendingCount).toBe(1)
+
+    const b = decideNotification(a.next ?? undefined, 'critical', {
+      now: 2_000,
+      minConsecutiveBreaches: 3,
+    })
+    expect(b.decision.notify).toBe(false)
+    expect(b.next?.pendingCount).toBe(2)
+
+    const c = decideNotification(b.next ?? undefined, 'critical', {
+      now: 3_000,
+      minConsecutiveBreaches: 3,
+    })
+    expect(c.decision.notify).toBe(true)
+    expect(c.decision.kind).toBe('new')
+    expect(c.next?.severity).toBe('critical')
+    expect(c.next?.pendingSeverity).toBeUndefined()
+    expect(c.next?.firstFiredAt).toBe(3_000)
+  })
+
+  test('clear hysteresis: a single dip below threshold does not recover', () => {
+    const firing: AlertStateRecord = {
+      severity: 'critical',
+      updatedAt: 1_000,
+      notifiedAt: 1_000,
+      firstFiredAt: 1_000,
+    }
+    // First ok read is held (needs 2 consecutive clears).
+    const dip = decideNotification(firing, 'ok', {
+      now: 2_000,
+      minConsecutiveClears: 2,
+    })
+    expect(dip.decision.notify).toBe(false)
+    expect(dip.next).toMatchObject({
+      severity: 'critical',
+      firstFiredAt: 1_000,
+      pendingSeverity: 'ok',
+      pendingCount: 1,
+    })
+
+    // Second consecutive ok read recovers, reporting the incident duration.
+    const recover = decideNotification(dip.next ?? undefined, 'ok', {
+      now: 3_000,
+      minConsecutiveClears: 2,
+    })
+    expect(recover.decision.notify).toBe(true)
+    expect(recover.decision.kind).toBe('recovery')
+    expect(recover.decision.incidentDurationMs).toBe(2_000)
+    expect(recover.next).toBeNull()
+  })
+
+  test('recovery carries incident duration from firstFiredAt', () => {
+    const firing: AlertStateRecord = {
+      severity: 'warning',
+      updatedAt: 10_000,
+      notifiedAt: 10_000,
+      firstFiredAt: 10_000,
+    }
+    const { decision } = decideNotification(firing, 'ok', { now: 70_000 })
+    expect(decision.kind).toBe('recovery')
+    expect(decision.incidentDurationMs).toBe(60_000)
+  })
+
+  test('flap sequence: with damping, exactly one fire + one recover', () => {
+    const store = new MemoryAlertStateStore()
+    const base = {
+      hostId: 0,
+      ruleId: 'disk-usage',
+      cooldownMs: 10_000_000, // large so no reminders interfere
+      minConsecutiveBreaches: 1,
+      minConsecutiveClears: 2,
+    }
+    // Alternating warning/ok every sweep — a classic flap around the threshold.
+    const severities: AlertRuleSeverity[] = [
+      'warning',
+      'ok',
+      'warning',
+      'ok',
+      'warning',
+      'ok',
+      'ok', // sustained recovery: two consecutive clears at the end
+    ]
+    const kinds: string[] = []
+    let now = 1_000
+    for (const severity of severities) {
+      const { decision, commit } = evaluateAlert(store, {
+        ...base,
+        severity,
+        now,
+      })
+      commit()
+      if (decision.notify) kinds.push(decision.kind)
+      now += 1_000
+    }
+    // Damping (clear hysteresis) bridges the single-sweep dips, so the whole
+    // flap collapses to one fire and one recover — the #2767 success criterion.
+    expect(kinds.filter((k) => k === 'new').length).toBe(1)
+    expect(kinds.filter((k) => k === 'recovery').length).toBe(1)
+    expect(kinds).toEqual(['new', 'recovery'])
+  })
+
+  test('default (1/1) hysteresis preserves the pre-#2767 transitions', () => {
+    // No hysteresis options → fire on first breach, recover on first clear.
+    const fire = decideNotification(undefined, 'warning', { now: 1_000 })
+    expect(fire.decision.kind).toBe('new')
+    const recover = decideNotification(fire.next ?? undefined, 'ok', {
+      now: 2_000,
+    })
+    expect(recover.decision.kind).toBe('recovery')
+    expect(recover.next).toBeNull()
   })
 })
 

--- a/apps/dashboard/src/lib/health/alert-state-store.ts
+++ b/apps/dashboard/src/lib/health/alert-state-store.ts
@@ -1,5 +1,5 @@
 /**
- * Alert de-duplication state store.
+ * Alert de-duplication state store + hysteresis state machine.
  *
  * The autonomous health sweep (`server-sweep.ts`) runs every few minutes over
  * every host. Without memory, a persistent unhealthy condition would webhook on
@@ -14,12 +14,34 @@
  * Anything else (same severity within the cooldown window, or ok → ok) is
  * suppressed.
  *
+ * ## Hysteresis (anti-flap, #2767)
+ *
+ * A metric hovering right at a threshold flaps ok↔warning every sweep, which
+ * without damping would emit a fire + recover pair on every oscillation. Two
+ * knobs, configurable per check, absorb that:
+ *
+ *   - `minConsecutiveBreaches` — a worsening must be observed this many sweeps
+ *     in a row before it actually fires (debounces a single blip up).
+ *   - `minConsecutiveClears` — a firing condition must read `ok` this many
+ *     sweeps in a row before it RECOVERS (bridges single dips below the
+ *     threshold, so a flapping metric fires once and recovers once).
+ *
+ * Both default to `1` in the pure {@link decideNotification} — i.e. no
+ * hysteresis, byte-identical to the pre-#2767 transition semantics. The product
+ * default (breach=1, clear=2) is applied one layer up, by the sweep's
+ * server-side config, so criticals still fire promptly but recovery is damped.
+ *
+ * The in-flight streak awaiting confirmation lives in the record's
+ * `pendingSeverity` / `pendingCount` fields; `firstFiredAt` records when the
+ * current incident began firing so a RECOVERY can report its duration.
+ *
  * Storage: an in-memory module singleton, mirroring the "memory fallback"
  * pattern the insights subsystem uses (`insights/store/memory-store.ts`) and the
- * table-existence cache. Alert dedup state is intentionally ephemeral — after a
- * cold start the worst case is a single duplicate alert per active condition,
- * which is acceptable. The pure {@link decideNotification} transition function
- * is decoupled from the backend so it is fully unit-testable.
+ * table-existence cache. To survive worker restarts (so hysteresis streaks and
+ * incident timers are not lost), the sweep hydrates this store from D1 at the
+ * start of a tick and flushes it back at the end — see `alert-state-persist.ts`.
+ * The pure {@link decideNotification} transition function is decoupled from the
+ * backend so it is fully unit-testable.
  *
  * The logical condition key is `host:ruleId`; the last-fired severity lives in
  * the stored record (so the identity a record represents is
@@ -41,12 +63,25 @@ const SEVERITY_ORDER: Record<AlertRuleSeverity, number> = {
 
 /** Persisted per-condition state. */
 export interface AlertStateRecord {
-  /** Last severity we recorded/notified for this condition. */
+  /** Last *confirmed* severity we recorded/notified for this condition. */
   severity: AlertRuleSeverity
   /** Epoch ms when the severity last changed. */
   updatedAt: number
   /** Epoch ms of the last notification actually dispatched. */
   notifiedAt: number
+  /**
+   * Epoch ms when the current incident began firing (ok → firing). Carried
+   * through escalation/de-escalation so a RECOVERY can report the incident
+   * duration. Absent while the condition is ok.
+   */
+  firstFiredAt?: number
+  /**
+   * Severity awaiting hysteresis confirmation — differs from {@link severity}.
+   * `undefined` when there is no in-flight streak (steady state).
+   */
+  pendingSeverity?: AlertRuleSeverity
+  /** Consecutive sweeps observed at {@link pendingSeverity}. */
+  pendingCount?: number
 }
 
 /** What kind of transition the current evaluation represents. */
@@ -65,6 +100,12 @@ export interface AlertDecision {
   severity: AlertRuleSeverity
   /** Severity previously on record (defaults to 'ok' when unseen). */
   previousSeverity: AlertRuleSeverity
+  /**
+   * For a RECOVERY, how long the incident was firing, in ms — `now` minus the
+   * incident's `firstFiredAt`. Absent when the fire time is unknown (e.g. a
+   * condition already firing before this store had a record for it).
+   */
+  incidentDurationMs?: number
 }
 
 /** Minimal persistence contract; swap in a DB-backed store later if needed. */
@@ -117,6 +158,18 @@ export interface DecideOptions {
   cooldownMs?: number
   /** Injectable clock for tests. Defaults to `Date.now()`. */
   now?: number
+  /**
+   * Consecutive worsening observations required before a NEW/ESCALATED alert
+   * fires (anti-flap, #2767). `1` (default) = fire on first breach — no
+   * hysteresis. Values below 1 are clamped to 1.
+   */
+  minConsecutiveBreaches?: number
+  /**
+   * Consecutive `ok` observations required before a firing condition RECOVERS
+   * (anti-flap, #2767). `1` (default) = recover on first clear — no hysteresis.
+   * Values below 1 are clamped to 1.
+   */
+  minConsecutiveClears?: number
 }
 
 /**
@@ -125,6 +178,13 @@ export interface DecideOptions {
  *
  * `next` is the record to store, or `null` when the condition is ok and no
  * record should be kept (recovery clears it, ok→ok keeps nothing).
+ *
+ * Hysteresis: a worsening is held (suppressed, streak tracked in the returned
+ * record's `pendingSeverity`/`pendingCount`) until observed
+ * `minConsecutiveBreaches` sweeps in a row; a clear is held until observed
+ * `minConsecutiveClears` sweeps in a row. A single opposing observation resets
+ * the streak, so a metric that flaps around a threshold fires once and recovers
+ * once instead of on every oscillation.
  */
 export function decideNotification(
   prev: AlertStateRecord | undefined,
@@ -133,54 +193,57 @@ export function decideNotification(
 ): { decision: AlertDecision; next: AlertStateRecord | null } {
   const now = opts.now ?? Date.now()
   const cooldownMs = opts.cooldownMs ?? DEFAULT_ALERT_COOLDOWN_MS
-  const previousSeverity: AlertRuleSeverity = prev?.severity ?? 'ok'
+  const minBreaches = Math.max(1, Math.floor(opts.minConsecutiveBreaches ?? 1))
+  const minClears = Math.max(1, Math.floor(opts.minConsecutiveClears ?? 1))
+  const confirmed: AlertRuleSeverity = prev?.severity ?? 'ok'
+  const firstFiredAt = prev?.firstFiredAt
+  const rankCurrent = SEVERITY_ORDER[current]
+  const rankConfirmed = SEVERITY_ORDER[confirmed]
 
-  // Condition is healthy now.
-  if (current === 'ok') {
-    if (previousSeverity !== 'ok') {
-      // A previously-firing condition recovered → emit RECOVERY, clear state.
+  // Consecutive streak for `target`, extending prev's pending streak when it
+  // was already tracking the same target, otherwise starting fresh at 1.
+  const streakFor = (target: AlertRuleSeverity): number =>
+    prev?.pendingSeverity === target ? (prev.pendingCount ?? 0) + 1 : 1
+
+  const withFired = (rec: AlertStateRecord): AlertStateRecord =>
+    firstFiredAt !== undefined ? { ...rec, firstFiredAt } : rec
+
+  // A "hold" keeps the confirmed state exactly as-is (so the cooldown clock and
+  // incident timer are untouched) while recording the in-flight pending streak.
+  const hold = (
+    pendingSeverity: AlertRuleSeverity,
+    pendingCount: number
+  ): { decision: AlertDecision; next: AlertStateRecord } => ({
+    decision: {
+      notify: false,
+      kind: 'suppressed',
+      severity: current,
+      previousSeverity: confirmed,
+    },
+    next: withFired({
+      severity: confirmed,
+      updatedAt: prev?.updatedAt ?? now,
+      notifiedAt: prev?.notifiedAt ?? (confirmed === 'ok' ? 0 : now),
+      pendingSeverity,
+      pendingCount,
+    }),
+  })
+
+  // (A) Steady at the confirmed severity — any pending streak is cleared.
+  if (current === confirmed) {
+    if (current === 'ok') {
+      // ok → ok: nothing to remember, nothing to send.
       return {
         decision: {
-          notify: true,
-          kind: 'recovery',
+          notify: false,
+          kind: 'suppressed',
           severity: 'ok',
-          previousSeverity,
+          previousSeverity: 'ok',
         },
         next: null,
       }
     }
-    // ok → ok: nothing to remember, nothing to send.
-    return {
-      decision: {
-        notify: false,
-        kind: 'suppressed',
-        severity: 'ok',
-        previousSeverity,
-      },
-      next: null,
-    }
-  }
-
-  // Condition is firing (warning | critical).
-  const rankCurrent = SEVERITY_ORDER[current]
-  const rankPrev = SEVERITY_ORDER[previousSeverity]
-
-  // NEW (ok → firing) or ESCALATED (warning → critical): always notify,
-  // regardless of cooldown — a worsening condition is important.
-  if (rankCurrent > rankPrev) {
-    return {
-      decision: {
-        notify: true,
-        kind: previousSeverity === 'ok' ? 'new' : 'escalated',
-        severity: current,
-        previousSeverity,
-      },
-      next: { severity: current, updatedAt: now, notifiedAt: now },
-    }
-  }
-
-  // Same severity persisting: re-notify only once the cooldown has elapsed.
-  if (rankCurrent === rankPrev) {
+    // Firing steady: re-notify only once the cooldown has elapsed.
     const elapsed = now - (prev?.notifiedAt ?? 0)
     if (cooldownMs > 0 && elapsed >= cooldownMs) {
       return {
@@ -188,46 +251,84 @@ export function decideNotification(
           notify: true,
           kind: 'reminder',
           severity: current,
-          previousSeverity,
+          previousSeverity: confirmed,
         },
-        next: {
+        next: withFired({
           severity: current,
           updatedAt: prev?.updatedAt ?? now,
           notifiedAt: now,
-        },
+        }),
       }
     }
-    // Still within cooldown → suppress, but keep the existing timestamps.
     return {
       decision: {
         notify: false,
         kind: 'suppressed',
         severity: current,
-        previousSeverity,
+        previousSeverity: confirmed,
       },
-      next: {
+      next: withFired({
         severity: current,
         updatedAt: prev?.updatedAt ?? now,
         notifiedAt: prev?.notifiedAt ?? now,
+      }),
+    }
+  }
+
+  // (B) Worsening (ok → firing, or warning → critical) — gated by hysteresis.
+  if (rankCurrent > rankConfirmed) {
+    const count = streakFor(current)
+    if (count < minBreaches) return hold(current, count)
+    // Confirmed: NEW or ESCALATED — always notify regardless of cooldown.
+    const started = confirmed === 'ok' ? now : (firstFiredAt ?? now)
+    return {
+      decision: {
+        notify: true,
+        kind: confirmed === 'ok' ? 'new' : 'escalated',
+        severity: current,
+        previousSeverity: confirmed,
+      },
+      next: {
+        severity: current,
+        updatedAt: now,
+        notifiedAt: now,
+        firstFiredAt: started,
       },
     }
   }
 
-  // De-escalation but still firing (critical → warning): not a new alert.
-  // Lower the recorded severity so a later re-escalation is detected, but keep
-  // the last notify timestamp so we don't reset the cooldown.
+  // (C) Improving toward ok — RECOVERY, gated by clear hysteresis.
+  if (current === 'ok') {
+    const count = streakFor('ok')
+    if (count < minClears) return hold('ok', count)
+    const decision: AlertDecision = {
+      notify: true,
+      kind: 'recovery',
+      severity: 'ok',
+      previousSeverity: confirmed,
+    }
+    if (firstFiredAt !== undefined) {
+      decision.incidentDurationMs = Math.max(0, now - firstFiredAt)
+    }
+    return { decision, next: null }
+  }
+
+  // (C2) De-escalation but still firing (critical → warning): not a new alert.
+  // Lower the recorded severity immediately (a later re-escalation is still
+  // detected) but keep the notify timestamp so the cooldown isn't reset, and
+  // carry the incident timer since it's the same incident.
   return {
     decision: {
       notify: false,
       kind: 'suppressed',
       severity: current,
-      previousSeverity,
+      previousSeverity: confirmed,
     },
-    next: {
+    next: withFired({
       severity: current,
       updatedAt: now,
       notifiedAt: prev?.notifiedAt ?? now,
-    },
+    }),
   }
 }
 
@@ -246,6 +347,8 @@ export function evaluateAlert(
     severity: AlertRuleSeverity
     cooldownMs?: number
     now?: number
+    minConsecutiveBreaches?: number
+    minConsecutiveClears?: number
   }
 ): { decision: AlertDecision; commit: () => void } {
   const key = alertStateKey(params.hostId, params.ruleId)
@@ -253,6 +356,8 @@ export function evaluateAlert(
   const { decision, next } = decideNotification(prev, params.severity, {
     cooldownMs: params.cooldownMs,
     now: params.now,
+    minConsecutiveBreaches: params.minConsecutiveBreaches,
+    minConsecutiveClears: params.minConsecutiveClears,
   })
   const commit = () => {
     if (next === null) {

--- a/apps/dashboard/src/lib/health/server-alert-config.test.ts
+++ b/apps/dashboard/src/lib/health/server-alert-config.test.ts
@@ -2,6 +2,7 @@ import {
   getServerAlertConfig,
   getServerChannelSettings,
   getServerEmailConfig,
+  getServerHysteresisConfig,
   getServerNtfyConfig,
   getServerOpsgenieConfig,
   getServerPushoverConfig,
@@ -665,6 +666,69 @@ describe('getServerPushoverConfig', () => {
     expect(getServerPushoverConfig()).toEqual({
       token: 'app_tok',
       user: 'usr_key',
+    })
+  })
+})
+
+describe('getServerHysteresisConfig', () => {
+  const HYST_KEYS = [
+    'HEALTH_HYSTERESIS_BREACHES',
+    'HEALTH_HYSTERESIS_CLEARS',
+    'HEALTH_HYSTERESIS_DISK_USAGE_BREACHES',
+    'HEALTH_HYSTERESIS_DISK_USAGE_CLEARS',
+  ] as const
+  let saved: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    for (const key of HYST_KEYS) {
+      saved[key] = process.env[key]
+      delete process.env[key]
+    }
+  })
+  afterEach(() => {
+    for (const key of HYST_KEYS) {
+      if (saved[key] === undefined) delete process.env[key]
+      else process.env[key] = saved[key]
+    }
+    saved = {}
+  })
+
+  it('falls back to the product default (fire=1, clear=2) when unset', () => {
+    const { defaults, byRule } = getServerHysteresisConfig(['disk-usage'])
+    expect(defaults).toEqual({
+      minConsecutiveBreaches: 1,
+      minConsecutiveClears: 2,
+    })
+    expect(byRule['disk-usage']).toEqual(defaults)
+  })
+
+  it('honors global overrides', () => {
+    process.env.HEALTH_HYSTERESIS_BREACHES = '3'
+    process.env.HEALTH_HYSTERESIS_CLEARS = '4'
+    const { defaults } = getServerHysteresisConfig([])
+    expect(defaults).toEqual({
+      minConsecutiveBreaches: 3,
+      minConsecutiveClears: 4,
+    })
+  })
+
+  it('per-rule override wins over global and default', () => {
+    process.env.HEALTH_HYSTERESIS_CLEARS = '5'
+    process.env.HEALTH_HYSTERESIS_DISK_USAGE_BREACHES = '2'
+    const { byRule } = getServerHysteresisConfig(['disk-usage'])
+    expect(byRule['disk-usage']).toEqual({
+      minConsecutiveBreaches: 2, // per-rule
+      minConsecutiveClears: 5, // inherits global
+    })
+  })
+
+  it('ignores non-numeric and < 1 values', () => {
+    process.env.HEALTH_HYSTERESIS_BREACHES = 'nope'
+    process.env.HEALTH_HYSTERESIS_CLEARS = '0'
+    const { defaults } = getServerHysteresisConfig([])
+    expect(defaults).toEqual({
+      minConsecutiveBreaches: 1,
+      minConsecutiveClears: 2,
     })
   })
 })

--- a/apps/dashboard/src/lib/health/server-alert-config.ts
+++ b/apps/dashboard/src/lib/health/server-alert-config.ts
@@ -429,6 +429,84 @@ export function getServerDigestWindowMinutes(): number {
   return Math.floor(minutes)
 }
 
+/**
+ * Per-check hysteresis config (anti-flap, #2767): how many consecutive sweeps a
+ * worsening must persist before it fires, and how many consecutive `ok` sweeps a
+ * firing condition needs before it recovers.
+ */
+export interface HysteresisConfig {
+  minConsecutiveBreaches: number
+  minConsecutiveClears: number
+}
+
+/**
+ * Product default hysteresis: fire promptly (1 breach — no delay on a genuine
+ * critical) but damp recovery (2 consecutive clears), so a metric flapping
+ * around a threshold fires once and recovers once instead of on every dip. This
+ * is the sweep's default; the pure {@link import('./alert-state-store')} engine
+ * itself defaults to 1/1 (no hysteresis) so its transitions stay unchanged
+ * unless a caller opts in.
+ */
+export const DEFAULT_HYSTERESIS: HysteresisConfig = {
+  minConsecutiveBreaches: 1,
+  minConsecutiveClears: 2,
+}
+
+function parsePositiveIntEnv(value: string | undefined): number | null {
+  if (value === undefined) return null
+  const trimmed = value.trim()
+  if (trimmed === '') return null
+  const num = Number(trimmed)
+  if (!Number.isFinite(num) || num < 1) return null
+  return Math.floor(num)
+}
+
+/**
+ * Resolve hysteresis config for the given rule ids from environment variables.
+ *
+ * Global defaults (override {@link DEFAULT_HYSTERESIS}):
+ *
+ *   HEALTH_HYSTERESIS_BREACHES  → minConsecutiveBreaches
+ *   HEALTH_HYSTERESIS_CLEARS    → minConsecutiveClears
+ *
+ * Per-rule overrides (highest precedence), where `<RULE_ID>` is the rule id
+ * uppercased with dashes replaced by underscores:
+ *
+ *   HEALTH_HYSTERESIS_<RULE_ID>_BREACHES
+ *   HEALTH_HYSTERESIS_<RULE_ID>_CLEARS
+ *
+ * Only finite integers ≥ 1 are accepted; anything else falls back to the next
+ * level down. Returns the resolved default plus a fully-resolved config for
+ * every requested rule id, so the sweep can look up `byRule[id] ?? defaults`.
+ */
+export function getServerHysteresisConfig(ruleIds: readonly string[]): {
+  defaults: HysteresisConfig
+  byRule: Record<string, HysteresisConfig>
+} {
+  const defaults: HysteresisConfig = {
+    minConsecutiveBreaches:
+      parsePositiveIntEnv(process.env.HEALTH_HYSTERESIS_BREACHES) ??
+      DEFAULT_HYSTERESIS.minConsecutiveBreaches,
+    minConsecutiveClears:
+      parsePositiveIntEnv(process.env.HEALTH_HYSTERESIS_CLEARS) ??
+      DEFAULT_HYSTERESIS.minConsecutiveClears,
+  }
+
+  const byRule: Record<string, HysteresisConfig> = {}
+  for (const id of ruleIds) {
+    const prefix = `HEALTH_HYSTERESIS_${id.toUpperCase().replace(/-/g, '_')}`
+    byRule[id] = {
+      minConsecutiveBreaches:
+        parsePositiveIntEnv(process.env[`${prefix}_BREACHES`]) ??
+        defaults.minConsecutiveBreaches,
+      minConsecutiveClears:
+        parsePositiveIntEnv(process.env[`${prefix}_CLEARS`]) ??
+        defaults.minConsecutiveClears,
+    }
+  }
+  return { defaults, byRule }
+}
+
 /** Default cron re-notify cooldown, in minutes, when the env var is unset. */
 export const DEFAULT_ALERT_COOLDOWN_MINUTES = 60
 

--- a/apps/dashboard/src/lib/health/server-sweep.test.ts
+++ b/apps/dashboard/src/lib/health/server-sweep.test.ts
@@ -453,6 +453,8 @@ const ENV_KEYS = [
   'HEALTH_ALERT_PAGERDUTY_ROUTING_KEY',
   'HEALTH_ALERT_HEALTHCHECKS_URL',
   'HEALTH_ALERT_DIGEST_MINUTES',
+  'HEALTH_HYSTERESIS_BREACHES',
+  'HEALTH_HYSTERESIS_CLEARS',
 ] as const
 const savedEnv: Record<string, string | undefined> = {}
 
@@ -464,6 +466,12 @@ beforeEach(() => {
   process.env.HEALTH_ALERT_WEBHOOK_URL =
     'https://hooks.slack.com/services/T000/B000/XXXX'
   process.env.HEALTH_ALERT_MIN_SEVERITY = 'warning'
+  // Pin hysteresis OFF (1 breach / 1 clear) for these plumbing tests so a fire
+  // and a recovery each land on a single sweep — the anti-flap state machine
+  // and the product default (fire=1, clear=2) are covered directly in
+  // alert-state-store.test.ts / server-alert-config.test.ts (#2767).
+  process.env.HEALTH_HYSTERESIS_BREACHES = '1'
+  process.env.HEALTH_HYSTERESIS_CLEARS = '1'
   delete process.env.HEALTH_ALERT_PAGERDUTY_ROUTING_KEY
   delete process.env.HEALTH_ALERT_HEALTHCHECKS_URL
   delete process.env.HEALTH_ALERT_DIGEST_MINUTES

--- a/apps/dashboard/src/lib/health/server-sweep.ts
+++ b/apps/dashboard/src/lib/health/server-sweep.ts
@@ -45,6 +45,7 @@ import {
   resolveTargets,
   resolveTelegramTargets,
 } from './alert-routing'
+import { flushAlertState, hydrateAlertState } from './alert-state-persist'
 import { alertStateStore, evaluateAlert } from './alert-state-store'
 import { dispatchDedupedAlertEvent } from './alert-webhook-events'
 import { loadCustomRulesIntoRegistry } from './custom-rules-store'
@@ -69,6 +70,7 @@ import {
 import {
   getServerAlertConfig,
   getServerAlertCooldownMs,
+  getServerHysteresisConfig,
   getServerThresholdOverrides,
 } from './server-alert-config'
 import { resolveServerChannels } from './server-channel-resolve'
@@ -86,6 +88,7 @@ import { generateInsights } from '@/lib/insights/generate-insights'
 import { generatePostgresInsights } from '@/lib/insights/generate-postgres-insights'
 import { buildAlertBlocksWithAck } from '@/lib/slack/blocks'
 import { isSlackAppConfigured } from '@/lib/slack/config'
+import { formatDuration } from '@/lib/utils'
 
 // Register pluggable alert rules into the global ruleRegistry once at module
 // load. The sweep drives itself from `ruleRegistry.getAll()`; the /health page
@@ -453,6 +456,19 @@ export async function runHealthSweep(): Promise<SweepSummary> {
   const rules = ruleRegistry.getAll()
   const thresholdOverrides = getServerThresholdOverrides(rules.map((r) => r.id))
 
+  // Hysteresis config (#2767): per-check anti-flap knobs. Resolved for every
+  // base + compound rule id; `dispatchFinding` looks up `byRule[id] ?? defaults`
+  // (compound ids fall through to defaults). Env-configured, like thresholds.
+  const hysteresis = getServerHysteresisConfig([
+    ...rules.map((r) => r.id),
+    ...compoundRuleRegistry.getAll().map((r) => r.id),
+  ])
+
+  // Durable state (#2767): hydrate the in-memory transition/hysteresis store
+  // from D1 so streaks + incident timers survive worker restarts. Best-effort —
+  // a no-op with no D1 binding (the OSS default), leaving ephemeral memory.
+  if (alertingEnabled) await hydrateAlertState(alertStateStore)
+
   // Compound rules (plans 31): base rules already ran above their sweep. Order
   // them once up front so dependency ordering is computed a single time, not
   // per host. A misconfigured compound rule (cycle / unknown dependency) must
@@ -619,11 +635,14 @@ export async function runHealthSweep(): Promise<SweepSummary> {
     } = params
     const effective: Severity =
       SEVERITY_ORDER[severity] >= minRank ? severity : 'ok'
+    const ruleHysteresis = hysteresis.byRule[ruleId] ?? hysteresis.defaults
     const { decision, commit } = evaluateAlert(alertStateStore, {
       hostId,
       ruleId,
       severity: effective,
       cooldownMs,
+      minConsecutiveBreaches: ruleHysteresis.minConsecutiveBreaches,
+      minConsecutiveClears: ruleHysteresis.minConsecutiveClears,
     })
 
     if (decision.notify && isSuppressed(windows, hostId, Date.now())) {
@@ -763,9 +782,14 @@ export async function runHealthSweep(): Promise<SweepSummary> {
       const isQuietCatchUp =
         decision.kind !== 'recovery' &&
         takeDueCatchUp(hostId, ruleId, Date.now())
+      // Recovery message reports the incident duration when known (#2767).
+      const recoveryDuration =
+        decision.incidentDurationMs !== undefined
+          ? ` after ${formatDuration(decision.incidentDurationMs)}`
+          : ''
       const text =
         decision.kind === 'recovery'
-          ? `[RECOVERY] ${ruleTitle} — resolved (host ${name})`
+          ? `[RECOVERY] ${ruleTitle} — resolved${recoveryDuration} (host ${name})`
           : `${isQuietCatchUp ? '[CATCH-UP] ' : ''}[${effective.toUpperCase()}] ${ruleTitle} — ${label} (host ${name})`
 
       // Per-channel + per-route gate (#2661). The severity a channel is judged
@@ -1829,6 +1853,11 @@ export async function runHealthSweep(): Promise<SweepSummary> {
   // per target that received >1 finding, then commit + count each deferred
   // finding. Runs after every host so grouping spans the whole pass.
   await flushDigests()
+
+  // Persist the post-sweep transition/hysteresis state to D1 (#2767) so the
+  // next tick (even after a restart) resumes streaks + incident timers. Runs
+  // after flushDigests so deferred commits are already applied. Best-effort.
+  if (alertingEnabled) await flushAlertState(alertStateStore)
 
   return {
     ranAt,

--- a/apps/dashboard/src/routes/api/v1/health/alert-state.ts
+++ b/apps/dashboard/src/routes/api/v1/health/alert-state.ts
@@ -1,0 +1,51 @@
+/**
+ * Current alert state endpoint (#2767)
+ * GET /api/v1/health/alert-state?hostId=0
+ *
+ * Returns the health sweep's persisted last-known state per (check, host) from
+ * the `alert_state` D1 table — the confirmed severity, when it last transitioned
+ * (`updatedAt`), when the incident began firing (`firstFiredAt`), and any
+ * in-flight hysteresis streak (`pendingSeverity`/`pendingCount`). Powers the
+ * "Current alert state" card in Alert Settings.
+ *
+ * Auth is centralized in middleware, same as the sibling /api/v1/health/*
+ * routes. `host_id` indexes the operator's env-configured hosts only (the sweep
+ * never touches per-user D1 connections), so there is no per-row tenant scoping.
+ *
+ * The underlying store is best-effort: it degrades to `[]` rather than throwing
+ * when D1 isn't configured (self-hosted/OSS default), so this route always
+ * returns 200 with a (possibly empty) `states` array.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { readAlertStates } from '@/lib/health/alert-state-persist'
+
+export const Route = createFileRoute('/api/v1/health/alert-state')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const { searchParams } = new URL(request.url)
+
+        let hostId: number | undefined
+        const hostIdParam = searchParams.get('hostId')
+        if (hostIdParam !== null && hostIdParam !== '') {
+          const parsed = Number(hostIdParam)
+          if (!Number.isInteger(parsed) || parsed < 0) {
+            return Response.json(
+              {
+                success: false,
+                error: { type: 'validation', message: 'Invalid hostId' },
+              },
+              { status: 400 }
+            )
+          }
+          hostId = parsed
+        }
+
+        const states = await readAlertStates(hostId)
+        return Response.json({ success: true, states })
+      },
+    },
+  },
+})

--- a/docs/content/guide/guides/alerting-slack-discord.mdx
+++ b/docs/content/guide/guides/alerting-slack-discord.mdx
@@ -79,6 +79,34 @@ dispatch attempt and whether delivery succeeded. That history isn't available
 on a self-hosted deployment without D1.
 </Callout>
 
+## Noise control: transitions, recovery & hysteresis
+
+Alerts are **transition-based**: the sweep notifies only when a condition
+actually changes state — `ok → warning`, `warning → critical`, or recovers back
+to `ok`. A condition that stays unhealthy is not re-sent on every run; it sends a
+single **reminder** at most once per `HEALTH_ALERT_COOLDOWN_MINUTES` (default 60;
+`0` disables reminders). A **recovery** message always goes out when a condition
+clears, and reports how long the incident was firing.
+
+To stop a metric that hovers on a threshold from flapping (fire/recover on every
+sweep), each check applies **hysteresis**:
+
+```bash
+# Consecutive breaches required before an alert fires (default 1 — fire promptly).
+HEALTH_HYSTERESIS_BREACHES=1
+# Consecutive "ok" sweeps required before a firing condition recovers (default 2).
+HEALTH_HYSTERESIS_CLEARS=2
+
+# Per-check overrides use the rule id, uppercased with dashes → underscores:
+HEALTH_HYSTERESIS_DISK_USAGE_CLEARS=3
+```
+
+The default (fire on the first breach, recover only after two consecutive clears)
+keeps genuine criticals prompt while collapsing a flapping metric into exactly
+one fire and one recover. The current state and last transition per check are
+shown on the **Active** tab of Alert Settings. State is persisted to D1 (when
+configured) so hysteresis streaks and incident timers survive worker restarts.
+
 ## Related
 
 - [Health](/guide/features/health) — every check, threshold, and environment


### PR DESCRIPTION
Closes #2767.

## What this does

Reduces alert noise by adding **hysteresis** and strengthening **transition-based** delivery on the health sweep.

### Hysteresis (anti-flap)
The transition engine (`alert-state-store.ts`) now damps flapping metrics with two per-check knobs:
- `minConsecutiveBreaches` — a worsening must persist N sweeps before it fires.
- `minConsecutiveClears` — a firing condition must read `ok` N sweeps before it recovers.

The pure state machine defaults to **1/1 (no behavior change)**; the sweep applies the product default **fire=1, clear=2** — criticals still fire promptly, but recovery is damped so a metric flapping around a threshold produces **exactly one fire + one recover** instead of N. Configurable via env, like thresholds:
```
HEALTH_HYSTERESIS_BREACHES / HEALTH_HYSTERESIS_CLEARS         # global
HEALTH_HYSTERESIS_<RULE_ID>_BREACHES / _CLEARS               # per-check
```

### Recovery with duration
Recovery notifications now report the incident duration (tracked via `firstFiredAt`), e.g. `[RECOVERY] Disk Usage — resolved after 42.0m (host …)`.

### Durable state per (check, host)
Last-known state persists to D1 (`alert_state` table + `0028` migration) via hydrate-at-start / flush-at-end around the sweep, so hysteresis streaks and incident timers survive worker restarts. Best-effort / fail-open like the other health stores (no D1 ⇒ ephemeral in-memory, exactly as before).

### UI
Alert Settings → **Active** tab gains a "Current alert state" card (current severity, last transition, in-flight hysteresis streak, firing duration), backed by `GET /api/v1/health/alert-state`.

### Docs
The Slack/Discord alerting guide gains a "Noise control: transitions, recovery & hysteresis" section.

## Tests
- `alert-state-store.test.ts`: fire, persist-while-firing (no re-notify), clear-below-hysteresis, recovery, and a **flap sequence producing exactly one fire + one recover**; plus a default-1/1 equivalence check.
- `server-alert-config.test.ts`: hysteresis env resolution (defaults, global, per-rule precedence, invalid values).
- `server-sweep.test.ts`: pins hysteresis 1/1 to isolate dispatch plumbing; exercises hydrate/flush degradation.

Full unit suite verified locally: **7213 pass, 0 fail** (with `--isolate`, as CI runs).

https://claude.ai/code/session_01EAzHsUVHPqCzE9M6o1yZZa