### PR TITLE
feat(traffic): p99 latency, legend toggle, zoom dialog grid, density

### DIFF
--- a/apps/dashboard/src/components/charts/chart-scale-context.tsx
+++ b/apps/dashboard/src/components/charts/chart-scale-context.tsx
@@ -49,6 +49,12 @@ interface ChartScaleProviderProps {
   children: React.ReactNode
   /** Override scale (when not using global preference) */
   initialScale?: YAxisScale
+  /**
+   * Persist changes to the shared localStorage preference (default true).
+   * Scoped providers (e.g. the chart zoom dialog) pass false so a local
+   * toggle doesn't restyle every other chart.
+   */
+  persist?: boolean
 }
 
 /**
@@ -58,23 +64,27 @@ interface ChartScaleProviderProps {
 export function ChartScaleProvider({
   children,
   initialScale,
+  persist = true,
 }: ChartScaleProviderProps) {
   const [scale, setScaleState] = useState<YAxisScale>(
     initialScale ?? getInitialScale
   )
 
-  const setScale = useCallback((newScale: YAxisScale) => {
-    setScaleState(newScale)
-    saveScale(newScale)
-  }, [])
+  const setScale = useCallback(
+    (newScale: YAxisScale) => {
+      setScaleState(newScale)
+      if (persist) saveScale(newScale)
+    },
+    [persist]
+  )
 
   const toggleScale = useCallback(() => {
     setScaleState((prev) => {
       const newScale = prev === 'linear' ? 'log' : 'linear'
-      saveScale(newScale)
+      if (persist) saveScale(newScale)
       return newScale
     })
-  }, [])
+  }, [persist])
 
   const value = useMemo<ChartScaleContextValue>(
     () => ({

--- a/apps/dashboard/src/components/charts/chart-zoom-dialog.tsx
+++ b/apps/dashboard/src/components/charts/chart-zoom-dialog.tsx
@@ -24,6 +24,10 @@ import {
   CodeBlock,
   CodeBlockCopyButton,
 } from '@/components/ai-elements/code-block'
+import {
+  ChartScaleProvider,
+  useChartScale,
+} from '@/components/charts/chart-scale-context'
 import { ChartStaleIndicator } from '@/components/charts/chart-stale-indicator'
 import { DataTable } from '@/components/data-table/data-table'
 import { DateRangeSelector } from '@/components/date-range'
@@ -62,9 +66,13 @@ function getInitialBeautifyState(): boolean {
 
 function CopyableValue({
   value,
+  display,
   className = '',
 }: {
+  /** Full value — always what gets copied and shown in the hover tooltip. */
   value: string | number
+  /** Optional shortened text to render in place of `value` (e.g. URL path). */
+  display?: string
   className?: string
 }) {
   const [copied, setCopied] = useState(false)
@@ -83,13 +91,13 @@ function CopyableValue({
             type="button"
             onClick={handleCopy}
             className={cn(
-              'font-mono font-medium text-right truncate min-w-0 hover:text-primary cursor-pointer transition-colors inline-flex items-center gap-1 group/copy max-w-full',
+              'font-mono font-medium text-left truncate min-w-0 hover:text-primary cursor-pointer transition-colors inline-flex items-center gap-1 group/copy max-w-full',
               className
             )}
           />
         }
       >
-        <span className="truncate flex-1 min-w-0">{value}</span>
+        <span className="truncate flex-1 min-w-0">{display ?? value}</span>
         {copied ? (
           <Check className="size-3 text-green-500 shrink-0" strokeWidth={2} />
         ) : (
@@ -107,6 +115,73 @@ function CopyableValue({
         {value}
       </TooltipContent>
     </Tooltip>
+  )
+}
+
+/**
+ * Controls bar for the enlarged chart: y-axis scale (linear/log) toggle,
+ * reading from the zoom-local ChartScaleProvider so the page chart keeps its
+ * own preference. Legend items in the chart itself toggle series visibility.
+ */
+function ZoomChartControls() {
+  const scaleContext = useChartScale()
+  if (!scaleContext) return null
+  const { isLogScale, setScale } = scaleContext
+
+  return (
+    <div className="flex items-center justify-end gap-2">
+      <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+        Y-axis
+      </span>
+      <div className="flex items-center rounded-md border border-border/50 p-0.5">
+        <Button
+          variant={isLogScale ? 'ghost' : 'secondary'}
+          size="sm"
+          className="h-5 px-2 text-[11px]"
+          onClick={() => setScale('linear')}
+        >
+          Linear
+        </Button>
+        <Button
+          variant={isLogScale ? 'secondary' : 'ghost'}
+          size="sm"
+          className="h-5 px-2 text-[11px]"
+          onClick={() => setScale('log')}
+        >
+          Log
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+/** One tile in the metadata grid: icon + label on top, copyable value below. */
+function MetadataTile({
+  icon: Icon,
+  label,
+  value,
+  display,
+  className,
+}: {
+  icon: React.ComponentType<{ className?: string; strokeWidth?: number }>
+  label: string
+  value: string | number
+  display?: string
+  className?: string
+}) {
+  return (
+    <div
+      className={cn(
+        'flex min-w-0 flex-col gap-0.5 rounded-md border border-border/50 bg-muted/20 px-2.5 py-1.5',
+        className
+      )}
+    >
+      <div className="flex items-center gap-1.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+        <Icon className="size-3" strokeWidth={1.5} />
+        {label}
+      </div>
+      <CopyableValue value={value} display={display} className="text-xs" />
+    </div>
   )
 }
 
@@ -215,13 +290,22 @@ export const ChartZoomDialog = function ChartZoomDialog({
     }
   })()
 
-  // Build full API URL
+  // Build full API URL; display only path + query (domain hidden), copy full.
   const fullApiUrl = (() => {
     if (!metadata?.api) return null
     const baseUrl = typeof window !== 'undefined' ? window.location.origin : ''
     return metadata.api.startsWith('http')
       ? metadata.api
       : `${baseUrl}${metadata.api}`
+  })()
+  const apiDisplay = (() => {
+    if (!fullApiUrl) return undefined
+    try {
+      const url = new URL(fullApiUrl)
+      return `${url.pathname}${url.search}`
+    } catch {
+      return fullApiUrl
+    }
   })()
 
   // Check if we have metadata to show
@@ -283,65 +367,52 @@ export const ChartZoomDialog = function ChartZoomDialog({
             </div>
           </div>
           {hasMetadata && (
-            <div className="rounded-lg border border-border/50 p-3 mt-3">
-              <dl className="grid grid-cols-2 gap-x-4 gap-y-1.5 text-xs">
-                {fullApiUrl && (
-                  <div className="col-span-2 flex items-center justify-between gap-3">
-                    <dt className="text-muted-foreground flex items-center gap-1.5 shrink-0">
-                      <ExternalLink className="size-3" strokeWidth={1.5} />
-                      API
-                    </dt>
-                    <dd className="min-w-0 flex-1 text-right">
-                      <CopyableValue value={fullApiUrl} />
-                    </dd>
-                  </div>
-                )}
-                {metadata?.duration !== undefined && (
-                  <div className="flex items-center justify-between gap-3">
-                    <dt className="text-muted-foreground flex items-center gap-1.5 shrink-0">
-                      <Clock className="size-3" strokeWidth={1.5} />
-                      Duration
-                    </dt>
-                    <CopyableValue value={`${metadata.duration}ms`} />
-                  </div>
-                )}
-                {metadata?.rows !== undefined && (
-                  <div className="flex items-center justify-between gap-3">
-                    <dt className="text-muted-foreground flex items-center gap-1.5 shrink-0">
-                      <Database className="size-3" strokeWidth={1.5} />
-                      Rows
-                    </dt>
-                    <CopyableValue value={metadata.rows.toLocaleString()} />
-                  </div>
-                )}
-                {metadata?.clickhouseVersion && (
-                  <div className="flex items-center justify-between gap-3">
-                    <dt className="text-muted-foreground flex items-center gap-1.5 shrink-0">
-                      <Zap className="size-3" strokeWidth={1.5} />
-                      Version
-                    </dt>
-                    <CopyableValue value={metadata.clickhouseVersion} />
-                  </div>
-                )}
-                {metadata?.host && (
-                  <div className="col-span-2 flex items-center justify-between gap-3">
-                    <dt className="text-muted-foreground flex items-center gap-1.5 shrink-0">
-                      <Server className="size-3" strokeWidth={1.5} />
-                      Host
-                    </dt>
-                    <CopyableValue value={metadata.host} />
-                  </div>
-                )}
-                {metadata?.queryId && (
-                  <div className="col-span-2 flex items-center justify-between gap-3">
-                    <dt className="text-muted-foreground flex items-center gap-1.5 shrink-0">
-                      <Hash className="size-3" strokeWidth={1.5} />
-                      Query ID
-                    </dt>
-                    <CopyableValue value={metadata.queryId} />
-                  </div>
-                )}
-              </dl>
+            <div className="mt-3 grid grid-cols-2 gap-1.5 sm:grid-cols-4">
+              {fullApiUrl && (
+                <MetadataTile
+                  icon={ExternalLink}
+                  label="API"
+                  value={fullApiUrl}
+                  display={apiDisplay}
+                  className="col-span-2 sm:col-span-4"
+                />
+              )}
+              {metadata?.duration !== undefined && (
+                <MetadataTile
+                  icon={Clock}
+                  label="Duration"
+                  value={`${metadata.duration}ms`}
+                />
+              )}
+              {metadata?.rows !== undefined && (
+                <MetadataTile
+                  icon={Database}
+                  label="Rows"
+                  value={metadata.rows.toLocaleString()}
+                />
+              )}
+              {metadata?.clickhouseVersion && (
+                <MetadataTile
+                  icon={Zap}
+                  label="Version"
+                  value={metadata.clickhouseVersion}
+                />
+              )}
+              {metadata?.host !== undefined && metadata.host !== '' && (
+                <MetadataTile
+                  icon={Server}
+                  label="Host"
+                  value={metadata.host}
+                />
+              )}
+              {metadata?.queryId && (
+                <MetadataTile
+                  icon={Hash}
+                  label="Query ID"
+                  value={metadata.queryId}
+                  className="col-span-2"
+                />
+              )}
             </div>
           )}
         </DialogHeader>
@@ -400,11 +471,17 @@ export const ChartZoomDialog = function ChartZoomDialog({
 
           <TabsContent
             value="chart"
-            className="flex-1 min-h-0 p-6 flex flex-col"
+            className="flex-1 min-h-0 p-6 pt-3 flex flex-col gap-2"
           >
-            <div className="w-full flex-1 min-h-[350px] relative h-full">
-              <div className="absolute inset-0">{children}</div>
-            </div>
+            {/* Zoom-local scale provider: overrides the page-level scale for
+                the enlarged chart only, so tweaking the view here doesn't
+                restyle the chart back on the page. */}
+            <ChartScaleProvider persist={false}>
+              <ZoomChartControls />
+              <div className="w-full flex-1 min-h-[350px] relative h-full">
+                <div className="absolute inset-0">{children}</div>
+              </div>
+            </ChartScaleProvider>
           </TabsContent>
 
           {queryConfig && (

--- a/apps/dashboard/src/components/charts/primitives/area.tsx
+++ b/apps/dashboard/src/components/charts/primitives/area.tsx
@@ -14,12 +14,15 @@ import {
   renderChartTooltip,
 } from './area-chart-tooltip'
 import { useChartScaleValue } from '@/components/charts/chart-scale-context'
+import {
+  InteractiveLegendContent,
+  useHiddenSeries,
+} from '@/components/charts/primitives/interactive-legend'
 import { seriesColorVar } from '@/components/charts/primitives/series-color'
 import {
   type ChartConfig,
   ChartContainer,
   ChartLegend,
-  ChartLegendContent,
 } from '@/components/ui/chart'
 import { getYAxisDomain, resolveYAxisScale } from '@/lib/chart-scale'
 import { augmentWithBand, OVERLAY_KEYS } from '@/lib/insights/anomaly-overlay'
@@ -159,6 +162,11 @@ export const AreaChart = function AreaChart({
   // Get scale preference from context (if available)
   const contextScale = useChartScaleValue()
 
+  // Legend click-to-toggle: hidden series stay mounted (recharts `hide`) so
+  // the legend keeps its entry and colors stay stable.
+  const { hidden, toggle, isHidden } = useHiddenSeries()
+  const visibleCategories = categories.filter((c) => !isHidden(c))
+
   // Statistics-Insights overlay settings (moving-average band + threshold).
   // Read unconditionally (hooks rule) but only applied when a chart opts in via
   // `anomalyOverlay`; every other area chart is unaffected.
@@ -187,17 +195,21 @@ export const AreaChart = function AreaChart({
   // Use prop if provided, otherwise use context, otherwise 'linear'
   const effectiveScale = yAxisScale ?? contextScale ?? 'linear'
 
-  // Resolve scale type (linear, log, or auto-detect)
+  // Resolve scale/domain from the VISIBLE series only, so hiding a spiky
+  // series (e.g. p99) rescales the y-axis to the remaining data. Fall back to
+  // all categories when everything is toggled off.
+  const domainCategories =
+    visibleCategories.length > 0 ? visibleCategories : categories
   const resolvedScale = resolveYAxisScale(
     effectiveScale,
     data as Record<string, unknown>[],
-    categories
+    domainCategories
   )
 
   // Get appropriate domain for the scale type
   const yAxisDomain = getYAxisDomain(
     data as Record<string, unknown>[],
-    categories,
+    domainCategories,
     resolvedScale === 'log'
   )
   const chartConfig = (() => {
@@ -301,6 +313,7 @@ export const AreaChart = function AreaChart({
           <Area
             key={`${category}`}
             dataKey={category}
+            hide={isHidden(category)}
             fill={`var(--color-${category})`}
             stroke={`var(--color-${category})`}
             strokeWidth={2}
@@ -367,7 +380,13 @@ export const AreaChart = function AreaChart({
           />
         )}
 
-        {showLegend && <ChartLegend content={<ChartLegendContent />} />}
+        {showLegend && (
+          <ChartLegend
+            content={
+              <InteractiveLegendContent hidden={hidden} onToggle={toggle} />
+            }
+          />
+        )}
 
         {deploymentMarkers.map(({ bucketKey, deployment }) => (
           <ReferenceLine

--- a/apps/dashboard/src/components/charts/primitives/bar/bar.tsx
+++ b/apps/dashboard/src/components/charts/primitives/bar/bar.tsx
@@ -28,10 +28,10 @@ import {
 } from './utils'
 import { useChartScaleValue } from '@/components/charts/chart-scale-context'
 import {
-  ChartContainer,
-  ChartLegend,
-  ChartLegendContent,
-} from '@/components/ui/chart'
+  InteractiveLegendContent,
+  useHiddenSeries,
+} from '@/components/charts/primitives/interactive-legend'
+import { ChartContainer, ChartLegend } from '@/components/ui/chart'
 import { getYAxisDomain, resolveYAxisScale } from '@/lib/chart-scale'
 import { cn } from '@/lib/utils'
 
@@ -69,6 +69,12 @@ export const BarChart = function BarChart({
   // Get scale preference from context (if available)
   const contextScale = useChartScaleValue()
 
+  // Legend click-to-toggle (same pattern as the area primitive).
+  const { hidden, toggle, isHidden } = useHiddenSeries()
+  const visibleCategories = categories.filter((c) => !isHidden(c))
+  const domainCategories =
+    visibleCategories.length > 0 ? visibleCategories : categories
+
   // Use prop if provided, otherwise use context, otherwise 'linear'
   const effectiveScale = yAxisScale ?? contextScale ?? 'linear'
 
@@ -76,13 +82,13 @@ export const BarChart = function BarChart({
   const resolvedScale = resolveYAxisScale(
     effectiveScale,
     data as Record<string, unknown>[],
-    categories
+    domainCategories
   )
 
   // Get appropriate domain for the scale type
   const yAxisDomain = getYAxisDomain(
     data as Record<string, unknown>[],
-    categories,
+    domainCategories,
     resolvedScale === 'log'
   )
 
@@ -136,6 +142,7 @@ export const BarChart = function BarChart({
           <Bar
             key={category}
             dataKey={category}
+            hide={isHidden(category)}
             fill={`var(--color-${sanitizeCssVarName(category)})`}
             stackId={stack ? 'a' : undefined}
             radius={getBarRadius({
@@ -150,7 +157,13 @@ export const BarChart = function BarChart({
 
         {tooltip}
 
-        {showLegend && <ChartLegend content={<ChartLegendContent />} />}
+        {showLegend && (
+          <ChartLegend
+            content={
+              <InteractiveLegendContent hidden={hidden} onToggle={toggle} />
+            }
+          />
+        )}
       </RechartBarChart>
     </ChartContainer>
   )

--- a/apps/dashboard/src/components/charts/primitives/interactive-legend.tsx
+++ b/apps/dashboard/src/components/charts/primitives/interactive-legend.tsx
@@ -1,0 +1,97 @@
+/**
+ * InteractiveLegendContent — a clickable variant of shadcn's ChartLegendContent
+ * (components/ui/chart.tsx stays untouched per project convention). Clicking a
+ * legend item toggles that series' visibility; hidden items render dimmed with
+ * a hollow swatch so they stay discoverable. Used by the area/bar primitives,
+ * so every chart with `showLegend` gets show/hide-per-series for free.
+ */
+
+import type { DefaultLegendContentProps } from 'recharts'
+
+import { useCallback, useState } from 'react'
+import { cn } from '@/lib/utils'
+
+/**
+ * Local hidden-series state for a chart. Returns the set plus a toggle and a
+ * `hide(category)` test the chart uses on its Area/Bar `hide` prop.
+ */
+export function useHiddenSeries() {
+  const [hidden, setHidden] = useState<ReadonlySet<string>>(new Set())
+
+  const toggle = useCallback((key: string) => {
+    setHidden((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) {
+        next.delete(key)
+      } else {
+        next.add(key)
+      }
+      return next
+    })
+  }, [])
+
+  const isHidden = useCallback((key: string) => hidden.has(key), [hidden])
+
+  return { hidden, toggle, isHidden }
+}
+
+export function InteractiveLegendContent({
+  payload,
+  verticalAlign = 'bottom',
+  hidden,
+  onToggle,
+  className,
+}: Pick<DefaultLegendContentProps, 'payload' | 'verticalAlign'> & {
+  hidden: ReadonlySet<string>
+  onToggle: (key: string) => void
+  className?: string
+}) {
+  if (!payload?.length) {
+    return null
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex flex-wrap items-center justify-center gap-x-4 gap-y-1',
+        verticalAlign === 'top' ? 'pb-3' : 'pt-3',
+        className
+      )}
+    >
+      {payload
+        .filter((item) => item.type !== 'none')
+        .map((item, index) => {
+          // Recharts puts the series dataKey in both `dataKey` and `value`;
+          // chart configs label series by their category name, so the key
+          // doubles as the display label (same as ChartLegendContent renders).
+          const key = String(item.dataKey ?? item.value ?? `item-${index}`)
+          const isHidden = hidden.has(key)
+          const label = String(item.value ?? key)
+
+          return (
+            <button
+              key={`${key}-${index}`}
+              type="button"
+              onClick={() => onToggle(key)}
+              aria-pressed={!isHidden}
+              title={isHidden ? `Show ${key}` : `Hide ${key}`}
+              className={cn(
+                'flex cursor-pointer items-center gap-1.5 rounded px-1 py-0.5 text-xs transition-opacity hover:bg-muted/60',
+                isHidden && 'opacity-40'
+              )}
+            >
+              <div
+                className="h-2 w-2 shrink-0 rounded-[2px]"
+                style={
+                  isHidden
+                    ? { boxShadow: `inset 0 0 0 1.5px ${item.color}` }
+                    : { backgroundColor: item.color }
+                }
+              />
+              <span className={cn(isHidden && 'line-through')}>{label}</span>
+            </button>
+          )
+        })}
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/charts/traffic/insert-performance-over-time.tsx
+++ b/apps/dashboard/src/components/charts/traffic/insert-performance-over-time.tsx
@@ -6,7 +6,7 @@ import { chartTickFormatters } from '@/lib/utils'
 export const ChartInsertPerformanceOverTime = createAreaChart({
   chartName: 'traffic-insert-performance',
   index: 'event_time',
-  categories: ['avg_duration_ms', 'p95_duration_ms'],
+  categories: ['avg_duration_ms', 'p95_duration_ms', 'p99_duration_ms'],
   defaultTitle: 'Insert Performance',
   defaultInterval: 'toStartOfHour',
   defaultLastHours: 24,
@@ -18,7 +18,7 @@ export const ChartInsertPerformanceOverTime = createAreaChart({
     showCartesianGrid: true,
     showLegend: true,
     opacity: 0.25,
-    colors: ['--chart-2', '--chart-red'],
+    colors: ['--chart-2', '--chart-red', '--chart-yellow'],
     yAxisTickFormatter: chartTickFormatters.duration,
   },
 })

--- a/apps/dashboard/src/components/charts/traffic/peerdb-performance-over-time.tsx
+++ b/apps/dashboard/src/components/charts/traffic/peerdb-performance-over-time.tsx
@@ -6,7 +6,7 @@ import { chartTickFormatters } from '@/lib/utils'
 export const ChartPeerdbPerformanceOverTime = createAreaChart({
   chartName: 'traffic-peerdb-performance',
   index: 'event_time',
-  categories: ['avg_duration_ms', 'p95_duration_ms'],
+  categories: ['avg_duration_ms', 'p95_duration_ms', 'p99_duration_ms'],
   defaultTitle: 'PeerDB Insert Performance',
   defaultInterval: 'toStartOfHour',
   defaultLastHours: 24,
@@ -18,7 +18,7 @@ export const ChartPeerdbPerformanceOverTime = createAreaChart({
     showCartesianGrid: true,
     showLegend: true,
     opacity: 0.25,
-    colors: ['--chart-2', '--chart-red'],
+    colors: ['--chart-2', '--chart-red', '--chart-yellow'],
     yAxisTickFormatter: chartTickFormatters.duration,
   },
 })

--- a/apps/dashboard/src/components/charts/traffic/traffic-peerdb-section.tsx
+++ b/apps/dashboard/src/components/charts/traffic/traffic-peerdb-section.tsx
@@ -1,7 +1,10 @@
+import type { TrafficSectionDensity } from '@/lib/traffic/traffic-settings'
+
 import { memo } from 'react'
 import { ChartPeerdbBytesOverTime } from '@/components/charts/traffic/peerdb-bytes-over-time'
 import { ChartPeerdbPerformanceOverTime } from '@/components/charts/traffic/peerdb-performance-over-time'
 import { ChartPeerdbRowsOverTime } from '@/components/charts/traffic/peerdb-rows-over-time'
+import { TrafficSectionHeader } from '@/components/charts/traffic/traffic-section-header'
 import { PeerDBLogo } from '@/components/icons/peerdb-brand-logo'
 import { REFRESH_INTERVAL, useChartData, useHostId } from '@/lib/swr'
 
@@ -22,6 +25,8 @@ export const TrafficPeerdbSection = memo(function TrafficPeerdbSection({
   chartClassName,
   chartCardContentClassName,
   visibility = 'auto',
+  density = 'full',
+  onToggleDensity,
 }: {
   chartClassName?: string
   chartCardContentClassName?: string
@@ -30,6 +35,9 @@ export const TrafficPeerdbSection = memo(function TrafficPeerdbSection({
    * (skipping detection), 'auto' (default) keeps the PeerDB smart detection.
    */
   visibility?: 'auto' | 'show' | 'hide'
+  /** Full chart grid vs compact mini-chart row (default 'full'). */
+  density?: TrafficSectionDensity
+  onToggleDensity?: () => void
 }) {
   const hostId = useHostId()
 
@@ -55,13 +63,28 @@ export const TrafficPeerdbSection = memo(function TrafficPeerdbSection({
 
   return (
     <div className="flex flex-col gap-3 sm:gap-4">
-      <div className="flex items-center gap-2">
-        <PeerDBLogo className="size-4 text-muted-foreground" />
-        <h2 className="text-sm font-medium text-foreground">
-          PeerDB Ingestion
-        </h2>
-      </div>
-      <div className="grid grid-cols-1 gap-3 sm:gap-4 lg:grid-cols-2">
+      {onToggleDensity ? (
+        <TrafficSectionHeader
+          icon={<PeerDBLogo className="size-4 text-muted-foreground" />}
+          title="PeerDB Ingestion"
+          density={density}
+          onToggleDensity={onToggleDensity}
+        />
+      ) : (
+        <div className="flex items-center gap-2">
+          <PeerDBLogo className="size-4 text-muted-foreground" />
+          <h2 className="text-sm font-medium text-foreground">
+            PeerDB Ingestion
+          </h2>
+        </div>
+      )}
+      <div
+        className={
+          density === 'compact'
+            ? 'grid grid-cols-2 gap-2 lg:grid-cols-3'
+            : 'grid grid-cols-1 gap-3 sm:gap-4 lg:grid-cols-2'
+        }
+      >
         <ChartPeerdbRowsOverTime
           chartClassName={chartClassName}
           chartCardContentClassName={chartCardContentClassName}

--- a/apps/dashboard/src/components/charts/traffic/traffic-replication-section.tsx
+++ b/apps/dashboard/src/components/charts/traffic/traffic-replication-section.tsx
@@ -1,8 +1,11 @@
 import { GitCompareArrowsIcon } from 'lucide-react'
 
+import type { TrafficSectionDensity } from '@/lib/traffic/traffic-settings'
+
 import { memo } from 'react'
 import { ChartDistributedQueriesOverTime } from '@/components/charts/traffic/distributed-queries-over-time'
 import { ChartReplicaFetchTraffic } from '@/components/charts/traffic/replica-fetch-traffic'
+import { TrafficSectionHeader } from '@/components/charts/traffic/traffic-section-header'
 import { useChartData } from '@/lib/query/use-chart-data'
 import { REFRESH_INTERVAL, useHostId } from '@/lib/swr'
 
@@ -23,6 +26,9 @@ interface TrafficReplicationSectionProps {
    * smart cluster-shape detection.
    */
   visibility?: 'auto' | 'show' | 'hide'
+  /** Full chart grid vs compact mini-chart row (default 'full'). */
+  density?: TrafficSectionDensity
+  onToggleDensity?: () => void
 }
 
 /**
@@ -42,6 +48,8 @@ export const TrafficReplicationSection = memo(
     chartClassName,
     chartCardContentClassName,
     visibility = 'auto',
+    density = 'full',
+    onToggleDensity,
   }: TrafficReplicationSectionProps) {
     const hostId = useHostId()
 
@@ -66,16 +74,36 @@ export const TrafficReplicationSection = memo(
 
     return (
       <div className="flex flex-col gap-3 sm:gap-4">
-        <div className="flex items-center gap-2">
-          <GitCompareArrowsIcon
-            className="size-4 text-muted-foreground"
-            strokeWidth={1.5}
+        {onToggleDensity ? (
+          <TrafficSectionHeader
+            icon={
+              <GitCompareArrowsIcon
+                className="size-4 text-muted-foreground"
+                strokeWidth={1.5}
+              />
+            }
+            title="Replication & Distribution"
+            density={density}
+            onToggleDensity={onToggleDensity}
           />
-          <h2 className="text-sm font-medium text-foreground">
-            Replication & Distribution
-          </h2>
-        </div>
-        <div className="grid grid-cols-1 gap-3 sm:gap-4 lg:grid-cols-2">
+        ) : (
+          <div className="flex items-center gap-2">
+            <GitCompareArrowsIcon
+              className="size-4 text-muted-foreground"
+              strokeWidth={1.5}
+            />
+            <h2 className="text-sm font-medium text-foreground">
+              Replication & Distribution
+            </h2>
+          </div>
+        )}
+        <div
+          className={
+            density === 'compact'
+              ? 'grid grid-cols-2 gap-2'
+              : 'grid grid-cols-1 gap-3 sm:gap-4 lg:grid-cols-2'
+          }
+        >
           {hasReplication ? (
             <ChartReplicaFetchTraffic
               chartClassName={chartClassName}

--- a/apps/dashboard/src/components/charts/traffic/traffic-section-header.tsx
+++ b/apps/dashboard/src/components/charts/traffic/traffic-section-header.tsx
@@ -1,0 +1,64 @@
+/**
+ * TrafficSectionHeader — shared header row for /traffic sections: icon +
+ * title on the left, a full/compact density toggle on the right. Compact mode
+ * renders the section's charts as a dense mini-chart row; the preference is
+ * persisted per section in traffic-view-settings (localStorage).
+ */
+
+import { LayoutGridIcon, Rows3Icon } from 'lucide-react'
+
+import type { TrafficSectionDensity } from '@/lib/traffic/traffic-settings'
+
+import { Button } from '@/components/ui/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+
+export function TrafficSectionHeader({
+  icon,
+  title,
+  density,
+  onToggleDensity,
+}: {
+  icon?: React.ReactNode
+  /** Omit when the section body renders its own title (e.g. a table card). */
+  title?: string
+  density: TrafficSectionDensity
+  onToggleDensity: () => void
+}) {
+  const compact = density === 'compact'
+  return (
+    <div className="flex items-center gap-2">
+      {icon}
+      {title ? (
+        <h2 className="text-sm font-medium text-foreground">{title}</h2>
+      ) : null}
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onToggleDensity}
+              aria-label={
+                compact ? 'Expand to full charts' : 'Collapse to compact row'
+              }
+              className="ml-auto size-6 text-muted-foreground"
+            />
+          }
+        >
+          {compact ? (
+            <LayoutGridIcon className="size-3.5" strokeWidth={1.5} />
+          ) : (
+            <Rows3Icon className="size-3.5" strokeWidth={1.5} />
+          )}
+        </TooltipTrigger>
+        <TooltipContent side="bottom" className="text-xs">
+          {compact ? 'Full charts' : 'Compact row'}
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  )
+}

--- a/apps/dashboard/src/lib/api/charts/traffic-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/traffic-charts.ts
@@ -190,7 +190,7 @@ export const trafficCharts: Record<string, ChartQueryBuilder> = {
   },
 
   /**
-   * Insert (write) performance over time — average and p95 duration of
+   * Insert (write) performance over time — average, p95, and p99 duration of
    * successful insert queries, so slow-ingest regressions are visible next to
    * the insert volume charts.
    */
@@ -203,7 +203,8 @@ export const trafficCharts: Record<string, ChartQueryBuilder> = {
       query: `
     SELECT ${applyInterval(interval, 'event_time')},
            round(avg(query_duration_ms), 1) AS avg_duration_ms,
-           round(quantile(0.95)(query_duration_ms), 1) AS p95_duration_ms
+           round(quantile(0.95)(query_duration_ms), 1) AS p95_duration_ms,
+           round(quantile(0.99)(query_duration_ms), 1) AS p99_duration_ms
     FROM system.query_log
     WHERE query_kind = 'Insert'
       AND type = 'QueryFinish'
@@ -499,7 +500,7 @@ export const trafficCharts: Record<string, ChartQueryBuilder> = {
   },
 
   /**
-   * PeerDB insert performance over time — average and p95 duration of
+   * PeerDB insert performance over time — average, p95, and p99 duration of
    * PeerDB-attributed insert queries, so CDC sync slowdowns are visible
    * separately from overall insert latency.
    */
@@ -512,7 +513,8 @@ export const trafficCharts: Record<string, ChartQueryBuilder> = {
       query: `
     SELECT ${applyInterval(interval, 'event_time')},
            round(avg(query_duration_ms), 1) AS avg_duration_ms,
-           round(quantile(0.95)(query_duration_ms), 1) AS p95_duration_ms
+           round(quantile(0.95)(query_duration_ms), 1) AS p95_duration_ms,
+           round(quantile(0.99)(query_duration_ms), 1) AS p99_duration_ms
     FROM system.query_log
     WHERE type = 'QueryFinish'
       AND query_kind = 'Insert'

--- a/apps/dashboard/src/lib/query-config/traffic/per-table-ingestion.ts
+++ b/apps/dashboard/src/lib/query-config/traffic/per-table-ingestion.ts
@@ -3,14 +3,15 @@ import type { QueryConfig } from '@/types/query-config'
 import { ColumnFormat } from '@/types/column-format'
 
 /**
- * Per-table ingestion over the last 24h (system.part_log NewPart events),
- * joined with the table's overall compression ratio from system.parts.
- * part_log is opt-in, so the whole view is optional.
+ * Per-table ingestion over a selectable window (system.part_log NewPart
+ * events; 24h default with 7d/14d/30d presets), joined with the table's
+ * overall compression ratio from system.parts. part_log is opt-in, so the
+ * whole view is optional.
  */
 export const trafficPerTableConfig: QueryConfig = {
   name: 'traffic-per-table',
   description:
-    'Tables ranked by data ingested in the last 24 hours: rows, on-disk bytes, parts created, and overall compression ratio',
+    'Tables ranked by data ingested in the selected window: rows, on-disk bytes, parts created, and overall compression ratio',
   optional: true,
   tableCheck: 'system.part_log',
   sql: `
@@ -34,7 +35,7 @@ export const trafficPerTableConfig: QueryConfig = {
           count() AS parts_created
         FROM system.part_log
         WHERE event_type = 'NewPart'
-          AND event_time >= now() - INTERVAL 24 HOUR
+          AND event_time >= now() - INTERVAL {lastHours: UInt32} HOUR
         GROUP BY 1
       ) AS ingest
       LEFT JOIN (
@@ -47,8 +48,15 @@ export const trafficPerTableConfig: QueryConfig = {
         GROUP BY 1
       ) AS parts USING (table)
       ORDER BY bytes_added DESC
-      LIMIT 100
+      LIMIT 1000
     `,
+  defaultParams: { lastHours: 24 },
+  filterParamPresets: [
+    { name: 'Last 24h', key: 'lastHours', value: '24' },
+    { name: 'Last 7d', key: 'lastHours', value: '168' },
+    { name: 'Last 14d', key: 'lastHours', value: '336' },
+    { name: 'Last 30d', key: 'lastHours', value: '720' },
+  ],
   columns: [
     'table',
     'readable_rows_added',

--- a/apps/dashboard/src/lib/traffic/traffic-settings.ts
+++ b/apps/dashboard/src/lib/traffic/traffic-settings.ts
@@ -21,8 +21,12 @@ export type TrafficSectionId = (typeof TRAFFIC_SECTION_IDS)[number]
 
 export type TrafficSectionVisibility = 'auto' | 'show' | 'hide'
 
+/** 'full' = regular chart grid; 'compact' = dense mini-chart row. */
+export type TrafficSectionDensity = 'full' | 'compact'
+
 export interface TrafficSettings {
   sections: Record<TrafficSectionId, TrafficSectionVisibility>
+  density: Record<TrafficSectionId, TrafficSectionDensity>
 }
 
 export const TRAFFIC_SECTION_LABELS: Record<TrafficSectionId, string> = {
@@ -40,6 +44,13 @@ export const DEFAULT_TRAFFIC_SETTINGS: TrafficSettings = {
     topTables: 'auto',
     replication: 'auto',
     peerdb: 'auto',
+  },
+  density: {
+    bytesOnDisk: 'full',
+    merges: 'full',
+    topTables: 'full',
+    replication: 'full',
+    peerdb: 'full',
   },
 }
 
@@ -102,18 +113,28 @@ function isVisibility(value: unknown): value is TrafficSectionVisibility {
   return value === 'auto' || value === 'show' || value === 'hide'
 }
 
+function isDensity(value: unknown): value is TrafficSectionDensity {
+  return value === 'full' || value === 'compact'
+}
+
 export function loadTrafficSettings(): TrafficSettings {
   if (typeof window === 'undefined') return DEFAULT_TRAFFIC_SETTINGS
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
     if (!raw) return DEFAULT_TRAFFIC_SETTINGS
-    const parsed = JSON.parse(raw) as { sections?: Record<string, unknown> }
+    const parsed = JSON.parse(raw) as {
+      sections?: Record<string, unknown>
+      density?: Record<string, unknown>
+    }
     const sections = { ...DEFAULT_TRAFFIC_SETTINGS.sections }
+    const density = { ...DEFAULT_TRAFFIC_SETTINGS.density }
     for (const id of TRAFFIC_SECTION_IDS) {
       const value = parsed?.sections?.[id]
       if (isVisibility(value)) sections[id] = value
+      const densityValue = parsed?.density?.[id]
+      if (isDensity(densityValue)) density[id] = densityValue
     }
-    return { sections }
+    return { sections, density }
   } catch {
     return DEFAULT_TRAFFIC_SETTINGS
   }
@@ -178,21 +199,36 @@ export function useTrafficSettings() {
     (id: TrafficSectionId, visibility: TrafficSectionVisibility) => {
       const current = loadTrafficSettings()
       saveTrafficSettings({
+        ...current,
         sections: { ...current.sections, [id]: visibility },
       })
     },
     []
   )
 
+  const toggleSectionDensity = useCallback((id: TrafficSectionId) => {
+    const current = loadTrafficSettings()
+    saveTrafficSettings({
+      ...current,
+      density: {
+        ...current.density,
+        [id]: current.density[id] === 'compact' ? 'full' : 'compact',
+      },
+    })
+  }, [])
+
+  // Presets only cover visibility; the per-section density choice sticks.
   const applyPreset = useCallback((presetId: string) => {
     const preset = TRAFFIC_PRESETS.find((p) => p.id === presetId)
     if (!preset) return
-    saveTrafficSettings({ sections: { ...preset.sections } })
+    const current = loadTrafficSettings()
+    saveTrafficSettings({ ...current, sections: { ...preset.sections } })
   }, [])
 
   return {
     settings,
     setSectionVisibility,
+    toggleSectionDensity,
     applyPreset,
     activePresetId: matchPresetId(settings),
   }

--- a/apps/dashboard/src/routes/(dashboard)/traffic.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/traffic.tsx
@@ -34,6 +34,7 @@ import { ChartPartMovesOverTime } from '@/components/charts/traffic/part-moves-o
 import { TrafficPartLogCallout } from '@/components/charts/traffic/traffic-part-log-callout'
 import { TrafficPeerdbSection } from '@/components/charts/traffic/traffic-peerdb-section'
 import { TrafficReplicationSection } from '@/components/charts/traffic/traffic-replication-section'
+import { TrafficSectionHeader } from '@/components/charts/traffic/traffic-section-header'
 import { TrafficSettingsPopover } from '@/components/charts/traffic/traffic-settings-popover'
 import { TrafficSummaryKpis } from '@/components/charts/traffic/traffic-summary-kpis'
 import { usePartLogAvailability } from '@/components/charts/traffic/use-part-log-availability'
@@ -48,8 +49,13 @@ import { useTrafficSettings } from '@/lib/traffic/traffic-settings'
 const CHART_CLASS = 'h-64 min-h-0 w-full'
 const CHART_CARD_CONTENT_CLASS = 'flex min-h-0 flex-1 flex-col px-3 pb-3 pt-0'
 
+// Compact ("mini chart row") density: short charts, packed 2-up/4-up.
+const COMPACT_CHART_CLASS = 'h-28 min-h-0 w-full'
+const FULL_GRID_CLASS = 'grid grid-cols-1 gap-3 sm:gap-4 lg:grid-cols-2'
+const COMPACT_GRID_CLASS = 'grid grid-cols-2 gap-2 lg:grid-cols-4'
+
 function TrafficPageContent() {
-  const { settings } = useTrafficSettings()
+  const { settings, toggleSectionDensity } = useTrafficSettings()
   const { available: partLogAvailable } = usePartLogAvailability()
 
   // 'show'/'hide' are explicit user overrides; 'auto' follows detection.
@@ -64,6 +70,9 @@ function TrafficPageContent() {
   )
   const showMerges = resolve(settings.sections.merges, partLogAvailable)
   const showTopTables = resolve(settings.sections.topTables, partLogAvailable)
+
+  const mergesChartClass =
+    settings.density.merges === 'compact' ? COMPACT_CHART_CLASS : CHART_CLASS
 
   // One callout replaces the auto-hidden part_log sections; explicit 'hide'
   // overrides suppress it (the user asked for them to be gone, not explained).
@@ -121,31 +130,39 @@ function TrafficPageContent() {
 
       {showMerges ? (
         <>
-          <div className="flex items-center gap-2">
-            <CombineIcon
-              className="size-4 text-muted-foreground"
-              strokeWidth={1.5}
-            />
-            <h2 className="text-sm font-medium text-foreground">
-              Merges &amp; Data Movement
-            </h2>
-          </div>
+          <TrafficSectionHeader
+            icon={
+              <CombineIcon
+                className="size-4 text-muted-foreground"
+                strokeWidth={1.5}
+              />
+            }
+            title="Merges & Data Movement"
+            density={settings.density.merges}
+            onToggleDensity={() => toggleSectionDensity('merges')}
+          />
 
-          <div className="grid grid-cols-1 gap-3 sm:gap-4 lg:grid-cols-2">
+          <div
+            className={
+              settings.density.merges === 'compact'
+                ? COMPACT_GRID_CLASS
+                : FULL_GRID_CLASS
+            }
+          >
             <ChartMergedBytesOverTime
-              chartClassName={CHART_CLASS}
+              chartClassName={mergesChartClass}
               chartCardContentClassName={CHART_CARD_CONTENT_CLASS}
             />
             <ChartPartMovesOverTime
-              chartClassName={CHART_CLASS}
+              chartClassName={mergesChartClass}
               chartCardContentClassName={CHART_CARD_CONTENT_CLASS}
             />
             <ChartWriteAmplificationOverTime
-              chartClassName={CHART_CLASS}
+              chartClassName={mergesChartClass}
               chartCardContentClassName={CHART_CARD_CONTENT_CLASS}
             />
             <ChartDiskWriteSpeedOverTime
-              chartClassName={CHART_CLASS}
+              chartClassName={mergesChartClass}
               chartCardContentClassName={CHART_CARD_CONTENT_CLASS}
             />
           </div>
@@ -153,22 +170,41 @@ function TrafficPageContent() {
       ) : null}
 
       {showTopTables ? (
-        <PageLayout
-          queryConfig={trafficPerTableConfig}
-          title="Top Tables by Ingestion (24h)"
-        />
+        <>
+          <TrafficSectionHeader
+            density={settings.density.topTables}
+            onToggleDensity={() => toggleSectionDensity('topTables')}
+          />
+          <PageLayout
+            queryConfig={trafficPerTableConfig}
+            title="Top Tables by Ingestion"
+            defaultPageSize={settings.density.topTables === 'compact' ? 5 : 20}
+          />
+        </>
       ) : null}
 
       <TrafficReplicationSection
-        chartClassName={CHART_CLASS}
+        chartClassName={
+          settings.density.replication === 'compact'
+            ? COMPACT_CHART_CLASS
+            : CHART_CLASS
+        }
         chartCardContentClassName={CHART_CARD_CONTENT_CLASS}
         visibility={settings.sections.replication}
+        density={settings.density.replication}
+        onToggleDensity={() => toggleSectionDensity('replication')}
       />
 
       <TrafficPeerdbSection
-        chartClassName={CHART_CLASS}
+        chartClassName={
+          settings.density.peerdb === 'compact'
+            ? COMPACT_CHART_CLASS
+            : CHART_CLASS
+        }
         chartCardContentClassName={CHART_CARD_CONTENT_CLASS}
         visibility={settings.sections.peerdb}
+        density={settings.density.peerdb}
+        onToggleDensity={() => toggleSectionDensity('peerdb')}
       />
     </div>
   )


### PR DESCRIPTION
## Summary

- **Insert Performance & PeerDB Insert Performance now track p99** alongside avg and p95 (`quantile(0.99)` in both traffic-charts builders, third series in yellow).
- **Clickable chart legends** — clicking a legend item toggles that series' visibility. Implemented in the area + bar primitives (new `InteractiveLegendContent` + `useHiddenSeries`), so every chart with `showLegend` gets it. Hidden series stay mounted (recharts `hide`) and the y-axis domain rescales to the visible series only.
- **Zoom dialog redesign**:
  - Metadata rendered as a grid of tiles (icon + label + copyable value); API tile shows only the path+query (domain hidden) but copies the full URL; hover tooltip shows the full value.
  - Chart tab keeps the chart full-size and adds a dialog-scoped Y-axis Linear/Log control (`ChartScaleProvider persist={false}` so it never restyles page charts).
- **Top Tables by Ingestion**: date-range presets (24h / 7d / 14d / 30d via `{lastHours}` query param), `LIMIT 1000` with 20-rows/page paging, title no longer hardcodes (24h).
- **Per-section compact density**: Merges & Data Movement, Top Tables, Replication & Distribution, and PeerDB Ingestion each get a header toggle switching between the full chart grid and a compact mini-chart row (persisted per section in `traffic-view-settings`; presets no longer clobber it).

## Verification
- `pnpm run lint` ✅
- `tsc --noEmit` ✅
- `bun test src/lib/api/__tests__/charts/` — 466 pass ✅
- `pnpm run build` ✅

https://claude.ai/code/session_016j7zQ5ZBmYt7qJL1uFkZp7