### PR TITLE
feat(menu): dim metadata-db-dependent items when no metadata DB configured

### DIFF
--- a/apps/dashboard/src/components/menu/types.ts
+++ b/apps/dashboard/src/components/menu/types.ts
@@ -31,6 +31,14 @@ export interface MenuItem {
   /** ClickHouse system table name(s) to check for availability/muting */
   tableCheck?: string | string[]
   /**
+   * Page needs the deployment's metadata database (D1 or Postgres) to persist
+   * its state (e.g. report subscriptions). When none is configured the item is
+   * dimmed — same treatment as a missing `tableCheck` table — never hidden, so
+   * the OSS UX surface stays intact. Resolved via `config.metadataDb.available`
+   * from `/api/v1/config` (see lib/menu/metadata-db.ts).
+   */
+  requiresMetadataDb?: boolean
+  /**
    * Cloud (SaaS)-only surface — hidden in self-host / OSS. Set on items that
    * make sense only in the cloud product (e.g. Billing, Organization). Filtered
    * centrally by `getVisibleMenuItems` (lib/menu/visible-items.ts) against

--- a/apps/dashboard/src/components/navigation/nav-main/collapsed-submenu.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/collapsed-submenu.tsx
@@ -4,6 +4,7 @@ import { lazy, Suspense, useState } from 'react'
 import { ClientOnly } from '@/components/client-only'
 import { useIsTableAvailable } from '@/components/menu/hooks/use-table-availability'
 import { HostPrefixedLink } from '@/components/menu/link-with-context'
+import { useMetadataDbSatisfied } from '@/lib/menu/metadata-db'
 import { useHostId } from '@/lib/swr'
 
 const NewBadge = lazy(() =>
@@ -54,7 +55,12 @@ const CollapsedSubMenuItem = function CollapsedSubMenuItem({
   setOpenMobile: (open: boolean) => void
   setOpen: (open: boolean) => void
 }) {
-  const { available } = useIsTableAvailable(subItem.tableCheck, hostId)
+  const { available: tableAvailable } = useIsTableAvailable(
+    subItem.tableCheck,
+    hostId
+  )
+  const dbSatisfied = useMetadataDbSatisfied(subItem)
+  const available = tableAvailable && dbSatisfied
   const isActive = isMenuItemActiveAmongSiblings(
     subItem.href,
     siblingHrefs,
@@ -65,7 +71,13 @@ const CollapsedSubMenuItem = function CollapsedSubMenuItem({
     <HostPrefixedLink
       href={subItem.href}
       className={available ? '' : 'opacity-50'}
-      title={available ? undefined : 'System table not found on this host'}
+      title={
+        available
+          ? undefined
+          : dbSatisfied
+            ? 'System table not found on this host'
+            : 'Requires a metadata database — configure D1 or Postgres'
+      }
       onClick={() => {
         setOpen(false)
         if (isMobile) {

--- a/apps/dashboard/src/components/navigation/nav-main/menu-item.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/menu-item.tsx
@@ -9,6 +9,7 @@ import { lazy, Suspense } from 'react'
 import { useIsTableAvailable } from '@/components/menu/hooks/use-table-availability'
 import { HostPrefixedLink } from '@/components/menu/link-with-context'
 import { useUserSettings } from '@/lib/hooks/use-user-settings'
+import { useMetadataDbSatisfied } from '@/lib/menu/metadata-db'
 import { useHostId } from '@/lib/swr'
 
 const NewBadge = lazy(() =>
@@ -84,13 +85,19 @@ const SingleMenuItem = function SingleMenuItem({
 }) {
   const closeMobileSidebar = useCloseMobileSidebar()
   const hostId = useHostId()
-  const { available } = useIsTableAvailable(item.tableCheck, hostId)
+  const { available: tableAvailable } = useIsTableAvailable(
+    item.tableCheck,
+    hostId
+  )
+  const dbSatisfied = useMetadataDbSatisfied(item)
+  const available = tableAvailable && dbSatisfied
   const { settings } = useUserSettings()
   const hasBadge = Boolean(item.isNew || item.countKey)
 
   // When the page's backing table is missing, either dim it (default) or hide
-  // it entirely per the user's Navigation setting.
-  if (!available && !settings.dimUnavailablePages) {
+  // it entirely per the user's Navigation setting. A missing metadata database
+  // only ever dims — the surface stays discoverable in OSS.
+  if (!tableAvailable && !settings.dimUnavailablePages) {
     return null
   }
 
@@ -101,7 +108,9 @@ const SingleMenuItem = function SingleMenuItem({
         tooltip={
           available
             ? item.title
-            : `${item.title} (System table not found on this host)`
+            : dbSatisfied
+              ? `${item.title} (System table not found on this host)`
+              : `${item.title} (Requires a metadata database — configure D1 or Postgres)`
         }
         className={available ? '' : 'opacity-50 text-muted-foreground/50'}
         render={
@@ -156,11 +165,16 @@ const SubMenuItem = function SubMenuItem({
   siblingHrefs: string[]
   closeMobileSidebar: () => void
 }) {
-  const { available } = useIsTableAvailable(subItem.tableCheck, hostId)
+  const { available: tableAvailable } = useIsTableAvailable(
+    subItem.tableCheck,
+    hostId
+  )
+  const dbSatisfied = useMetadataDbSatisfied(subItem)
+  const available = tableAvailable && dbSatisfied
   const { settings } = useUserSettings()
   const hasBadge = Boolean(subItem.isNew || subItem.countKey)
 
-  if (!available && !settings.dimUnavailablePages) {
+  if (!tableAvailable && !settings.dimUnavailablePages) {
     return null
   }
 

--- a/apps/dashboard/src/lib/feature-permissions/types.ts
+++ b/apps/dashboard/src/lib/feature-permissions/types.ts
@@ -82,6 +82,16 @@ export interface UserConnectionsPublicConfig {
   requiresAuth: boolean
 }
 
+/**
+ * Whether this deployment has a metadata database (D1 binding or a Postgres
+ * `DATABASE_URL`/`POSTGRES_URL`) for persisting app state — report
+ * subscriptions, per-user connections, shared dashboards. OSS deployments
+ * without one keep the UI surface intact but dim the menu items that need it.
+ */
+export interface MetadataDbPublicConfig {
+  available: boolean
+}
+
 export interface PublicFeaturePermissionConfig {
   authProvider: 'none' | 'clerk' | 'proxy' | 'trusted'
   principal: Principal
@@ -91,4 +101,6 @@ export interface PublicFeaturePermissionConfig {
   capabilities?: AnonymousCapabilities
   /** Per-user ClickHouse connection storage capabilities. */
   userConnections?: UserConnectionsPublicConfig
+  /** Metadata-database availability for state-persisting features. */
+  metadataDb?: MetadataDbPublicConfig
 }

--- a/apps/dashboard/src/lib/menu/metadata-db.test.ts
+++ b/apps/dashboard/src/lib/menu/metadata-db.test.ts
@@ -1,0 +1,43 @@
+import type { PublicFeaturePermissionConfig } from '@/lib/feature-permissions/types'
+
+import { metadataDbSatisfied } from './metadata-db'
+import { describe, expect, it } from 'bun:test'
+
+const baseConfig: PublicFeaturePermissionConfig = {
+  authProvider: 'none',
+  principal: 'anonymous',
+  features: {},
+}
+
+describe('metadataDbSatisfied', () => {
+  it('passes items without the flag regardless of config', () => {
+    expect(metadataDbSatisfied({}, baseConfig)).toBe(true)
+    expect(
+      metadataDbSatisfied(
+        {},
+        { ...baseConfig, metadataDb: { available: false } }
+      )
+    ).toBe(true)
+  })
+
+  it('dims flagged items only when the server reports no metadata DB', () => {
+    expect(
+      metadataDbSatisfied(
+        { requiresMetadataDb: true },
+        { ...baseConfig, metadataDb: { available: false } }
+      )
+    ).toBe(false)
+    expect(
+      metadataDbSatisfied(
+        { requiresMetadataDb: true },
+        { ...baseConfig, metadataDb: { available: true } }
+      )
+    ).toBe(true)
+  })
+
+  it('fails open when the config has no metadataDb block (older server / fetch error)', () => {
+    expect(metadataDbSatisfied({ requiresMetadataDb: true }, baseConfig)).toBe(
+      true
+    )
+  })
+})

--- a/apps/dashboard/src/lib/menu/metadata-db.ts
+++ b/apps/dashboard/src/lib/menu/metadata-db.ts
@@ -1,0 +1,34 @@
+/**
+ * Metadata-database gate for menu items (`requiresMetadataDb`).
+ *
+ * Items whose page persists state in the deployment's metadata database
+ * (report subscriptions, shared dashboards, per-user connections) are DIMMED —
+ * not hidden — when no metadata DB (D1 binding or Postgres URL) is configured,
+ * mirroring the `tableCheck` muting treatment so OSS keeps its UX surface.
+ */
+import type { MenuItem } from '@/components/menu/types'
+import type { PublicFeaturePermissionConfig } from '@/lib/feature-permissions/types'
+
+import { useFeaturePermissions } from '@/lib/feature-permissions/context'
+
+/**
+ * Whether the item's metadata-DB requirement is satisfied. Items without the
+ * flag always pass. An ABSENT `metadataDb` block in the config (older server,
+ * config fetch failed) also passes — fail-open so the menu never dims on a
+ * transient config error.
+ */
+export function metadataDbSatisfied(
+  item: Pick<MenuItem, 'requiresMetadataDb'>,
+  config: PublicFeaturePermissionConfig
+): boolean {
+  if (!item.requiresMetadataDb) return true
+  return config.metadataDb?.available !== false
+}
+
+/** Hook form of {@link metadataDbSatisfied} for nav renderers. */
+export function useMetadataDbSatisfied(
+  item: Pick<MenuItem, 'requiresMetadataDb'>
+): boolean {
+  const { config } = useFeaturePermissions()
+  return metadataDbSatisfied(item, config)
+}

--- a/apps/dashboard/src/menu.ts
+++ b/apps/dashboard/src/menu.ts
@@ -170,6 +170,9 @@ export const menuItemsConfig: MenuItem[] = [
           'Weekly or monthly cluster health reports, delivered to your alert channels',
         icon: CalendarClockIcon,
         isNew: true,
+        // Subscriptions persist in the metadata DB (report-subscription-store);
+        // dimmed when the deployment has no D1/Postgres configured.
+        requiresMetadataDb: true,
       },
     ],
   },

--- a/apps/dashboard/src/routes/api/v1/config.ts
+++ b/apps/dashboard/src/routes/api/v1/config.ts
@@ -43,6 +43,7 @@ import {
   FEATURE_ACCESS_VALUES,
   FEATURE_IDS,
 } from '@/lib/feature-permissions/types'
+import { getPlatformBindings } from '@/lib/platform-native'
 
 // ---------------------------------------------------------------------------
 // Inlined feature-permission resolution (mirror lib/feature-permissions/shared.ts).
@@ -216,6 +217,19 @@ function getPublicFeaturePermissionConfig(): PublicFeaturePermissionConfig {
 
   const userConnections = getUserConnectionsServerConfig()
 
+  // Metadata DB = anywhere app state (report subscriptions, per-user
+  // connections, shared dashboards) can persist: the D1 binding on Cloudflare,
+  // or a Postgres URL on Docker/K8s. Fail-open false so an OSS deploy without
+  // one just dims the dependent menu items instead of hiding them.
+  let metadataDbAvailable = false
+  try {
+    metadataDbAvailable =
+      getPlatformBindings().getD1Database('CHM_CLOUD_D1') !== null ||
+      Boolean(readEnv('DATABASE_URL') ?? readEnv('POSTGRES_URL'))
+  } catch {
+    metadataDbAvailable = false
+  }
+
   return {
     authProvider,
     // WORKERD: no server-side Clerk auth() here → always anonymous.
@@ -228,6 +242,7 @@ function getPublicFeaturePermissionConfig(): PublicFeaturePermissionConfig {
       dbStorageEnabled: userConnections.dbStorageEnabled,
       requiresAuth: userConnections.requiresAuth,
     },
+    metadataDb: { available: metadataDbAvailable },
   }
 }
 


### PR DESCRIPTION
## Summary
- New `metadataDb.available` capability in `/api/v1/config`: true when the D1 binding or a Postgres `DATABASE_URL`/`POSTGRES_URL` is present (fail-open false, wrapped in try/catch).
- New `requiresMetadataDb` flag on `MenuItem`; flagged items are **dimmed** (same `opacity-50` treatment as missing `tableCheck` tables) with tooltip "Requires a metadata database — configure D1 or Postgres". Never hidden, keeping the OSS surface intact.
- Marked **Scheduled Reports** (`/report-settings`), whose subscription store is metadata-DB-backed.
- Verified: Billing/Organization footer items are already correctly hidden in OSS via the existing `cloudOnly` gate in `getVisibleMenuItems` (build-time fail-closed cloud mode) — no change needed there.

## Tests
- `metadata-db.test.ts`: flag-off pass, dim only when server reports unavailable, fail-open on absent config block.
- `tsc --noEmit` clean.

https://claude.ai/code/session_01AZT2vFfSh2NNjUUdsEX5M7