### PR TITLE
refactor(landing): cohere theme toggle into Base + ThemeToggle

### DIFF
--- a/apps/landing/src/components/Footer.astro
+++ b/apps/landing/src/components/Footer.astro
@@ -1,6 +1,7 @@
 ---
 import { loadLatestChangelogVersion } from '../data/changelog-features'
 import { useCases } from '../data/use-cases'
+import ThemeToggle from './ThemeToggle.astro'
 
 const latestVersion = loadLatestChangelogVersion()
 ---
@@ -62,13 +63,9 @@ const latestVersion = loadLatestChangelogVersion()
         <span>© 2026 chmonitor · Open source (GPL-3.0)</span>
         <div class="flex items-center gap-3">
           <span class="font-mono text-xs">Not affiliated with ClickHouse, Inc.</span>
-          {/* Theme toggle lives in the footer (moved from the top nav). The
-              global .theme-toggle CSS + the querySelectorAll('.theme-toggle')
-              wiring in Nav.astro bind it automatically. */}
-          <button type="button" class="theme-toggle" aria-label="Toggle dark mode" title="Toggle theme">
-            <svg class="i-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
-            <svg class="i-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>
-          </button>
+          {/* Theme toggle (moved from the top nav) — wired globally via
+              .theme-toggle in Base.astro (CSS + click handler). */}
+          <ThemeToggle />
         </div>
       </div>
     </div>

--- a/apps/landing/src/components/Nav.astro
+++ b/apps/landing/src/components/Nav.astro
@@ -1,6 +1,7 @@
 ---
 import { btnOutline, btnOutlineBlock, btnPrimary, btnPrimaryBlock } from '../lib/button-classes'
 import { formatCount, getGitHubStats } from '../lib/github-stars'
+import ThemeToggle from './ThemeToggle.astro'
 
 // Build-time star count for the nav GitHub button (shared, fail-open fetch —
 // see github-stars.ts). Empty string when unknown, so the label degrades to
@@ -136,10 +137,7 @@ const featureIco = (d: string) =>
       <div class="nav-drawer-foot">
         <div class="nav-drawer-theme">
           <span>Theme</span>
-          <button type="button" class="theme-toggle" aria-label="Toggle dark mode" title="Toggle theme">
-            <svg class="i-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
-            <svg class="i-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>
-          </button>
+          <ThemeToggle />
         </div>
         <a class={btnOutlineBlock} href="https://github.com/chmonitor/chmonitor" target="_blank" rel="noopener">
           <svg class="size-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49l-.01-1.9c-2.78.62-3.37-1.2-3.37-1.2-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.36-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.4 9.4 0 0 1 5 0c1.91-1.32 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.35 4.8-4.58 5.06.36.32.68.94.68 1.9l-.01 2.82c0 .27.18.6.69.49A10.03 10.03 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"/></svg>
@@ -177,20 +175,6 @@ const featureIco = (d: string) =>
       group.addEventListener('focusout', function (e) {
         if (!group.contains(e.relatedTarget)) set(false)
       })
-    })
-
-    // Theme toggle: flip data-theme, persist the choice. The head script set the
-    // initial value (saved choice or OS preference) before paint. Use event
-    // delegation on document so EVERY .theme-toggle works — the footer toggle
-    // renders AFTER this inline script runs, so querySelectorAll-at-parse-time
-    // would miss it. Delegation binds once, covers all (and any future) toggles.
-    document.addEventListener('click', function (e) {
-      var toggle = e.target.closest && e.target.closest('.theme-toggle')
-      if (!toggle) return
-      var next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark'
-      document.documentElement.setAttribute('data-theme', next)
-      try { localStorage.setItem('chm-theme', next) } catch (err) {}
-      if (typeof window.chmSyncThemedImages === 'function') window.chmSyncThemedImages()
     })
 
     // Mobile drawer: open/close the off-canvas menu shown at ≤1024px.
@@ -264,13 +248,4 @@ const featureIco = (d: string) =>
       e.preventDefault()
       history.pushState(null, '', url.hash)
     })
-
-    // Follow OS changes only while the user hasn't picked a theme.
-    try {
-      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function (e) {
-        if (!localStorage.getItem('chm-theme')) {
-          document.documentElement.setAttribute('data-theme', e.matches ? 'dark' : 'light')
-        }
-      })
-    } catch (e) {}
   </script>

--- a/apps/landing/src/components/ThemeToggle.astro
+++ b/apps/landing/src/components/ThemeToggle.astro
@@ -1,0 +1,9 @@
+---
+// Dark-mode toggle — markup only. The global `.theme-toggle` CSS and the
+// click-delegation handler both live in Base.astro, so every instance works
+// regardless of where it's rendered (mobile drawer, footer, …).
+---
+<button type="button" class="theme-toggle" aria-label="Toggle dark mode" title="Toggle theme">
+  <svg class="i-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
+  <svg class="i-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>
+</button>

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -95,7 +95,7 @@ const ogImage = new URL(image, Astro.site).toString()
     // Theme-aware screenshots: a single <img data-src-light data-src-dark>
     // per slot picks the right variant for the current theme, so only ONE
     // image ever downloads (no display:none sibling to fetch on scroll).
-    // Exposed on window so the theme toggle (Nav.astro) can re-run it.
+    // Exposed on window so the toggle click handler (below) can re-run it.
     window.chmSyncThemedImages = function (root) {
       var theme = document.documentElement.getAttribute('data-theme')
       var imgs = (root || document).querySelectorAll('img[data-src-light]')
@@ -106,6 +106,25 @@ const ogImage = new URL(image, Astro.site).toString()
         if (wanted && img.getAttribute('src') !== wanted) img.setAttribute('src', wanted)
       }
     }
+    // Theme toggle: event delegation on document so EVERY .theme-toggle works
+    // regardless of where it's rendered (nav drawer, footer, …) — bound in
+    // <head>, so parse order can never miss a button.
+    document.addEventListener('click', function (e) {
+      var toggle = e.target.closest('.theme-toggle')
+      if (!toggle) return
+      var next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark'
+      document.documentElement.setAttribute('data-theme', next)
+      try { localStorage.setItem('chm-theme', next) } catch (err) {}
+      if (typeof window.chmSyncThemedImages === 'function') window.chmSyncThemedImages()
+    })
+    // Follow OS theme changes only while the user hasn't picked one.
+    try {
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function (e) {
+        if (!localStorage.getItem('chm-theme')) {
+          document.documentElement.setAttribute('data-theme', e.matches ? 'dark' : 'light')
+        }
+      })
+    } catch (e) {}
   </script>
   <style is:global>
     /* All of the legacy hand-authored global CSS lives in @layer base so that

--- a/apps/landing/src/lib/button-classes.ts
+++ b/apps/landing/src/lib/button-classes.ts
@@ -22,9 +22,6 @@ export const btnPrimary = `${size} bg-primary text-primary-foreground shadow-xs 
 /** shadcn "outline" variant. */
 export const btnOutline = `${size} border border-[var(--hairline-strong)] bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground`
 
-/** shadcn "ghost" variant. */
-export const btnGhost = `${size} text-muted-foreground hover:bg-accent hover:text-accent-foreground`
-
 /** Larger ink-on-canvas CTA for "Self-host" style secondary actions. */
 export const btnDownload = `${size} bg-primary text-primary-foreground shadow-xs hover:bg-primary/90`
 


### PR DESCRIPTION
## What

`/simplify` cleanup of the landing theme-toggle work from #2780 / #2781. Four
parallel review agents (reuse / simplification / efficiency / altitude) ran on
the combined diff; this PR applies the findings that survived dedup.

- **Extract `ThemeToggle.astro`** — the `<button class="theme-toggle">` + moon/sun
  SVGs were byte-identical in the nav drawer and the footer. CSS was already
  global; only the markup was duplicated. Now one component, used in both.
- **Move the click handler + OS-theme listener from `Nav.astro` → `Base.astro`** —
  delegation (#2781) already made the handler position-independent, so it no
  longer needs to live in Nav. Base already owns the rest of the theme system
  (`.theme-toggle` CSS, pre-paint resolve, `chmSyncThemedImages`). Co-locating
  the click wiring there means any `.theme-toggle` anywhere works because the
  *layout* owns it — not because Nav happens to ship a script. Also drops the
  over-defensive `e.target.closest &&` guard and fixes the stale footer comment
  that still referenced `querySelectorAll` / Nav.
- **Drop orphaned `btnGhost`** — Hero was its only consumer (removed in #2780).

## Skipped (with reasons)

- Footer wrapper `<div>` — actually does work (groups the "Not affiliated" span
  + toggle as the right-side pair under `justify-between`).
- `btnDownload` / `btnInk` standalone / `btnOnDarkPrimary` — pre-existing
  orphans, not caused by this diff (surgical-change rule: mention, don't delete).
- `GitHubStarButton` extraction — YAGNI, single use in Nav.
- Efficiency — all clean (module-level memo already shared; delegation cost
  negligible).

## Verify

- `pnpm run build` — 26 pages, no errors.
- Built `dist/index.html`: 2 `.theme-toggle` buttons rendered (drawer + footer),
  head click-delegation + OS listener present. Behavior unchanged.

Co-Authored-By: duyetbot <bot@duyet.net>