### PR TITLE
feat(ci): multi-component release-please (dashboard, CLI, helm chart)

### DIFF
--- a/.github/.release-please-manifest.json
+++ b/.github/.release-please-manifest.json
@@ -1,3 +1,5 @@
 {
-  ".": "0.2.15"
+  ".": "0.2.15",
+  "rust/ch-monitor-cli": "0.1.0",
+  "deploy/helm/chmonitor": "0.2.15"
 }

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -5,6 +5,7 @@
   "bump-patch-for-minor-pre-major": true,
   "include-component-in-tag": false,
   "tag-separator": "-",
+  "separate-pull-requests": true,
   "packages": {
     ".": {
       "release-type": "simple",
@@ -12,6 +13,7 @@
       "changelog-path": "CHANGELOG.md",
       "draft": false,
       "prerelease": false,
+      "exclude-paths": ["rust/ch-monitor-cli", "deploy/helm/chmonitor"],
       "extra-files": [
         {
           "type": "json",
@@ -31,6 +33,25 @@
         { "type": "ci", "section": "👷 CI", "hidden": true },
         { "type": "style", "section": "💅 Style", "hidden": true }
       ]
+    },
+    "rust/ch-monitor-cli": {
+      "release-type": "rust",
+      "package-name": "ch-monitor-cli",
+      "component": "chm",
+      "include-component-in-tag": true,
+      "include-v-in-tag": true,
+      "changelog-path": "CHANGELOG.md",
+      "draft": false,
+      "prerelease": false
+    },
+    "deploy/helm/chmonitor": {
+      "release-type": "helm",
+      "package-name": "chmonitor-chart",
+      "component": "helm-chmonitor",
+      "include-component-in-tag": true,
+      "include-v-in-tag": false,
+      "changelog-path": "CHANGELOG.md",
+      "skip-github-release": true
     }
   }
 }

--- a/.github/workflows/cli-rust-release.yml
+++ b/.github/workflows/cli-rust-release.yml
@@ -2,6 +2,11 @@ name: CLI Rust Release
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'chm-v* tag to build and attach binaries to (required when dispatched by release-please, whose GITHUB_TOKEN-created tags cannot fire the push trigger)'
+        required: false
+        type: string
   push:
     tags:
       - 'chm-v*'
@@ -29,6 +34,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          # On tag push this is the tag itself; on dispatch, check out the
+          # requested tag so the built binary matches the release version.
+          ref: ${{ inputs.tag || github.ref }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -55,6 +64,7 @@ jobs:
           cd dist
           shasum -a 256 ${{ matrix.bin }}-${{ matrix.target }} > ${{ matrix.bin }}-${{ matrix.target }}.sha256
       - uses: softprops/action-gh-release@v3
-        if: github.ref_type == 'tag'
+        if: github.ref_type == 'tag' || inputs.tag != ''
         with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
           files: dist/*

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -50,3 +50,18 @@ jobs:
         # No checkout precedes this step (release-please-action works via the
         # API), so gh has no local repo to infer. Pass -R explicitly.
         run: gh workflow run release.yml -R ${{ github.repository }} -f tag=${{ steps.release.outputs.tag_name }}
+
+      # Same anti-recursion rule for the CLI component: the chm-vX.Y.Z tag
+      # release-please creates won't fire cli-rust-release.yml's `on: push:
+      # tags` by itself, so dispatch it explicitly with the tag to build.
+      - name: Trigger CLI release build
+        if: steps.release.outputs['rust/ch-monitor-cli--release_created'] == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run cli-rust-release.yml -R ${{ github.repository }} -f tag=${{ steps.release.outputs['rust/ch-monitor-cli--tag_name'] }}
+
+      # Helm: no dispatch needed. The helm-chmonitor release PR bumps
+      # deploy/helm/chmonitor/Chart.yaml, and merging it fires helm-release.yml
+      # via its `paths: deploy/helm/**` push trigger; chart-releaser then owns
+      # the helm-chmonitor-X.Y.Z tag + release (skip-github-release in the
+      # release-please config keeps the two from double-tagging).


### PR DESCRIPTION
release-please now audits conventional commits per component and maintains a separate release PR + changelog for each:

| Component | Path | Tag | Release owner |
|---|---|---|---|
| Dashboard/app | `.` (excludes CLI+helm paths) | `vX.Y.Z` | release-please (unchanged) |
| CLI | `rust/ch-monitor-cli` | `chm-vX.Y.Z` | release-please → dispatches `cli-rust-release.yml` to build/attach binaries |
| Helm chart | `deploy/helm/chmonitor` | `helm-chmonitor-X.Y.Z` | release PR bumps Chart.yaml; chart-releaser keeps owning tags/releases (`skip-github-release`) |

Commits scoped to `rust/ch-monitor-cli/**` now automatically feed the CLI's next release PR — no more manual tag pushes (#2727's failure mode).

https://claude.ai/code/session_016pN3dJ84hj6Qkv9qiZ2pzo