### PR TITLE
feat(nav): pin favorite menu items (browser-local)

### DIFF
--- a/apps/dashboard/src/components/controls/command-palette.tsx
+++ b/apps/dashboard/src/components/controls/command-palette.tsx
@@ -6,6 +6,7 @@ import {
   GlobeIcon,
   History,
   Moon,
+  Pin,
   Search,
   SearchX,
   Settings,
@@ -32,12 +33,14 @@ import {
   CommandSeparator,
 } from '@/components/ui/command'
 import { IconButton } from '@/components/ui/icon-button'
+import { useFavoriteHrefs } from '@/hooks/use-favorites'
 import {
   addRecentItem,
   getRecentItems,
 } from '@/lib/command-palette/recent-items'
 import { useFeaturePermissions } from '@/lib/feature-permissions/context'
 import { useActiveHostEngine } from '@/lib/hooks/use-active-pg-connection'
+import { getFavoriteMenuItems } from '@/lib/menu/derive-favorites'
 import { getVisibleMenuItems } from '@/lib/menu/visible-items'
 import { usePathname, useRouter, useSearchParams } from '@/lib/next-compat'
 import { apiFetch } from '@/lib/swr/api-fetch'
@@ -121,6 +124,8 @@ export const CommandPalette = function CommandPalette({
   const { config } = useFeaturePermissions()
   const engine = useActiveHostEngine()
   const menuItems = getVisibleMenuItems(config, engine)
+  const favoriteHrefs = useFavoriteHrefs()
+  const favoriteMenuItems = getFavoriteMenuItems(menuItems, favoriteHrefs)
   const { setTheme, resolvedTheme } = useTheme()
   const { hosts } = useMergedHosts()
 
@@ -337,6 +342,37 @@ export const CommandPalette = function CommandPalette({
               </p>
             </div>
           </CommandEmpty>
+
+          {/* Pinned favorites (issue #2769) surface first, above Recent —
+              cmdk's own value-based filter still narrows this group when the
+              user types, so it isn't gated to the empty-query state. */}
+          {favoriteMenuItems.length > 0 && (
+            <>
+              <CommandGroup heading="Favorites">
+                {favoriteMenuItems.map((item) => (
+                  <CommandItem
+                    key={`favorite-${item.href}`}
+                    onSelect={() =>
+                      navigate(item.href, {
+                        id: `page-${item.href}`,
+                        title: item.title,
+                        description: item.description,
+                      })
+                    }
+                    value={`favorite ${[item.title, item.description]
+                      .filter(Boolean)
+                      .join(' ')}`}
+                    className="group"
+                  >
+                    <Pin className="size-4 shrink-0 fill-current text-muted-foreground" />
+                    <span className="font-medium">{item.title}</span>
+                    <EnterHint />
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+              <CommandSeparator />
+            </>
+          )}
 
           {/* Recent items only make sense as a starting point — once the user
               is actively searching, cmdk's own filter takes over. */}

--- a/apps/dashboard/src/components/navigation/nav-main/index.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/index.tsx
@@ -1,6 +1,7 @@
 import type { NavMainProps, NavRenderSection } from './types'
 
 import { MenuGroup } from './menu-group'
+import { NavFavorites } from './nav-favorites'
 import { usePathname } from '@/lib/next-compat'
 
 /**
@@ -25,6 +26,7 @@ export function NavMain({ items }: NavMainProps) {
 
   return (
     <>
+      <NavFavorites items={items} pathname={pathname} />
       {sections.map((section) => (
         <MenuGroup
           key={section}

--- a/apps/dashboard/src/components/navigation/nav-main/menu-item.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/menu-item.tsx
@@ -4,6 +4,7 @@ import type { MenuItem as MenuItemType } from '@/components/menu/types'
 import type { MenuItemActiveState, MenuItemProps } from './types'
 
 import { CollapsedSubmenu } from './collapsed-submenu'
+import { PinButton, SubPinButton } from './pin-button'
 import { lazy, Suspense } from 'react'
 import { useIsTableAvailable } from '@/components/menu/hooks/use-table-availability'
 import { HostPrefixedLink } from '@/components/menu/link-with-context'
@@ -83,6 +84,7 @@ const SingleMenuItem = function SingleMenuItem({
   const closeMobileSidebar = useCloseMobileSidebar()
   const hostId = useHostId()
   const { available } = useIsTableAvailable(item.tableCheck, hostId)
+  const hasBadge = Boolean(item.isNew || item.countKey)
 
   return (
     <SidebarMenuItem>
@@ -107,6 +109,7 @@ const SingleMenuItem = function SingleMenuItem({
           {item.title}
         </span>
       </SidebarMenuButton>
+      <PinButton href={item.href} title={item.title} hasBadge={hasBadge} />
       {item.isNew && (
         <SidebarMenuBadge>
           <Suspense fallback={null}>
@@ -146,6 +149,7 @@ const SubMenuItem = function SubMenuItem({
   closeMobileSidebar: () => void
 }) {
   const { available } = useIsTableAvailable(subItem.tableCheck, hostId)
+  const hasBadge = Boolean(subItem.isNew || subItem.countKey)
 
   return (
     <SidebarMenuSubItem>
@@ -187,6 +191,11 @@ const SubMenuItem = function SubMenuItem({
           </span>
         )}
       </SidebarMenuSubButton>
+      <SubPinButton
+        href={subItem.href}
+        title={subItem.title}
+        hasBadge={hasBadge}
+      />
     </SidebarMenuSubItem>
   )
 }

--- a/apps/dashboard/src/components/navigation/nav-main/nav-favorites.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/nav-favorites.tsx
@@ -1,0 +1,46 @@
+import type { MenuItem as MenuItemType } from '@/components/menu/types'
+
+import { MenuItem } from './menu-item'
+import {
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarMenu,
+} from '@/components/ui/sidebar'
+import { useFavoriteHrefs } from '@/hooks/use-favorites'
+import { getFavoriteMenuItems } from '@/lib/menu/derive-favorites'
+
+interface NavFavoritesProps {
+  /** Full menu tree (all sections) — favorites are resolved by href across
+   * every section, including nested sub-items. */
+  items: MenuItemType[]
+  pathname: string
+}
+
+/**
+ * "Favorites" group — pinned menu items in pin order, rendered above the
+ * regular Main/Others sections. Hidden entirely when there are no favorites
+ * (issue #2769). Favorites are derived from the live menu tree by href, so a
+ * pinned route that got renamed or removed is dropped silently instead of
+ * rendering a broken link.
+ */
+export function NavFavorites({ items, pathname }: NavFavoritesProps) {
+  const favoriteHrefs = useFavoriteHrefs()
+  const favoriteItems = getFavoriteMenuItems(items, favoriteHrefs)
+
+  if (favoriteItems.length === 0) {
+    return null
+  }
+
+  return (
+    <SidebarGroup>
+      <SidebarGroupLabel className="text-xs font-semibold uppercase tracking-wider text-muted-foreground px-3 py-2">
+        Favorites
+      </SidebarGroupLabel>
+      <SidebarMenu>
+        {favoriteItems.map((item) => (
+          <MenuItem key={item.href} item={item} pathname={pathname} />
+        ))}
+      </SidebarMenu>
+    </SidebarGroup>
+  )
+}

--- a/apps/dashboard/src/components/navigation/nav-main/pin-button.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/pin-button.tsx
@@ -1,0 +1,81 @@
+import { Pin } from 'lucide-react'
+
+import { SidebarMenuAction } from '@/components/ui/sidebar'
+import { useIsFavorite, useToggleFavorite } from '@/hooks/use-favorites'
+import { cn } from '@/lib/utils'
+
+interface PinButtonProps {
+  href: string
+  title: string
+  /**
+   * Shift the action left of the `isNew`/count badge slot when one is
+   * present — both live in the same absolute right-1 corner (see
+   * `SidebarMenuBadge`).
+   */
+  hasBadge?: boolean
+}
+
+/**
+ * Hover-revealed pin/unpin affordance for a top-level sidebar menu item
+ * (issue #2769) — same reveal pattern as `CardToolbar`. Renders as a sibling
+ * of `SidebarMenuButton` via `SidebarMenuAction` rather than nesting inside
+ * the link, so clicking it never triggers navigation.
+ */
+export function PinButton({ href, title, hasBadge }: PinButtonProps) {
+  const isPinned = useIsFavorite(href)
+  const toggleFavorite = useToggleFavorite()
+
+  return (
+    <SidebarMenuAction
+      showOnHover={!isPinned}
+      className={cn(hasBadge && 'right-6', isPinned && 'opacity-100')}
+      onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+        event.preventDefault()
+        event.stopPropagation()
+        toggleFavorite(href)
+      }}
+      aria-label={isPinned ? `Unpin ${title}` : `Pin ${title}`}
+      aria-pressed={isPinned}
+    >
+      <Pin className={cn('size-3.5', isPinned && 'fill-current')} />
+    </SidebarMenuAction>
+  )
+}
+
+interface SubPinButtonProps {
+  href: string
+  title: string
+  hasBadge?: boolean
+}
+
+/**
+ * Hover-revealed pin/unpin affordance for a sidebar sub-item.
+ * `SidebarMenuSubButton` has no `peer/menu-button` sizing hooks like the
+ * top-level button, so this is a standalone absolutely-positioned sibling
+ * tied to the existing `group/menu-sub-item` hover group instead of reusing
+ * `SidebarMenuAction`.
+ */
+export function SubPinButton({ href, title, hasBadge }: SubPinButtonProps) {
+  const isPinned = useIsFavorite(href)
+  const toggleFavorite = useToggleFavorite()
+
+  return (
+    <button
+      type="button"
+      onClick={(event) => {
+        event.preventDefault()
+        event.stopPropagation()
+        toggleFavorite(href)
+      }}
+      aria-label={isPinned ? `Unpin ${title}` : `Pin ${title}`}
+      aria-pressed={isPinned}
+      className={cn(
+        'absolute top-1/2 right-1 flex aspect-square size-5 -translate-y-1/2 items-center justify-center rounded-md p-0 text-sidebar-foreground opacity-0 outline-hidden transition-opacity hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:opacity-100 focus-visible:ring-2 group-hover/menu-sub-item:opacity-100 group-focus-within/menu-sub-item:opacity-100 group-data-[collapsible=icon]:hidden',
+        hasBadge && 'right-6',
+        isPinned && 'opacity-100'
+      )}
+    >
+      <Pin className={cn('size-3.5', isPinned && 'fill-current')} />
+    </button>
+  )
+}

--- a/apps/dashboard/src/hooks/use-favorites.ts
+++ b/apps/dashboard/src/hooks/use-favorites.ts
@@ -1,0 +1,31 @@
+/**
+ * React binding for the pinned-favorites store (issue #2769). Thin
+ * `useSyncExternalStore` wrapper — mirrors `usePaywall()` in
+ * `components/billing/paywall-host.tsx`.
+ */
+
+import { useCallback, useSyncExternalStore } from 'react'
+import {
+  getFavoriteHrefs,
+  getFavoritesServerSnapshot,
+  subscribeFavorites,
+  toggleFavorite,
+} from '@/lib/menu/favorites-store'
+
+/** Pinned hrefs in pin order (oldest pin first). */
+export function useFavoriteHrefs(): string[] {
+  return useSyncExternalStore(
+    subscribeFavorites,
+    getFavoriteHrefs,
+    getFavoritesServerSnapshot
+  )
+}
+
+export function useIsFavorite(href: string): boolean {
+  const hrefs = useFavoriteHrefs()
+  return hrefs.includes(href)
+}
+
+export function useToggleFavorite(): (href: string) => void {
+  return useCallback((href: string) => toggleFavorite(href), [])
+}

--- a/apps/dashboard/src/lib/menu/derive-favorites.test.ts
+++ b/apps/dashboard/src/lib/menu/derive-favorites.test.ts
@@ -1,0 +1,103 @@
+import type { MenuItem } from '@/components/menu/types'
+
+import { flattenMenuItems, getFavoriteMenuItems } from './derive-favorites'
+import { describe, expect, test } from 'bun:test'
+
+const FIXTURE_MENU: MenuItem[] = [
+  { title: 'Overview', href: '/overview', section: 'main' },
+  { title: 'Traffic', href: '/traffic', section: 'main' },
+  {
+    // Group header — no own href, so it's not independently favoritable, but
+    // its children are.
+    title: 'Queries',
+    href: '',
+    section: 'main',
+    items: [
+      { title: 'Running Queries', href: '/running-queries' },
+      { title: 'History Queries', href: '/history-queries' },
+    ],
+  },
+  {
+    title: 'Tables',
+    href: '/tables',
+    section: 'main',
+    items: [{ title: 'Data Explorer', href: '/explorer' }],
+  },
+]
+
+describe('flattenMenuItems', () => {
+  test('drops group headers with an empty href', () => {
+    const flat = flattenMenuItems(FIXTURE_MENU)
+    expect(flat.some((item) => item.title === 'Queries')).toBe(false)
+  })
+
+  test('includes both a parent with its own href and its children', () => {
+    const flat = flattenMenuItems(FIXTURE_MENU)
+    expect(flat.map((item) => item.href)).toEqual(
+      expect.arrayContaining(['/tables', '/explorer'])
+    )
+  })
+
+  test('includes nested children of an href-less group header', () => {
+    const flat = flattenMenuItems(FIXTURE_MENU)
+    expect(flat.map((item) => item.href)).toEqual(
+      expect.arrayContaining(['/running-queries', '/history-queries'])
+    )
+  })
+
+  test('flattens a plain leaf-only menu unchanged', () => {
+    const flat = flattenMenuItems(FIXTURE_MENU)
+    expect(flat.find((item) => item.href === '/overview')?.title).toBe(
+      'Overview'
+    )
+  })
+})
+
+describe('getFavoriteMenuItems', () => {
+  test('resolves favorites in pin order, not menu order', () => {
+    const favorites = getFavoriteMenuItems(FIXTURE_MENU, [
+      '/explorer',
+      '/overview',
+    ])
+    expect(favorites.map((item) => item.href)).toEqual([
+      '/explorer',
+      '/overview',
+    ])
+  })
+
+  test('resolves a favorited nested sub-item by href', () => {
+    const favorites = getFavoriteMenuItems(FIXTURE_MENU, ['/running-queries'])
+    expect(favorites).toHaveLength(1)
+    expect(favorites[0].title).toBe('Running Queries')
+  })
+
+  test('silently drops a pinned href that no longer exists in the menu', () => {
+    const favorites = getFavoriteMenuItems(FIXTURE_MENU, [
+      '/overview',
+      '/renamed-or-removed-route',
+      '/traffic',
+    ])
+    expect(favorites.map((item) => item.href)).toEqual([
+      '/overview',
+      '/traffic',
+    ])
+  })
+
+  test('returns an empty array when no favorites are pinned', () => {
+    expect(getFavoriteMenuItems(FIXTURE_MENU, [])).toEqual([])
+  })
+
+  test('returns an empty array when every pinned href is stale', () => {
+    expect(getFavoriteMenuItems(FIXTURE_MENU, ['/nope', '/also-nope'])).toEqual(
+      []
+    )
+  })
+
+  test('a group header href (empty string) can never be favorited', () => {
+    // Even if somehow persisted, an empty-string href must never match.
+    const menuWithEmptyHref: MenuItem[] = [
+      { title: 'Queries', href: '', section: 'main' },
+    ]
+    expect(getFavoriteMenuItems(menuWithEmptyHref, [''])).toEqual([])
+  })
+})

--- a/apps/dashboard/src/lib/menu/derive-favorites.ts
+++ b/apps/dashboard/src/lib/menu/derive-favorites.ts
@@ -1,0 +1,38 @@
+/**
+ * Derives the "Favorites" nav group and command-palette entries from pinned
+ * hrefs (issue #2769). Favorites are never stored as a separate copy of menu
+ * data — they are resolved against the live menu tree by href every render,
+ * so a rename/removal of a route silently drops the stale pin instead of
+ * rendering a broken link.
+ */
+
+import type { MenuItem } from '@/components/menu/types'
+
+/**
+ * Recursively flattens a menu tree into leaf items (items with a real href).
+ * Parent group headers (`href: ''`, e.g. "Queries", "Tables") are dropped —
+ * they aren't independently navigable and can't be favorited themselves, but
+ * their children are still included.
+ */
+export function flattenMenuItems(items: readonly MenuItem[]): MenuItem[] {
+  return items.flatMap((item) => {
+    const children = item.items ? flattenMenuItems(item.items) : []
+    return item.href ? [item, ...children] : children
+  })
+}
+
+/**
+ * Resolves pinned hrefs (in pin order) against the live menu tree. Hrefs that
+ * no longer match any menu item are dropped silently.
+ */
+export function getFavoriteMenuItems(
+  items: readonly MenuItem[],
+  favoriteHrefs: readonly string[]
+): MenuItem[] {
+  const byHref = new Map(
+    flattenMenuItems(items).map((item) => [item.href, item])
+  )
+  return favoriteHrefs
+    .map((href) => byHref.get(href))
+    .filter((item): item is MenuItem => item !== undefined)
+}

--- a/apps/dashboard/src/lib/menu/favorites-store.test.ts
+++ b/apps/dashboard/src/lib/menu/favorites-store.test.ts
@@ -1,0 +1,180 @@
+import {
+  __resetFavoritesForTests,
+  getFavoriteHrefs,
+  isFavoriteHref,
+  pinFavorite,
+  subscribeFavorites,
+  toggleFavorite,
+  unpinFavorite,
+} from './favorites-store'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+// In-memory localStorage shim — mirrors recent-items.test.ts / dismissed-insights.test.ts
+class MemoryStorage {
+  private store = new Map<string, string>()
+
+  getItem(k: string): string | null {
+    return this.store.has(k) ? (this.store.get(k) as string) : null
+  }
+
+  setItem(k: string, v: string): void {
+    this.store.set(k, String(v))
+  }
+
+  removeItem(k: string): void {
+    this.store.delete(k)
+  }
+
+  clear(): void {
+    this.store.clear()
+  }
+}
+
+beforeEach(() => {
+  ;(globalThis as { localStorage?: unknown }).localStorage = new MemoryStorage()
+  ;(globalThis as { window?: unknown }).window = globalThis
+  __resetFavoritesForTests()
+})
+
+afterEach(() => {
+  ;(globalThis as { localStorage?: unknown }).localStorage = undefined
+  ;(globalThis as { window?: unknown }).window = undefined
+})
+
+describe('SSR guard (window === undefined)', () => {
+  test('getFavoriteHrefs returns empty array when window is undefined', () => {
+    pinFavorite('/overview')
+    ;(globalThis as { window?: unknown }).window = undefined
+    __resetFavoritesForTests()
+    expect(getFavoriteHrefs()).toEqual([])
+  })
+
+  test('pinFavorite is a no-op (in-memory only) when window is undefined', () => {
+    ;(globalThis as { window?: unknown }).window = undefined
+    pinFavorite('/overview')
+    expect(getFavoriteHrefs()).toEqual(['/overview'])
+  })
+})
+
+describe('pinFavorite / unpinFavorite / isFavoriteHref', () => {
+  test('pins an href and reports it as favorited', () => {
+    pinFavorite('/overview')
+    expect(isFavoriteHref('/overview')).toBe(true)
+    expect(getFavoriteHrefs()).toEqual(['/overview'])
+  })
+
+  test('pinning the same href twice does not duplicate it', () => {
+    pinFavorite('/overview')
+    pinFavorite('/overview')
+    expect(getFavoriteHrefs()).toEqual(['/overview'])
+  })
+
+  test('preserves pin order across multiple pins', () => {
+    pinFavorite('/overview')
+    pinFavorite('/traffic')
+    pinFavorite('/merges')
+    expect(getFavoriteHrefs()).toEqual(['/overview', '/traffic', '/merges'])
+  })
+
+  test('unpinFavorite removes only the given href, keeping order', () => {
+    pinFavorite('/overview')
+    pinFavorite('/traffic')
+    pinFavorite('/merges')
+    unpinFavorite('/traffic')
+    expect(getFavoriteHrefs()).toEqual(['/overview', '/merges'])
+    expect(isFavoriteHref('/traffic')).toBe(false)
+  })
+
+  test('unpinning a non-pinned href is a no-op', () => {
+    pinFavorite('/overview')
+    unpinFavorite('/not-pinned')
+    expect(getFavoriteHrefs()).toEqual(['/overview'])
+  })
+})
+
+describe('toggleFavorite', () => {
+  test('pins when not favorited, unpins when favorited', () => {
+    toggleFavorite('/overview')
+    expect(isFavoriteHref('/overview')).toBe(true)
+    toggleFavorite('/overview')
+    expect(isFavoriteHref('/overview')).toBe(false)
+  })
+})
+
+describe('persistence round-trip', () => {
+  test('reload picks up hrefs persisted by a prior "session"', () => {
+    pinFavorite('/overview')
+    pinFavorite('/traffic')
+    __resetFavoritesForTests()
+    expect(getFavoriteHrefs()).toEqual(['/overview', '/traffic'])
+  })
+
+  test('tolerates malformed JSON in localStorage', () => {
+    ;(
+      globalThis as unknown as { localStorage: MemoryStorage }
+    ).localStorage.setItem('chm-pinned-favorites', 'not-valid-json')
+    expect(getFavoriteHrefs()).toEqual([])
+  })
+
+  test('tolerates a non-array JSON value in localStorage', () => {
+    ;(
+      globalThis as unknown as { localStorage: MemoryStorage }
+    ).localStorage.setItem(
+      'chm-pinned-favorites',
+      JSON.stringify({ not: 'an array' })
+    )
+    expect(getFavoriteHrefs()).toEqual([])
+  })
+
+  test('drops non-string entries from a malformed stored array', () => {
+    ;(
+      globalThis as unknown as { localStorage: MemoryStorage }
+    ).localStorage.setItem(
+      'chm-pinned-favorites',
+      JSON.stringify(['/overview', 42, null, '/traffic'])
+    )
+    expect(getFavoriteHrefs()).toEqual(['/overview', '/traffic'])
+  })
+
+  test('still works normally after corrupt data was present', () => {
+    ;(
+      globalThis as unknown as { localStorage: MemoryStorage }
+    ).localStorage.setItem('chm-pinned-favorites', 'CORRUPT')
+    pinFavorite('/recovery')
+    expect(getFavoriteHrefs()).toEqual(['/recovery'])
+  })
+})
+
+describe('subscribeFavorites', () => {
+  test('notifies listeners on pin and unpin', () => {
+    let calls = 0
+    const unsubscribe = subscribeFavorites(() => {
+      calls += 1
+    })
+    pinFavorite('/overview')
+    unpinFavorite('/overview')
+    unsubscribe()
+    expect(calls).toBe(2)
+  })
+
+  test('does not notify after unsubscribing', () => {
+    let calls = 0
+    const unsubscribe = subscribeFavorites(() => {
+      calls += 1
+    })
+    unsubscribe()
+    pinFavorite('/overview')
+    expect(calls).toBe(0)
+  })
+
+  test('pinning an already-pinned href does not notify (no state change)', () => {
+    pinFavorite('/overview')
+    let calls = 0
+    const unsubscribe = subscribeFavorites(() => {
+      calls += 1
+    })
+    pinFavorite('/overview')
+    unsubscribe()
+    expect(calls).toBe(0)
+  })
+})

--- a/apps/dashboard/src/lib/menu/favorites-store.ts
+++ b/apps/dashboard/src/lib/menu/favorites-store.ts
@@ -1,0 +1,109 @@
+/**
+ * Pinned favorite menu items — browser-local only (issue #2769).
+ *
+ * Persists hrefs in pin order to localStorage. Device-level, no server/DB
+ * storage: works signed-out and in OSS mode. Stale hrefs (a pinned route that
+ * got renamed or removed) are tolerated by the reader
+ * (`lib/menu/derive-favorites.ts`), not here — this module only persists the
+ * raw href list.
+ *
+ * Same external-store shape as `lib/billing/paywall-store.ts`: a module-level
+ * snapshot + listener set, read reactively via `useSyncExternalStore`
+ * (`hooks/use-favorites.ts`). Mirrors the localStorage-guard style of
+ * `lib/insights/dismissed-insights.ts`.
+ */
+
+const STORAGE_KEY = 'chm-pinned-favorites'
+
+let hrefs: string[] = []
+let loaded = false
+const listeners = new Set<() => void>()
+
+function load(): string[] {
+  if (typeof window === 'undefined') return []
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (!stored) return []
+    const parsed = JSON.parse(stored)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((v): v is string => typeof v === 'string')
+  } catch {
+    return []
+  }
+}
+
+function ensureLoaded(): void {
+  if (loaded) return
+  hrefs = load()
+  loaded = true
+}
+
+function persist(): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(hrefs))
+  } catch {
+    // Silently fail if localStorage is full or disabled.
+  }
+}
+
+function emit(): void {
+  for (const listener of listeners) listener()
+}
+
+/** Pinned hrefs in pin order (oldest pin first). */
+export function getFavoriteHrefs(): string[] {
+  ensureLoaded()
+  return hrefs
+}
+
+export function isFavoriteHref(href: string): boolean {
+  return getFavoriteHrefs().includes(href)
+}
+
+export function pinFavorite(href: string): void {
+  ensureLoaded()
+  if (hrefs.includes(href)) return
+  hrefs = [...hrefs, href]
+  persist()
+  emit()
+}
+
+export function unpinFavorite(href: string): void {
+  ensureLoaded()
+  if (!hrefs.includes(href)) return
+  hrefs = hrefs.filter((h) => h !== href)
+  persist()
+  emit()
+}
+
+export function toggleFavorite(href: string): void {
+  if (isFavoriteHref(href)) {
+    unpinFavorite(href)
+  } else {
+    pinFavorite(href)
+  }
+}
+
+export function subscribeFavorites(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+/** Stable reference for `useSyncExternalStore` — only reassigned on change. */
+export function getFavoritesSnapshot(): string[] {
+  return getFavoriteHrefs()
+}
+
+const EMPTY_FAVORITES: string[] = []
+
+/** SSR/prerender snapshot — always empty; the store never mutates server-side. */
+export function getFavoritesServerSnapshot(): string[] {
+  return EMPTY_FAVORITES
+}
+
+/** Test-only: reset in-memory + persisted state between test cases. */
+export function __resetFavoritesForTests(): void {
+  hrefs = []
+  loaded = false
+}


### PR DESCRIPTION
## Summary
- Hover-revealed pin/unpin star on sidebar menu items (top-level and sub-items), same reveal pattern as `CardToolbar`
- "Favorites" group at the top of the sidebar nav, in pin order, hidden entirely when empty
- Persistence is localStorage-only (`chm-pinned-favorites`), device-level — works signed-out and in OSS mode; stale/renamed hrefs are dropped silently when resolved against the live `menu.ts` tree
- `?host=` routing and `CountBadge` keep working inside the Favorites group (it reuses the same `MenuItem` renderer as Main/Others)
- Pinned items also surface first in the command palette (⌘K), ahead of Recent

## Implementation
- `lib/menu/favorites-store.ts` — plain module-level store (pin/unpin/toggle + localStorage persistence), same external-store shape as `lib/billing/paywall-store.ts`
- `lib/menu/derive-favorites.ts` — flattens the menu tree and resolves pinned hrefs against it in pin order, dropping unknown ids
- `hooks/use-favorites.ts` — `useSyncExternalStore` binding
- `components/navigation/nav-main/pin-button.tsx` — `PinButton` (top-level, via `SidebarMenuAction`) and `SubPinButton` (sub-items, custom absolute sibling tied to `group/menu-sub-item`)
- `components/navigation/nav-main/nav-favorites.tsx` — the Favorites `SidebarGroup`, wired into `NavMain`
- `components/controls/command-palette.tsx` — Favorites `CommandGroup` rendered first

Menu data itself (`menu.ts`) is untouched — favorites are derived by href, never forked.

## Test plan
- [x] `pnpm run lint` — clean
- [x] `pnpm run build` — Vite build + `tsc --noEmit`, all 114 pages prerender
- [x] `pnpm run test:unit` — 7256 pass (26 new: `favorites-store.test.ts`, `derive-favorites.test.ts` covering pin/unpin, ordering, stale-id pruning, localStorage round-trip, malformed-JSON tolerance)
- [x] Known flake `outbound-bus.test.ts` (#2777) verified in isolation — passes

Closes #2769