### PR TITLE
feat(oss): Postgres and ClickHouse state backends for self-hosted deployments

### DIFF
--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -328,6 +328,14 @@ AGENTSTATE_API_KEY=
 # (Docker/K8s): Postgres via POSTGRES_URL (or POSTGRES_PRISMA_URL), else DATABASE_URL.
 # DATABASE_URL=
 # POSTGRES_URL=
+# Alternatively, persist UI state (dashboards, per-user connections) in your
+# own ClickHouse (checked before Postgres; tables auto-created as
+# ReplacingMergeTree). See docs: /operate/advanced/state-backends.
+# CHM_STATE_CLICKHOUSE_URL=http://clickhouse:8123
+# CHM_STATE_CLICKHOUSE_USER=default
+# CHM_STATE_CLICKHOUSE_PASSWORD=
+# CHM_STATE_CLICKHOUSE_DATABASE=chmonitor
+# CHM_STATE_CLICKHOUSE_TABLE_PREFIX=chm_state_
 # Redis-backed ClickHouse version cache (optional; falls back to in-memory).
 # REDIS_URL=
 # Query-config source: ts (default — hand-written TS configs) | declarative

--- a/apps/dashboard/src/lib/connection-store/clickhouse-store.test.ts
+++ b/apps/dashboard/src/lib/connection-store/clickhouse-store.test.ts
@@ -5,10 +5,10 @@
  * delete-not-found contract.
  */
 
-import { describe, expect, mock, test } from 'bun:test'
-
 import type { StateClickHouseExecutor } from '@/lib/state-backend/clickhouse-client'
 import type { StateClickHouseConfig } from '@/lib/state-backend/config'
+
+import { describe, expect, mock, test } from 'bun:test'
 
 mock.module('@chm/platform', () => ({
   getPlatformBindings: () => ({ getD1Database: () => undefined }),

--- a/apps/dashboard/src/lib/connection-store/clickhouse-store.test.ts
+++ b/apps/dashboard/src/lib/connection-store/clickhouse-store.test.ts
@@ -1,0 +1,133 @@
+/**
+ * SQL-generation tests for the ClickHouse connection store, run against a
+ * mocked state-ClickHouse executor (no live ClickHouse required). Verifies
+ * the DDL shape, user scoping via bound params, FINAL reads, and the
+ * delete-not-found contract.
+ */
+
+import { describe, expect, mock, test } from 'bun:test'
+
+import type { StateClickHouseExecutor } from '@/lib/state-backend/clickhouse-client'
+import type { StateClickHouseConfig } from '@/lib/state-backend/config'
+
+mock.module('@chm/platform', () => ({
+  getPlatformBindings: () => ({ getD1Database: () => undefined }),
+}))
+
+const { buildConnectionsDdl, ClickHouseConnectionStore } = await import(
+  './clickhouse-store'
+)
+const { ConnectionStoreError } = await import('./types')
+
+const CONFIG: StateClickHouseConfig = {
+  url: 'http://ch:8123',
+  user: 'default',
+  password: '',
+  database: 'chmonitor',
+  tablePrefix: 'chm_state_',
+}
+
+interface Call {
+  kind: 'command' | 'query'
+  sql: string
+  params?: Record<string, string | number>
+}
+
+function mockExecutor(queryResult: unknown[] = []) {
+  const calls: Call[] = []
+  const executor: StateClickHouseExecutor = {
+    async command(sql, params) {
+      calls.push({ kind: 'command', sql, params })
+    },
+    async query<T>(sql: string, params?: Record<string, string | number>) {
+      calls.push({ kind: 'query', sql, params })
+      return queryResult as T[]
+    },
+  }
+  return { executor, calls }
+}
+
+const ROW = {
+  id: 'conn-1',
+  user_id: 'user-a',
+  name: 'Prod',
+  host_url: 'https://ch.example:8443',
+  ch_user: 'monitor',
+  host_id: -1000,
+  engine: 'clickhouse',
+  encrypted_payload: 'payload',
+  created_at: 1,
+  updated_at: 1,
+}
+
+describe('buildConnectionsDdl', () => {
+  test('creates a ReplacingMergeTree versioned by updated_at, keyed (user_id, id)', () => {
+    const ddl = buildConnectionsDdl('chmonitor', 'chm_state_')
+    expect(ddl).toContain(
+      'CREATE TABLE IF NOT EXISTS chmonitor.chm_state_user_connections'
+    )
+    expect(ddl).toContain('ENGINE = ReplacingMergeTree(updated_at)')
+    expect(ddl).toContain('ORDER BY (user_id, id)')
+  })
+})
+
+describe('ClickHouseConnectionStore SQL', () => {
+  test('lazily creates database + table before the first read', async () => {
+    const { executor, calls } = mockExecutor()
+    const store = new ClickHouseConnectionStore(CONFIG, executor)
+    await store.list('user-a')
+    expect(calls[0]?.sql).toBe('CREATE DATABASE IF NOT EXISTS chmonitor')
+    expect(calls[1]?.sql).toContain('CREATE TABLE IF NOT EXISTS')
+  })
+
+  test('list is user-scoped, reads FINAL, and binds params', async () => {
+    const { executor, calls } = mockExecutor([ROW])
+    const store = new ClickHouseConnectionStore(CONFIG, executor)
+    const metas = await store.list('user-a')
+    const listCall = calls.find((c) => c.kind === 'query')
+    expect(listCall?.sql).toContain(
+      'FROM chmonitor.chm_state_user_connections FINAL'
+    )
+    expect(listCall?.sql).toContain('user_id = {user_id:String}')
+    expect(listCall?.params).toEqual({ user_id: 'user-a' })
+    // Row mapping (and no encrypted payload in list metadata).
+    expect(metas[0]).toMatchObject({
+      id: 'conn-1',
+      userId: 'user-a',
+      hostId: -1000,
+      engine: 'clickhouse',
+    })
+    expect(metas[0]).not.toHaveProperty('encryptedPayload')
+  })
+
+  test('get scopes by user AND id with bound params', async () => {
+    const { executor, calls } = mockExecutor([ROW])
+    const store = new ClickHouseConnectionStore(CONFIG, executor)
+    const stored = await store.get('user-a', 'conn-1')
+    const getCall = calls.find((c) => c.kind === 'query')
+    expect(getCall?.sql).toContain(
+      'user_id = {user_id:String} AND id = {id:String}'
+    )
+    expect(getCall?.params).toEqual({ user_id: 'user-a', id: 'conn-1' })
+    expect(stored?.encryptedPayload).toBe('payload')
+  })
+
+  test('delete issues a user-scoped lightweight DELETE after existence check', async () => {
+    const { executor, calls } = mockExecutor([ROW])
+    const store = new ClickHouseConnectionStore(CONFIG, executor)
+    await store.delete('user-a', 'conn-1')
+    const del = calls.find((c) => c.sql.startsWith('DELETE FROM'))
+    expect(del?.sql).toContain(
+      'WHERE user_id = {user_id:String} AND id = {id:String}'
+    )
+    expect(del?.params).toEqual({ user_id: 'user-a', id: 'conn-1' })
+  })
+
+  test('delete throws NOT_FOUND when the connection does not exist', async () => {
+    const { executor } = mockExecutor([])
+    const store = new ClickHouseConnectionStore(CONFIG, executor)
+    await expect(store.delete('user-a', 'missing')).rejects.toThrow(
+      ConnectionStoreError
+    )
+  })
+})

--- a/apps/dashboard/src/lib/connection-store/clickhouse-store.ts
+++ b/apps/dashboard/src/lib/connection-store/clickhouse-store.ts
@@ -24,11 +24,11 @@ import type {
 
 import { decryptCredentials, encryptCredentials } from './crypto'
 import { allocateDbHostId, ConnectionStoreError } from './types'
+import { DEFAULT_SOURCE_ENGINE, parseSourceEngine } from '@chm/types'
 import {
   StateClickHouseClient,
   type StateClickHouseExecutor,
 } from '@/lib/state-backend/clickhouse-client'
-import { DEFAULT_SOURCE_ENGINE, parseSourceEngine } from '@chm/types'
 
 interface ClickHouseUserConnectionRow {
   id: string

--- a/apps/dashboard/src/lib/connection-store/clickhouse-store.ts
+++ b/apps/dashboard/src/lib/connection-store/clickhouse-store.ts
@@ -1,0 +1,252 @@
+/**
+ * ClickHouse-backed connection store (server-only, self-hosted OSS).
+ *
+ * Lets an operator persist per-user connections in their own ClickHouse
+ * instead of Cloudflare D1 or Postgres. Configured via `CHM_STATE_CLICKHOUSE_*`
+ * (see `lib/state-backend/config.ts`); resolved by `resolve-store.ts` after
+ * D1 and before Postgres.
+ *
+ * Storage model: one `${prefix}user_connections` table on
+ * `ReplacingMergeTree(updated_at)` keyed `(user_id, id)` — updates are plain
+ * inserts with a newer `updated_at`, reads use `FINAL` for
+ * read-your-writes correctness, deletes are lightweight `DELETE FROM`.
+ */
+
+import type { StateClickHouseConfig } from '@/lib/state-backend/config'
+import type {
+  ConnectionStore,
+  CreateLimitEnforcement,
+  CreateUserConnectionInput,
+  StoredUserConnection,
+  UpdateUserConnectionInput,
+  UserConnectionMeta,
+} from './types'
+
+import { decryptCredentials, encryptCredentials } from './crypto'
+import { allocateDbHostId, ConnectionStoreError } from './types'
+import {
+  StateClickHouseClient,
+  type StateClickHouseExecutor,
+} from '@/lib/state-backend/clickhouse-client'
+import { DEFAULT_SOURCE_ENGINE, parseSourceEngine } from '@chm/types'
+
+interface ClickHouseUserConnectionRow {
+  id: string
+  user_id: string
+  name: string
+  host_url: string
+  ch_user: string
+  host_id: number
+  engine: string
+  encrypted_payload: string
+  created_at: number
+  updated_at: number
+}
+
+/** Exported for SQL-generation tests. */
+export function buildConnectionsDdl(database: string, prefix: string): string {
+  return `CREATE TABLE IF NOT EXISTS ${database}.${prefix}user_connections (
+  id String,
+  user_id String,
+  name String,
+  host_url String,
+  ch_user String,
+  host_id Int64,
+  engine String DEFAULT 'clickhouse',
+  encrypted_payload String,
+  created_at Int64,
+  updated_at Int64
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (user_id, id)`
+}
+
+const COLUMNS =
+  'id, user_id, name, host_url, ch_user, host_id, engine, encrypted_payload, created_at, updated_at'
+
+function rowToMeta(row: ClickHouseUserConnectionRow): UserConnectionMeta {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    name: row.name,
+    hostUrl: row.host_url,
+    chUser: row.ch_user,
+    hostId: Number(row.host_id),
+    engine: parseSourceEngine(row.engine),
+    createdAt: Number(row.created_at),
+    updatedAt: Number(row.updated_at),
+  }
+}
+
+export class ClickHouseConnectionStore implements ConnectionStore {
+  private readonly client: StateClickHouseExecutor
+  private readonly table: string
+  private readonly database: string
+  private readonly prefix: string
+  private initialized = false
+
+  constructor(config: StateClickHouseConfig, client?: StateClickHouseExecutor) {
+    this.client = client ?? new StateClickHouseClient(config)
+    this.database = config.database
+    this.prefix = config.tablePrefix
+    this.table = `${config.database}.${config.tablePrefix}user_connections`
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (this.initialized) return
+    await this.client.command(`CREATE DATABASE IF NOT EXISTS ${this.database}`)
+    await this.client.command(buildConnectionsDdl(this.database, this.prefix))
+    this.initialized = true
+  }
+
+  private async insertRow(row: ClickHouseUserConnectionRow): Promise<void> {
+    await this.client.command(
+      `INSERT INTO ${this.table} (${COLUMNS}) VALUES
+        ({id:String}, {user_id:String}, {name:String}, {host_url:String}, {ch_user:String},
+         {host_id:Int64}, {engine:String}, {encrypted_payload:String}, {created_at:Int64}, {updated_at:Int64})`,
+      { ...row }
+    )
+  }
+
+  async list(userId: string): Promise<UserConnectionMeta[]> {
+    await this.ensureInitialized()
+    const rows = await this.client.query<ClickHouseUserConnectionRow>(
+      `SELECT ${COLUMNS} FROM ${this.table} FINAL
+       WHERE user_id = {user_id:String} ORDER BY created_at ASC`,
+      { user_id: userId }
+    )
+    return rows.map(rowToMeta)
+  }
+
+  async get(
+    userId: string,
+    connectionId: string
+  ): Promise<StoredUserConnection | null> {
+    await this.ensureInitialized()
+    const rows = await this.client.query<ClickHouseUserConnectionRow>(
+      `SELECT ${COLUMNS} FROM ${this.table} FINAL
+       WHERE user_id = {user_id:String} AND id = {id:String} LIMIT 1`,
+      { user_id: userId, id: connectionId }
+    )
+    const row = rows[0]
+    if (!row) return null
+    return { ...rowToMeta(row), encryptedPayload: row.encrypted_payload }
+  }
+
+  async create(
+    userId: string,
+    input: CreateUserConnectionInput,
+    limit?: CreateLimitEnforcement
+  ): Promise<UserConnectionMeta> {
+    await this.ensureInitialized()
+
+    // Best-effort limit check. ClickHouse has no transactions/advisory locks,
+    // so unlike the Postgres store this pre-check is not race-proof under
+    // concurrent creates — acceptable for the self-hosted OSS path this
+    // backend targets (single operator, no billing enforcement stakes).
+    if (limit && limit.limit != null && limit.memberUserIds.length > 0) {
+      const memberIds = JSON.stringify(limit.memberUserIds)
+      const rows = await this.client.query<{ cnt: string | number }>(
+        `SELECT count() AS cnt FROM ${this.table} FINAL
+         WHERE has(JSONExtract({member_ids:String}, 'Array(String)'), user_id)`,
+        { member_ids: memberIds }
+      )
+      const count = Number(rows[0]?.cnt ?? 0)
+      if (count >= limit.limit) {
+        throw new ConnectionStoreError('Host limit reached', 'LIMIT_EXCEEDED')
+      }
+    }
+
+    const existing = await this.list(userId)
+    const now = Date.now()
+    const id = crypto.randomUUID()
+    const hostId = allocateDbHostId(existing.map((c) => c.hostId))
+    const engine = input.engine ?? DEFAULT_SOURCE_ENGINE
+    const encryptedPayload = await encryptCredentials(input.credentials)
+
+    await this.insertRow({
+      id,
+      user_id: userId,
+      name: input.name,
+      host_url: input.hostUrl,
+      ch_user: input.chUser,
+      host_id: hostId,
+      engine,
+      encrypted_payload: encryptedPayload,
+      created_at: now,
+      updated_at: now,
+    })
+
+    return {
+      id,
+      userId,
+      name: input.name,
+      hostUrl: input.hostUrl,
+      chUser: input.chUser,
+      hostId,
+      engine,
+      createdAt: now,
+      updatedAt: now,
+    }
+  }
+
+  async update(
+    userId: string,
+    connectionId: string,
+    input: UpdateUserConnectionInput
+  ): Promise<UserConnectionMeta> {
+    const existing = await this.get(userId, connectionId)
+    if (!existing) {
+      throw new ConnectionStoreError('Connection not found', 'NOT_FOUND')
+    }
+
+    const now = Date.now()
+    const name = input.name ?? existing.name
+    const hostUrl = input.hostUrl ?? existing.hostUrl
+    const chUser = input.chUser ?? existing.chUser
+
+    let encryptedPayload = existing.encryptedPayload
+    if (input.credentials) {
+      encryptedPayload = await encryptCredentials(input.credentials)
+    } else if (input.hostUrl || input.chUser) {
+      const current = await decryptCredentials(existing.encryptedPayload)
+      encryptedPayload = await encryptCredentials({
+        host: hostUrl,
+        user: chUser,
+        password: current.password,
+      })
+    }
+
+    // ReplacingMergeTree "update": insert the full row with a newer version.
+    await this.insertRow({
+      id: existing.id,
+      user_id: existing.userId,
+      name,
+      host_url: hostUrl,
+      ch_user: chUser,
+      host_id: existing.hostId,
+      engine: existing.engine,
+      encrypted_payload: encryptedPayload,
+      created_at: existing.createdAt,
+      updated_at: now,
+    })
+
+    return { ...existing, name, hostUrl, chUser, updatedAt: now }
+  }
+
+  async delete(userId: string, connectionId: string): Promise<void> {
+    const existing = await this.get(userId, connectionId)
+    if (!existing) {
+      throw new ConnectionStoreError('Connection not found', 'NOT_FOUND')
+    }
+    await this.client.command(
+      `DELETE FROM ${this.table} WHERE user_id = {user_id:String} AND id = {id:String}`,
+      { user_id: userId, id: connectionId }
+    )
+  }
+
+  async getCredentials(userId: string, connectionId: string) {
+    const stored = await this.get(userId, connectionId)
+    if (!stored) return null
+    return decryptCredentials(stored.encryptedPayload)
+  }
+}

--- a/apps/dashboard/src/lib/connection-store/resolve-store.ts
+++ b/apps/dashboard/src/lib/connection-store/resolve-store.ts
@@ -3,10 +3,13 @@ import type { ConnectionStore } from './types'
 import { D1ConnectionStore } from './d1-store'
 import { getUserConnectionsServerConfig } from './server-feature'
 import { ConnectionStoreError } from './types'
+import {
+  getStateClickHouseConfig,
+  getStatePostgresUrl,
+} from '@/lib/state-backend/config'
 import { getPlatformBindings } from '@chm/platform'
 
 const D1_BINDING_NAME = 'CHM_CLOUD_D1'
-const DATABASE_URL = 'DATABASE_URL'
 
 export async function resolveConnectionStore(): Promise<ConnectionStore> {
   const config = getUserConnectionsServerConfig()
@@ -26,7 +29,15 @@ export async function resolveConnectionStore(): Promise<ConnectionStore> {
     // not CF
   }
 
-  if (process.env[DATABASE_URL] || process.env.POSTGRES_URL) {
+  // Self-hosted ClickHouse state backend (CHM_STATE_CLICKHOUSE_*) — checked
+  // after D1 (Cloud unchanged) and before Postgres.
+  const chConfig = getStateClickHouseConfig()
+  if (chConfig) {
+    const { ClickHouseConnectionStore } = await import('./clickhouse-store')
+    return new ClickHouseConnectionStore(chConfig)
+  }
+
+  if (getStatePostgresUrl()) {
     const { PostgresConnectionStore } = await import('./postgres-store')
     return new PostgresConnectionStore()
   }

--- a/apps/dashboard/src/lib/connection-store/resolve-store.ts
+++ b/apps/dashboard/src/lib/connection-store/resolve-store.ts
@@ -3,11 +3,11 @@ import type { ConnectionStore } from './types'
 import { D1ConnectionStore } from './d1-store'
 import { getUserConnectionsServerConfig } from './server-feature'
 import { ConnectionStoreError } from './types'
+import { getPlatformBindings } from '@chm/platform'
 import {
   getStateClickHouseConfig,
   getStatePostgresUrl,
 } from '@/lib/state-backend/config'
-import { getPlatformBindings } from '@chm/platform'
 
 const D1_BINDING_NAME = 'CHM_CLOUD_D1'
 

--- a/apps/dashboard/src/lib/conversation-store/resolve-store.ts
+++ b/apps/dashboard/src/lib/conversation-store/resolve-store.ts
@@ -19,12 +19,12 @@ import { ConversationStoreError } from './types'
 // first and never hits this branch.
 import { getPlatformBindings } from '@chm/platform'
 import { featureFlags } from '@/lib/feature-flags'
+import { getStatePostgresUrl } from '@/lib/state-backend/config'
 
 /**
  * Environment variable names for database configuration.
  */
 const D1_BINDING_NAME = 'CHM_CLOUD_D1'
-const DATABASE_URL = 'DATABASE_URL'
 const AGENTSTATE_API_KEY = 'AGENTSTATE_API_KEY'
 const AGENTSTATE_BASE_URL = 'AGENTSTATE_BASE_URL'
 const AGENTSTATE_AI_ENRICH = 'AGENTSTATE_AI_ENRICH'
@@ -38,7 +38,7 @@ const CONVERSATION_STORE_BACKEND = 'CONVERSATION_STORE_BACKEND'
  * 2. AgentState (forced via CONVERSATION_STORE_BACKEND=agentstate, or when
  *    AGENTSTATE_API_KEY is set and no other backend is explicitly forced)
  * 3. D1 binding available → D1Store (Cloudflare D1)
- * 4. DATABASE_URL env var → PostgresStore
+ * 4. DATABASE_URL / POSTGRES_URL env var → PostgresStore
  * 5. No database config → MemoryStore with warning
  *
  * @returns Promise resolving to ConversationStore instance
@@ -92,9 +92,10 @@ export async function resolveStore(): Promise<ConversationStore> {
   // 4. Check for Postgres DATABASE_URL (traditional database, Node-only path).
   // Dynamic import keeps the `postgres` package out of the Cloudflare Workers
   // bundle — workerd never reaches this branch (D1 is resolved above).
-  if (process.env[DATABASE_URL]) {
+  const postgresUrl = getStatePostgresUrl()
+  if (postgresUrl) {
     const { PostgresStore } = await import('./postgres-store')
-    return new PostgresStore(process.env[DATABASE_URL])
+    return new PostgresStore(postgresUrl)
   }
 
   // 5. Fallback to MemoryStore with warning

--- a/apps/dashboard/src/lib/dashboard-storage/clickhouse-store.test.ts
+++ b/apps/dashboard/src/lib/dashboard-storage/clickhouse-store.test.ts
@@ -1,0 +1,148 @@
+/**
+ * SQL-generation tests for the ClickHouse dashboard store, run against a
+ * mocked state-ClickHouse executor (no live ClickHouse required). Verifies
+ * the DDL shape (ReplacingMergeTree keyed by owner), that every read/write
+ * is owner-scoped via bound params (never string interpolation), that reads
+ * use FINAL, and the empty-share-slug guard.
+ */
+
+import { describe, expect, mock, test } from 'bun:test'
+
+import type { StateClickHouseExecutor } from '@/lib/state-backend/clickhouse-client'
+import type { StateClickHouseConfig } from '@/lib/state-backend/config'
+
+mock.module('@chm/platform', () => ({
+  getPlatformBindings: () => ({ getD1Database: () => undefined }),
+}))
+
+const { buildDashboardsDdl, ClickHouseDashboardStore } = await import(
+  './clickhouse-store'
+)
+
+const CONFIG: StateClickHouseConfig = {
+  url: 'http://ch:8123',
+  user: 'default',
+  password: '',
+  database: 'chmonitor',
+  tablePrefix: 'chm_state_',
+}
+
+interface Call {
+  kind: 'command' | 'query'
+  sql: string
+  params?: Record<string, string | number>
+}
+
+function mockExecutor(queryResult: unknown[] = []) {
+  const calls: Call[] = []
+  const executor: StateClickHouseExecutor = {
+    async command(sql, params) {
+      calls.push({ kind: 'command', sql, params })
+    },
+    async query<T>(sql: string, params?: Record<string, string | number>) {
+      calls.push({ kind: 'query', sql, params })
+      return queryResult as T[]
+    },
+  }
+  return { executor, calls }
+}
+
+describe('buildDashboardsDdl', () => {
+  test('creates a ReplacingMergeTree versioned by updated_at, keyed (owner_id, name)', () => {
+    const ddl = buildDashboardsDdl('chmonitor', 'chm_state_')
+    expect(ddl).toContain(
+      'CREATE TABLE IF NOT EXISTS chmonitor.chm_state_dashboards'
+    )
+    expect(ddl).toContain('ENGINE = ReplacingMergeTree(updated_at)')
+    expect(ddl).toContain('ORDER BY (owner_id, name)')
+  })
+
+  test('honors a custom database and table prefix', () => {
+    expect(buildDashboardsDdl('ops', 'ui_')).toContain(
+      'CREATE TABLE IF NOT EXISTS ops.ui_dashboards'
+    )
+  })
+})
+
+describe('ClickHouseDashboardStore SQL', () => {
+  test('lazily creates database + table before the first read', async () => {
+    const { executor, calls } = mockExecutor()
+    const store = new ClickHouseDashboardStore(CONFIG, executor)
+    await store.list('owner-a')
+    expect(calls[0]?.sql).toBe('CREATE DATABASE IF NOT EXISTS chmonitor')
+    expect(calls[1]?.sql).toContain('CREATE TABLE IF NOT EXISTS')
+  })
+
+  test('list is owner-scoped, reads FINAL, and binds params', async () => {
+    const { executor, calls } = mockExecutor()
+    const store = new ClickHouseDashboardStore(CONFIG, executor)
+    await store.list('owner-a')
+    const listCall = calls.at(-1)
+    expect(listCall?.sql).toContain('FROM chmonitor.chm_state_dashboards FINAL')
+    expect(listCall?.sql).toContain('owner_id = {owner_id:String}')
+    expect(listCall?.params).toEqual({ owner_id: 'owner-a' })
+  })
+
+  test('saveByName inserts a full row with bound params (no interpolation)', async () => {
+    const { executor, calls } = mockExecutor()
+    const store = new ClickHouseDashboardStore(CONFIG, executor)
+    const saved = await store.saveByName('owner-a', 'My Board', { widgets: [] })
+    const insert = calls.find((c) => c.sql.includes('INSERT INTO'))
+    expect(insert?.sql).toContain('INSERT INTO chmonitor.chm_state_dashboards')
+    expect(insert?.params).toMatchObject({
+      owner_id: 'owner-a',
+      name: 'My Board',
+      is_shared: 0,
+      share_slug: '',
+    })
+    // The raw layout/name never appear inside the SQL text itself.
+    expect(insert?.sql).not.toContain('My Board')
+    expect(saved.ownerId).toBe('owner-a')
+    expect(saved.shareSlug).toBeNull()
+  })
+
+  test('delete is owner-scoped via a lightweight DELETE', async () => {
+    const { executor, calls } = mockExecutor()
+    const store = new ClickHouseDashboardStore(CONFIG, executor)
+    await store.delete('owner-a', 'My Board')
+    const del = calls.find((c) => c.sql.startsWith('DELETE FROM'))
+    expect(del?.sql).toContain(
+      'WHERE owner_id = {owner_id:String} AND name = {name:String}'
+    )
+    expect(del?.params).toEqual({ owner_id: 'owner-a', name: 'My Board' })
+  })
+
+  test('getByShareSlug requires is_shared = 1 and never matches the empty slug', async () => {
+    const { executor, calls } = mockExecutor()
+    const store = new ClickHouseDashboardStore(CONFIG, executor)
+
+    // Empty string means "no slug" in storage — must short-circuit to null
+    // without ever querying.
+    expect(await store.getByShareSlug('')).toBeNull()
+    expect(calls.filter((c) => c.kind === 'query')).toHaveLength(0)
+
+    await store.getByShareSlug('slug-1')
+    const read = calls.find((c) => c.kind === 'query')
+    expect(read?.sql).toContain('share_slug = {slug:String} AND is_shared = 1')
+    expect(read?.params).toEqual({ slug: 'slug-1' })
+  })
+
+  test('setSharing revokes by clearing the slug in the same write', async () => {
+    const existingRow = {
+      id: 'id-1',
+      owner_id: 'owner-a',
+      name: 'My Board',
+      layout_json: '{"widgets":[]}',
+      is_shared: 1,
+      share_slug: 'slug-1',
+      updated_at: 1,
+    }
+    const { executor, calls } = mockExecutor([existingRow])
+    const store = new ClickHouseDashboardStore(CONFIG, executor)
+    const revoked = await store.setSharing('owner-a', 'My Board', false)
+    expect(revoked?.isShared).toBe(false)
+    expect(revoked?.shareSlug).toBeNull()
+    const insert = calls.find((c) => c.sql.includes('INSERT INTO'))
+    expect(insert?.params).toMatchObject({ is_shared: 0, share_slug: '' })
+  })
+})

--- a/apps/dashboard/src/lib/dashboard-storage/clickhouse-store.test.ts
+++ b/apps/dashboard/src/lib/dashboard-storage/clickhouse-store.test.ts
@@ -6,10 +6,10 @@
  * use FINAL, and the empty-share-slug guard.
  */
 
-import { describe, expect, mock, test } from 'bun:test'
-
 import type { StateClickHouseExecutor } from '@/lib/state-backend/clickhouse-client'
 import type { StateClickHouseConfig } from '@/lib/state-backend/config'
+
+import { describe, expect, mock, test } from 'bun:test'
 
 mock.module('@chm/platform', () => ({
   getPlatformBindings: () => ({ getD1Database: () => undefined }),

--- a/apps/dashboard/src/lib/dashboard-storage/clickhouse-store.ts
+++ b/apps/dashboard/src/lib/dashboard-storage/clickhouse-store.ts
@@ -1,0 +1,222 @@
+/**
+ * ClickHouse-backed dashboard storage (server-only, self-hosted OSS).
+ *
+ * Persists saved dashboards in the operator's own ClickHouse via
+ * `CHM_STATE_CLICKHOUSE_*` (see `lib/state-backend/config.ts`). Resolved by
+ * `resolve-server-store.ts` after D1 and before Postgres.
+ *
+ * Storage model: `${prefix}dashboards` on `ReplacingMergeTree(updated_at)`
+ * keyed `(owner_id, name)` — a save is a plain insert with a newer
+ * `updated_at`; reads use `FINAL`; deletes are lightweight `DELETE FROM`.
+ * `share_slug` uses an empty string for "no slug" (ClickHouse non-Nullable
+ * column keeps the sorting key simple); the row mapper converts it to null.
+ */
+
+import type { StateClickHouseConfig } from '@/lib/state-backend/config'
+import type { DashboardLayout } from '@/types/dashboard-layout'
+import type {
+  DashboardStore,
+  PublicSharedDashboard,
+  StoredDashboard,
+} from './types'
+
+import { DashboardStoreError } from './types'
+import {
+  StateClickHouseClient,
+  type StateClickHouseExecutor,
+} from '@/lib/state-backend/clickhouse-client'
+import { normalizeLayout } from '@/types/dashboard-layout'
+
+interface ClickHouseDashboardRow {
+  id: string
+  owner_id: string
+  name: string
+  layout_json: string
+  is_shared: number
+  share_slug: string
+  updated_at: number
+}
+
+/** Exported for SQL-generation tests. */
+export function buildDashboardsDdl(database: string, prefix: string): string {
+  return `CREATE TABLE IF NOT EXISTS ${database}.${prefix}dashboards (
+  id String,
+  owner_id String,
+  name String,
+  layout_json String,
+  is_shared UInt8,
+  share_slug String,
+  updated_at Int64
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (owner_id, name)`
+}
+
+const COLUMNS =
+  'id, owner_id, name, layout_json, is_shared, share_slug, updated_at'
+
+function parseLayoutJson(layoutJson: string): DashboardLayout {
+  let parsed: unknown = null
+  try {
+    parsed = JSON.parse(layoutJson)
+  } catch {
+    parsed = null
+  }
+  return normalizeLayout(parsed)
+}
+
+function rowToDashboard(row: ClickHouseDashboardRow): StoredDashboard {
+  return {
+    id: row.id,
+    ownerId: row.owner_id,
+    name: row.name,
+    layout: parseLayoutJson(row.layout_json),
+    isShared: Number(row.is_shared) === 1,
+    shareSlug: row.share_slug === '' ? null : row.share_slug,
+    updatedAt: Number(row.updated_at),
+  }
+}
+
+export class ClickHouseDashboardStore implements DashboardStore {
+  private readonly client: StateClickHouseExecutor
+  private readonly table: string
+  private readonly database: string
+  private readonly prefix: string
+  private initialized = false
+
+  constructor(config: StateClickHouseConfig, client?: StateClickHouseExecutor) {
+    this.client = client ?? new StateClickHouseClient(config)
+    this.database = config.database
+    this.prefix = config.tablePrefix
+    this.table = `${config.database}.${config.tablePrefix}dashboards`
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (this.initialized) return
+    await this.client.command(`CREATE DATABASE IF NOT EXISTS ${this.database}`)
+    await this.client.command(buildDashboardsDdl(this.database, this.prefix))
+    this.initialized = true
+  }
+
+  async list(ownerId: string): Promise<StoredDashboard[]> {
+    await this.ensureInitialized()
+    const rows = await this.client.query<ClickHouseDashboardRow>(
+      `SELECT ${COLUMNS} FROM ${this.table} FINAL
+       WHERE owner_id = {owner_id:String} ORDER BY name ASC`,
+      { owner_id: ownerId }
+    )
+    return rows.map(rowToDashboard)
+  }
+
+  async get(ownerId: string, name: string): Promise<StoredDashboard | null> {
+    await this.ensureInitialized()
+    const rows = await this.client.query<ClickHouseDashboardRow>(
+      `SELECT ${COLUMNS} FROM ${this.table} FINAL
+       WHERE owner_id = {owner_id:String} AND name = {name:String} LIMIT 1`,
+      { owner_id: ownerId, name }
+    )
+    const row = rows[0]
+    return row ? rowToDashboard(row) : null
+  }
+
+  async upsert(dashboard: StoredDashboard): Promise<{ written: boolean }> {
+    await this.ensureInitialized()
+    // ReplacingMergeTree keyed (owner_id, name): the insert replaces only the
+    // caller's own row for that name — a different owner's row is a different
+    // key, so cross-owner reassignment is structurally impossible and the D1
+    // ownership guard has nothing to defend against here.
+    await this.client.command(
+      `INSERT INTO ${this.table} (${COLUMNS}) VALUES
+        ({id:String}, {owner_id:String}, {name:String}, {layout_json:String},
+         {is_shared:UInt8}, {share_slug:String}, {updated_at:Int64})`,
+      {
+        id: dashboard.id,
+        owner_id: dashboard.ownerId,
+        name: dashboard.name,
+        layout_json: JSON.stringify(dashboard.layout),
+        is_shared: dashboard.isShared ? 1 : 0,
+        share_slug: dashboard.shareSlug ?? '',
+        updated_at: dashboard.updatedAt,
+      }
+    )
+    return { written: true }
+  }
+
+  async saveByName(
+    ownerId: string,
+    name: string,
+    layout: DashboardLayout
+  ): Promise<StoredDashboard> {
+    const existing = await this.get(ownerId, name)
+    const now = Date.now()
+
+    const dashboard: StoredDashboard = existing
+      ? { ...existing, layout, updatedAt: now }
+      : {
+          id: crypto.randomUUID(),
+          ownerId,
+          name,
+          layout,
+          isShared: false,
+          shareSlug: null,
+          updatedAt: now,
+        }
+
+    await this.upsert(dashboard)
+    return dashboard
+  }
+
+  async delete(ownerId: string, name: string): Promise<void> {
+    await this.ensureInitialized()
+    try {
+      await this.client.command(
+        `DELETE FROM ${this.table} WHERE owner_id = {owner_id:String} AND name = {name:String}`,
+        { owner_id: ownerId, name }
+      )
+    } catch (error) {
+      throw new DashboardStoreError(
+        `Failed to delete dashboard: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        'STORAGE_ERROR',
+        error
+      )
+    }
+  }
+
+  async setSharing(
+    ownerId: string,
+    name: string,
+    shared: boolean
+  ): Promise<StoredDashboard | null> {
+    const existing = await this.get(ownerId, name)
+    if (!existing) return null
+
+    if (shared && existing.isShared && existing.shareSlug) {
+      return existing
+    }
+
+    const updated: StoredDashboard = {
+      ...existing,
+      isShared: shared,
+      shareSlug: shared ? crypto.randomUUID() : null,
+      updatedAt: Date.now(),
+    }
+
+    await this.upsert(updated)
+    return updated
+  }
+
+  async getByShareSlug(slug: string): Promise<PublicSharedDashboard | null> {
+    await this.ensureInitialized()
+    // Guard: the empty string means "no slug" in storage — never let it match.
+    if (!slug) return null
+    const rows = await this.client.query<
+      Pick<ClickHouseDashboardRow, 'name' | 'layout_json'>
+    >(
+      `SELECT name, layout_json FROM ${this.table} FINAL
+       WHERE share_slug = {slug:String} AND is_shared = 1 LIMIT 1`,
+      { slug }
+    )
+    const row = rows[0]
+    if (!row) return null
+    return { name: row.name, layout: parseLayoutJson(row.layout_json) }
+  }
+}

--- a/apps/dashboard/src/lib/dashboard-storage/index.ts
+++ b/apps/dashboard/src/lib/dashboard-storage/index.ts
@@ -6,11 +6,12 @@
  *
  * Backend selection mirrors
  * `conversation-store/adapter/resolve-thread-list-adapter.ts`:
- *   - D1 available (Cloudflare deployment with conversation/dashboard
- *     storage enabled) → persisted server-side per owner, synced across
- *     devices, with optional read-only sharing.
- *   - Otherwise (self-hosted/Docker, or D1 disabled) → localStorage, scoped
- *     to the browser profile.
+ *   - Server-side storage enabled → persisted server-side per owner, synced
+ *     across devices, with optional read-only sharing. The actual server
+ *     backend (D1 on Cloudflare, or ClickHouse/Postgres on self-hosted —
+ *     see `resolve-server-store.ts`) is resolved inside the
+ *     `/api/dashboards/*` routes; the client only knows "remote vs local".
+ *   - Otherwise → localStorage, scoped to the browser profile.
  *
  * Deliberately reuses `featureFlags.conversationDb()` rather than adding a
  * dedicated `dashboardDb` flag: both features persist into the same

--- a/apps/dashboard/src/lib/dashboard-storage/postgres-store.ts
+++ b/apps/dashboard/src/lib/dashboard-storage/postgres-store.ts
@@ -1,0 +1,217 @@
+/**
+ * Postgres-backed dashboard storage (server-only, self-hosted OSS).
+ *
+ * Mirrors `d1-store.ts`'s interface and ownership guarantees, following the
+ * client-creation / lazy-migration pattern of
+ * `connection-store/postgres-store.ts`. Resolved by
+ * `resolve-server-store.ts` when no D1 binding is present and
+ * `DATABASE_URL` / `POSTGRES_URL` is set.
+ *
+ * Node-only: imports the `postgres` package. Reached only via dynamic import
+ * so it never enters the Cloudflare Workers bundle.
+ */
+
+import type { DashboardLayout } from '@/types/dashboard-layout'
+import type {
+  DashboardStore,
+  PublicSharedDashboard,
+  StoredDashboard,
+} from './types'
+
+import { DashboardStoreError } from './types'
+import { normalizeLayout } from '@/types/dashboard-layout'
+import postgres from 'postgres'
+
+interface PostgresDashboardRow {
+  id: string
+  owner_id: string
+  name: string
+  layout_json: string
+  is_shared: boolean
+  share_slug: string | null
+  updated_at: string | number
+}
+
+const MIGRATION_SQL = `
+CREATE TABLE IF NOT EXISTS dashboards (
+  id TEXT PRIMARY KEY,
+  owner_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  layout_json TEXT NOT NULL,
+  is_shared BOOLEAN NOT NULL DEFAULT FALSE,
+  share_slug TEXT,
+  updated_at BIGINT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_dashboards_owner_id ON dashboards(owner_id);
+CREATE INDEX IF NOT EXISTS idx_dashboards_share_slug ON dashboards(share_slug);
+`
+
+function parseLayoutJson(layoutJson: string): DashboardLayout {
+  let parsed: unknown = null
+  try {
+    parsed = JSON.parse(layoutJson)
+  } catch {
+    parsed = null
+  }
+  return normalizeLayout(parsed)
+}
+
+function rowToDashboard(row: PostgresDashboardRow): StoredDashboard {
+  return {
+    id: row.id,
+    ownerId: row.owner_id,
+    name: row.name,
+    layout: parseLayoutJson(row.layout_json),
+    isShared: row.is_shared === true,
+    shareSlug: row.share_slug,
+    updatedAt: Number(row.updated_at),
+  }
+}
+
+export class PostgresDashboardStore implements DashboardStore {
+  private sql: ReturnType<typeof postgres>
+  private initialized = false
+
+  constructor(connectionString?: string) {
+    const url =
+      connectionString ??
+      process.env.DATABASE_URL ??
+      process.env.POSTGRES_URL ??
+      process.env.POSTGRES_PRISMA_URL
+
+    if (!url) {
+      throw new DashboardStoreError(
+        'DATABASE_URL is required for Postgres dashboard storage',
+        'STORAGE_ERROR'
+      )
+    }
+
+    this.sql = postgres(url, { max: 5 })
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (this.initialized) return
+    await this.sql.unsafe(MIGRATION_SQL)
+    this.initialized = true
+  }
+
+  async list(ownerId: string): Promise<StoredDashboard[]> {
+    await this.ensureInitialized()
+    const rows = await this.sql<PostgresDashboardRow[]>`
+      SELECT id, owner_id, name, layout_json, is_shared, share_slug, updated_at
+      FROM dashboards WHERE owner_id = ${ownerId} ORDER BY name ASC
+    `
+    return rows.map(rowToDashboard)
+  }
+
+  async get(ownerId: string, name: string): Promise<StoredDashboard | null> {
+    await this.ensureInitialized()
+    const rows = await this.sql<PostgresDashboardRow[]>`
+      SELECT id, owner_id, name, layout_json, is_shared, share_slug, updated_at
+      FROM dashboards WHERE owner_id = ${ownerId} AND name = ${name} LIMIT 1
+    `
+    const row = rows[0]
+    return row ? rowToDashboard(row) : null
+  }
+
+  async upsert(dashboard: StoredDashboard): Promise<{ written: boolean }> {
+    await this.ensureInitialized()
+    // Same ownership guard as D1_UPSERT_DASHBOARD_SQL: an id conflict with a
+    // row owned by a different owner writes nothing rather than reassigning.
+    const rows = await this.sql<{ id: string }[]>`
+      INSERT INTO dashboards (id, owner_id, name, layout_json, is_shared, share_slug, updated_at)
+      VALUES (${dashboard.id}, ${dashboard.ownerId}, ${dashboard.name},
+              ${JSON.stringify(dashboard.layout)}, ${dashboard.isShared},
+              ${dashboard.shareSlug}, ${dashboard.updatedAt})
+      ON CONFLICT (id) DO UPDATE SET
+        name = excluded.name,
+        layout_json = excluded.layout_json,
+        is_shared = excluded.is_shared,
+        share_slug = excluded.share_slug,
+        updated_at = excluded.updated_at
+      WHERE dashboards.owner_id = excluded.owner_id
+      RETURNING id
+    `
+    return { written: rows.length > 0 }
+  }
+
+  async saveByName(
+    ownerId: string,
+    name: string,
+    layout: DashboardLayout
+  ): Promise<StoredDashboard> {
+    const existing = await this.get(ownerId, name)
+    const now = Date.now()
+
+    const dashboard: StoredDashboard = existing
+      ? { ...existing, layout, updatedAt: now }
+      : {
+          id: crypto.randomUUID(),
+          ownerId,
+          name,
+          layout,
+          isShared: false,
+          shareSlug: null,
+          updatedAt: now,
+        }
+
+    const { written } = await this.upsert(dashboard)
+    if (!written) {
+      throw new DashboardStoreError(
+        'Dashboard save was blocked (id ownership mismatch).',
+        'STORAGE_ERROR'
+      )
+    }
+    return dashboard
+  }
+
+  async delete(ownerId: string, name: string): Promise<void> {
+    await this.ensureInitialized()
+    await this.sql`
+      DELETE FROM dashboards WHERE owner_id = ${ownerId} AND name = ${name}
+    `
+  }
+
+  async setSharing(
+    ownerId: string,
+    name: string,
+    shared: boolean
+  ): Promise<StoredDashboard | null> {
+    const existing = await this.get(ownerId, name)
+    if (!existing) return null
+
+    if (shared && existing.isShared && existing.shareSlug) {
+      return existing
+    }
+
+    const updated: StoredDashboard = {
+      ...existing,
+      isShared: shared,
+      shareSlug: shared ? crypto.randomUUID() : null,
+      updatedAt: Date.now(),
+    }
+
+    const { written } = await this.upsert(updated)
+    if (!written) {
+      throw new DashboardStoreError(
+        'Dashboard sharing update was blocked (id ownership mismatch).',
+        'STORAGE_ERROR'
+      )
+    }
+    return updated
+  }
+
+  async getByShareSlug(slug: string): Promise<PublicSharedDashboard | null> {
+    await this.ensureInitialized()
+    const rows = await this.sql<
+      Pick<PostgresDashboardRow, 'name' | 'layout_json'>[]
+    >`
+      SELECT name, layout_json FROM dashboards
+      WHERE share_slug = ${slug} AND is_shared = TRUE LIMIT 1
+    `
+    const row = rows[0]
+    if (!row) return null
+    return { name: row.name, layout: parseLayoutJson(row.layout_json) }
+  }
+}

--- a/apps/dashboard/src/lib/dashboard-storage/postgres-store.ts
+++ b/apps/dashboard/src/lib/dashboard-storage/postgres-store.ts
@@ -19,8 +19,8 @@ import type {
 } from './types'
 
 import { DashboardStoreError } from './types'
-import { normalizeLayout } from '@/types/dashboard-layout'
 import postgres from 'postgres'
+import { normalizeLayout } from '@/types/dashboard-layout'
 
 interface PostgresDashboardRow {
   id: string

--- a/apps/dashboard/src/lib/dashboard-storage/resolve-server-store.test.ts
+++ b/apps/dashboard/src/lib/dashboard-storage/resolve-server-store.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Resolution-order tests for the server-side dashboard store resolver:
+ * D1 binding → ClickHouse state env → Postgres env → D1 fallback.
+ * `@chm/platform` is mocked (bun test runs outside Cloudflare).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+let d1Binding: unknown
+
+mock.module('@chm/platform', () => ({
+  getPlatformBindings: () => ({ getD1Database: () => d1Binding }),
+}))
+
+const { resolveDashboardStore } = await import('./resolve-server-store')
+const { D1DashboardStore } = await import('./d1-store')
+const { ClickHouseDashboardStore } = await import('./clickhouse-store')
+const { PostgresDashboardStore } = await import('./postgres-store')
+
+const STATE_ENV_KEYS = [
+  'CHM_STATE_CLICKHOUSE_URL',
+  'DATABASE_URL',
+  'POSTGRES_URL',
+  'POSTGRES_PRISMA_URL',
+] as const
+
+let savedEnv: Record<string, string | undefined>
+
+beforeEach(() => {
+  d1Binding = undefined
+  savedEnv = {}
+  for (const key of STATE_ENV_KEYS) {
+    savedEnv[key] = process.env[key]
+    delete process.env[key]
+  }
+})
+
+afterEach(() => {
+  for (const key of STATE_ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key]
+    else process.env[key] = savedEnv[key]
+  }
+})
+
+describe('resolveDashboardStore', () => {
+  test('D1 binding wins over everything (cloud behavior unchanged)', async () => {
+    d1Binding = {}
+    process.env.CHM_STATE_CLICKHOUSE_URL = 'http://ch:8123'
+    process.env.DATABASE_URL = 'postgres://a'
+    expect(await resolveDashboardStore()).toBeInstanceOf(D1DashboardStore)
+  })
+
+  test('ClickHouse state env wins over Postgres env', async () => {
+    process.env.CHM_STATE_CLICKHOUSE_URL = 'http://ch:8123'
+    process.env.DATABASE_URL = 'postgres://a'
+    expect(await resolveDashboardStore()).toBeInstanceOf(
+      ClickHouseDashboardStore
+    )
+  })
+
+  test('Postgres env resolves when no D1 and no ClickHouse state env', async () => {
+    process.env.DATABASE_URL = 'postgres://a'
+    expect(await resolveDashboardStore()).toBeInstanceOf(PostgresDashboardStore)
+  })
+
+  test('falls back to the D1 store (which errors on use) when nothing is configured', async () => {
+    expect(await resolveDashboardStore()).toBeInstanceOf(D1DashboardStore)
+  })
+})

--- a/apps/dashboard/src/lib/dashboard-storage/resolve-server-store.ts
+++ b/apps/dashboard/src/lib/dashboard-storage/resolve-server-store.ts
@@ -17,11 +17,11 @@
 import type { DashboardStore } from './types'
 
 import { D1DashboardStore } from './d1-store'
+import { getPlatformBindings } from '@chm/platform'
 import {
   getStateClickHouseConfig,
   getStatePostgresUrl,
 } from '@/lib/state-backend/config'
-import { getPlatformBindings } from '@chm/platform'
 
 const D1_BINDING_NAME = 'CHM_CLOUD_D1'
 

--- a/apps/dashboard/src/lib/dashboard-storage/resolve-server-store.ts
+++ b/apps/dashboard/src/lib/dashboard-storage/resolve-server-store.ts
@@ -1,0 +1,50 @@
+/**
+ * Server-side dashboard store resolver (used by the /api/dashboards/* routes).
+ *
+ * Resolution order (fail-open, OSS-first — mirrors
+ * `connection-store/resolve-store.ts`):
+ *   1. Cloudflare D1 binding (`CHM_CLOUD_D1`) → D1DashboardStore
+ *   2. ClickHouse state env (`CHM_STATE_CLICKHOUSE_URL`) → ClickHouseDashboardStore
+ *   3. Postgres env (`DATABASE_URL` / `POSTGRES_URL`) → PostgresDashboardStore
+ *   4. Fallback: D1DashboardStore (throws its existing STORAGE_ERROR on use,
+ *      preserving the pre-existing "no backend" behavior).
+ *
+ * The Postgres store is dynamically imported so the Node-only `postgres`
+ * package never enters the Cloudflare Workers bundle (the CF path resolves
+ * D1 first and never reaches that branch). Cloud behavior is unchanged.
+ */
+
+import type { DashboardStore } from './types'
+
+import { D1DashboardStore } from './d1-store'
+import {
+  getStateClickHouseConfig,
+  getStatePostgresUrl,
+} from '@/lib/state-backend/config'
+import { getPlatformBindings } from '@chm/platform'
+
+const D1_BINDING_NAME = 'CHM_CLOUD_D1'
+
+export async function resolveDashboardStore(): Promise<DashboardStore> {
+  try {
+    const db = getPlatformBindings().getD1Database(D1_BINDING_NAME)
+    if (db) {
+      return new D1DashboardStore()
+    }
+  } catch {
+    // not Cloudflare — continue to self-hosted backends
+  }
+
+  const chConfig = getStateClickHouseConfig()
+  if (chConfig) {
+    const { ClickHouseDashboardStore } = await import('./clickhouse-store')
+    return new ClickHouseDashboardStore(chConfig)
+  }
+
+  if (getStatePostgresUrl()) {
+    const { PostgresDashboardStore } = await import('./postgres-store')
+    return new PostgresDashboardStore()
+  }
+
+  return new D1DashboardStore()
+}

--- a/apps/dashboard/src/lib/dashboard-storage/types.ts
+++ b/apps/dashboard/src/lib/dashboard-storage/types.ts
@@ -45,11 +45,12 @@ export interface PublicSharedDashboard {
 }
 
 /**
- * Dashboard storage adapter interface. `D1DashboardStore` (server-only) is
- * the sole persistent backend today (Postgres is explicitly out of scope —
- * see plans/56-dashboard-d1-persistence-sharing.md); the client-side
- * fallback when D1 is unavailable is `local-store.ts` (localStorage), which
- * does not implement this interface (it has no owner/sharing concept).
+ * Dashboard storage adapter interface. Server-only persistent backends:
+ * `D1DashboardStore` (Cloudflare), `ClickHouseDashboardStore` and
+ * `PostgresDashboardStore` (self-hosted, resolved via
+ * `resolve-server-store.ts`); the client-side fallback when no server
+ * backend is available is `local-store.ts` (localStorage), which does not
+ * implement this interface (it has no owner/sharing concept).
  */
 export interface DashboardStore {
   list(ownerId: string): Promise<StoredDashboard[]>

--- a/apps/dashboard/src/lib/state-backend/clickhouse-client.ts
+++ b/apps/dashboard/src/lib/state-backend/clickhouse-client.ts
@@ -1,0 +1,80 @@
+/**
+ * Minimal ClickHouse HTTP client for the state backend (server-only).
+ *
+ * Deliberately fetch-based and dependency-free: it runs in both the Node and
+ * (theoretical) Workers runtimes, is trivially mockable in unit tests, and
+ * keeps the Node-only `@clickhouse/client` package out of any bundle that
+ * imports the state stores. Parameters are bound server-side via ClickHouse's
+ * `param_*` HTTP query parameters (`{name:Type}` placeholders in SQL) — never
+ * string-interpolated.
+ */
+
+import type { StateClickHouseConfig } from './config'
+
+export type StateQueryParams = Record<string, string | number>
+
+export class StateClickHouseError extends Error {
+  constructor(
+    message: string,
+    public readonly status?: number
+  ) {
+    super(message)
+    this.name = 'StateClickHouseError'
+  }
+}
+
+export interface StateClickHouseExecutor {
+  /** Run a statement with no result set (DDL, INSERT, DELETE). */
+  command(sql: string, params?: StateQueryParams): Promise<void>
+  /** Run a SELECT; rows come back as JSONEachRow objects. */
+  query<T>(sql: string, params?: StateQueryParams): Promise<T[]>
+}
+
+export class StateClickHouseClient implements StateClickHouseExecutor {
+  constructor(private readonly config: StateClickHouseConfig) {}
+
+  private buildUrl(params?: StateQueryParams): URL {
+    const url = new URL(this.config.url)
+    url.searchParams.set('database', this.config.database)
+    for (const [key, value] of Object.entries(params ?? {})) {
+      url.searchParams.set(`param_${key}`, String(value))
+    }
+    return url
+  }
+
+  private async execute(
+    sql: string,
+    params?: StateQueryParams
+  ): Promise<string> {
+    const response = await fetch(this.buildUrl(params), {
+      method: 'POST',
+      headers: {
+        'X-ClickHouse-User': this.config.user,
+        'X-ClickHouse-Key': this.config.password,
+        'Content-Type': 'text/plain',
+      },
+      body: sql,
+    })
+
+    const text = await response.text()
+    if (!response.ok) {
+      throw new StateClickHouseError(
+        `ClickHouse state query failed (${response.status}): ${text.slice(0, 500)}`,
+        response.status
+      )
+    }
+    return text
+  }
+
+  async command(sql: string, params?: StateQueryParams): Promise<void> {
+    await this.execute(sql, params)
+  }
+
+  async query<T>(sql: string, params?: StateQueryParams): Promise<T[]> {
+    const text = await this.execute(`${sql} FORMAT JSONEachRow`, params)
+    return text
+      .split('\n')
+      .filter((line) => line.trim().length > 0)
+      .map((line) => JSON.parse(line) as T)
+  }
+}

--- a/apps/dashboard/src/lib/state-backend/config.test.ts
+++ b/apps/dashboard/src/lib/state-backend/config.test.ts
@@ -4,14 +4,13 @@
  * precedence shared by the three UI-state stores.
  */
 
-import { describe, expect, test } from 'bun:test'
-
 import {
   DEFAULT_STATE_CLICKHOUSE_DATABASE,
   DEFAULT_STATE_CLICKHOUSE_TABLE_PREFIX,
   getStateClickHouseConfig,
   getStatePostgresUrl,
 } from './config'
+import { describe, expect, test } from 'bun:test'
 
 describe('getStateClickHouseConfig', () => {
   test('returns null when CHM_STATE_CLICKHOUSE_URL is unset or blank', () => {

--- a/apps/dashboard/src/lib/state-backend/config.test.ts
+++ b/apps/dashboard/src/lib/state-backend/config.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for the shared state-backend env parsing: opt-in ClickHouse
+ * config (defaults + identifier-injection fail-open) and the Postgres URL
+ * precedence shared by the three UI-state stores.
+ */
+
+import { describe, expect, test } from 'bun:test'
+
+import {
+  DEFAULT_STATE_CLICKHOUSE_DATABASE,
+  DEFAULT_STATE_CLICKHOUSE_TABLE_PREFIX,
+  getStateClickHouseConfig,
+  getStatePostgresUrl,
+} from './config'
+
+describe('getStateClickHouseConfig', () => {
+  test('returns null when CHM_STATE_CLICKHOUSE_URL is unset or blank', () => {
+    expect(getStateClickHouseConfig({})).toBeNull()
+    expect(
+      getStateClickHouseConfig({ CHM_STATE_CLICKHOUSE_URL: '   ' })
+    ).toBeNull()
+  })
+
+  test('applies defaults for user, password, database, and table prefix', () => {
+    const config = getStateClickHouseConfig({
+      CHM_STATE_CLICKHOUSE_URL: 'http://ch:8123',
+    })
+    expect(config).toEqual({
+      url: 'http://ch:8123',
+      user: 'default',
+      password: '',
+      database: DEFAULT_STATE_CLICKHOUSE_DATABASE,
+      tablePrefix: DEFAULT_STATE_CLICKHOUSE_TABLE_PREFIX,
+    })
+  })
+
+  test('uses explicit values when set', () => {
+    const config = getStateClickHouseConfig({
+      CHM_STATE_CLICKHOUSE_URL: 'https://ch.internal:8443',
+      CHM_STATE_CLICKHOUSE_USER: 'state',
+      CHM_STATE_CLICKHOUSE_PASSWORD: 'secret',
+      CHM_STATE_CLICKHOUSE_DATABASE: 'ops',
+      CHM_STATE_CLICKHOUSE_TABLE_PREFIX: 'ui_',
+    })
+    expect(config).toEqual({
+      url: 'https://ch.internal:8443',
+      user: 'state',
+      password: 'secret',
+      database: 'ops',
+      tablePrefix: 'ui_',
+    })
+  })
+
+  test('fails open to defaults on invalid identifiers (DDL injection guard)', () => {
+    const config = getStateClickHouseConfig({
+      CHM_STATE_CLICKHOUSE_URL: 'http://ch:8123',
+      CHM_STATE_CLICKHOUSE_DATABASE: 'bad; DROP TABLE x',
+      CHM_STATE_CLICKHOUSE_TABLE_PREFIX: 'evil`--',
+    })
+    expect(config?.database).toBe(DEFAULT_STATE_CLICKHOUSE_DATABASE)
+    expect(config?.tablePrefix).toBe(DEFAULT_STATE_CLICKHOUSE_TABLE_PREFIX)
+  })
+})
+
+describe('getStatePostgresUrl', () => {
+  test('returns null when nothing is configured', () => {
+    expect(getStatePostgresUrl({})).toBeNull()
+  })
+
+  test('precedence: DATABASE_URL > POSTGRES_URL > POSTGRES_PRISMA_URL', () => {
+    expect(
+      getStatePostgresUrl({
+        DATABASE_URL: 'postgres://a',
+        POSTGRES_URL: 'postgres://b',
+        POSTGRES_PRISMA_URL: 'postgres://c',
+      })
+    ).toBe('postgres://a')
+    expect(
+      getStatePostgresUrl({
+        POSTGRES_URL: 'postgres://b',
+        POSTGRES_PRISMA_URL: 'postgres://c',
+      })
+    ).toBe('postgres://b')
+    expect(getStatePostgresUrl({ POSTGRES_PRISMA_URL: 'postgres://c' })).toBe(
+      'postgres://c'
+    )
+  })
+})

--- a/apps/dashboard/src/lib/state-backend/config.ts
+++ b/apps/dashboard/src/lib/state-backend/config.ts
@@ -1,0 +1,87 @@
+/**
+ * State-backend env parsing (server-only), shared by the three UI-state
+ * stores: connection-store, conversation-store, and dashboard-storage.
+ *
+ * A self-hosted (OSS) deployment can persist its UI state in the operator's
+ * own database instead of Cloudflare D1. Resolution order everywhere is
+ * fail-open, OSS-first:
+ *
+ *   explicit backend override (where one exists) → D1 binding →
+ *   ClickHouse state env (`CHM_STATE_CLICKHOUSE_*`) →
+ *   Postgres env (`DATABASE_URL` / `POSTGRES_URL`) → local/memory fallback.
+ *
+ * This module only centralizes the env reads so the stores share one source
+ * of truth — it does not talk to any database itself.
+ */
+
+/** Valid ClickHouse identifier (database name / table prefix). */
+const IDENTIFIER_RE = /^[A-Za-z0-9_]+$/
+
+export const DEFAULT_STATE_CLICKHOUSE_DATABASE = 'chmonitor'
+export const DEFAULT_STATE_CLICKHOUSE_TABLE_PREFIX = 'chm_state_'
+
+export interface StateClickHouseConfig {
+  url: string
+  user: string
+  password: string
+  database: string
+  tablePrefix: string
+}
+
+/**
+ * Reads the dedicated state-ClickHouse env. Returns `null` when
+ * `CHM_STATE_CLICKHOUSE_URL` is unset (the backend is opt-in).
+ *
+ * Fail-open: an invalid `database`/`tablePrefix` (would-be SQL-identifier
+ * injection into DDL) logs a warning and falls back to the default rather
+ * than throwing, so a typo never takes the app down.
+ */
+export function getStateClickHouseConfig(
+  env: Record<string, string | undefined> = process.env
+): StateClickHouseConfig | null {
+  const url = env.CHM_STATE_CLICKHOUSE_URL?.trim()
+  if (!url) return null
+
+  let database =
+    env.CHM_STATE_CLICKHOUSE_DATABASE?.trim() ||
+    DEFAULT_STATE_CLICKHOUSE_DATABASE
+  if (!IDENTIFIER_RE.test(database)) {
+    console.warn(
+      `[state-backend] Invalid CHM_STATE_CLICKHOUSE_DATABASE "${database}" (must match ${IDENTIFIER_RE}); using "${DEFAULT_STATE_CLICKHOUSE_DATABASE}"`
+    )
+    database = DEFAULT_STATE_CLICKHOUSE_DATABASE
+  }
+
+  let tablePrefix =
+    env.CHM_STATE_CLICKHOUSE_TABLE_PREFIX?.trim() ||
+    DEFAULT_STATE_CLICKHOUSE_TABLE_PREFIX
+  if (!IDENTIFIER_RE.test(tablePrefix)) {
+    console.warn(
+      `[state-backend] Invalid CHM_STATE_CLICKHOUSE_TABLE_PREFIX "${tablePrefix}" (must match ${IDENTIFIER_RE}); using "${DEFAULT_STATE_CLICKHOUSE_TABLE_PREFIX}"`
+    )
+    tablePrefix = DEFAULT_STATE_CLICKHOUSE_TABLE_PREFIX
+  }
+
+  return {
+    url,
+    user: env.CHM_STATE_CLICKHOUSE_USER ?? 'default',
+    password: env.CHM_STATE_CLICKHOUSE_PASSWORD ?? '',
+    database,
+    tablePrefix,
+  }
+}
+
+/**
+ * Postgres state-backend connection string, if configured. Same precedence
+ * as the existing connection-store Postgres path.
+ */
+export function getStatePostgresUrl(
+  env: Record<string, string | undefined> = process.env
+): string | null {
+  return (
+    env.DATABASE_URL?.trim() ||
+    env.POSTGRES_URL?.trim() ||
+    env.POSTGRES_PRISMA_URL?.trim() ||
+    null
+  )
+}

--- a/apps/dashboard/src/routes/api/dashboards/delete.ts
+++ b/apps/dashboard/src/routes/api/dashboards/delete.ts
@@ -18,7 +18,7 @@ import {
 } from '@/lib/api/shared/response-builder'
 import { ApiErrorType } from '@/lib/api/types'
 import { resolveDashboardOwnerId } from '@/lib/dashboard-storage/auth'
-import { D1DashboardStore } from '@/lib/dashboard-storage/d1-store'
+import { resolveDashboardStore } from '@/lib/dashboard-storage/resolve-server-store'
 import { DashboardStoreError } from '@/lib/dashboard-storage/types'
 import { isFeatureEnabled } from '@/lib/feature-flags'
 import { autoMigrate } from '@/lib/migration/auto-migrate'
@@ -64,7 +64,7 @@ async function handleDelete(request: Request): Promise<Response> {
       )
     }
 
-    const store = new D1DashboardStore()
+    const store = await resolveDashboardStore()
     const existing = await store.get(ownerId, name)
     if (!existing) {
       return createApiErrorResponse(

--- a/apps/dashboard/src/routes/api/dashboards/list.ts
+++ b/apps/dashboard/src/routes/api/dashboards/list.ts
@@ -20,7 +20,7 @@ import {
 } from '@/lib/api/shared/response-builder'
 import { ApiErrorType } from '@/lib/api/types'
 import { resolveDashboardOwnerId } from '@/lib/dashboard-storage/auth'
-import { D1DashboardStore } from '@/lib/dashboard-storage/d1-store'
+import { resolveDashboardStore } from '@/lib/dashboard-storage/resolve-server-store'
 import { DashboardStoreError } from '@/lib/dashboard-storage/types'
 import { isFeatureEnabled } from '@/lib/feature-flags'
 import { autoMigrate } from '@/lib/migration/auto-migrate'
@@ -49,7 +49,7 @@ async function handleGet(): Promise<Response> {
     const ownerId = await resolveDashboardOwnerId()
     debug('[GET /api/dashboards/list] Owner resolved', { ownerId, requestId })
 
-    const store = new D1DashboardStore()
+    const store = await resolveDashboardStore()
     const dashboards = await store.list(ownerId)
 
     const responseData = dashboards.map((d) => ({

--- a/apps/dashboard/src/routes/api/dashboards/save.ts
+++ b/apps/dashboard/src/routes/api/dashboards/save.ts
@@ -24,7 +24,7 @@ import {
 } from '@/lib/api/shared/response-builder'
 import { ApiErrorType } from '@/lib/api/types'
 import { resolveDashboardOwnerId } from '@/lib/dashboard-storage/auth'
-import { D1DashboardStore } from '@/lib/dashboard-storage/d1-store'
+import { resolveDashboardStore } from '@/lib/dashboard-storage/resolve-server-store'
 import { DashboardStoreError } from '@/lib/dashboard-storage/types'
 import { isFeatureEnabled } from '@/lib/feature-flags'
 import { autoMigrate } from '@/lib/migration/auto-migrate'
@@ -98,7 +98,7 @@ async function handlePost(request: Request): Promise<Response> {
       )
     }
 
-    const store = new D1DashboardStore()
+    const store = await resolveDashboardStore()
     const saved = await store.saveByName(
       ownerId,
       validated.name,

--- a/apps/dashboard/src/routes/api/dashboards/share.$slug.ts
+++ b/apps/dashboard/src/routes/api/dashboards/share.$slug.ts
@@ -44,7 +44,7 @@ import {
   createSuccessResponse,
 } from '@/lib/api/shared/response-builder'
 import { ApiErrorType } from '@/lib/api/types'
-import { D1DashboardStore } from '@/lib/dashboard-storage/d1-store'
+import { resolveDashboardStore } from '@/lib/dashboard-storage/resolve-server-store'
 import { isFeatureEnabled } from '@/lib/feature-flags'
 import { autoMigrate } from '@/lib/migration/auto-migrate'
 
@@ -96,7 +96,7 @@ async function handleGet(request: Request, slug: string): Promise<Response> {
       )
     }
 
-    const store = new D1DashboardStore()
+    const store = await resolveDashboardStore()
     const dashboard = await store.getByShareSlug(slug)
 
     if (!dashboard) {

--- a/apps/dashboard/src/routes/api/dashboards/share.ts
+++ b/apps/dashboard/src/routes/api/dashboards/share.ts
@@ -22,7 +22,7 @@ import {
 } from '@/lib/api/shared/response-builder'
 import { ApiErrorType } from '@/lib/api/types'
 import { resolveDashboardOwnerId } from '@/lib/dashboard-storage/auth'
-import { D1DashboardStore } from '@/lib/dashboard-storage/d1-store'
+import { resolveDashboardStore } from '@/lib/dashboard-storage/resolve-server-store'
 import { DashboardStoreError } from '@/lib/dashboard-storage/types'
 import { isFeatureEnabled } from '@/lib/feature-flags'
 import { autoMigrate } from '@/lib/migration/auto-migrate'
@@ -108,7 +108,7 @@ async function handlePost(request: Request): Promise<Response> {
       )
     }
 
-    const store = new D1DashboardStore()
+    const store = await resolveDashboardStore()
     const updated = await store.setSharing(ownerId, body.name, true)
     if (!updated) {
       return notFoundResponse(body.name, ROUTE_CONTEXT_POST)
@@ -174,7 +174,7 @@ async function handleDelete(request: Request): Promise<Response> {
       )
     }
 
-    const store = new D1DashboardStore()
+    const store = await resolveDashboardStore()
     const updated = await store.setSharing(ownerId, name, false)
     if (!updated) {
       return notFoundResponse(name, ROUTE_CONTEXT_DELETE)

--- a/docs/content/operate/advanced/state-backends.mdx
+++ b/docs/content/operate/advanced/state-backends.mdx
@@ -1,0 +1,77 @@
+---
+title: Self-Hosted State Backends
+description: Persist dashboards, per-user connections, and conversations in your own ClickHouse or Postgres instead of Cloudflare D1 — env vars and resolution order for Docker and Kubernetes deployments.
+icon: Database
+---
+
+Self-hosted (Docker / Kubernetes) deployments can persist UI-monitoring state —
+saved **dashboards**, per-user **connections**, and agent **conversations** —
+in a database you operate, instead of Cloudflare D1 (which only exists on the
+hosted Workers deployment). Without a backend, dashboards fall back to browser
+`localStorage` and conversations to memory.
+
+Two self-hosted backends are supported:
+
+- **ClickHouse** — reuse (or dedicate) a ClickHouse instance via
+  `CHM_STATE_CLICKHOUSE_*`. Tables are created lazily
+  (`CREATE TABLE IF NOT EXISTS`, `ReplacingMergeTree`) — no migrations to run.
+- **Postgres** — via `DATABASE_URL` / `POSTGRES_URL`. Tables are also created
+  lazily on first use.
+
+## Resolution order
+
+Each store resolves its backend at runtime, fail-open and OSS-first:
+
+1. Explicit backend override, where one exists
+   (`CONVERSATION_STORE_BACKEND` for conversations)
+2. Cloudflare D1 binding (`CHM_CLOUD_D1`, hosted deployment only)
+3. ClickHouse state env (`CHM_STATE_CLICKHOUSE_URL` set) — dashboards and
+   connections
+4. Postgres env (`DATABASE_URL` / `POSTGRES_URL` / `POSTGRES_PRISMA_URL`)
+5. Fallback: `localStorage` (dashboards) / memory (conversations)
+
+Server-side dashboard and connection storage additionally requires the
+per-user feature gates (`CHM_FEATURE_CONVERSATION_DB` /
+`CHM_FEATURE_USER_CONNECTIONS_DB`) and an auth provider, since rows are keyed
+by user id — see [Environment variables](/reference/environment-variables).
+
+## ClickHouse state backend
+
+```bash
+# Required — enables the backend
+CHM_STATE_CLICKHOUSE_URL=http://clickhouse:8123
+
+# Optional
+CHM_STATE_CLICKHOUSE_USER=default          # default: default
+CHM_STATE_CLICKHOUSE_PASSWORD=             # default: empty
+CHM_STATE_CLICKHOUSE_DATABASE=chmonitor    # default: chmonitor
+CHM_STATE_CLICKHOUSE_TABLE_PREFIX=chm_state_  # default: chm_state_
+```
+
+The user needs `CREATE DATABASE` / `CREATE TABLE`, `INSERT`, `SELECT`, and
+lightweight `DELETE` permissions on the state database. Tables
+(`chm_state_dashboards`, `chm_state_user_connections`) use
+`ReplacingMergeTree(updated_at)` with `FINAL` reads, so updates are plain
+inserts and no mutations are required for normal operation.
+
+This can be the same ClickHouse you monitor, but a monitoring user is often
+read-only — point `CHM_STATE_CLICKHOUSE_USER` at a writable account (or a
+separate small instance) if so.
+
+## Postgres state backend
+
+```bash
+DATABASE_URL=postgres://user:pass@host:5432/chmonitor
+# or POSTGRES_URL / POSTGRES_PRISMA_URL
+```
+
+One connection string serves all three stores (`user_connections`,
+`dashboards`, and the conversation tables).
+
+## Related
+
+<Cards>
+  <Card title="Environment variables" href="/reference/environment-variables" description="Full reference for every CHM_* variable, including the state backends." />
+  <Card title="Conversation store backends" href="/guide/ai-agent/conversation-history/backends" description="Per-backend setup for conversation history persistence." />
+  <Card title="Deploy with Docker" href="/operate/deploy/docker" description="Compose-based self-hosted deployment." />
+</Cards>

--- a/docs/content/reference/environment-variables.mdx
+++ b/docs/content/reference/environment-variables.mdx
@@ -433,6 +433,23 @@ Configure a backend at runtime via `CONVERSATION_STORE_BACKEND`.
 See [Conversation history — backends](/guide/ai-agent/conversation-history/backends)
 for setup and fallback behavior.
 
+**ClickHouse state backend (self-hosted):**
+
+Persists dashboards and per-user connections in your own ClickHouse instead of
+Cloudflare D1 or Postgres. Opt-in; tables are created lazily
+(`CREATE TABLE IF NOT EXISTS`, `ReplacingMergeTree`). Resolution order per
+store: D1 binding → ClickHouse state env → Postgres env → local/memory.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `CHM_STATE_CLICKHOUSE_URL` | — | ClickHouse HTTP(S) URL for state storage. Setting it enables the backend. |
+| `CHM_STATE_CLICKHOUSE_USER` | `default` | ClickHouse user (needs CREATE/INSERT/SELECT/DELETE on the state database). |
+| `CHM_STATE_CLICKHOUSE_PASSWORD` | (empty) | ClickHouse password (secret). |
+| `CHM_STATE_CLICKHOUSE_DATABASE` | `chmonitor` | Database holding the state tables. |
+| `CHM_STATE_CLICKHOUSE_TABLE_PREFIX` | `chm_state_` | Prefix for the state tables (`chm_state_dashboards`, `chm_state_user_connections`). |
+
+See [Self-hosted state backends](/operate/advanced/state-backends) for setup.
+
 ## User connections (server storage)
 
 Let signed-in users save personal ClickHouse hosts to the server. All **four** of


### PR DESCRIPTION
## Summary
OSS deployments (Docker/K8s) can now persist UI-monitoring state (per-user connections, dashboards, conversations) in their own **Postgres** or **ClickHouse** database instead of Cloudflare D1.

- New shared `lib/state-backend/` module: `CHM_STATE_CLICKHOUSE_URL/USER/PASSWORD/DATABASE` (default `chmonitor`) + `CHM_STATE_CLICKHOUSE_TABLE_PREFIX` (default `chm_state_`), and unified Postgres URL resolution (`DATABASE_URL` → `POSTGRES_URL`).
- ClickHouse stores for connection-store + dashboard-storage: dependency-free fetch client, `param_*` server-side binding, `ReplacingMergeTree(updated_at)` with owner-first keys, `FINAL` reads, lazy `CREATE TABLE IF NOT EXISTS`.
- New Postgres dashboard store mirroring the D1 store (incl. ownership-guarded upsert); dashboard API routes now resolve D1 → ClickHouse → Postgres → D1 error.
- Cloud unchanged: D1 always resolves first; feature gates untouched.
- Docs: new `operate/advanced/state-backends.mdx`, env-var reference, `.env.example`.

## Tests
90 store/config/resolution tests pass (mocked executors, no live DB); `pnpm run build` + `tsc --noEmit` clean.

https://claude.ai/code/session_01AZT2vFfSh2NNjUUdsEX5M7