### PR TITLE
fix(ui): pin icon sizing, host switcher spacing, settings redesign

### DIFF
--- a/apps/dashboard/src/components/host/host-switcher.tsx
+++ b/apps/dashboard/src/components/host/host-switcher.tsx
@@ -270,7 +270,7 @@ export function HostSwitcher() {
                 </div>
                 {showExpanded && (
                   <>
-                    <div className="grid flex-1 text-left text-sm leading-tight">
+                    <div className="grid flex-1 gap-2 py-1.5 text-left text-sm leading-tight">
                       <span className="flex items-center gap-1.5 truncate font-semibold">
                         <span className="truncate">
                           {activeHost.name || getHost(activeHost.host)}

--- a/apps/dashboard/src/components/navigation/nav-main/menu-item.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/menu-item.tsx
@@ -8,6 +8,7 @@ import { PinButton, SubPinButton } from './pin-button'
 import { lazy, Suspense } from 'react'
 import { useIsTableAvailable } from '@/components/menu/hooks/use-table-availability'
 import { HostPrefixedLink } from '@/components/menu/link-with-context'
+import { useUserSettings } from '@/lib/hooks/use-user-settings'
 import { useHostId } from '@/lib/swr'
 
 const NewBadge = lazy(() =>
@@ -84,7 +85,14 @@ const SingleMenuItem = function SingleMenuItem({
   const closeMobileSidebar = useCloseMobileSidebar()
   const hostId = useHostId()
   const { available } = useIsTableAvailable(item.tableCheck, hostId)
+  const { settings } = useUserSettings()
   const hasBadge = Boolean(item.isNew || item.countKey)
+
+  // When the page's backing table is missing, either dim it (default) or hide
+  // it entirely per the user's Navigation setting.
+  if (!available && !settings.dimUnavailablePages) {
+    return null
+  }
 
   return (
     <SidebarMenuItem>
@@ -149,7 +157,12 @@ const SubMenuItem = function SubMenuItem({
   closeMobileSidebar: () => void
 }) {
   const { available } = useIsTableAvailable(subItem.tableCheck, hostId)
+  const { settings } = useUserSettings()
   const hasBadge = Boolean(subItem.isNew || subItem.countKey)
+
+  if (!available && !settings.dimUnavailablePages) {
+    return null
+  }
 
   return (
     <SidebarMenuSubItem>

--- a/apps/dashboard/src/components/navigation/nav-main/pin-button.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/pin-button.tsx
@@ -28,7 +28,13 @@ export function PinButton({ href, title, hasBadge }: PinButtonProps) {
   return (
     <SidebarMenuAction
       showOnHover={!isPinned}
-      className={cn(hasBadge && 'right-6', isPinned && 'opacity-100')}
+      className={cn(
+        // `SidebarMenuAction` forces `[&>svg]:size-4`; override so the pin
+        // stays small and inset from the very right edge with breathing room.
+        'right-2 [&>svg]:size-3',
+        hasBadge && 'right-7',
+        isPinned && 'opacity-100'
+      )}
       onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
         event.preventDefault()
         event.stopPropagation()
@@ -37,7 +43,7 @@ export function PinButton({ href, title, hasBadge }: PinButtonProps) {
       aria-label={isPinned ? `Unpin ${title}` : `Pin ${title}`}
       aria-pressed={isPinned}
     >
-      <Pin className={cn('size-3.5', isPinned && 'fill-current')} />
+      <Pin className={cn(isPinned && 'fill-current')} />
     </SidebarMenuAction>
   )
 }
@@ -70,12 +76,12 @@ export function SubPinButton({ href, title, hasBadge }: SubPinButtonProps) {
       aria-label={isPinned ? `Unpin ${title}` : `Pin ${title}`}
       aria-pressed={isPinned}
       className={cn(
-        'absolute top-1/2 right-1 flex aspect-square size-5 -translate-y-1/2 items-center justify-center rounded-md p-0 text-sidebar-foreground opacity-0 outline-hidden transition-opacity hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:opacity-100 focus-visible:ring-2 group-hover/menu-sub-item:opacity-100 group-focus-within/menu-sub-item:opacity-100 group-data-[collapsible=icon]:hidden',
-        hasBadge && 'right-6',
+        'absolute top-1/2 right-2 flex aspect-square size-5 -translate-y-1/2 items-center justify-center rounded-md p-0 text-sidebar-foreground opacity-0 outline-hidden transition-opacity hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:opacity-100 focus-visible:ring-2 group-hover/menu-sub-item:opacity-100 group-focus-within/menu-sub-item:opacity-100 group-data-[collapsible=icon]:hidden',
+        hasBadge && 'right-7',
         isPinned && 'opacity-100'
       )}
     >
-      <Pin className={cn('size-3.5', isPinned && 'fill-current')} />
+      <Pin className={cn('size-3', isPinned && 'fill-current')} />
     </button>
   )
 }

--- a/apps/dashboard/src/components/settings/settings-dialog.tsx
+++ b/apps/dashboard/src/components/settings/settings-dialog.tsx
@@ -46,7 +46,10 @@ export function SettingsDialog({
           }
         />
       )}
-      <DialogContent className="sm:max-w-md" data-testid="settings-dialog">
+      <DialogContent
+        className="max-h-[85vh] sm:max-w-3xl"
+        data-testid="settings-dialog"
+      >
         <DialogHeader>
           <DialogTitle>Settings</DialogTitle>
         </DialogHeader>

--- a/apps/dashboard/src/components/settings/settings-form.tsx
+++ b/apps/dashboard/src/components/settings/settings-form.tsx
@@ -1,13 +1,19 @@
 import {
   Binary,
+  BlocksIcon,
+  Clock,
+  EyeOff,
   Globe,
   Hash,
-  Monitor,
+  LayoutGrid,
   Moon,
   Palette,
   RotateCcw,
   Rows3,
+  Settings,
+  SlidersHorizontal,
   Sun,
+  Type,
 } from 'lucide-react'
 
 import type {
@@ -35,6 +41,8 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Separator } from '@/components/ui/separator'
+import { Switch } from '@/components/ui/switch'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { TIMEZONE_GROUPS } from '@/lib/constants/timezones'
 import { TIME_RANGE_PRESETS } from '@/lib/context/time-range-context'
 import {
@@ -56,7 +64,7 @@ const themeOptions = [
   {
     value: 'system',
     label: 'System',
-    icon: Monitor,
+    icon: Settings,
     description: 'Sync with system',
   },
 ] as const
@@ -87,12 +95,15 @@ const BYTE_PREVIEW_SAMPLE = 1.5 * 1024 ** 3
 /** Sample quantity (1,200,000) used for the live numbers preview. */
 const NUMBER_PREVIEW_SAMPLE = 1_200_000
 
-function SectionHeader({ children }: { children: React.ReactNode }) {
-  return (
-    <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-      {children}
-    </h3>
-  )
+/**
+ * Representative swatches for each chart palette so the user can see the
+ * difference at a glance. Values mirror the `--chart-1..5` tokens defined in
+ * `styles.css` (default orange ramp, Okabe-Ito, single-hue ramp).
+ */
+const PALETTE_SWATCHES: Record<ChartPalette, string[]> = {
+  default: ['#f5a524', '#fb923c', '#f97316', '#ea580c', '#c2410c'],
+  'colorblind-safe': ['#e69f00', '#56b4e9', '#009e73', '#f0e442', '#0072b2'],
+  monochrome: ['#f59e0b', '#d97706', '#b45309', '#92400e', '#78350f'],
 }
 
 function Field({
@@ -116,6 +127,67 @@ function Field({
       {description && (
         <p className="text-xs text-muted-foreground">{description}</p>
       )}
+    </div>
+  )
+}
+
+/** A row of colour dots previewing a chart palette. */
+function PaletteSwatches({ palette }: { palette: ChartPalette }) {
+  return (
+    <div className="flex items-center gap-1">
+      {PALETTE_SWATCHES[palette].map((color, i) => (
+        <span
+          key={`${palette}-${i}`}
+          className="size-4 rounded-full ring-1 ring-black/10 dark:ring-white/15"
+          style={{ backgroundColor: color }}
+        />
+      ))}
+    </div>
+  )
+}
+
+/**
+ * Mini illustration of table row density — taller, looser rows for
+ * "comfortable", tighter rows for "compact".
+ */
+function DensityPreview({ density }: { density: TableDensity }) {
+  const isCompact = density === 'compact'
+  return (
+    <div
+      className={cn(
+        'flex w-full flex-col rounded-md border border-border bg-muted/30 p-2',
+        isCompact ? 'gap-1' : 'gap-2.5'
+      )}
+    >
+      {[0, 1, 2].map((i) => (
+        <div
+          key={i}
+          className={cn(
+            'rounded bg-foreground/10',
+            isCompact ? 'h-2' : 'h-3.5'
+          )}
+        />
+      ))}
+    </div>
+  )
+}
+
+/**
+ * Mini sidebar-menu illustration for the Navigation tab — shows a normal item
+ * alongside an "unavailable" one (dimmed), so the dim/hide behaviour is
+ * visible at a glance.
+ */
+function MenuPreview() {
+  return (
+    <div className="flex w-full flex-col gap-1 rounded-md border border-border bg-muted/20 p-2">
+      <div className="flex items-center gap-2 rounded px-1.5 py-1 text-xs">
+        <LayoutGrid className="size-3.5 text-foreground" />
+        <span>Queries</span>
+      </div>
+      <div className="flex items-center gap-2 rounded px-1.5 py-1 text-xs text-muted-foreground/50">
+        <BlocksIcon className="size-3.5" />
+        <span>Backups</span>
+      </div>
     </div>
   )
 }
@@ -179,214 +251,278 @@ export function SettingsForm({
     'short'
   )} ↔ ${formatReadableQuantity(NUMBER_PREVIEW_SAMPLE, 'long')}`
 
+  const tabs = [
+    { value: 'general', label: 'General', icon: Clock },
+    { value: 'appearance', label: 'Appearance', icon: Palette },
+    { value: 'units', label: 'Units', icon: Binary },
+    { value: 'layout', label: 'Layout', icon: Rows3 },
+    { value: 'navigation', label: 'Navigation', icon: EyeOff },
+    { value: 'integrations', label: 'Integrations', icon: Globe },
+  ] as const
+
   return (
-    <div className="max-h-[70vh] space-y-6 overflow-y-auto py-4 pr-1">
-      {/* General */}
-      <section className="space-y-3">
-        <SectionHeader>General</SectionHeader>
-        <Field
-          label="Timezone"
-          description="All datetimes will be displayed in your selected timezone"
-        >
-          {!isLoadingDefault && defaultTimezone && (
-            <div className="flex justify-end">
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="h-7 px-2 text-xs"
-                onClick={handleResetTimezone}
-                disabled={!!isUsingDefault}
+    <div className="flex min-h-0 flex-1 flex-col">
+      <Tabs
+        defaultValue="general"
+        orientation="vertical"
+        className="flex min-h-0 flex-1 gap-4"
+      >
+        <TabsList className="h-fit w-44 shrink-0 flex-col items-stretch border-r border-border pr-1">
+          {tabs.map((tab) => {
+            const Icon = tab.icon
+            return (
+              <TabsTrigger
+                key={tab.value}
+                value={tab.value}
+                className="justify-start gap-2 px-3 py-2"
               >
-                <RotateCcw className="mr-1 size-3" />
-                Reset to default
-              </Button>
-            </div>
-          )}
-          <Select
-            value={settings.timezone}
-            onValueChange={(value) =>
-              onUpdate({ timezone: value ?? undefined })
-            }
-          >
-            <SelectTrigger id="timezone" className="h-9">
-              <SelectValue placeholder="Select timezone" />
-            </SelectTrigger>
-            <SelectContent>
-              {TIMEZONE_GROUPS.map((group) => (
-                <SelectGroup key={group.label}>
-                  <SelectLabel className="text-xs">{group.label}</SelectLabel>
-                  {group.timezones.map((tz) => (
-                    <SelectItem
-                      key={tz.value}
-                      value={tz.value}
-                      className="text-xs"
+                <Icon className="size-4" aria-hidden="true" />
+                {tab.label}
+              </TabsTrigger>
+            )
+          })}
+        </TabsList>
+
+        <div className="min-w-0 flex-1 overflow-y-auto pr-1">
+          {/* General */}
+          <TabsContent value="general" className="space-y-4 px-1 pb-2">
+            <Field
+              label="Timezone"
+              icon={Clock}
+              description="All datetimes will be displayed in your selected timezone"
+            >
+              {!isLoadingDefault && defaultTimezone && (
+                <div className="flex justify-end">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 px-2 text-xs"
+                    onClick={handleResetTimezone}
+                    disabled={!!isUsingDefault}
+                  >
+                    <RotateCcw className="mr-1 size-3" />
+                    Reset to default
+                  </Button>
+                </div>
+              )}
+              <Select
+                value={settings.timezone}
+                onValueChange={(value) =>
+                  onUpdate({ timezone: value ?? undefined })
+                }
+              >
+                <SelectTrigger id="timezone" className="h-9">
+                  <SelectValue placeholder="Select timezone" />
+                </SelectTrigger>
+                <SelectContent>
+                  {TIMEZONE_GROUPS.map((group) => (
+                    <SelectGroup key={group.label}>
+                      <SelectLabel className="text-xs">
+                        {group.label}
+                      </SelectLabel>
+                      {group.timezones.map((tz) => (
+                        <SelectItem
+                          key={tz.value}
+                          value={tz.value}
+                          className="text-xs"
+                        >
+                          <div className="flex items-center justify-between gap-2">
+                            <span>{tz.label}</span>
+                            {defaultTimezone === tz.value && (
+                              <span className="text-[10px] text-muted-foreground">
+                                (default)
+                              </span>
+                            )}
+                          </div>
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  ))}
+                </SelectContent>
+              </Select>
+            </Field>
+          </TabsContent>
+
+          {/* Appearance */}
+          <TabsContent value="appearance" className="space-y-5 px-1 pb-2">
+            <Field label="Theme">
+              <div className="grid grid-cols-3 gap-2">
+                {themeOptions.map((option) => {
+                  const Icon = option.icon
+                  const isSelected = settings.theme === option.value
+                  return (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() => handleThemeChange(option.value)}
+                      className={cn(
+                        'relative flex flex-col items-center justify-center rounded-lg border-2 p-3 transition-[opacity,border-color,background-color,box-shadow] hover:opacity-80',
+                        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50',
+                        isSelected
+                          ? 'border-primary bg-primary/5 ring-2 ring-primary/20'
+                          : 'border-muted bg-muted/20'
+                      )}
+                      aria-pressed={isSelected}
+                      aria-label={`Select ${option.description}`}
                     >
-                      <div className="flex items-center justify-between gap-2">
-                        <span>{tz.label}</span>
-                        {defaultTimezone === tz.value && (
-                          <span className="text-[10px] text-muted-foreground">
-                            (default)
-                          </span>
-                        )}
-                      </div>
+                      <Icon className="mb-2 size-5" aria-hidden="true" />
+                      <span className="text-xs font-medium">
+                        {option.label}
+                      </span>
+                    </button>
+                  )
+                })}
+              </div>
+            </Field>
+
+            <Field
+              label="Chart palette"
+              icon={Palette}
+              description="Colour scheme for chart series. Colorblind uses the Okabe-Ito palette; Mono is a single-hue ramp."
+            >
+              <SegmentedControl
+                ariaLabel="Chart palette"
+                value={settings.chartPalette}
+                onChange={(value) => onUpdate({ chartPalette: value })}
+                options={chartPaletteOptions}
+              />
+              <PaletteSwatches palette={settings.chartPalette} />
+            </Field>
+          </TabsContent>
+
+          {/* Units */}
+          <TabsContent value="units" className="space-y-5 px-1 pb-2">
+            <Field
+              label="Byte sizes"
+              icon={Binary}
+              description={`Binary uses 1024-based KiB/MiB; Decimal uses 1000-based KB/MB. e.g. ${bytePreview}`}
+            >
+              <SegmentedControl
+                ariaLabel="Byte sizes"
+                value={settings.byteUnit}
+                onChange={(value) => onUpdate({ byteUnit: value })}
+                options={byteUnitOptions}
+              />
+            </Field>
+
+            <Field
+              label="Large numbers"
+              icon={Hash}
+              description={`Abbreviated shows compact suffixes; Full shows grouped digits. e.g. ${numberPreview}`}
+            >
+              <SegmentedControl
+                ariaLabel="Large numbers"
+                value={settings.numberFormat}
+                onChange={(value) => onUpdate({ numberFormat: value })}
+                options={numberFormatOptions}
+              />
+            </Field>
+
+            <div className="flex items-center gap-2 rounded-md border border-border bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
+              <Type className="size-3.5 shrink-0" />
+              <span className="tabular-nums">{bytePreview}</span>
+              <Separator orientation="vertical" className="mx-1 h-4" />
+              <span className="tabular-nums">{numberPreview}</span>
+            </div>
+          </TabsContent>
+
+          {/* Layout */}
+          <TabsContent value="layout" className="space-y-5 px-1 pb-2">
+            <Field
+              label="Table density"
+              icon={Rows3}
+              description="Row height for data tables. Compact fits more rows on screen."
+            >
+              <SegmentedControl
+                ariaLabel="Table density"
+                value={settings.tableDensity}
+                onChange={(value) => onUpdate({ tableDensity: value })}
+                options={densityOptions}
+              />
+              <DensityPreview density={settings.tableDensity} />
+            </Field>
+
+            <Field
+              label="Default time range"
+              icon={Clock}
+              description="Initial time range for time-series pages. Explicit clicks and shared ?range= links still take priority."
+            >
+              <Select
+                value={settings.defaultTimeRange}
+                onValueChange={(value) =>
+                  value &&
+                  onUpdate({ defaultTimeRange: value as DefaultTimeRange })
+                }
+              >
+                <SelectTrigger id="default-time-range" className="h-9">
+                  <SelectValue placeholder="Select default range" />
+                </SelectTrigger>
+                <SelectContent>
+                  {TIME_RANGE_PRESETS.map((preset) => (
+                    <SelectItem key={preset.value} value={preset.value}>
+                      {preset.label}
                     </SelectItem>
                   ))}
-                </SelectGroup>
-              ))}
-            </SelectContent>
-          </Select>
-        </Field>
-      </section>
+                </SelectContent>
+              </Select>
+            </Field>
+          </TabsContent>
 
-      <Separator />
+          {/* Navigation */}
+          <TabsContent value="navigation" className="space-y-4 px-1 pb-2">
+            <Field
+              label="Dim unavailable pages"
+              icon={EyeOff}
+              description="Pages whose backing system table isn't found on this host appear grayed out in the menu. Turn off to hide them completely."
+            >
+              <div className="flex items-center gap-3 rounded-md border border-border bg-muted/20 px-3 py-3">
+                <Switch
+                  checked={settings.dimUnavailablePages}
+                  onCheckedChange={(checked) =>
+                    onUpdate({ dimUnavailablePages: checked })
+                  }
+                  aria-label="Dim unavailable pages"
+                />
+                <div className="flex-1">
+                  <p className="text-sm font-medium">
+                    {settings.dimUnavailablePages ? 'Dimmed' : 'Hidden'}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {settings.dimUnavailablePages
+                      ? 'Unavailable pages stay visible but grayed out.'
+                      : 'Unavailable pages are removed from the menu.'}
+                  </p>
+                </div>
+                <SlidersHorizontal className="size-4 shrink-0 text-muted-foreground" />
+              </div>
+            </Field>
+            <MenuPreview />
+          </TabsContent>
 
-      {/* Appearance */}
-      <section className="space-y-4">
-        <SectionHeader>Appearance</SectionHeader>
+          {/* Integrations */}
+          <TabsContent value="integrations" className="space-y-4 px-1 pb-2">
+            <Field
+              label="MCP Server"
+              icon={Globe}
+              description="Connect AI assistants to your ClickHouse cluster via the Model Context Protocol."
+            >
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="w-full justify-start text-xs"
+                onClick={() => window.open('/mcp', '_blank')}
+              >
+                <Globe className="mr-2 size-3" />
+                View MCP Server Details
+              </Button>
+            </Field>
+          </TabsContent>
+        </div>
+      </Tabs>
 
-        <Field label="Theme">
-          <div className="grid grid-cols-3 gap-2">
-            {themeOptions.map((option) => {
-              const Icon = option.icon
-              const isSelected = settings.theme === option.value
-              return (
-                <button
-                  key={option.value}
-                  type="button"
-                  onClick={() => handleThemeChange(option.value)}
-                  className={cn(
-                    'relative flex flex-col items-center justify-center rounded-lg border-2 p-3 transition-[opacity,border-color,background-color,box-shadow] hover:opacity-80',
-                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50',
-                    isSelected
-                      ? 'border-primary bg-primary/5 ring-2 ring-primary/20'
-                      : 'border-muted bg-muted/20'
-                  )}
-                  aria-pressed={isSelected}
-                  aria-label={`Select ${option.description}`}
-                >
-                  <Icon className="mb-2 size-5" aria-hidden="true" />
-                  <span className="text-xs font-medium">{option.label}</span>
-                </button>
-              )
-            })}
-          </div>
-        </Field>
-
-        <Field
-          label="Chart palette"
-          icon={Palette}
-          description="Color scheme for chart series. Colorblind uses the Okabe-Ito palette; Mono is a single-hue ramp."
-        >
-          <SegmentedControl
-            ariaLabel="Chart palette"
-            value={settings.chartPalette}
-            onChange={(value) => onUpdate({ chartPalette: value })}
-            options={chartPaletteOptions}
-          />
-        </Field>
-      </section>
-
-      <Separator />
-
-      {/* Units */}
-      <section className="space-y-4">
-        <SectionHeader>Units</SectionHeader>
-
-        <Field
-          label="Byte sizes"
-          icon={Binary}
-          description={`Binary uses 1024-based KiB/MiB; Decimal uses 1000-based KB/MB. e.g. ${bytePreview}`}
-        >
-          <SegmentedControl
-            ariaLabel="Byte sizes"
-            value={settings.byteUnit}
-            onChange={(value) => onUpdate({ byteUnit: value })}
-            options={byteUnitOptions}
-          />
-        </Field>
-
-        <Field
-          label="Large numbers"
-          icon={Hash}
-          description={`Abbreviated shows compact suffixes; Full shows grouped digits. e.g. ${numberPreview}`}
-        >
-          <SegmentedControl
-            ariaLabel="Large numbers"
-            value={settings.numberFormat}
-            onChange={(value) => onUpdate({ numberFormat: value })}
-            options={numberFormatOptions}
-          />
-        </Field>
-      </section>
-
-      <Separator />
-
-      {/* Layout */}
-      <section className="space-y-4">
-        <SectionHeader>Layout</SectionHeader>
-
-        <Field
-          label="Table density"
-          icon={Rows3}
-          description="Row height for data tables. Compact fits more rows on screen."
-        >
-          <SegmentedControl
-            ariaLabel="Table density"
-            value={settings.tableDensity}
-            onChange={(value) => onUpdate({ tableDensity: value })}
-            options={densityOptions}
-          />
-        </Field>
-
-        <Field
-          label="Default time range"
-          description="Initial time range for time-series pages. Explicit clicks and shared ?range= links still take priority."
-        >
-          <Select
-            value={settings.defaultTimeRange}
-            onValueChange={(value) =>
-              value && onUpdate({ defaultTimeRange: value as DefaultTimeRange })
-            }
-          >
-            <SelectTrigger id="default-time-range" className="h-9">
-              <SelectValue placeholder="Select default range" />
-            </SelectTrigger>
-            <SelectContent>
-              {TIME_RANGE_PRESETS.map((preset) => (
-                <SelectItem key={preset.value} value={preset.value}>
-                  {preset.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </Field>
-      </section>
-
-      <Separator />
-
-      {/* Integrations */}
-      <section className="space-y-3">
-        <SectionHeader>Integrations</SectionHeader>
-        <Field
-          label="MCP Server"
-          icon={Globe}
-          description="Connect AI assistants to your ClickHouse cluster via the Model Context Protocol."
-        >
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="w-full justify-start text-xs"
-            onClick={() => window.open('/mcp', '_blank')}
-          >
-            <Globe className="mr-2 size-3" />
-            View MCP Server Details
-          </Button>
-        </Field>
-      </section>
-
-      <div className="flex justify-end pt-4">
+      <div className="flex justify-end pt-2">
         <Button onClick={onClose}>Done</Button>
       </div>
     </div>

--- a/apps/dashboard/src/lib/types/user-settings.ts
+++ b/apps/dashboard/src/lib/types/user-settings.ts
@@ -17,6 +17,12 @@ export interface UserSettings {
   tableDensity: TableDensity
   /** Initial global time range for time-series pages. */
   defaultTimeRange: DefaultTimeRange
+  /**
+   * Dim (gray out) menu pages whose backing table is unavailable on the host.
+   * When false, those pages are hidden from the menu entirely. Defaults to
+   * true to preserve the long-standing "gray, don't hide" behaviour.
+   */
+  dimUnavailablePages: boolean
 }
 
 export const DEFAULT_USER_SETTINGS: UserSettings = {
@@ -27,6 +33,7 @@ export const DEFAULT_USER_SETTINGS: UserSettings = {
   chartPalette: 'default',
   tableDensity: 'comfortable',
   defaultTimeRange: '24h',
+  dimUnavailablePages: true,
 }
 
 export const USER_SETTINGS_STORAGE_KEY = 'clickhouse-monitor-user-settings'


### PR DESCRIPTION
## Summary

Three small UI fixes bundled together.

### Pin icon
The pin/favorite button on sidebar menu items rendered too large and flush to the right edge with no gap from the label. Root cause: `SidebarMenuAction` forces `[&>svg]:size-4` (descendant-selector specificity beats the `size-3.5` utility on the icon). Fixed by overriding at the action level (`[&>svg]:size-3`) and insetting to `right-2`.

### Host switcher
The trigger button stacked the host name and version/uptime rows with no gap. Added vertical gap + padding so the two rows breathe.

### Settings dialog
- Widened from `sm:max-w-md` to `sm:max-w-3xl`.
- Converted to a **vertical tab rail**: General / Appearance / Units / Layout / **Navigation** / Integrations, each iconified.
- New **Navigation → "Dim unavailable pages"** toggle (default on, preserves current gray behaviour). Turn it off to fully hide menu pages whose backing system table is missing on the host.
- Inline previews: chart-palette colour swatches, table-density row illustration, units live preview, and a mini menu demo for the dim/hide behaviour.

## Test plan
- [ ] Hover a top-level and a sub menu item — pin icon is small, inset from the right edge, doesn't overlap the label.
- [ ] Host switcher trigger shows clear space between name and version rows.
- [ ] Open Settings — dialog is wider, vertical tabs switch panels.
- [ ] Toggle "Dim unavailable pages" off → an unsupported page (e.g. Backups when `system.backup_log` is absent) disappears from the menu; on → it reappears grayed.