### PR TITLE
feat(command-palette): databases/tables, recent items, quick actions

### DIFF
--- a/apps/dashboard/src/components/controls/command-palette.tsx
+++ b/apps/dashboard/src/components/controls/command-palette.tsx
@@ -2,16 +2,26 @@
 
 import {
   CornerDownLeft,
+  Database,
+  GlobeIcon,
+  History,
+  Moon,
   Search,
   SearchX,
   Settings,
+  Sparkles,
+  Sun,
   Table,
   TextSearch,
 } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
+
+import type { RecentPaletteItemKind } from '@/lib/command-palette/recent-items'
 
 import { detectQuickNav, parseTableName } from './command-palette-utils'
+import { useTheme } from 'next-themes'
 import * as React from 'react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   CommandDialog,
   CommandEmpty,
@@ -22,12 +32,39 @@ import {
   CommandSeparator,
 } from '@/components/ui/command'
 import { IconButton } from '@/components/ui/icon-button'
+import {
+  addRecentItem,
+  getRecentItems,
+} from '@/lib/command-palette/recent-items'
 import { useFeaturePermissions } from '@/lib/feature-permissions/context'
 import { useActiveHostEngine } from '@/lib/hooks/use-active-pg-connection'
 import { getVisibleMenuItems } from '@/lib/menu/visible-items'
-import { useRouter, useSearchParams } from '@/lib/next-compat'
+import { usePathname, useRouter, useSearchParams } from '@/lib/next-compat'
+import { apiFetch } from '@/lib/swr/api-fetch'
+import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
 import { buildUrl } from '@/lib/url/url-builder'
-import { cn } from '@/lib/utils'
+import { cn, getHost } from '@/lib/utils'
+
+// Cap how many databases/tables are rendered — cmdk fuzzy-filters the
+// remaining rows as the user types, but that's about UX (not fetch cost);
+// the API call itself is already limited server-side.
+const EXPLORER_RESULTS_LIMIT = 200
+const EXPLORER_GROUP_MAX = 8
+
+interface ExplorerTableRow {
+  database: string
+  name: string
+  engine: string
+}
+
+async function fetchTables(hostId: number): Promise<ExplorerTableRow[]> {
+  const res = await apiFetch(
+    `/api/v1/tables?hostId=${hostId}&limit=${EXPLORER_RESULTS_LIMIT}`
+  )
+  if (!res.ok) throw new Error(`Failed to fetch tables: ${res.status}`)
+  const json = (await res.json()) as { data: ExplorerTableRow[] }
+  return json.data || []
+}
 
 interface CommandPaletteProps {
   open?: boolean
@@ -74,14 +111,31 @@ export const CommandPalette = function CommandPalette({
 }: CommandPaletteProps = {}) {
   const router = useRouter()
   const searchParams = useSearchParams()
+  const pathname = usePathname()
   const [internalOpen, setInternalOpen] = React.useState(false)
   const [inputValue, setInputValue] = useState('')
+  const [recentItems, setRecentItems] = useState<
+    ReturnType<typeof getRecentItems>
+  >([])
+  const [mounted, setMounted] = useState(false)
   const { config } = useFeaturePermissions()
   const engine = useActiveHostEngine()
   const menuItems = getVisibleMenuItems(config, engine)
+  const { setTheme, resolvedTheme } = useTheme()
+  const { hosts } = useMergedHosts()
 
   const open = controlledOpen ?? internalOpen
   const setOpen = onOpenChange ?? setInternalOpen
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  // Recent items can be added from any palette instance (or a prior session),
+  // so re-read them each time the palette opens rather than only on mount.
+  useEffect(() => {
+    if (open) setRecentItems(getRecentItems())
+  }, [open])
 
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -97,10 +151,54 @@ export const CommandPalette = function CommandPalette({
   }, [open, setOpen])
 
   const hostId = searchParams.get('host') || '0'
+  const hostIdNum = Number(hostId)
 
-  const navigate = (href: string) => {
+  // Databases/tables are lazy-loaded: the query only runs once the palette is
+  // actually open, so browsing the dashboard never pays for this fetch.
+  const { data: tableRows } = useQuery({
+    queryKey: ['/api/v1/tables', 'command-palette', hostIdNum],
+    queryFn: () => fetchTables(hostIdNum),
+    enabled: open && Number.isFinite(hostIdNum),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  })
+
+  const databases = React.useMemo(() => {
+    const seen = new Set<string>()
+    for (const row of tableRows ?? []) seen.add(row.database)
+    return [...seen].slice(0, EXPLORER_GROUP_MAX)
+  }, [tableRows])
+
+  const tables = React.useMemo(
+    () => (tableRows ?? []).slice(0, EXPLORER_GROUP_MAX),
+    [tableRows]
+  )
+
+  const rememberSelection = (
+    id: string,
+    title: string,
+    href: string,
+    kind: RecentPaletteItemKind,
+    description?: string
+  ) => {
+    addRecentItem({ id, title, href, kind, description })
+  }
+
+  const navigate = (
+    href: string,
+    recent?: { id: string; title: string; description?: string }
+  ) => {
     setOpen(false)
     setInputValue('')
+    if (recent) {
+      rememberSelection(
+        recent.id,
+        recent.title,
+        href,
+        'page',
+        recent.description
+      )
+    }
     // External destinations (e.g. Docs → docs.chmonitor.dev) open in a new tab
     // instead of being routed through the SPA.
     if (/^https?:\/\//.test(href)) {
@@ -139,9 +237,38 @@ export const CommandPalette = function CommandPalette({
     router.push(url)
   }
 
+  const openExplorerFor = (database: string, table?: string) => {
+    setOpen(false)
+    setInputValue('')
+    const url = buildUrl('/explorer', { host: hostId, database, table })
+    if (table) {
+      rememberSelection(
+        `table-${hostId}-${database}-${table}`,
+        `${database}.${table}`,
+        url,
+        'table'
+      )
+    } else {
+      rememberSelection(`db-${hostId}-${database}`, database, url, 'database')
+    }
+    router.push(url)
+  }
+
   const handleOpenSettings = () => {
     setOpen(false)
     onOpenSettings?.()
+  }
+
+  const handleToggleTheme = () => {
+    setOpen(false)
+    setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')
+  }
+
+  const handleSwitchHost = (id: number) => {
+    setOpen(false)
+    setInputValue('')
+    const url = buildUrl(pathname || '/overview', { host: id }, searchParams)
+    router.push(url)
   }
 
   // Top-level entries without sub-items (Overview, AI Agent, Insights, Health…)
@@ -154,6 +281,8 @@ export const CommandPalette = function CommandPalette({
   const sectionedItems = menuItems.filter(
     (group) => group.items && group.items.length > 0
   )
+
+  const otherHosts = hosts.filter((h) => h.id !== hostIdNum)
 
   return (
     <>
@@ -209,6 +338,44 @@ export const CommandPalette = function CommandPalette({
             </div>
           </CommandEmpty>
 
+          {/* Recent items only make sense as a starting point — once the user
+              is actively searching, cmdk's own filter takes over. */}
+          {inputValue.length === 0 && recentItems.length > 0 && (
+            <>
+              <CommandGroup heading="Recent">
+                {recentItems.map((recent) => (
+                  <CommandItem
+                    key={recent.id}
+                    onSelect={() => {
+                      setOpen(false)
+                      setInputValue('')
+                      rememberSelection(
+                        recent.id,
+                        recent.title,
+                        recent.href,
+                        recent.kind,
+                        recent.description
+                      )
+                      router.push(recent.href)
+                    }}
+                    value={`recent-${recent.id}`}
+                    className="group"
+                  >
+                    <History className="size-4 shrink-0" />
+                    <span className="font-medium">{recent.title}</span>
+                    {recent.description && (
+                      <span className="ml-1 truncate text-xs text-muted-foreground">
+                        {recent.description}
+                      </span>
+                    )}
+                    <EnterHint />
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+              <CommandSeparator />
+            </>
+          )}
+
           {showQuickNav && (
             <>
               <CommandGroup heading="Quick Navigation">
@@ -250,7 +417,13 @@ export const CommandPalette = function CommandPalette({
               {leafItems.map((group) => (
                 <CommandItem
                   key={group.href}
-                  onSelect={() => navigate(group.href)}
+                  onSelect={() =>
+                    navigate(group.href, {
+                      id: `page-${group.href}`,
+                      title: group.title,
+                      description: group.description,
+                    })
+                  }
                   value={[group.title, group.description]
                     .filter(Boolean)
                     .join(' ')}
@@ -269,7 +442,13 @@ export const CommandPalette = function CommandPalette({
               {group.items?.map((item) => (
                 <CommandItem
                   key={item.href}
-                  onSelect={() => navigate(item.href)}
+                  onSelect={() =>
+                    navigate(item.href, {
+                      id: `page-${item.href}`,
+                      title: item.title,
+                      description: item.description,
+                    })
+                  }
                   value={[group.title, item.title, item.description]
                     .filter(Boolean)
                     .join(' ')}
@@ -290,22 +469,105 @@ export const CommandPalette = function CommandPalette({
             </CommandGroup>
           ))}
 
-          {onOpenSettings && (
-            <>
-              <CommandSeparator />
-              <CommandGroup heading="Actions">
+          {databases.length > 0 && (
+            <CommandGroup heading="Databases">
+              {databases.map((database) => (
                 <CommandItem
-                  onSelect={handleOpenSettings}
-                  value="Settings preferences"
+                  key={`db-${database}`}
+                  onSelect={() => openExplorerFor(database)}
+                  value={`database ${database}`}
                   className="group"
                 >
-                  <Settings className="size-4 shrink-0" />
-                  <span>Settings</span>
-                  <Kbd className="ml-auto">⌘,</Kbd>
+                  <Database className="size-4 shrink-0" />
+                  <span className="font-medium">{database}</span>
+                  <EnterHint />
                 </CommandItem>
-              </CommandGroup>
-            </>
+              ))}
+            </CommandGroup>
           )}
+
+          {tables.length > 0 && (
+            <CommandGroup heading="Tables">
+              {tables.map((row) => (
+                <CommandItem
+                  key={`table-${row.database}-${row.name}`}
+                  onSelect={() => openExplorerFor(row.database, row.name)}
+                  value={`table ${row.database}.${row.name} ${row.engine}`}
+                  className="group"
+                >
+                  <Table className="size-4 shrink-0" />
+                  <span className="font-medium">
+                    {row.database}.{row.name}
+                  </span>
+                  <span className="ml-1 truncate text-xs text-muted-foreground">
+                    {row.engine}
+                  </span>
+                  <EnterHint />
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )}
+
+          <CommandSeparator />
+          <CommandGroup heading="Actions">
+            <CommandItem
+              onSelect={() =>
+                navigate('/agents', {
+                  id: 'action-open-ai-chat',
+                  title: 'Open AI Agent chat',
+                })
+              }
+              value="Open AI Agent chat assistant"
+              className="group"
+            >
+              <Sparkles className="size-4 shrink-0" />
+              <span>Open AI Agent chat</span>
+              <EnterHint />
+            </CommandItem>
+
+            {mounted && (
+              <CommandItem
+                onSelect={handleToggleTheme}
+                value="Toggle dark light theme appearance"
+                className="group"
+              >
+                {resolvedTheme === 'dark' ? (
+                  <Sun className="size-4 shrink-0" />
+                ) : (
+                  <Moon className="size-4 shrink-0" />
+                )}
+                <span>
+                  Switch to {resolvedTheme === 'dark' ? 'light' : 'dark'} mode
+                </span>
+                <EnterHint />
+              </CommandItem>
+            )}
+
+            {otherHosts.map((host) => (
+              <CommandItem
+                key={`switch-host-${host.id}`}
+                onSelect={() => handleSwitchHost(host.id)}
+                value={`switch host ${host.name || getHost(host.host)}`}
+                className="group"
+              >
+                <GlobeIcon className="size-4 shrink-0" />
+                <span>Switch to {host.name || getHost(host.host)}</span>
+                <EnterHint />
+              </CommandItem>
+            ))}
+
+            {onOpenSettings && (
+              <CommandItem
+                onSelect={handleOpenSettings}
+                value="Settings preferences"
+                className="group"
+              >
+                <Settings className="size-4 shrink-0" />
+                <span>Settings</span>
+                <Kbd className="ml-auto">⌘,</Kbd>
+              </CommandItem>
+            )}
+          </CommandGroup>
         </CommandList>
 
         {/* Footer with keyboard hints — the hallmark of a polished palette. */}

--- a/apps/dashboard/src/lib/command-palette/recent-items.test.ts
+++ b/apps/dashboard/src/lib/command-palette/recent-items.test.ts
@@ -1,0 +1,167 @@
+import type { RecentPaletteItem } from './recent-items'
+
+import { addRecentItem, clearRecentItems, getRecentItems } from './recent-items'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+// ---------------------------------------------------------------------------
+// In-memory localStorage shim (bun has no DOM) — mirrors dismissed-insights.test.ts
+// ---------------------------------------------------------------------------
+
+class MemoryStorage {
+  private store = new Map<string, string>()
+
+  getItem(k: string): string | null {
+    return this.store.has(k) ? (this.store.get(k) as string) : null
+  }
+
+  setItem(k: string, v: string): void {
+    this.store.set(k, String(v))
+  }
+
+  removeItem(k: string): void {
+    this.store.delete(k)
+  }
+
+  clear(): void {
+    this.store.clear()
+  }
+}
+
+function makeItem(id: string, overrides: Partial<RecentPaletteItem> = {}) {
+  return {
+    id,
+    title: id,
+    href: `/${id}`,
+    kind: 'page' as const,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  ;(globalThis as { localStorage?: unknown }).localStorage = new MemoryStorage()
+  ;(globalThis as { window?: unknown }).window = globalThis
+})
+
+afterEach(() => {
+  ;(globalThis as { localStorage?: unknown }).localStorage = undefined
+  ;(globalThis as { window?: unknown }).window = undefined
+})
+
+describe('SSR guard (window === undefined)', () => {
+  test('getRecentItems returns empty array when window is undefined', () => {
+    addRecentItem(makeItem('ssr'))
+    ;(globalThis as { window?: unknown }).window = undefined
+    expect(getRecentItems()).toEqual([])
+  })
+
+  test('addRecentItem is a no-op when window is undefined', () => {
+    ;(globalThis as { window?: unknown }).window = undefined
+    addRecentItem(makeItem('noop'))
+    ;(globalThis as { window?: unknown }).window = globalThis
+    expect(getRecentItems()).toEqual([])
+  })
+
+  test('clearRecentItems is a no-op when window is undefined', () => {
+    addRecentItem(makeItem('pre-stored'))
+    ;(globalThis as { window?: unknown }).window = undefined
+    clearRecentItems()
+    ;(globalThis as { window?: unknown }).window = globalThis
+    expect(getRecentItems()).toHaveLength(1)
+  })
+})
+
+describe('getRecentItems', () => {
+  test('returns an empty array when localStorage is empty', () => {
+    expect(getRecentItems()).toEqual([])
+  })
+
+  test('returns items in most-recently-added-first order', () => {
+    addRecentItem(makeItem('a'))
+    addRecentItem(makeItem('b'))
+    expect(getRecentItems().map((i) => i.id)).toEqual(['b', 'a'])
+  })
+})
+
+describe('addRecentItem', () => {
+  test('de-duplicates by id, moving the item to the front', () => {
+    addRecentItem(makeItem('a'))
+    addRecentItem(makeItem('b'))
+    addRecentItem(makeItem('a'))
+    const items = getRecentItems()
+    expect(items.map((i) => i.id)).toEqual(['a', 'b'])
+    expect(items).toHaveLength(2)
+  })
+
+  test('caps the stored list at 5 items', () => {
+    for (let i = 0; i < 8; i++) addRecentItem(makeItem(`item-${i}`))
+    const items = getRecentItems()
+    expect(items).toHaveLength(5)
+    // Most recent 5 (item-7 .. item-3), newest first.
+    expect(items.map((i) => i.id)).toEqual([
+      'item-7',
+      'item-6',
+      'item-5',
+      'item-4',
+      'item-3',
+    ])
+  })
+
+  test('persists title, description, href, and kind', () => {
+    addRecentItem(
+      makeItem('t', {
+        title: 'Traffic',
+        description: 'Data flowing into the cluster',
+        href: '/traffic?host=0',
+        kind: 'page',
+      })
+    )
+    expect(getRecentItems()[0]).toEqual({
+      id: 't',
+      title: 'Traffic',
+      description: 'Data flowing into the cluster',
+      href: '/traffic?host=0',
+      kind: 'page',
+    })
+  })
+})
+
+describe('clearRecentItems', () => {
+  test('removes all stored items', () => {
+    addRecentItem(makeItem('a'))
+    addRecentItem(makeItem('b'))
+    clearRecentItems()
+    expect(getRecentItems()).toEqual([])
+  })
+
+  test('is safe to call on an already-empty store', () => {
+    clearRecentItems()
+    expect(getRecentItems()).toEqual([])
+  })
+})
+
+describe('malformed JSON in localStorage', () => {
+  test('getRecentItems returns empty array for non-JSON value', () => {
+    ;(
+      globalThis as unknown as { localStorage: MemoryStorage }
+    ).localStorage.setItem('command-palette-recent-items', 'not-valid-json')
+    expect(getRecentItems()).toEqual([])
+  })
+
+  test('getRecentItems returns empty array for a JSON object (non-array)', () => {
+    ;(
+      globalThis as unknown as { localStorage: MemoryStorage }
+    ).localStorage.setItem(
+      'command-palette-recent-items',
+      JSON.stringify({ not: 'an array' })
+    )
+    expect(getRecentItems()).toEqual([])
+  })
+
+  test('addRecentItem still works after corrupt data was present', () => {
+    ;(
+      globalThis as unknown as { localStorage: MemoryStorage }
+    ).localStorage.setItem('command-palette-recent-items', 'CORRUPT')
+    addRecentItem(makeItem('recovery'))
+    expect(getRecentItems().map((i) => i.id)).toEqual(['recovery'])
+  })
+})

--- a/apps/dashboard/src/lib/command-palette/recent-items.ts
+++ b/apps/dashboard/src/lib/command-palette/recent-items.ts
@@ -1,0 +1,53 @@
+/**
+ * Recently-selected command palette items, persisted in localStorage.
+ *
+ * Kept free of React imports so it can be unit-tested in isolation and reused
+ * by any palette surface (mirrors lib/insights/dismissed-insights.ts).
+ */
+
+const STORAGE_KEY = 'command-palette-recent-items'
+const MAX_RECENT = 5
+
+/** Generic kind used to pick an icon at render time (no JSX stored). */
+export type RecentPaletteItemKind = 'page' | 'database' | 'table' | 'action'
+
+export interface RecentPaletteItem {
+  /** Stable identity for de-duping (e.g. the href, or `db-<name>`). */
+  id: string
+  title: string
+  description?: string
+  href: string
+  kind: RecentPaletteItemKind
+}
+
+export function getRecentItems(): RecentPaletteItem[] {
+  if (typeof window === 'undefined') return []
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (!stored) return []
+    const parsed = JSON.parse(stored)
+    return Array.isArray(parsed) ? (parsed as RecentPaletteItem[]) : []
+  } catch {
+    return []
+  }
+}
+
+export function addRecentItem(item: RecentPaletteItem): void {
+  if (typeof window === 'undefined') return
+  try {
+    const existing = getRecentItems().filter((i) => i.id !== item.id)
+    const next = [item, ...existing].slice(0, MAX_RECENT)
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+  } catch {
+    // Silently fail if localStorage is full or disabled.
+  }
+}
+
+export function clearRecentItems(): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    // Silently fail.
+  }
+}


### PR DESCRIPTION
## Summary
- Extends the existing ⌘K / Ctrl+K command palette (`components/controls/command-palette.tsx`, already wired with the full `menu.ts` nav tree, quick-nav for query-id / `database.table`, and Settings) to cover the remaining requirements from #2768.
- Adds a **Databases** and **Tables** group, lazy-loaded only once the palette is opened (`enabled: open && ...` on the TanStack Query), reusing the existing `/api/v1/tables` endpoint — no new API routes.
- Adds a localStorage-backed **Recent** section (`lib/command-palette/recent-items.ts`), capped at 5 items, shown when the input is empty.
- Adds quick actions: open the AI Agent chat, toggle theme (light/dark), and switch host (lists other configured hosts via `useMergedHosts`) — all preserving `?host=` routing and the current path where relevant.
- No `components/ui/*` changes.

Closes #2768

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm run build` (apps/dashboard — Vite build + `tsc --noEmit`, 114 pages prerendered)
- [x] `bun test src/ --isolate` (apps/dashboard) — 7226 pass, 0 fail
- [x] New unit tests for `lib/command-palette/recent-items.ts`