### PR TITLE
fix(review): post-merge code-review fixes for the issue-sweep wave

### DIFF
--- a/apps/dashboard/src/components/agents/mentions/prompt-input-with-mentions.tsx
+++ b/apps/dashboard/src/components/agents/mentions/prompt-input-with-mentions.tsx
@@ -189,7 +189,7 @@ export function PromptInputTextareaWithMentions({
 
   return (
     <div className="relative">
-      <InputGroup className={cn('rounded-xl px-3 py-2', className)}>
+      <InputGroup className={cn('rounded-lg px-3 py-2', className)}>
         {hasMentions && (
           <InputGroupAddon align="block-start">
             <div className="flex flex-wrap gap-1">

--- a/apps/dashboard/src/components/agents/welcome/agent-settings-sidebar.tsx
+++ b/apps/dashboard/src/components/agents/welcome/agent-settings-sidebar.tsx
@@ -221,7 +221,7 @@ export function AgentSettingsSidebar({
             : SUGGESTED_PROMPTS.slice(0, 3)
           ).map((entry) => (
             <button
-              key={entry.title}
+              key={`${entry.category}-${entry.title}`}
               type="button"
               onClick={() => onPickPrompt?.(entry.prompt)}
               className="text-muted-foreground hover:text-foreground hover:bg-muted/40 -mx-1 flex w-[calc(100%+0.5rem)] items-start gap-1.5 rounded px-1 py-0.5 text-left transition-colors"

--- a/apps/dashboard/src/components/agents/welcome/recommendations-list.tsx
+++ b/apps/dashboard/src/components/agents/welcome/recommendations-list.tsx
@@ -84,7 +84,7 @@ export function RecommendationsList({
             CATEGORY_COLORS[entry.category] ?? 'bg-muted text-muted-foreground'
           return (
             <button
-              key={entry.title}
+              key={`${entry.category}-${entry.title}`}
               type="button"
               onClick={() => onPickPrompt?.(entry.prompt)}
               style={{ animationDelay: `${index * 40}ms` }}
@@ -147,7 +147,7 @@ export function PromptTilesGrid({
           const Icon = CATEGORY_ICONS[entry.category] ?? SparklesIcon
           return (
             <button
-              key={entry.title}
+              key={`${entry.category}-${entry.title}`}
               type="button"
               onClick={() => onPickPrompt?.(entry.prompt)}
               style={{ animationDelay: `${index * 40}ms` }}

--- a/apps/dashboard/src/components/reports/report-settings-panel.tsx
+++ b/apps/dashboard/src/components/reports/report-settings-panel.tsx
@@ -147,6 +147,8 @@ export function ReportSettingsPanel() {
       }
       const blob = new Blob([data.html], { type: 'text/html' })
       window.open(URL.createObjectURL(blob), '_blank', 'noopener')
+    } catch {
+      toast.error('Report generation failed')
     } finally {
       setBusy(null)
     }
@@ -187,6 +189,8 @@ export function ReportSettingsPanel() {
         const blob = new Blob([data.html], { type: 'text/html' })
         window.open(URL.createObjectURL(blob), '_blank', 'noopener')
       }
+    } catch {
+      toast.error('PDF export failed')
     } finally {
       setBusy(null)
     }

--- a/apps/dashboard/src/routes/api/v1/insights/weekly-report.ts
+++ b/apps/dashboard/src/routes/api/v1/insights/weekly-report.ts
@@ -27,6 +27,7 @@ import type { WeeklyReportSummary } from '@/lib/insights/types'
 
 import { env } from 'cloudflare:workers'
 import { error, generateRequestId } from '@chm/logger'
+import { requirePlanCapability } from '@/lib/billing/plan-capability'
 import { renderReportPdf, reportPdfFilename } from '@/lib/insights/report-pdf'
 import { renderWeeklyReportHtml } from '@/lib/insights/weekly-report-html'
 import {
@@ -98,14 +99,18 @@ export const Route = createFileRoute('/api/v1/insights/weekly-report')({
           const html = htmlFor(record)
 
           if (params.get('format') === 'pdf') {
+            // PDF export is a Pro+ (`data_export`) capability — same gate as
+            // POST /api/v1/reports/generate. HTML/JSON stay ungated.
+            const denied = await requirePlanCapability('data_export', request)
+            if (denied) return denied
             const pdf = await renderReportPdf(
               html,
               env as unknown as Record<string, unknown>
             )
             if (pdf) {
               const filename = reportPdfFilename(
-                record.hostId,
-                'report',
+                `host-${record.hostId}`,
+                'weekly',
                 record.weekStart
               )
               return new Response(pdf, {


### PR DESCRIPTION
Two-axis code review (standards + spec) of the merged wave #2816/#2817/#2818/#2819 surfaced these defects, fixed here:

- **Plan-gate bypass**: `GET /api/v1/insights/weekly-report?format=pdf` rendered Pro+ PDFs with no `data_export` gate; now gated identically to `POST /api/v1/reports/generate`.
- `reportPdfFilename` argument misuse in weekly-report (hostId passed as label, literal 'report' as period).
- Missing `catch` in `generateNow`/`downloadPdf` — network failures left only `finally`, surfacing as unhandled rejections; now toast errors.
- React key collisions on prompt tiles/settings sidebar when two entries share a title.
- Composer `rounded-xl` → `rounded-lg` per #2800 acceptance.
- Removed stray untracked `apps/landing/public/landing-assets/` (#2810 leftover, local only).

Deferred (structural/product, not defects): move EmptyState out of components/ui/, onboarding cards (#2800), R2-backed PDF links (#2794), report-fanout PDF dedup + typed BROWSER env.

https://claude.ai/code/session_016pN3dJ84hj6Qkv9qiZ2pzo