### PR TITLE
fix(landing): footer theme toggle not working

### DIFF
--- a/apps/landing/src/components/Nav.astro
+++ b/apps/landing/src/components/Nav.astro
@@ -180,15 +180,17 @@ const featureIco = (d: string) =>
     })
 
     // Theme toggle: flip data-theme, persist the choice. The head script set the
-    // initial value (saved choice or OS preference) before paint. Wire every
-    // toggle (desktop nav bar + the mobile drawer) so both stay in sync.
-    document.querySelectorAll('.theme-toggle').forEach(function (toggle) {
-      toggle.addEventListener('click', function () {
-        var next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark'
-        document.documentElement.setAttribute('data-theme', next)
-        try { localStorage.setItem('chm-theme', next) } catch (e) {}
-        if (typeof window.chmSyncThemedImages === 'function') window.chmSyncThemedImages()
-      })
+    // initial value (saved choice or OS preference) before paint. Use event
+    // delegation on document so EVERY .theme-toggle works — the footer toggle
+    // renders AFTER this inline script runs, so querySelectorAll-at-parse-time
+    // would miss it. Delegation binds once, covers all (and any future) toggles.
+    document.addEventListener('click', function (e) {
+      var toggle = e.target.closest && e.target.closest('.theme-toggle')
+      if (!toggle) return
+      var next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark'
+      document.documentElement.setAttribute('data-theme', next)
+      try { localStorage.setItem('chm-theme', next) } catch (err) {}
+      if (typeof window.chmSyncThemedImages === 'function') window.chmSyncThemedImages()
     })
 
     // Mobile drawer: open/close the off-canvas menu shown at ≤1024px.


### PR DESCRIPTION
## Problem
After #2780 moved the dark-mode toggle from the nav to the footer, the footer toggle did nothing on click.

## Root cause
The toggle wiring lives in \`Nav.astro\` as \`<script is:inline>\`, which runs at parse time at the Nav's position (top of page). It bound handlers via \`document.querySelectorAll('.theme-toggle').forEach(...)\`. The old desktop toggle worked because it was *inside* Nav (in the DOM when the script ran). The **footer toggle renders after Nav**, so at script-execution time it wasn't in the DOM yet and never got a handler.

## Fix
Switch to **event delegation** on \`document\` (\`e.target.closest('.theme-toggle')\`). This binds once and covers every \`.theme-toggle\` — drawer + footer, present or future — regardless of DOM position or script timing.

## Verified
- \`pnpm run build\` clean (26/26 pages).
- Rendered \`/index.html\`: delegated \`addEventListener('click', ... .theme-toggle)\` present; old \`querySelectorAll('.theme-toggle').forEach\` gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: duyetbot <bot@duyet.net>