### PR TITLE
test(events): fix flaky outbound-bus test via shared @chm/platform mock fixture

### DIFF
--- a/apps/dashboard/src/lib/events/__tests__/platform-mock.ts
+++ b/apps/dashboard/src/lib/events/__tests__/platform-mock.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared `@chm/platform` module mock for the `lib/events` test suites
+ * (issue #2777 — same root cause as `lib/health`'s `__tests__/platform-mock.ts`,
+ * see #2672).
+ *
+ * bun's `mock.module` patches the module registry for the WHOLE test process.
+ * Each of `event-store.test.ts`, `queue-consumer.test.ts`,
+ * `outbound-bus.test.ts`, and `subscription-store.sql.test.ts` used to call
+ * `mock.module('@chm/platform', ...)` with its own factory closing over its
+ * own suite-local fake D1 variable. Whichever file's factory happened to be
+ * registered LAST (an execution-order accident, not something any one file
+ * controls) is the one that actually backs every subsequent `import
+ * '@chm/platform'` for the rest of the process — including modules other
+ * suites import — so `pnpm run test:unit` (no `--isolate`) was flaky
+ * depending on file order.
+ *
+ * The fix: every suite installs the SAME mock factory, whose
+ * `getD1Database` calls a mutable provider at call time. The suite that is
+ * currently running registers its own provider, so it never matters which
+ * file loaded `@chm/platform` first — the mock always resolves to the
+ * running suite's fake D1.
+ *
+ * Usage (at the top of a test file, before importing the module under test):
+ *
+ *   let fakeDb: FakeD1 | null = null
+ *   installEventsPlatformMock(() => fakeDb)
+ *   const { thing } = await import('./thing-under-test')
+ *
+ * Reassignments of the suite-local variable are picked up automatically
+ * because the provider is evaluated lazily on every `getD1Database` call.
+ */
+
+import { mock } from 'bun:test'
+
+type D1Provider = () => unknown
+
+let currentProvider: D1Provider = () => undefined
+
+/**
+ * Install (or re-point) the shared `@chm/platform` mock so that
+ * `getPlatformBindings().getD1Database(...)` resolves through `provider`.
+ */
+export function installEventsPlatformMock(provider?: D1Provider): void {
+  if (provider) currentProvider = provider
+  mock.module('@chm/platform', () => ({
+    getPlatformBindings: () => ({
+      getD1Database: () => currentProvider(),
+      getQueue: () => null,
+      getDurableObjectNamespace: () => null,
+    }),
+  }))
+}

--- a/apps/dashboard/src/lib/events/event-store.test.ts
+++ b/apps/dashboard/src/lib/events/event-store.test.ts
@@ -7,13 +7,15 @@
  * throw) when CHM_CLOUD_D1 is unbound, which is the normal state on
  * self-host/local dev.
  *
- * Uses a minimal in-memory D1 fake injected via mock.module('@chm/platform')
- * — the same pattern as src/lib/billing/ai-usage-store.test.ts.
+ * Uses a minimal in-memory D1 fake injected via the shared
+ * `./__tests__/platform-mock` fixture (issue #2777) so the `@chm/platform`
+ * mock doesn't leak across sibling event-bus test files.
  */
 
 import type { NormalizedEvent } from './types'
 
-import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import { installEventsPlatformMock } from './__tests__/platform-mock'
+import { beforeEach, describe, expect, test } from 'bun:test'
 
 // ---------------------------------------------------------------------------
 // In-memory D1 fake
@@ -135,13 +137,7 @@ function makeFakeD1(store: Map<string, Row>) {
 
 let currentDb: ReturnType<typeof makeFakeD1> | null = null
 
-mock.module('@chm/platform', () => ({
-  getPlatformBindings: () => ({
-    getD1Database: () => currentDb,
-    getQueue: () => null,
-    getDurableObjectNamespace: () => null,
-  }),
-}))
+installEventsPlatformMock(() => currentDb)
 
 const { upsertEvent, listEvents, pruneEventsOlderThan, EVENT_RETENTION_MS } =
   await import('./event-store')

--- a/apps/dashboard/src/lib/events/outbound-bus.test.ts
+++ b/apps/dashboard/src/lib/events/outbound-bus.test.ts
@@ -420,13 +420,22 @@ describe('emitInstanceEvent', () => {
     ])
 
     // Each subscriber's OWN secret signs the payload — verify independently.
+    // `emitInstanceEvent` fans out via `Promise.allSettled`, delivering to
+    // every subscription CONCURRENTLY, so `captured` is not guaranteed to
+    // land in `subs` order — matching by index flickers depending on which
+    // concurrent `crypto.subtle.sign` call resolves first (a real WebCrypto
+    // op, not a deterministic microtask), which only surfaces under
+    // different timing such as coverage instrumentation (#2777). Match each
+    // subscriber's captured request by its (distinct) URL instead.
     const bodyStr = JSON.stringify(alertEvent)
-    for (const [idx, sub] of subs.entries()) {
+    for (const sub of subs) {
+      const capturedForSub = captured.find((c) => c.url === sub.url)
+      expect(capturedForSub).toBeDefined()
       const expectedSig = independentHmacHex(sub.secret, bodyStr)
-      expect(captured[idx].headers['X-Chmonitor-Signature']).toBe(
+      expect(capturedForSub?.headers['X-Chmonitor-Signature']).toBe(
         `sha256=${expectedSig}`
       )
-      expect(captured[idx].headers['X-Chmonitor-Event']).toBe('alert.fired')
+      expect(capturedForSub?.headers['X-Chmonitor-Event']).toBe('alert.fired')
     }
   })
 

--- a/apps/dashboard/src/lib/events/outbound-bus.test.ts
+++ b/apps/dashboard/src/lib/events/outbound-bus.test.ts
@@ -4,22 +4,19 @@
  * which imports `getPlatformBindings` from `@chm/platform` — resolving (via
  * the tsconfig alias) to `platform-native.ts`'s
  * `import { env } from 'cloudflare:workers'`, a virtual module `bun test`
- * doesn't provide. Mock it before importing, mirroring
- * `conversation-store/d1-store.sql.test.ts`'s established pattern. Every test
- * here injects its own `recordDelivery`/`listSubscriptionsForEvent` deps, so
- * the mocked D1 binding itself is never actually touched.
+ * doesn't provide. Mock it via the shared `./__tests__/platform-mock`
+ * fixture (issue #2777) before importing — every test here injects its own
+ * `recordDelivery`/`listSubscriptionsForEvent` deps, so the mocked D1
+ * binding itself is never actually touched.
  */
 
 import type { WebhookSubscription } from './subscription-store'
 
+import { installEventsPlatformMock } from './__tests__/platform-mock'
 import { beforeEach, describe, expect, mock, test } from 'bun:test'
 import { createHmac } from 'node:crypto'
 
-mock.module('@chm/platform', () => ({
-  getPlatformBindings: () => ({
-    getD1Database: () => undefined,
-  }),
-}))
+installEventsPlatformMock()
 
 const { deliver, emitEvent, emitInstanceEvent, signPayload } = await import(
   './outbound-bus'

--- a/apps/dashboard/src/lib/events/queue-consumer.test.ts
+++ b/apps/dashboard/src/lib/events/queue-consumer.test.ts
@@ -5,7 +5,8 @@
  * ones, retries the invalid ones, and never throws.
  */
 
-import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import { installEventsPlatformMock } from './__tests__/platform-mock'
+import { beforeEach, describe, expect, test } from 'bun:test'
 
 let currentDb: {
   prepare: (sql: string) => {
@@ -13,13 +14,7 @@ let currentDb: {
   }
 } | null = null
 
-mock.module('@chm/platform', () => ({
-  getPlatformBindings: () => ({
-    getD1Database: () => currentDb,
-    getQueue: () => null,
-    getDurableObjectNamespace: () => null,
-  }),
-}))
+installEventsPlatformMock(() => currentDb)
 
 const { processEventBatch, processEventPayload } = await import(
   './queue-consumer'

--- a/apps/dashboard/src/lib/events/subscription-store.sql.test.ts
+++ b/apps/dashboard/src/lib/events/subscription-store.sql.test.ts
@@ -6,21 +6,18 @@
  * guard is actually executed, not re-derived.
  */
 
+import { installEventsPlatformMock } from './__tests__/platform-mock'
 import { Database } from 'bun:sqlite'
-import { describe, expect, mock, test } from 'bun:test'
+import { describe, expect, test } from 'bun:test'
 
 // subscription-store.ts imports `getPlatformBindings` from '@chm/platform',
 // which resolves to `platform-native.ts`'s
 // `import { env } from 'cloudflare:workers'` — a virtual module `bun test`
-// doesn't provide. Mock it before importing, mirroring
-// `conversation-store/d1-store.sql.test.ts`'s established pattern. The D1
-// binding value is irrelevant here — this file only needs the exported SQL
-// string constants.
-mock.module('@chm/platform', () => ({
-  getPlatformBindings: () => ({
-    getD1Database: () => undefined,
-  }),
-}))
+// doesn't provide. Mock it via the shared `./__tests__/platform-mock`
+// fixture (issue #2777) so the mock doesn't leak across sibling event-bus
+// test files depending on execution order. The D1 binding value is
+// irrelevant here — this file only needs the exported SQL string constants.
+installEventsPlatformMock()
 
 const {
   D1_UPDATE_SUBSCRIPTION_SQL,


### PR DESCRIPTION
## Summary
- Root cause: `event-store.test.ts`, `queue-consumer.test.ts`, `outbound-bus.test.ts`, and `subscription-store.sql.test.ts` each called bun's global `mock.module('@chm/platform', ...)` with their own factory. bun's module mock registry is process-wide, so whichever file's factory registered LAST (an accident of file execution order, not something any one file controls) is the one that backs every subsequent `@chm/platform` import for the rest of the process. This made `pnpm run test:unit` (no `--isolate`) intermittently flaky.
- Fix: consolidate into a shared `apps/dashboard/src/lib/events/__tests__/platform-mock.ts` fixture — mirroring the same pattern already used for `lib/health` (issue #2672) — whose `getD1Database` resolves through a mutable per-suite provider evaluated lazily, so it never matters which file loaded `@chm/platform` first.
- No assertions were weakened or removed.

Closes #2777

## Test plan
- [x] `bun test src/lib/events/` in both file orders (forward + reverse), 3x each — all green (63 pass / 0 fail)
- [x] `pnpm run test:unit` from repo root, 3 runs — all green (7252 pass / 0 fail)
- [x] `pnpm run lint`
- [x] `cd apps/dashboard && pnpm run build`