### PR TITLE
feat(landing): rework hero — star count in nav, theme toggle in footer

### DIFF
--- a/apps/landing/src/components/Footer.astro
+++ b/apps/landing/src/components/Footer.astro
@@ -60,7 +60,16 @@ const latestVersion = loadLatestChangelogVersion()
       </div>
       <div class="mt-10 sm:mt-12 flex flex-col sm:flex-row sm:flex-wrap items-start sm:items-center justify-between gap-2 sm:gap-3 border-t border-border pt-6 text-sm text-muted-foreground">
         <span>© 2026 chmonitor · Open source (GPL-3.0)</span>
-        <span class="font-mono text-xs">Not affiliated with ClickHouse, Inc.</span>
+        <div class="flex items-center gap-3">
+          <span class="font-mono text-xs">Not affiliated with ClickHouse, Inc.</span>
+          {/* Theme toggle lives in the footer (moved from the top nav). The
+              global .theme-toggle CSS + the querySelectorAll('.theme-toggle')
+              wiring in Nav.astro bind it automatically. */}
+          <button type="button" class="theme-toggle" aria-label="Toggle dark mode" title="Toggle theme">
+            <svg class="i-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
+            <svg class="i-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>
+          </button>
+        </div>
       </div>
     </div>
   </footer>

--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -1,14 +1,5 @@
 ---
 import ScreenshotShot from './ScreenshotShot.astro'
-import {
-  btnGhost,
-  btnOutline,
-  btnPrimary,
-} from '../lib/button-classes'
-import { formatCount, getGitHubStats } from '../lib/github-stars'
-
-const { stars } = await getGitHubStats()
-const starLabel = formatCount(stars)
 
 /* The anchor image(s). Framed "with background" variants of the overview
    capture (sharp at the 1080px column). They rotate on a slow interval;
@@ -36,9 +27,6 @@ const HERO_FEATURES = [
 ] as const
 
 const checkSvg = `<svg class="mt-0.5 size-3.5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m5 12 5 5L20 7"/></svg>`
-const arrowSvg = `<svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>`
-const bookSvg = `<svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 7v14"/><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"/></svg>`
-const starSvg = `<svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z"/></svg>`
 const githubSvg = `<svg class="size-3.5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49l-.01-1.9c-2.78.62-3.37-1.2-3.37-1.2-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.36-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.4 9.4 0 0 1 5 0c1.91-1.32 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.35 4.8-4.58 5.06.36.32.68.94.68 1.9l-.01 2.82c0 .27.18.6.69.49A10.03 10.03 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"/></svg>`
 ---
 
@@ -79,43 +67,6 @@ const githubSvg = `<svg class="size-3.5" viewBox="0 0 24 24" fill="currentColor"
       <p class="mx-auto mt-6 sm:mt-8 max-w-xl text-pretty text-muted-foreground text-lg sm:text-xl leading-relaxed tracking-[0.005em]">
         Monitor queries, merges, parts, replication, and health. An AI advisor on top — open source, self-host free.
       </p>
-
-      <div class="mt-7 sm:mt-8 flex w-full max-w-md sm:max-w-none mx-auto flex-col sm:flex-row flex-wrap items-stretch sm:items-center justify-center gap-2.5">
-        <a
-          href="https://dash.chmonitor.dev"
-          target="_blank"
-          rel="noopener"
-          data-cta="hero-primary"
-          class={`${btnPrimary} w-full sm:w-auto`}
-        >
-          Start Free
-          <span class="inline-flex items-center justify-center size-4 shrink-0" set:html={arrowSvg} />
-        </a>
-        <a
-          href="https://docs.chmonitor.dev"
-          target="_blank"
-          rel="noopener"
-          data-cta="hero-self-host"
-          class={`${btnOutline} w-full sm:w-auto`}
-        >
-          <span class="inline-flex items-center justify-center size-4 shrink-0" set:html={bookSvg} />
-          Self-Host
-        </a>
-        {
-          starLabel ? (
-            <a
-              href="https://github.com/chmonitor/chmonitor"
-              target="_blank"
-              rel="noopener"
-              data-cta="github-star-hero"
-              class={`${btnGhost} w-full sm:w-auto`}
-            >
-              <span class="inline-flex items-center justify-center size-4 shrink-0" set:html={starSvg} />
-              <span class="tabular-nums">{starLabel}</span>
-            </a>
-          ) : null
-        }
-      </div>
     </div>
 
     {/* Anchor screenshot(s). The hairline lives on THIS wrapper — see

--- a/apps/landing/src/components/Nav.astro
+++ b/apps/landing/src/components/Nav.astro
@@ -1,5 +1,12 @@
 ---
 import { btnOutline, btnOutlineBlock, btnPrimary, btnPrimaryBlock } from '../lib/button-classes'
+import { formatCount, getGitHubStats } from '../lib/github-stars'
+
+// Build-time star count for the nav GitHub button (shared, fail-open fetch —
+// see github-stars.ts). Empty string when unknown, so the label degrades to
+// "Star" instead of showing a fabricated number.
+const { stars } = await getGitHubStats()
+const starLabel = formatCount(stars)
 
 // Lucide glyphs (inner paths only) for the Features dropdown — one per child so
 // the mega-menu scans visually. Rendered inside `.nav-ico > svg` via set:html.
@@ -64,13 +71,9 @@ const featureIco = (d: string) =>
         </div>
       </nav>
       <div class="nav-cta">
-        <button type="button" class="theme-toggle" aria-label="Toggle dark mode" title="Toggle theme">
-          <svg class="i-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
-          <svg class="i-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>
-        </button>
-        <a class={btnOutline} href="https://github.com/chmonitor/chmonitor" target="_blank" rel="noopener">
+        <a class={btnOutline} href="https://github.com/chmonitor/chmonitor" target="_blank" rel="noopener" data-cta="github-star-nav">
           <svg class="size-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49l-.01-1.9c-2.78.62-3.37-1.2-3.37-1.2-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.36-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.4 9.4 0 0 1 5 0c1.91-1.32 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.35 4.8-4.58 5.06.36.32.68.94.68 1.9l-.01 2.82c0 .27.18.6.69.49A10.03 10.03 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"/></svg>
-          Star
+          {starLabel ? <><span class="tabular-nums">{starLabel}</span> Stars</> : 'Star'}
         </a>
         <a class={btnPrimary} href="https://dash.chmonitor.dev" target="_blank" rel="noopener">
           Dashboard

--- a/apps/landing/src/lib/button-classes.ts
+++ b/apps/landing/src/lib/button-classes.ts
@@ -1,8 +1,8 @@
 /**
  * Shared landing button classes — shadcn/ui geometry: rounded-md, compact
- * heights, subtle shadow-xs on filled/outline variants. CTAs use the lg size
- * (h-11, px-6); color stays monochrome — the primary CTA is a solid ink/white
- * button. Color comes from screenshots and art panels, not from buttons.
+ * heights, subtle shadow-xs on filled/outline variants. CTAs use a compact
+ * size (h-10, px-4); color stays monochrome — the primary CTA is a solid
+ * ink/white button. Color comes from screenshots and art panels, not buttons.
  *
  * Buttons use `rounded-md` (shadcn default). Cards keep `rounded-xl` (12px).
  */
@@ -10,8 +10,8 @@
 const base =
   'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors active:scale-[.98] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-[var(--brand)]/40 disabled:pointer-events-none disabled:opacity-50'
 
-/** shadcn lg size — the one size used across the landing CTAs. */
-const size = `${base} h-11 px-6`
+/** Compact size — the one size used across the landing CTAs. */
+const size = `${base} h-10 px-4`
 
 /**
  * The one primary CTA — shadcn "default" variant. Solid white on black in


### PR DESCRIPTION
## What
Landing hero/nav/footer polish.

- **Hero:** remove the Start Free, Self-Host and GitHub star-count CTAs. Hero is now headline + screenshot + feature list; primary CTA stays in the nav (Dashboard). OSS badge kept.
- **Nav:** GitHub button now shows the live build-time star count (e.g. \`250 Stars\`), reusing the shared fail-open \`getGitHubStats\`. Degrades to \`Star\` when the fetch fails.
- **Theme toggle:** moved from the top nav into the footer bottom bar. Mobile drawer keeps its own toggle. Global \`.theme-toggle\` CSS + \`querySelectorAll\` wiring bind the new button as-is.
- **Buttons:** tighten shared CTA padding \`h-11 px-6\` → \`h-10 px-4\` (one source in \`button-classes.ts\`).

## Verified
- \`pnpm run build\` builds all 26 pages.
- Rendered \`/index.html\`: no \`Start Free\` / \`Self-Host\` / \`github-star-hero\`; nav renders \`<span class="tabular-nums">250</span> Stars\`; footer has the theme toggle; OSS badge present.

## Notes
- Star count is fetched at build time (shared memoized call). On CI it refreshes each build; offline builds fail open to \`Star\`.
- The desktop top-bar toggle is removed; theme is reachable from the footer (all viewports) and the mobile drawer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: duyetbot <bot@duyet.net>