### PR TITLE
style(agent): biome format autocomplete-popover

### DIFF
--- a/apps/dashboard/src/components/agents/mentions/autocomplete-popover.tsx
+++ b/apps/dashboard/src/components/agents/mentions/autocomplete-popover.tsx
@@ -30,7 +30,9 @@ function ItemIcon({ type }: { type: AutocompleteItem['type'] }) {
     case 'database':
       return <Database className="size-3.5 shrink-0 text-[var(--chart-blue)]" />
     case 'resource':
-      return <Terminal className="size-3.5 shrink-0 text-[var(--chart-green)]" />
+      return (
+        <Terminal className="size-3.5 shrink-0 text-[var(--chart-green)]" />
+      )
     case 'skill':
       return <Zap className="size-3.5 shrink-0 text-[var(--chart-1)]" />
     case 'command':


### PR DESCRIPTION
Biome formatter fix — `pnpm run check` fails on main since #2822, blocking every pre-push hook (including tag pushes).

https://claude.ai/code/session_016pN3dJ84hj6Qkv9qiZ2pzo