### PR TITLE
feat(agent): redesign agent page — welcome, composer, thread polish, token colors (#2811)

### DIFF
--- a/apps/dashboard/src/components/agents/advisor-recommendations-panel.tsx
+++ b/apps/dashboard/src/components/agents/advisor-recommendations-panel.tsx
@@ -32,10 +32,10 @@ import { cn } from '@/lib/utils'
 // Same rose/amber/sky severity triad used elsewhere for graded status
 // (see components/agents/agent-diagnostics.tsx's SEVERITY_CLASS).
 const RISK_CLASS: Record<Recommendation['risk'], string> = {
-  high: 'border-rose-500/30 bg-rose-500/10 text-rose-700 dark:text-rose-300',
+  high: 'border-destructive/30 bg-destructive/10 text-destructive',
   medium:
-    'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300',
-  low: 'border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-300',
+    'border-[var(--chart-yellow)]/30 bg-[var(--chart-yellow)]/10 text-[var(--chart-yellow)]',
+  low: 'border-[var(--chart-blue)]/30 bg-[var(--chart-blue)]/10 text-[var(--chart-blue)]',
 }
 
 const KIND_ICON: Record<Recommendation['kind'], typeof FilterIcon> = {

--- a/apps/dashboard/src/components/agents/agent-diagnostics.tsx
+++ b/apps/dashboard/src/components/agents/agent-diagnostics.tsx
@@ -66,11 +66,10 @@ interface TableDesignOutput {
 }
 
 const SEVERITY_CLASS: Record<Severity, string> = {
-  critical:
-    'border-rose-500/30 bg-rose-500/10 text-rose-700 dark:text-rose-300',
+  critical: 'border-destructive/30 bg-destructive/10 text-destructive',
   warning:
-    'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300',
-  info: 'border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-300',
+    'border-[var(--chart-yellow)]/30 bg-[var(--chart-yellow)]/10 text-[var(--chart-yellow)]',
+  info: 'border-[var(--chart-blue)]/30 bg-[var(--chart-blue)]/10 text-[var(--chart-blue)]',
 }
 
 const SEVERITY_ICON: Record<Severity, typeof AlertTriangleIcon> = {
@@ -103,7 +102,7 @@ export function AgentIssuesPanel({ output }: { output: AgentIssuesOutput }) {
     <div className="rounded-md border border-border/60 bg-muted/20">
       <div className="flex items-center justify-between gap-3 border-b border-border/50 px-3 py-2">
         <div className="flex min-w-0 items-center gap-2">
-          <AlertTriangleIcon className="size-4 text-amber-500" />
+          <AlertTriangleIcon className="size-4 text-[var(--chart-yellow)]" />
           <span className="text-sm font-semibold">Issue scan</span>
         </div>
         <Badge variant="outline" className="text-[10px]">
@@ -113,7 +112,7 @@ export function AgentIssuesPanel({ output }: { output: AgentIssuesOutput }) {
 
       {output.issues.length === 0 ? (
         <div className="flex items-center gap-2 p-3 text-sm text-muted-foreground">
-          <CheckCircle2Icon className="size-4 text-emerald-500" />
+          <CheckCircle2Icon className="size-4 text-[var(--chart-green)]" />
           No confirmed issues found in the selected window.
         </div>
       ) : (

--- a/apps/dashboard/src/components/agents/agent-visualization/chart-controls.tsx
+++ b/apps/dashboard/src/components/agents/agent-visualization/chart-controls.tsx
@@ -282,7 +282,7 @@ export function ChartControls({
                   className={cn(
                     'h-6 px-2 rounded border text-[11px] transition-colors',
                     isRight
-                      ? 'bg-blue-500/15 text-blue-600 border-blue-300 dark:text-blue-400 dark:border-blue-700'
+                      ? 'bg-[var(--chart-blue)]/15 text-[var(--chart-blue)] border-[var(--chart-blue)]/40'
                       : 'bg-muted/50 text-muted-foreground border-input hover:bg-muted'
                   )}
                   title={

--- a/apps/dashboard/src/components/agents/agent-workflow-plan.tsx
+++ b/apps/dashboard/src/components/agents/agent-workflow-plan.tsx
@@ -27,11 +27,13 @@ export interface AgentWorkflowPlanProps {
 
 function StepIcon({ status }: { status: WorkflowPlanStepStatus }) {
   if (status === 'completed') {
-    return <CheckCircle2Icon className="size-4 shrink-0 text-emerald-500" />
+    return (
+      <CheckCircle2Icon className="size-4 shrink-0 text-[var(--chart-green)]" />
+    )
   }
   if (status === 'in_progress') {
     return (
-      <Loader2Icon className="size-4 shrink-0 animate-spin text-yellow-500" />
+      <Loader2Icon className="size-4 shrink-0 animate-spin text-[var(--chart-yellow)]" />
     )
   }
   return <CircleDashedIcon className="size-4 shrink-0 text-muted-foreground" />

--- a/apps/dashboard/src/components/agents/ask-user-widget.tsx
+++ b/apps/dashboard/src/components/agents/ask-user-widget.tsx
@@ -81,8 +81,8 @@ export function AskUserWidget({
 
   if (submitted) {
     return (
-      <div className="my-2 rounded-lg border border-green-200 bg-green-50 px-4 py-3 dark:border-green-900 dark:bg-green-950/30">
-        <div className="flex items-center gap-2 text-sm text-green-700 dark:text-green-400">
+      <div className="my-2 rounded-lg border border-[var(--chart-green)]/30 bg-[var(--chart-green)]/10 px-4 py-3">
+        <div className="flex items-center gap-2 text-sm text-[var(--chart-green)]">
           <CheckIcon className="size-4" />
           <span>Response submitted</span>
         </div>
@@ -91,10 +91,10 @@ export function AskUserWidget({
   }
 
   return (
-    <div className="my-2 rounded-lg border border-blue-200 bg-blue-50/50 px-4 py-3 dark:border-blue-900 dark:bg-blue-950/20">
+    <div className="my-2 rounded-lg border border-primary/30 bg-primary/5 px-4 py-3">
       {/* Question header */}
       <div className="flex items-start gap-2 mb-3">
-        <MessageCircleQuestionIcon className="size-4 mt-0.5 text-blue-600 dark:text-blue-400 shrink-0" />
+        <MessageCircleQuestionIcon className="size-4 mt-0.5 text-primary shrink-0" />
         <div>
           {output.context && (
             <p className="text-xs text-muted-foreground mb-1">
@@ -116,7 +116,7 @@ export function AskUserWidget({
               className={cn(
                 'flex w-full items-start gap-2 rounded-md border px-3 py-2 text-left text-sm transition-colors',
                 selectedValue === opt.value
-                  ? 'border-blue-500 bg-blue-100 dark:bg-blue-900/30'
+                  ? 'border-primary bg-primary/10'
                   : 'border-border hover:bg-muted/50'
               )}
             >
@@ -124,12 +124,12 @@ export function AskUserWidget({
                 className={cn(
                   'mt-0.5 h-4 w-4 rounded-full border-2 shrink-0 flex items-center justify-center',
                   selectedValue === opt.value
-                    ? 'border-blue-500'
+                    ? 'border-primary'
                     : 'border-muted-foreground/40'
                 )}
               >
                 {selectedValue === opt.value && (
-                  <div className="size-2 rounded-full bg-blue-500" />
+                  <div className="size-2 rounded-full bg-primary" />
                 )}
               </div>
               <div>
@@ -161,7 +161,7 @@ export function AskUserWidget({
               className={cn(
                 'flex w-full items-start gap-2 rounded-md border px-3 py-2 text-sm cursor-pointer transition-colors',
                 selectedValues.has(opt.value)
-                  ? 'border-blue-500 bg-blue-100 dark:bg-blue-900/30'
+                  ? 'border-primary bg-primary/10'
                   : 'border-border hover:bg-muted/50'
               )}
             >
@@ -253,8 +253,8 @@ export function AskUserWidget({
                   className={cn(
                     'p-1 transition-colors',
                     ratingValue >= n
-                      ? 'text-yellow-500'
-                      : 'text-muted-foreground/30 hover:text-yellow-300'
+                      ? 'text-[var(--chart-yellow)]'
+                      : 'text-muted-foreground/30 hover:text-[var(--chart-yellow)]/60'
                   )}
                 >
                   <StarIcon

--- a/apps/dashboard/src/components/agents/chat/query-insights-card.tsx
+++ b/apps/dashboard/src/components/agents/chat/query-insights-card.tsx
@@ -45,11 +45,11 @@ const METRIC_ICONS: Record<string, typeof HardDriveIcon> = {
 }
 
 const METRIC_COLORS: Record<string, string> = {
-  'Largest Data Scan': 'text-blue-500',
-  'Most Rows Scanned': 'text-purple-500',
-  'Fastest Scan Speed': 'text-yellow-500',
-  'Longest Query': 'text-red-500',
-  'Peak Memory': 'text-orange-500',
+  'Largest Data Scan': 'text-[var(--chart-blue)]',
+  'Most Rows Scanned': 'text-[var(--chart-1)]',
+  'Fastest Scan Speed': 'text-[var(--chart-yellow)]',
+  'Longest Query': 'text-[var(--chart-red)]',
+  'Peak Memory': 'text-[var(--chart-3)]',
 }
 
 function InsightCard({ highlight }: { readonly highlight: InsightHighlight }) {

--- a/apps/dashboard/src/components/agents/chat/tool-output.tsx
+++ b/apps/dashboard/src/components/agents/chat/tool-output.tsx
@@ -289,7 +289,7 @@ function renderStructuredOutput(output: unknown): ReactNode {
                 href="https://github.com/chmonitor/chmonitor/blob/main/docs/deployment.md"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-blue-600 dark:text-blue-400 hover:underline"
+                className="text-[var(--chart-blue)] hover:underline"
               >
                 Use Docker deployment for full chart support.
               </a>
@@ -493,7 +493,7 @@ function AnimatedDots() {
  */
 function RunningIndicator() {
   return (
-    <span className="inline-flex items-center gap-1.5 text-xs font-medium text-amber-600 dark:text-amber-400">
+    <span className="inline-flex items-center gap-1.5 text-xs font-medium text-[var(--chart-yellow)]">
       Running
       <AnimatedDots />
     </span>
@@ -641,9 +641,9 @@ export function ToolCallPart({
           <div
             className={cn(
               'size-1.5 shrink-0 rounded-full',
-              isActive && 'animate-pulse bg-amber-500',
-              hasOutput && 'bg-emerald-500',
-              hasError && 'bg-red-500'
+              isActive && 'animate-pulse bg-[var(--chart-yellow)]',
+              hasOutput && 'bg-[var(--chart-green)]',
+              hasError && 'bg-destructive'
             )}
           />
 
@@ -667,7 +667,7 @@ export function ToolCallPart({
             {hasOutput && (
               <Badge
                 variant="outline"
-                className="shrink-0 text-[10px] text-emerald-600 dark:text-emerald-400"
+                className="shrink-0 text-[10px] text-[var(--chart-green)]"
               >
                 ✓ Done
               </Badge>
@@ -675,7 +675,7 @@ export function ToolCallPart({
             {hasError && (
               <Badge
                 variant="outline"
-                className="shrink-0 text-[10px] text-red-600 dark:text-red-400"
+                className="shrink-0 text-[10px] text-destructive"
               >
                 ✗ Failed
               </Badge>

--- a/apps/dashboard/src/components/agents/mentions/autocomplete-popover.tsx
+++ b/apps/dashboard/src/components/agents/mentions/autocomplete-popover.tsx
@@ -28,13 +28,13 @@ function ItemIcon({ type }: { type: AutocompleteItem['type'] }) {
   switch (type) {
     case 'table':
     case 'database':
-      return <Database className="size-3.5 shrink-0 text-blue-500" />
+      return <Database className="size-3.5 shrink-0 text-[var(--chart-blue)]" />
     case 'resource':
-      return <Terminal className="size-3.5 shrink-0 text-green-500" />
+      return <Terminal className="size-3.5 shrink-0 text-[var(--chart-green)]" />
     case 'skill':
-      return <Zap className="size-3.5 shrink-0 text-purple-500" />
+      return <Zap className="size-3.5 shrink-0 text-[var(--chart-1)]" />
     case 'command':
-      return <Slash className="size-3.5 shrink-0 text-orange-500" />
+      return <Slash className="size-3.5 shrink-0 text-[var(--chart-3)]" />
     default:
       return null
   }

--- a/apps/dashboard/src/components/agents/mentions/mention-badge.tsx
+++ b/apps/dashboard/src/components/agents/mentions/mention-badge.tsx
@@ -14,11 +14,11 @@ interface MentionBadgeProps {
 
 const TYPE_CLASSES: Record<Mention['type'], string> = {
   table:
-    'border-transparent bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300 hover:bg-blue-200 dark:hover:bg-blue-900/50',
+    'border-transparent bg-[var(--chart-blue)]/15 text-[var(--chart-blue)] hover:bg-[var(--chart-blue)]/25',
   resource:
-    'border-transparent bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300 hover:bg-green-200 dark:hover:bg-green-900/50',
+    'border-transparent bg-[var(--chart-green)]/15 text-[var(--chart-green)] hover:bg-[var(--chart-green)]/25',
   skill:
-    'border-transparent bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300 hover:bg-purple-200 dark:hover:bg-purple-900/50',
+    'border-transparent bg-[var(--chart-1)]/15 text-[var(--chart-1)] hover:bg-[var(--chart-1)]/25',
 }
 
 export function MentionBadge({ mention, onRemove }: MentionBadgeProps) {
@@ -57,7 +57,7 @@ export function SlashCommandBadge({
       variant="outline"
       className={cn(
         'inline-flex items-center gap-1 py-0.5 pl-2 pr-1 text-xs font-medium',
-        'border-transparent bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300 hover:bg-orange-200 dark:hover:bg-orange-900/50'
+        'border-transparent bg-[var(--chart-3)]/15 text-[var(--chart-3)] hover:bg-[var(--chart-3)]/25'
       )}
     >
       <span>{command.label}</span>

--- a/apps/dashboard/src/components/agents/settings/provider-models-tab.tsx
+++ b/apps/dashboard/src/components/agents/settings/provider-models-tab.tsx
@@ -77,7 +77,7 @@ function ProviderStatusBadge({
   return status.configured ? (
     <Badge
       variant="outline"
-      className="h-4 gap-1 px-1.5 text-[10px] font-normal text-emerald-700 dark:text-emerald-400"
+      className="h-4 gap-1 px-1.5 text-[10px] font-normal text-[var(--chart-green)]"
     >
       <CheckCircle2Icon className="size-2.5" />
       Configured

--- a/apps/dashboard/src/components/agents/tuning-findings-panel.tsx
+++ b/apps/dashboard/src/components/agents/tuning-findings-panel.tsx
@@ -33,10 +33,10 @@ import { cn } from '@/lib/utils'
 
 // Same rose/amber/sky severity triad used by the query advisor panel.
 const SEVERITY_CLASS: Record<TuningFinding['severity'], string> = {
-  high: 'border-rose-500/30 bg-rose-500/10 text-rose-700 dark:text-rose-300',
+  high: 'border-destructive/30 bg-destructive/10 text-destructive',
   medium:
-    'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300',
-  low: 'border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-300',
+    'border-[var(--chart-yellow)]/30 bg-[var(--chart-yellow)]/10 text-[var(--chart-yellow)]',
+  low: 'border-[var(--chart-blue)]/30 bg-[var(--chart-blue)]/10 text-[var(--chart-blue)]',
 }
 
 const RULE_ICON: Record<TuningFinding['ruleId'], typeof HashIcon> = {

--- a/apps/dashboard/src/components/agents/welcome/agent-mcp-panel.tsx
+++ b/apps/dashboard/src/components/agents/welcome/agent-mcp-panel.tsx
@@ -50,16 +50,16 @@ export type { McpServer }
 function StatusBadge({ status }: { status: McpServer['status'] }) {
   if (status === 'connected') {
     return (
-      <span className="flex items-center gap-1 text-[10px] text-emerald-600 dark:text-emerald-400">
-        <span className="size-1.5 rounded-full bg-emerald-500" />
+      <span className="flex items-center gap-1 text-[10px] text-[var(--chart-green)]">
+        <span className="size-1.5 rounded-full bg-[var(--chart-green)]" />
         Connected
       </span>
     )
   }
   if (status === 'connecting') {
     return (
-      <span className="flex items-center gap-1 text-[10px] text-amber-600 dark:text-amber-400">
-        <span className="size-1.5 animate-pulse rounded-full bg-amber-500" />
+      <span className="flex items-center gap-1 text-[10px] text-[var(--chart-yellow)]">
+        <span className="size-1.5 animate-pulse rounded-full bg-[var(--chart-yellow)]" />
         Connecting
       </span>
     )
@@ -275,8 +275,8 @@ export function AgentMcpPanel() {
           {servers.length} active
         </span>
         {panelStatus === 'configured' ? (
-          <span className="flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
-            <span className="size-1.5 rounded-full bg-emerald-500" />
+          <span className="flex items-center gap-1 text-[var(--chart-green)]">
+            <span className="size-1.5 rounded-full bg-[var(--chart-green)]" />
             Configured
           </span>
         ) : (

--- a/apps/dashboard/src/components/agents/welcome/agent-model-picker.tsx
+++ b/apps/dashboard/src/components/agents/welcome/agent-model-picker.tsx
@@ -40,15 +40,15 @@ interface AgentModelPickerProps {
 }
 
 const PROVIDER_TEXT_CLASS: Record<string, string> = {
-  openrouter: 'text-blue-600 dark:text-blue-400',
-  anyrouter: 'text-violet-600 dark:text-violet-400',
-  nvidia: 'text-emerald-600 dark:text-emerald-400',
+  openrouter: 'text-[var(--chart-blue)]',
+  anyrouter: 'text-[var(--chart-1)]',
+  nvidia: 'text-[var(--chart-green)]',
 }
 
 const PROVIDER_DOT_CLASS: Record<string, string> = {
-  openrouter: 'bg-blue-500',
-  anyrouter: 'bg-violet-500',
-  nvidia: 'bg-emerald-500',
+  openrouter: 'bg-[var(--chart-blue)]',
+  anyrouter: 'bg-[var(--chart-1)]',
+  nvidia: 'bg-[var(--chart-green)]',
 }
 
 export function providerColorClass(provider: string): string {
@@ -66,15 +66,13 @@ function badgeTone(model: ModelDisplayInfo): {
   if (model.isFree) {
     return {
       label: 'free',
-      className:
-        'bg-emerald-50 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-300',
+      className: 'bg-[var(--chart-green)]/10 text-[var(--chart-green)]',
     }
   }
   if (model.modelId.endsWith('/free') || model.modelId.endsWith('/auto')) {
     return {
       label: 'default',
-      className:
-        'bg-blue-50 text-blue-700 dark:bg-blue-500/10 dark:text-blue-300',
+      className: 'bg-[var(--chart-blue)]/10 text-[var(--chart-blue)]',
     }
   }
   return null
@@ -154,7 +152,7 @@ export function ModelOptionRow({
         </Badge>
       ) : null}
       {active ? (
-        <CheckIcon className="size-3 shrink-0 text-emerald-500" />
+        <CheckIcon className="size-3 shrink-0 text-[var(--chart-green)]" />
       ) : null}
     </button>
   )

--- a/apps/dashboard/src/components/agents/welcome/agent-settings-sidebar.tsx
+++ b/apps/dashboard/src/components/agents/welcome/agent-settings-sidebar.tsx
@@ -390,7 +390,7 @@ function AiUsagePanel() {
               depleted
                 ? 'text-destructive'
                 : low
-                  ? 'text-amber-600 dark:text-amber-500'
+                  ? 'text-[var(--chart-yellow)]'
                   : 'text-foreground'
             )}
           >
@@ -405,7 +405,11 @@ function AiUsagePanel() {
           <div
             className={cn(
               'h-full rounded-full transition-all',
-              depleted ? 'bg-destructive' : low ? 'bg-amber-500' : 'bg-primary'
+              depleted
+                ? 'bg-destructive'
+                : low
+                  ? 'bg-[var(--chart-yellow)]'
+                  : 'bg-primary'
             )}
             style={{ width: `${pct}%` }}
           />

--- a/apps/dashboard/src/components/agents/welcome/agent-settings-sidebar.tsx
+++ b/apps/dashboard/src/components/agents/welcome/agent-settings-sidebar.tsx
@@ -73,6 +73,7 @@ export function AgentSettingsSidebar({
     totalSkillCount,
   } = useAgentSkills()
   const topSkills = skills.slice(0, 3)
+  const [showAllPrompts, setShowAllPrompts] = useState(false)
   const [skillDetail, setSkillDetail] = useState<Skill | null>(null)
   const [libraryOpen, setLibraryOpen] = useState(false)
   const [connectOpen, setConnectOpen] = useState(false)
@@ -203,16 +204,22 @@ export function AgentSettingsSidebar({
       <SidebarSection
         label="Suggested prompts"
         right={
-          <button
-            type="button"
-            className="text-muted-foreground hover:text-foreground text-[10.5px]"
-          >
-            Show more
-          </button>
+          SUGGESTED_PROMPTS.length > 3 ? (
+            <button
+              type="button"
+              onClick={() => setShowAllPrompts((v) => !v)}
+              className="text-muted-foreground hover:text-foreground text-[10.5px]"
+            >
+              {showAllPrompts ? 'Show less' : 'Show more'}
+            </button>
+          ) : null
         }
       >
         <div className="space-y-1.5 text-[11.5px]">
-          {SUGGESTED_PROMPTS.slice(0, 3).map((entry) => (
+          {(showAllPrompts
+            ? SUGGESTED_PROMPTS
+            : SUGGESTED_PROMPTS.slice(0, 3)
+          ).map((entry) => (
             <button
               key={entry.title}
               type="button"

--- a/apps/dashboard/src/components/agents/welcome/agent-welcome-screen.tsx
+++ b/apps/dashboard/src/components/agents/welcome/agent-welcome-screen.tsx
@@ -82,7 +82,7 @@ export function AgentWelcomeScreen({
 
       {/* Footer status */}
       <div className="text-muted-foreground mt-4 flex items-center justify-center gap-2 text-center text-[11px] tracking-[0.02em]">
-        <span className="size-1.5 rounded-full bg-emerald-500 animate-pulse motion-reduce:animate-none" />
+        <span className="size-1.5 rounded-full bg-[var(--chart-green)] animate-pulse motion-reduce:animate-none" />
         Connected to{' '}
         <span className="text-foreground font-mono">
           {clusterName ?? 'cluster'}

--- a/apps/dashboard/src/components/agents/welcome/agent-welcome-screen.tsx
+++ b/apps/dashboard/src/components/agents/welcome/agent-welcome-screen.tsx
@@ -16,7 +16,7 @@ import { SparklesIcon } from 'lucide-react'
 import type { ReactNode } from 'react'
 
 import { RecentThreadsRail } from '@/components/agents/welcome/recent-threads-rail'
-import { RecommendationsList } from '@/components/agents/welcome/recommendations-list'
+import { PromptTilesGrid } from '@/components/agents/welcome/recommendations-list'
 import { useAgentGreeting } from '@/lib/hooks/use-agent-greeting'
 
 interface AgentWelcomeScreenProps {
@@ -52,9 +52,9 @@ export function AgentWelcomeScreen({
     <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col px-6 pt-10 pb-6">
       {/* Greeting */}
       <div className="mb-8 text-center">
-        <div className="mx-auto mb-4 inline-flex size-11 items-center justify-center rounded-xl bg-foreground/[0.04]">
+        <div className="mx-auto mb-4 inline-flex size-11 items-center justify-center rounded-xl bg-primary/10 text-primary ring-1 ring-primary/20">
           <SparklesIcon
-            className="text-foreground/70 size-[18px]"
+            className="size-[18px]"
             strokeWidth={1.8}
             aria-hidden="true"
           />
@@ -74,8 +74,8 @@ export function AgentWelcomeScreen({
       {/* Composer (parent-owned) */}
       <div className="mb-8">{composer}</div>
 
-      {/* Suggested questions */}
-      <RecommendationsList onPickPrompt={onPickPrompt} limit={6} />
+      {/* Suggested questions — example-prompt tile grid (issue #2800) */}
+      <PromptTilesGrid onPickPrompt={onPickPrompt} limit={6} />
 
       {/* Recent threads */}
       <RecentThreadsRail />

--- a/apps/dashboard/src/components/agents/welcome/composer-toolbar.tsx
+++ b/apps/dashboard/src/components/agents/welcome/composer-toolbar.tsx
@@ -17,7 +17,7 @@
  * is a sibling that lives in the same outer card.
  */
 
-import { HashIcon, SparklesIcon, WrenchIcon } from 'lucide-react'
+import { PaperclipIcon, SparklesIcon, WrenchIcon } from 'lucide-react'
 
 import { useState } from 'react'
 import {
@@ -249,7 +249,7 @@ export function ComposerToolbar({
         onClick={() => setAddContextOpen(true)}
         className="text-muted-foreground hover:text-foreground h-7 gap-1.5 px-2 text-[11.5px]"
       >
-        <HashIcon className="size-3" />
+        <PaperclipIcon className="size-3" />
         <span>
           Add context
           {contextCount > 0 ? (

--- a/apps/dashboard/src/components/agents/welcome/composer-toolbar.tsx
+++ b/apps/dashboard/src/components/agents/welcome/composer-toolbar.tsx
@@ -144,7 +144,7 @@ export function ComposerToolbar({
                             className={cn(
                               'h-4 px-1.5 text-[10px] font-normal',
                               skill.source === 'system'
-                                ? 'bg-blue-50 text-blue-700 hover:bg-blue-50 dark:bg-blue-500/10 dark:text-blue-300'
+                                ? 'bg-[var(--chart-blue)]/10 text-[var(--chart-blue)]'
                                 : 'text-muted-foreground'
                             )}
                           >
@@ -214,7 +214,7 @@ export function ComposerToolbar({
                     <span
                       className={cn(
                         'inline-block size-1.5 shrink-0 rounded-full',
-                        on ? 'bg-emerald-500' : 'bg-muted-foreground/40'
+                        on ? 'bg-[var(--chart-green)]' : 'bg-muted-foreground/40'
                       )}
                     />
                     <div className="min-w-0 flex-1">
@@ -314,7 +314,7 @@ function AiQuotaIndicator() {
           depleted
             ? 'text-destructive'
             : low
-              ? 'text-amber-600 dark:text-amber-500'
+              ? 'text-[var(--chart-yellow)]'
               : 'text-foreground'
         )}
       >

--- a/apps/dashboard/src/components/agents/welcome/mcp-tools-resources-dialog.tsx
+++ b/apps/dashboard/src/components/agents/welcome/mcp-tools-resources-dialog.tsx
@@ -30,12 +30,9 @@ import { useMcpServerInfo } from '@/lib/swr/use-mcp-server-info'
 // ---------------------------------------------------------------------------
 
 const CATEGORY_STYLES: Record<string, string> = {
-  query:
-    'bg-blue-50 text-blue-700 hover:bg-blue-50 dark:bg-blue-500/10 dark:text-blue-300',
-  schema:
-    'bg-violet-50 text-violet-700 hover:bg-violet-50 dark:bg-violet-500/10 dark:text-violet-300',
-  system:
-    'bg-amber-50 text-amber-700 hover:bg-amber-50 dark:bg-amber-500/10 dark:text-amber-300',
+  query: 'bg-[var(--chart-blue)]/10 text-[var(--chart-blue)]',
+  schema: 'bg-[var(--chart-1)]/10 text-[var(--chart-1)]',
+  system: 'bg-[var(--chart-yellow)]/10 text-[var(--chart-yellow)]',
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/dashboard/src/components/agents/welcome/recommendations-list.tsx
+++ b/apps/dashboard/src/components/agents/welcome/recommendations-list.tsx
@@ -6,7 +6,17 @@
  * full-text prompt; clicking the row submits the prompt immediately.
  */
 
-import { ArrowRightIcon } from 'lucide-react'
+import {
+  ActivityIcon,
+  AlertTriangleIcon,
+  ArrowRightIcon,
+  CpuIcon,
+  DatabaseIcon,
+  GitMergeIcon,
+  HardDriveIcon,
+  type LucideIcon,
+  SparklesIcon,
+} from 'lucide-react'
 
 import { useEffect, useState } from 'react'
 import {
@@ -15,6 +25,16 @@ import {
   shufflePrompts,
 } from '@/components/agents/welcome/suggested-prompts'
 import { cn } from '@/lib/utils'
+
+const CATEGORY_ICONS: Record<string, LucideIcon> = {
+  INSIGHTS: SparklesIcon,
+  SCHEMA: DatabaseIcon,
+  STORAGE: HardDriveIcon,
+  QUERIES: ActivityIcon,
+  ERRORS: AlertTriangleIcon,
+  MERGES: GitMergeIcon,
+  SYSTEM: CpuIcon,
+}
 
 const CATEGORY_COLORS: Record<string, string> = {
   INSIGHTS: 'bg-[var(--chart-1)]/10 text-[var(--chart-1)]',
@@ -82,6 +102,73 @@ export function RecommendationsList({
                 {entry.prompt}
               </span>
               <ArrowRightIcon className="text-muted-foreground/60 group-hover:text-foreground mt-1 size-3 shrink-0 transition-transform duration-150 group-hover:translate-x-0.5" />
+            </button>
+          )
+        })}
+      </div>
+    </section>
+  )
+}
+
+/**
+ * Example-prompt tile grid for the welcome/empty state (issue #2800): each tile
+ * pairs a category-tinted icon with a short title + full-prompt subtitle.
+ * Clicking a tile fills the composer. A visual alternative to the flat
+ * {@link RecommendationsList}; both draw from the same SUGGESTED_PROMPTS pool.
+ */
+export function PromptTilesGrid({
+  onPickPrompt,
+  limit = 6,
+}: RecommendationsListProps) {
+  const [pool, setPool] =
+    useState<readonly SuggestedPrompt[]>(SUGGESTED_PROMPTS)
+  useEffect(() => {
+    setPool(shufflePrompts(SUGGESTED_PROMPTS))
+  }, [])
+
+  const prompts =
+    typeof limit === 'number' && limit > 0 ? pool.slice(0, limit) : pool
+
+  return (
+    <section className="mb-8">
+      <div className="mb-3">
+        <h3 className="text-[13px] font-semibold tracking-tight">
+          Suggested questions
+        </h3>
+        <p className="text-muted-foreground text-[11.5px]">
+          Pick one to get started, or write your own.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {prompts.map((entry, index) => {
+          const colorClass =
+            CATEGORY_COLORS[entry.category] ?? 'bg-muted text-muted-foreground'
+          const Icon = CATEGORY_ICONS[entry.category] ?? SparklesIcon
+          return (
+            <button
+              key={entry.title}
+              type="button"
+              onClick={() => onPickPrompt?.(entry.prompt)}
+              style={{ animationDelay: `${index * 40}ms` }}
+              className="hover:bg-muted/40 hover:border-border active:scale-[0.99] group flex items-start gap-3 rounded-lg border border-border/60 bg-card px-3 py-2.5 text-left shadow-sm transition-[transform,background-color,border-color] duration-150 touch-manipulation animate-in fade-in-0 slide-in-from-bottom-1"
+            >
+              <span
+                className={cn(
+                  'inline-flex size-7 shrink-0 items-center justify-center rounded-md',
+                  colorClass
+                )}
+              >
+                <Icon className="size-3.5" strokeWidth={1.8} />
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-[12.5px] font-medium text-foreground">
+                  {entry.title}
+                </span>
+                <span className="text-muted-foreground line-clamp-2 text-[11.5px] leading-snug">
+                  {entry.prompt}
+                </span>
+              </span>
             </button>
           )
         })}

--- a/apps/dashboard/src/components/agents/welcome/recommendations-list.tsx
+++ b/apps/dashboard/src/components/agents/welcome/recommendations-list.tsx
@@ -17,17 +17,13 @@ import {
 import { cn } from '@/lib/utils'
 
 const CATEGORY_COLORS: Record<string, string> = {
-  INSIGHTS:
-    'bg-violet-50 text-violet-600 dark:bg-violet-500/10 dark:text-violet-400',
-  SCHEMA: 'bg-blue-50 text-blue-600 dark:bg-blue-500/10 dark:text-blue-400',
-  STORAGE:
-    'bg-amber-50 text-amber-600 dark:bg-amber-500/10 dark:text-amber-400',
-  QUERIES:
-    'bg-emerald-50 text-emerald-600 dark:bg-emerald-500/10 dark:text-emerald-400',
-  ERRORS: 'bg-red-50 text-red-600 dark:bg-red-500/10 dark:text-red-400',
-  MERGES: 'bg-cyan-50 text-cyan-600 dark:bg-cyan-500/10 dark:text-cyan-400',
-  SYSTEM:
-    'bg-slate-100 text-slate-600 dark:bg-slate-500/10 dark:text-slate-400',
+  INSIGHTS: 'bg-[var(--chart-1)]/10 text-[var(--chart-1)]',
+  SCHEMA: 'bg-[var(--chart-blue)]/10 text-[var(--chart-blue)]',
+  STORAGE: 'bg-[var(--chart-yellow)]/10 text-[var(--chart-yellow)]',
+  QUERIES: 'bg-[var(--chart-green)]/10 text-[var(--chart-green)]',
+  ERRORS: 'bg-[var(--chart-red)]/10 text-[var(--chart-red)]',
+  MERGES: 'bg-[var(--chart-2)]/10 text-[var(--chart-2)]',
+  SYSTEM: 'bg-muted text-muted-foreground',
 }
 
 interface RecommendationsListProps {

--- a/apps/dashboard/src/components/agents/welcome/skill-detail-dialog.tsx
+++ b/apps/dashboard/src/components/agents/welcome/skill-detail-dialog.tsx
@@ -54,7 +54,7 @@ export function SkillDetailDialog({
                   className={cn(
                     'h-4 px-1.5 text-[10px] font-normal',
                     skill.source === 'system'
-                      ? 'bg-blue-50 text-blue-700 hover:bg-blue-50 dark:bg-blue-500/10 dark:text-blue-300'
+                      ? 'bg-[var(--chart-blue)]/10 text-[var(--chart-blue)]'
                       : 'text-muted-foreground'
                   )}
                 >
@@ -63,7 +63,7 @@ export function SkillDetailDialog({
                 {isEnabled ? (
                   <Badge
                     variant="secondary"
-                    className="h-4 gap-1 px-1.5 text-[10px] font-normal bg-emerald-50 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-300"
+                    className="h-4 gap-1 px-1.5 text-[10px] font-normal bg-[var(--chart-green)]/10 text-[var(--chart-green)]"
                   >
                     <CheckIcon className="size-2.5" /> active
                   </Badge>
@@ -93,7 +93,7 @@ export function SkillDetailDialog({
                     key={tool}
                     className="border-border bg-card flex items-center gap-2 rounded-md border px-2.5 py-1.5"
                   >
-                    <span className="inline-block size-1.5 shrink-0 rounded-full bg-emerald-500" />
+                    <span className="inline-block size-1.5 shrink-0 rounded-full bg-[var(--chart-green)]" />
                     <span className="truncate font-mono text-[11.5px]">
                       {tool}
                     </span>

--- a/apps/dashboard/src/components/agents/welcome/skills-library-dialog.tsx
+++ b/apps/dashboard/src/components/agents/welcome/skills-library-dialog.tsx
@@ -131,7 +131,7 @@ export function SkillsLibraryList({
                         className={cn(
                           'h-4 px-1.5 text-[10px] font-normal',
                           skill.source === 'system'
-                            ? 'bg-blue-50 text-blue-700 hover:bg-blue-50 dark:bg-blue-500/10 dark:text-blue-300'
+                            ? 'bg-[var(--chart-blue)]/10 text-[var(--chart-blue)]'
                             : 'text-muted-foreground'
                         )}
                       >

--- a/apps/dashboard/src/components/assistant-ui/-thread/chain-of-thought.tsx
+++ b/apps/dashboard/src/components/assistant-ui/-thread/chain-of-thought.tsx
@@ -28,6 +28,11 @@ import {
   ReasoningTrigger,
 } from '@/components/assistant-ui/reasoning'
 import { ToolFallback } from '@/components/assistant-ui/tool-fallback'
+import {
+  ToolGroupContent,
+  ToolGroupRoot,
+  ToolGroupTrigger,
+} from '@/components/assistant-ui/tool-group'
 
 // ---------------------------------------------------------------------------
 // GroupedParts groupBy — module-level stable reference
@@ -131,9 +136,19 @@ export function renderGroupedPart({ part, children }: GroupedRenderInfo) {
       )
     }
     case 'group-tool': {
-      // Render each tool call as its own sibling row (one fold per tool),
-      // not a single outer "N tool calls" group that requires two folds.
-      return <>{children}</>
+      // Collapse a run of adjacent tool calls into ONE "N tool calls"
+      // disclosure (issue #2803). While the run streams it auto-expands; once
+      // finished it collapses into tidy history. A single tool call needs no
+      // outer group — render it as a bare sibling row.
+      const count = 'indices' in part ? part.indices.length : 0
+      const isRunning = part.status?.type === 'running'
+      if (count <= 1) return <>{children}</>
+      return (
+        <ToolGroupRoot isRunning={isRunning}>
+          <ToolGroupTrigger count={count} status={part.status} />
+          <ToolGroupContent>{children}</ToolGroupContent>
+        </ToolGroupRoot>
+      )
     }
     default: {
       // Leaf part — cast is safe: non-group parts are EnrichedPartState

--- a/apps/dashboard/src/components/assistant-ui/-thread/composer.tsx
+++ b/apps/dashboard/src/components/assistant-ui/-thread/composer.tsx
@@ -19,6 +19,41 @@ import { ComposerToolbar } from '@/components/agents/welcome/composer-toolbar'
 import { PageContextChip } from '@/components/assistant-ui/-thread/page-context-chip'
 import { useAgentAuthGate } from '@/components/assistant-ui/agent-auth-gate'
 import { track } from '@/lib/telemetry'
+import { cn } from '@/lib/utils'
+
+/**
+ * Compact keyboard-hint row shown under the composer in both the welcome and
+ * in-thread positions (issue #2804).
+ */
+function ComposerHints({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        'flex flex-wrap items-center gap-x-3 gap-y-1 px-1 text-[11px] text-muted-foreground',
+        className
+      )}
+    >
+      <span className="flex items-center gap-1">
+        <kbd className="inline-flex h-4 min-w-4 items-center justify-center rounded border bg-muted px-1 font-sans text-[10px] font-medium">
+          Enter
+        </kbd>
+        send
+      </span>
+      <span className="flex items-center gap-1">
+        <kbd className="inline-flex h-4 items-center justify-center rounded border bg-muted px-1 font-sans text-[10px] font-medium">
+          Shift+Enter
+        </kbd>
+        newline
+      </span>
+      <span className="flex items-center gap-1">
+        <kbd className="inline-flex h-4 items-center justify-center rounded border bg-muted px-1 font-sans text-[10px] font-medium">
+          ⌘K
+        </kbd>
+        new chat
+      </span>
+    </div>
+  )
+}
 
 /**
  * Welcome-screen composer card: mentions textarea + toolbar (model · skills ·
@@ -58,6 +93,7 @@ export function WelcomeComposer() {
           setContextItems((prev) => prev.filter((i) => i.id !== id))
         }
       />
+      <ComposerHints />
     </div>
   )
 }
@@ -66,6 +102,7 @@ export function ThreadComposer() {
   const threadRuntime = useThreadRuntime()
   const isRunning = useThread((thread) => thread.isRunning)
   const { ensureAuthed } = useAgentAuthGate()
+  const [contextItems, setContextItems] = useState<ContextItem[]>([])
 
   return (
     <div className="flex w-full flex-col gap-1.5">
@@ -76,14 +113,27 @@ export function ThreadComposer() {
           const trimmed = text.trim()
           if (!trimmed) return
           if (!ensureAuthed()) return
+          const block = formatContextBlock(contextItems)
+          const full = block ? `${block}\n\n${trimmed}` : trimmed
           threadRuntime.append({
             role: 'user',
-            content: [{ type: 'text', text: trimmed }],
+            content: [{ type: 'text', text: full }],
           })
           track('ai_query_sent')
+          setContextItems([])
         }}
         onStop={() => threadRuntime.cancelRun()}
       />
+      {/* Keep the toolbar (model · skills · tools · add-context) available
+          mid-conversation, not just on the welcome screen (issue #2804). */}
+      <ComposerToolbar
+        contextItems={contextItems}
+        onAddContext={(item) => setContextItems((prev) => [...prev, item])}
+        onRemoveContext={(id) =>
+          setContextItems((prev) => prev.filter((i) => i.id !== id))
+        }
+      />
+      <ComposerHints />
     </div>
   )
 }

--- a/apps/dashboard/src/components/assistant-ui/-thread/message-stats.tsx
+++ b/apps/dashboard/src/components/assistant-ui/-thread/message-stats.tsx
@@ -285,11 +285,11 @@ export function MessageStatsFooter() {
     usage?.resolvedModel != null && usage.resolvedModel !== usage?.model
 
   return (
-    <div className="mt-1 flex items-center gap-3 text-[10px] text-muted-foreground/55">
+    <div className="mt-1 flex items-center gap-3 text-[11px] text-muted-foreground">
       {/* Duration */}
       {hasDuration && timing?.totalStreamTime != null && (
         <span className="flex items-center gap-0.5">
-          <ClockIcon className="size-2.5 shrink-0" />
+          <ClockIcon className="size-3 shrink-0" />
           <span className="font-mono tabular-nums">
             {formatDuration(timing.totalStreamTime)}
           </span>
@@ -299,7 +299,7 @@ export function MessageStatsFooter() {
       {/* Throughput */}
       {timing?.tokensPerSecond != null && (
         <span className="flex items-center gap-0.5">
-          <GaugeIcon className="size-2.5 shrink-0" />
+          <GaugeIcon className="size-3 shrink-0" />
           <span className="font-mono tabular-nums">
             {timing.tokensPerSecond.toFixed(1)}
           </span>
@@ -309,7 +309,7 @@ export function MessageStatsFooter() {
       {/* Token total */}
       {hasTokens && (
         <span className="flex items-center gap-0.5">
-          <CpuIcon className="size-2.5 shrink-0" />
+          <CpuIcon className="size-3 shrink-0" />
           <span className="font-mono tabular-nums">
             {totalTokens.toLocaleString()}
           </span>
@@ -319,7 +319,7 @@ export function MessageStatsFooter() {
       {/* Tool call count */}
       {toolCount > 0 && (
         <span className="flex items-center gap-0.5">
-          <WrenchIcon className="size-2.5 shrink-0" />
+          <WrenchIcon className="size-3 shrink-0" />
           <span className="font-mono tabular-nums">{toolCount}</span>
         </span>
       )}
@@ -333,7 +333,7 @@ export function MessageStatsFooter() {
           {isResolved && (
             <Badge
               variant="outline"
-              className="px-1 py-0 text-[9px] h-3.5 leading-none border-border/40"
+              className="px-1 py-0 text-[10px] h-4 leading-none border-border/40"
             >
               resolved
             </Badge>
@@ -367,7 +367,7 @@ export function MessageStatsFooter() {
               />
             }
           >
-            <InfoIcon className="size-2.5 shrink-0" />
+            <InfoIcon className="size-3 shrink-0" />
           </DialogTrigger>
           <DialogContent className="max-w-md">
             <DialogHeader>

--- a/apps/dashboard/src/components/assistant-ui/json-render-message.tsx
+++ b/apps/dashboard/src/components/assistant-ui/json-render-message.tsx
@@ -201,7 +201,7 @@ export function JsonRenderMessage() {
           />
         </ErrorBoundary>
       ) : (
-        <div className="rounded border border-yellow-200/40 bg-yellow-50/40 p-2 text-xs text-yellow-800 dark:border-yellow-900/50 dark:bg-yellow-950/30 dark:text-yellow-200">
+        <div className="rounded border border-[var(--chart-yellow)]/40 bg-[var(--chart-yellow)]/10 p-2 text-xs text-[var(--chart-yellow)]">
           {jsonRender.parseError}
         </div>
       )}

--- a/apps/dashboard/src/components/assistant-ui/reasoning.tsx
+++ b/apps/dashboard/src/components/assistant-ui/reasoning.tsx
@@ -112,20 +112,20 @@ export function ReasoningTrigger({
     <CollapsibleTrigger
       className={cn(
         'flex w-full items-center gap-1.5 px-3 py-2 rounded-md',
-        'bg-purple-50/50 dark:bg-purple-950/20',
-        'text-xs font-medium text-purple-700 dark:text-purple-300',
-        'hover:bg-purple-100/50 dark:hover:bg-purple-950/30 transition-colors',
+        'bg-muted/50',
+        'text-xs font-medium text-muted-foreground',
+        'hover:bg-muted transition-colors',
         className
       )}
     >
       <SparklesIcon
         className={cn(
-          'size-3.5 shrink-0 text-purple-600 dark:text-purple-400',
+          'size-3.5 shrink-0 text-muted-foreground',
           active && 'animate-pulse'
         )}
       />
       <span className="flex-1 text-left">{children ?? 'Thought process'}</span>
-      <ChevronRightIcon className="size-3 shrink-0 text-purple-600 dark:text-purple-400 transition-transform duration-200 group-data-[state=open]/reasoning:rotate-90" />
+      <ChevronRightIcon className="size-3 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]/reasoning:rotate-90" />
     </CollapsibleTrigger>
   )
 }

--- a/apps/dashboard/src/components/assistant-ui/thread.tsx
+++ b/apps/dashboard/src/components/assistant-ui/thread.tsx
@@ -106,8 +106,10 @@ export function Thread({
     <ThreadPrimitive.Root
       className="aui-root flex h-full flex-col overflow-hidden bg-background"
       style={{
-        // Assistant responses (charts, tables, SQL) use the full container width.
-        ['--assistant-max-width' as string]: '100%',
+        // Cap assistant content to a readable measure (~64rem) instead of
+        // stretching edge-to-edge; charts/tables/SQL still fill this column
+        // and it centers within wider containers (issue #2803).
+        ['--assistant-max-width' as string]: 'min(100%, 64rem)',
       }}
     >
       {/* Empty (welcome) state lives OUTSIDE the scroll container. The tall
@@ -284,9 +286,9 @@ const EditComposer: FC = () => {
 // ---------------------------------------------------------------------------
 
 /**
- * Shows a subtle spinner while the thread is running and the current assistant
- * message has no real parts yet. The visible "Thinking…" label is intentionally
- * dropped for a cleaner starting state; the text is kept screen-reader-only.
+ * Shows a spinner + visible "Thinking…" pill while the thread is running and
+ * the current assistant message has no real parts yet, so sighted users get a
+ * clear streaming affordance (not just an aria-live region).
  */
 function LoadingIndicator() {
   const isRunning = useThread((thread) => thread.isRunning)
@@ -314,7 +316,11 @@ function LoadingIndicator() {
       <MarkerIcon>
         <LoaderCircleIcon className="animate-spin" />
       </MarkerIcon>
-      <span className="sr-only">Thinking…</span>
+      {/* Visible "Thinking…" pill so sighted users get the streaming affordance
+          too, not just an aria-live region (issue #2803). */}
+      <span className="animate-pulse text-xs font-medium text-muted-foreground motion-reduce:animate-none">
+        Thinking…
+      </span>
     </Marker>
   )
 }

--- a/apps/dashboard/src/components/assistant-ui/tool-group.tsx
+++ b/apps/dashboard/src/components/assistant-ui/tool-group.tsx
@@ -112,15 +112,15 @@ export function ToolGroupTrigger({
     <CollapsibleTrigger
       className={cn(
         'flex w-full items-center gap-1.5 px-3 py-2 rounded-md',
-        'bg-orange-50/50 dark:bg-orange-950/20',
-        'text-xs font-medium text-orange-700 dark:text-orange-300',
-        'hover:bg-orange-100/50 dark:hover:bg-orange-950/30 transition-colors',
+        'bg-muted/50',
+        'text-xs font-medium text-muted-foreground',
+        'hover:bg-muted transition-colors',
         className
       )}
     >
       <WrenchIcon
         className={cn(
-          'size-3.5 shrink-0 text-orange-600 dark:text-orange-400',
+          'size-3.5 shrink-0 text-muted-foreground',
           isRunning && 'animate-pulse'
         )}
       />
@@ -130,9 +130,9 @@ export function ToolGroupTrigger({
           : 'Tool calls'}
       </span>
       {isRunning && (
-        <span className="mr-1 inline-block size-2 animate-pulse rounded-full bg-orange-500/60" />
+        <span className="mr-1 inline-block size-2 animate-pulse rounded-full bg-primary/60" />
       )}
-      <ChevronRightIcon className="size-3 shrink-0 text-orange-600 dark:text-orange-400 transition-transform duration-200 group-data-[state=open]/toolgroup:rotate-90" />
+      <ChevronRightIcon className="size-3 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]/toolgroup:rotate-90" />
     </CollapsibleTrigger>
   )
 }


### PR DESCRIPTION
Part of epic #2811 (redesign AI agent page). This PR lands the tractable,
low-risk children; the two larger structural children (#2802 rail, #2805
visualization consolidation) and the dedup pass (#2809) are called out below as
follow-ups so the epic stays honest.

## What changed

### #2800 — Welcome / empty-state redesign
- Example-prompt **tile grid** (category-tinted icon + title + full-prompt
  subtitle, 2-col on desktop) replacing the flat suggested-questions list; each
  tile is a `rounded-lg` bordered card.
- Brand glyph made visible: `primary`-tinted chip with ring instead of the
  near-invisible `bg-foreground/[0.04]` sparkle.
- Composer already renders as an elevated bordered `InputGroup` card.
- _Not in this PR:_ a bespoke brand illustration + first-run onboarding cards —
  left to the illustration-system work (#2806).

### #2801 — Migrate hardcoded colors to OKLCH tokens
- Replaced every raw Tailwind palette class (`purple/orange/emerald/amber/red/
  blue/violet/slate/yellow/cyan/rose/sky/green-*`) across `components/agents/**`
  and `components/assistant-ui/**` with semantic + chart-accent design tokens
  (`muted`, `primary`, `destructive`, `--chart-green/yellow/red/blue/1..3`).
- Fixes dark-mode hue jumps and the `METRIC_COLORS` that lacked dark variants.
- Verified: `grep` for palette classes under both dirs returns clean.

### #2803 — Thread rendering polish
- Restored a visible **"Thinking…" pill** (not just an aria-live region) while a
  turn streams.
- **Revived `ToolGroup`**: a run of N adjacent tool calls now collapses into one
  "N tool calls" disclosure that auto-expands while running and collapses when
  done (single-tool runs stay bare).
- Message-stats footer brought to a legible size/contrast
  (`text-[10px]/55` → `text-[11px] muted-foreground`, icons `size-2.5` →
  `size-3`, "resolved" badge `text-[9px]` → `text-[10px]`).
- Capped assistant content width to `min(100%, 64rem)` instead of edge-to-edge.

### #2804 — Composer polish
- Keyboard-hint row (Enter send · Shift+Enter newline · ⌘K new chat) under the
  composer in both welcome and in-thread positions.
- Kept the toolbar (model · skills · tools · add-context) in the **in-thread**
  composer, not just welcome; thread composer now carries add-context state.
- `HashIcon` → `PaperclipIcon` for the add-context button.
- Wired the previously dead "Show more" suggested-prompts button in the settings
  sidebar (toggles full list / first 3).
- Composer card chrome + visible send/stop button were already provided by the
  `InputGroup` migration.

## Verification
- `tsc --noEmit`: zero new errors in `components/agents/**` or
  `components/assistant-ui/**` (pre-existing errors are all in `routes/api` +
  `next-compat`, the known routeTree.gen worktree artifact — regenerated in CI).
- No raw Tailwind palette classes remain under the two agent dirs.

## Follow-ups (intentionally not closed here)
- #2802 — persistent conversation rail (large layout change).
- #2805 — consolidate visualization on ChartCard/ChartContainer; retire
  AgentChartRenderer (large refactor spanning agent-visualization + tool-output).
- #2809 — unify duplicated surfaces (suggested prompts / AI usage / recent
  threads) — deferred to avoid visual regression without a live preview.

Closes #2800
Closes #2801
Closes #2803
Closes #2804
