### PR TITLE
fix(charts): reserve close-button space in chart-zoom header

### DIFF
--- a/apps/dashboard/src/components/charts/chart-zoom-dialog.tsx
+++ b/apps/dashboard/src/components/charts/chart-zoom-dialog.tsx
@@ -351,7 +351,7 @@ export const ChartZoomDialog = function ChartZoomDialog({
         style={{ height: dialogHeight, maxHeight: '95vh' }}
       >
         <DialogHeader className="px-6 pt-6 pb-4 border-b shrink-0">
-          <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center justify-between gap-4 pr-6">
             <DialogTitle className="truncate flex-1">{title}</DialogTitle>
             <div className="flex items-center gap-2 shrink-0">
               {staleError && onRetry && (


### PR DESCRIPTION
## What

The chart-zoom dialog header placed the `DateRangeSelector` in the top-right, directly under the absolute-positioned close (`X`) button. `chart-zoom-dialog` was the only dialog using `p-0` content padding without reserving close-button space, so the controls could sit on top of the X.

## Fix

Add `pr-6` to the chart-zoom header row, matching the close-button-space convention already used by `host-details-dialog.tsx` and `dialogs/dialog-content.tsx`:

```diff
 <DialogHeader className="px-6 pt-6 pb-4 border-b shrink-0">
-  <div className="flex items-center justify-between gap-4">
+  <div className="flex items-center justify-between gap-4 pr-6">
```

With the header's existing `px-6` (1.5rem) plus `pr-6` (1.5rem), the controls' right edge lands ~3rem from the popup edge, clearing the close X (which reaches ~2.25rem).

## Verification

- `pnpm run build` ✅ (Vite + `tsc --noEmit`)
- Pre-push test suite: 1016 pass / 0 fail