### PR TITLE
feat(cli): chm update — self-update from GitHub releases

### DIFF
--- a/docs/content/guide/guides/diagnostics-cli.mdx
+++ b/docs/content/guide/guides/diagnostics-cli.mdx
@@ -48,6 +48,30 @@ CLICKHOUSE_HOST=http://localhost:8123 CLICKHOUSE_USER=default \
 ```
 </Callout>
 
+## Update
+
+`chm` can update itself in place from GitHub Releases — no re-running the
+install script, no `sudo`:
+
+```bash
+chm update            # download + verify + replace with the latest chm-v* release
+chm update --check     # only report whether a newer release exists (exit 1 if so)
+chm update --version chm-v0.2.0   # pin a specific release
+```
+
+`update` downloads the binary for your platform plus its `.sha256`, verifies the
+checksum (mandatory — it aborts on a mismatch or missing checksum), then
+atomically replaces the running executable. If the install directory is not
+writable it prints the manual command instead of asking for `sudo`. Installed
+via `cargo install`? Use `cargo install ch-monitor-cli` to upgrade instead.
+
+<Callout type="info" title="Update reminder">
+After a `chm diagnose` run, `chm` does a fast, best-effort check for a newer
+release and prints a one-line hint to stderr if one is available. Silence it
+with `CHM_NO_UPDATE_CHECK=1`. The check has a sub-second timeout and never
+affects the diagnose exit code.
+</Callout>
+
 ## Configuration
 
 Same env var names the dashboard uses, so if you already have `CLICKHOUSE_HOST`/`CLICKHOUSE_USER`/`CLICKHOUSE_PASSWORD` set for a self-hosted deploy, `diagnose` picks them up as-is. Flags override env vars.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -202,6 +202,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "toml",
 ]

--- a/rust/ch-monitor-cli/Cargo.toml
+++ b/rust/ch-monitor-cli/Cargo.toml
@@ -25,6 +25,7 @@ comfy-table = "7"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 toml = "1.0"
 dirs = "6"

--- a/rust/ch-monitor-cli/README.md
+++ b/rust/ch-monitor-cli/README.md
@@ -30,6 +30,22 @@ cargo build --release --manifest-path rust/ch-monitor-cli/Cargo.toml
 CLICKHOUSE_HOST=http://localhost:8123 CLICKHOUSE_USER=default chm diagnose
 ```
 
+## Update
+
+`chm` self-updates from GitHub Releases (downloads the matching binary, verifies
+its sha256, and atomically replaces itself — no sudo):
+
+```bash
+chm update                       # install the latest chm-v* release
+chm update --check               # only report if a newer release exists (exit 1 if so)
+chm update --version chm-v0.2.0  # pin a specific release
+```
+
+After a `chm diagnose` run, a one-line "update available" hint is printed to
+stderr when a newer release exists (best-effort, sub-second timeout). Silence it
+with `CHM_NO_UPDATE_CHECK=1`. Installed via `cargo install`? Upgrade with
+`cargo install ch-monitor-cli` instead.
+
 See [docs.chmonitor.dev/guide/guides/diagnostics-cli](https://docs.chmonitor.dev/guide/guides/diagnostics-cli)
 for the full CLI reference.
 

--- a/rust/ch-monitor-cli/build.rs
+++ b/rust/ch-monitor-cli/build.rs
@@ -1,0 +1,7 @@
+// Expose the compile-time target triple (e.g. `x86_64-unknown-linux-gnu`) to the
+// crate as `env!("CHM_TARGET")`. Cargo sets `TARGET` for build scripts; we re-emit
+// it as a rustc-env so `chm update` can pick the matching release asset.
+fn main() {
+    let target = std::env::var("TARGET").unwrap_or_else(|_| "unknown".to_string());
+    println!("cargo:rustc-env=CHM_TARGET={target}");
+}

--- a/rust/ch-monitor-cli/src/main.rs
+++ b/rust/ch-monitor-cli/src/main.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 mod diagnose;
+mod update;
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 struct FileConfig {
@@ -77,6 +78,15 @@ enum Commands {
         /// Print the report as JSON instead of a table.
         #[arg(long)]
         json: bool,
+    },
+    /// Update chm to the latest release from GitHub (self-update).
+    Update {
+        /// Only check whether an update is available; exit 1 if one exists.
+        #[arg(long)]
+        check: bool,
+        /// Install a specific release tag, e.g. chm-v0.2.0.
+        #[arg(long)]
+        version: Option<String>,
     },
 }
 
@@ -423,12 +433,25 @@ async fn main() -> Result<()> {
             } else {
                 print!("{}", diagnose::render_text(&report));
             }
+            // Gentle, best-effort "update available" hint (opt out with
+            // CHM_NO_UPDATE_CHECK=1). Never fails the command.
+            update::hint(&client).await;
             if report
                 .findings
                 .iter()
                 .any(|f| f.severity == diagnose::Severity::Critical)
             {
                 std::process::exit(1);
+            }
+        }
+        Commands::Update { check, version } => {
+            if check {
+                let available = update::check(&client).await?;
+                if available {
+                    std::process::exit(1);
+                }
+            } else {
+                update::run(&client, version).await?;
             }
         }
     }

--- a/rust/ch-monitor-cli/src/update.rs
+++ b/rust/ch-monitor-cli/src/update.rs
@@ -1,0 +1,357 @@
+//! Self-update: `chm update`.
+//!
+//! Downloads the newest (or a pinned) `chm-v*` release from GitHub, verifies its
+//! sha256 checksum, and atomically replaces the running executable. No sudo — if
+//! the install directory is not writable we print the manual command instead.
+
+use std::{env, fs, path::Path, time::Duration};
+
+use anyhow::{anyhow, bail, Context, Result};
+use reqwest::Client;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+
+const RELEASES_API: &str = "https://api.github.com/repos/chmonitor/chmonitor/releases";
+const RELEASE_DOWNLOAD: &str = "https://github.com/chmonitor/chmonitor/releases/download";
+const USER_AGENT: &str = concat!("chm-cli/", env!("CARGO_PKG_VERSION"));
+
+/// Compile-time target triple, injected by `build.rs`.
+const TARGET: &str = env!("CHM_TARGET");
+
+/// The four platform triples we publish release assets for.
+const SUPPORTED_TARGETS: &[&str] = &[
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+];
+
+#[derive(Debug, Deserialize)]
+struct Release {
+    tag_name: String,
+    #[serde(default)]
+    prerelease: bool,
+    #[serde(default)]
+    draft: bool,
+}
+
+/// A parsed semantic version (major.minor.patch), ignoring any pre-release/build
+/// suffix for ordering purposes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct Version(u64, u64, u64);
+
+/// Strip the `chm-v` (or bare `v`) prefix and parse `major.minor.patch`.
+fn parse_version(tag: &str) -> Option<Version> {
+    let s = tag
+        .strip_prefix("chm-v")
+        .or_else(|| tag.strip_prefix("chm-"))
+        .or_else(|| tag.strip_prefix('v'))
+        .unwrap_or(tag);
+    // Drop any pre-release / build metadata (e.g. `1.2.3-rc1`, `1.2.3+abc`).
+    let core = s.split(['-', '+']).next().unwrap_or(s);
+    let mut it = core.split('.');
+    let major = it.next()?.parse().ok()?;
+    let minor = it.next().unwrap_or("0").parse().ok()?;
+    let patch = it.next().unwrap_or("0").parse().ok()?;
+    Some(Version(major, minor, patch))
+}
+
+/// Pick the newest `chm-v*` tag from a releases list (skips drafts/prereleases).
+fn newest_chm_tag(releases: &[Release]) -> Option<String> {
+    releases
+        .iter()
+        .filter(|r| !r.draft && !r.prerelease && r.tag_name.starts_with("chm-v"))
+        .filter_map(|r| parse_version(&r.tag_name).map(|v| (v, r.tag_name.clone())))
+        .max_by(|a, b| a.0.cmp(&b.0))
+        .map(|(_, tag)| tag)
+}
+
+/// Fetch the newest published `chm-v*` release tag.
+async fn latest_tag(client: &Client) -> Result<String> {
+    let releases: Vec<Release> = client
+        .get(RELEASES_API)
+        .header("User-Agent", USER_AGENT)
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await
+        .context("failed to reach GitHub releases API")?
+        .error_for_status()
+        .context("GitHub releases API returned an error status")?
+        .json()
+        .await
+        .context("failed to parse GitHub releases JSON")?;
+    newest_chm_tag(&releases)
+        .ok_or_else(|| anyhow!("no chm-v* release found — has the CLI been released yet?"))
+}
+
+fn current_version() -> Version {
+    parse_version(env!("CARGO_PKG_VERSION")).unwrap_or(Version(0, 0, 0))
+}
+
+fn ensure_supported_target() -> Result<()> {
+    if !SUPPORTED_TARGETS.contains(&TARGET) {
+        bail!(
+            "unsupported platform for self-update ('{TARGET}'). \
+             Install from source instead: cargo install ch-monitor-cli"
+        );
+    }
+    Ok(())
+}
+
+/// `chm update --check`: report whether a newer release exists.
+/// Returns `true` when an update is available.
+pub async fn check(client: &Client) -> Result<bool> {
+    let current = current_version();
+    let latest_tag = latest_tag(client).await?;
+    let latest = parse_version(&latest_tag)
+        .ok_or_else(|| anyhow!("could not parse latest release tag '{latest_tag}'"))?;
+    if latest > current {
+        println!(
+            "update available: {} -> {latest_tag} (run `chm update`)",
+            env!("CARGO_PKG_VERSION")
+        );
+        Ok(true)
+    } else {
+        println!("chm is up to date (v{})", env!("CARGO_PKG_VERSION"));
+        Ok(false)
+    }
+}
+
+/// Best-effort background hint for `chm diagnose`: prints a one-line notice to
+/// stderr if a newer release exists. Never fails the caller; opt out with
+/// `CHM_NO_UPDATE_CHECK=1`.
+pub async fn hint(client: &Client) {
+    if env::var("CHM_NO_UPDATE_CHECK").is_ok_and(|v| !v.is_empty() && v != "0") {
+        return;
+    }
+    let fut = async {
+        let releases: Vec<Release> = client
+            .get(RELEASES_API)
+            .header("User-Agent", USER_AGENT)
+            .header("Accept", "application/vnd.github+json")
+            .send()
+            .await
+            .ok()?
+            .json()
+            .await
+            .ok()?;
+        let tag = newest_chm_tag(&releases)?;
+        let latest = parse_version(&tag)?;
+        if latest > current_version() {
+            Some(tag)
+        } else {
+            None
+        }
+    };
+    if let Ok(Some(tag)) = tokio::time::timeout(Duration::from_millis(900), fut).await {
+        eprintln!(
+            "note: a newer chm is available ({} -> {tag}). Run `chm update`. (set CHM_NO_UPDATE_CHECK=1 to silence)",
+            env!("CARGO_PKG_VERSION")
+        );
+    }
+}
+
+/// `chm update` (and `chm update --version <tag>`): download, verify, replace.
+pub async fn run(client: &Client, pinned: Option<String>) -> Result<()> {
+    ensure_supported_target()?;
+    let current = current_version();
+
+    let target_tag = match pinned {
+        Some(tag) => {
+            if tag.starts_with("chm-v") {
+                tag
+            } else {
+                format!("chm-v{}", tag.trim_start_matches('v'))
+            }
+        }
+        None => latest_tag(client).await?,
+    };
+    let target_version = parse_version(&target_tag)
+        .ok_or_else(|| anyhow!("could not parse target tag '{target_tag}'"))?;
+
+    if pinned_is_none_and_current(&target_version, &current) {
+        println!("chm is already up to date (v{})", env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+
+    let asset = format!("chm-{TARGET}");
+    let bin_url = format!("{RELEASE_DOWNLOAD}/{target_tag}/{asset}");
+    let sha_url = format!("{bin_url}.sha256");
+
+    println!("Downloading {asset} ({target_tag})...");
+    let bin_bytes = client
+        .get(&bin_url)
+        .header("User-Agent", USER_AGENT)
+        .send()
+        .await
+        .with_context(|| format!("failed to download {bin_url}"))?
+        .error_for_status()
+        .with_context(|| {
+            format!("no release asset at {bin_url} — is {TARGET} published for {target_tag}?")
+        })?
+        .bytes()
+        .await
+        .context("failed to read downloaded binary")?;
+
+    // Checksum verification is mandatory: abort on a missing or mismatched sum.
+    let sha_text = client
+        .get(&sha_url)
+        .header("User-Agent", USER_AGENT)
+        .send()
+        .await
+        .and_then(|r| r.error_for_status())
+        .with_context(|| {
+            format!("no checksum asset at {sha_url} — refusing to install unverified binary")
+        })?
+        .text()
+        .await
+        .context("failed to read checksum file")?;
+    let expected = sha_text
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .to_lowercase();
+    if expected.is_empty() {
+        bail!("checksum file was empty — refusing to install unverified binary");
+    }
+    let actual = hex_sha256(&bin_bytes);
+    if actual != expected {
+        bail!("checksum mismatch for {asset}: expected {expected}, got {actual}. Download may be corrupt or tampered with — aborting.");
+    }
+
+    let exe = env::current_exe().context("could not locate the running executable")?;
+    let dir = exe
+        .parent()
+        .ok_or_else(|| anyhow!("executable has no parent directory"))?;
+
+    install_binary(dir, &exe, &bin_bytes).map_err(|e| manual_hint(&exe, &e))?;
+
+    println!(
+        "Updated chm {} -> {target_tag} ({})",
+        env!("CARGO_PKG_VERSION"),
+        exe.display()
+    );
+    Ok(())
+}
+
+fn pinned_is_none_and_current(target: &Version, current: &Version) -> bool {
+    target == current
+}
+
+fn hex_sha256(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+
+/// Write the new binary to a temp file in the same directory, chmod 0755, then
+/// rename over the original. Handles "text file busy" by moving the running
+/// binary aside first.
+fn install_binary(dir: &Path, exe: &Path, bytes: &[u8]) -> Result<()> {
+    let tmp = dir.join(format!(".chm-update-{}", std::process::id()));
+    fs::write(&tmp, bytes).with_context(|| format!("cannot write to {}", dir.display()))?;
+    set_executable(&tmp)?;
+
+    if let Err(err) = fs::rename(&tmp, exe) {
+        // ETXTBSY / EBUSY: rename the running binary aside, then move the new one in.
+        let backup = dir.join(format!(".chm-old-{}", std::process::id()));
+        if fs::rename(exe, &backup).is_ok() {
+            match fs::rename(&tmp, exe) {
+                Ok(()) => {
+                    let _ = fs::remove_file(&backup);
+                }
+                Err(e2) => {
+                    // Roll back so we never leave the user without a binary.
+                    let _ = fs::rename(&backup, exe);
+                    let _ = fs::remove_file(&tmp);
+                    return Err(e2).context("failed to move updated binary into place");
+                }
+            }
+        } else {
+            let _ = fs::remove_file(&tmp);
+            return Err(err).context("failed to replace the running executable");
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_executable(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755))
+        .with_context(|| format!("failed to set permissions on {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+/// Turn an install failure into a clear, sudo-free manual instruction.
+fn manual_hint(exe: &Path, err: &anyhow::Error) -> anyhow::Error {
+    anyhow!(
+        "could not install the update automatically ({err}).\n\
+         The install directory may not be writable ({}).\n\
+         Re-run the installer manually (no sudo needed if you own the dir):\n\
+             curl -sSf https://raw.githubusercontent.com/chmonitor/chmonitor/main/scripts/install.sh | bash\n\
+         or move a downloaded `chm-{TARGET}` binary over {} yourself.",
+        exe.parent().map(|p| p.display().to_string()).unwrap_or_default(),
+        exe.display(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_chm_v_prefix() {
+        assert_eq!(parse_version("chm-v0.1.0"), Some(Version(0, 1, 0)));
+        assert_eq!(parse_version("chm-v1.20.3"), Some(Version(1, 20, 3)));
+        assert_eq!(parse_version("v2.0.0"), Some(Version(2, 0, 0)));
+        assert_eq!(parse_version("0.3"), Some(Version(0, 3, 0)));
+        assert_eq!(parse_version("chm-v1.2.3-rc1"), Some(Version(1, 2, 3)));
+    }
+
+    #[test]
+    fn semver_ordering() {
+        assert!(parse_version("chm-v0.2.0") > parse_version("chm-v0.1.9"));
+        assert!(parse_version("chm-v1.0.0") > parse_version("chm-v0.99.99"));
+        assert!(parse_version("chm-v0.1.10") > parse_version("chm-v0.1.9"));
+        assert_eq!(parse_version("chm-v0.1.0"), parse_version("chm-v0.1.0"));
+    }
+
+    #[test]
+    fn newest_tag_from_release_list() {
+        // GitHub returns compact single-line JSON; make sure we parse and rank it.
+        let json = r#"[{"tag_name":"chm-v0.1.0","prerelease":false,"draft":false},{"tag_name":"chm-v0.3.0","prerelease":false,"draft":false},{"tag_name":"chm-v0.2.0","prerelease":false,"draft":false},{"tag_name":"other-v9.9.9","prerelease":false,"draft":false}]"#;
+        let releases: Vec<Release> = serde_json::from_str(json).unwrap();
+        assert_eq!(newest_chm_tag(&releases).as_deref(), Some("chm-v0.3.0"));
+    }
+
+    #[test]
+    fn newest_tag_skips_drafts_and_prereleases() {
+        let json = r#"[{"tag_name":"chm-v0.9.0","prerelease":true,"draft":false},{"tag_name":"chm-v0.8.0","prerelease":false,"draft":true},{"tag_name":"chm-v0.5.0","prerelease":false,"draft":false}]"#;
+        let releases: Vec<Release> = serde_json::from_str(json).unwrap();
+        assert_eq!(newest_chm_tag(&releases).as_deref(), Some("chm-v0.5.0"));
+    }
+
+    #[test]
+    fn checksum_matches_known_vector() {
+        // sha256("abc")
+        assert_eq!(
+            hex_sha256(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn supported_targets_cover_shipped_platforms() {
+        assert!(SUPPORTED_TARGETS.contains(&"x86_64-unknown-linux-gnu"));
+        assert!(SUPPORTED_TARGETS.contains(&"aarch64-apple-darwin"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `chm update` subcommand to the standalone Rust CLI (`rust/ch-monitor-cli`) so users can self-update without re-running the install script.

- Queries `https://api.github.com/repos/chmonitor/chmonitor/releases` (User-Agent set) for the newest `chm-v*` tag and semver-compares it with the compiled-in `CARGO_PKG_VERSION`.
- Downloads `chm-<target-triple>` + its `.sha256`, **verifies the checksum (mandatory — aborts on mismatch/missing)**, then atomically replaces the running executable (temp file in the same dir → chmod 0755 → rename over original, with a rename-aside fallback for the "text file busy" case). Never uses sudo; prints a manual command if the dir is not writable.
- `--check` reports only (exit 0 if current, exit 1 if an update exists).
- `--version chm-vX.Y.Z` pins a specific release. Prints before/after versions on success.
- `build.rs` exposes the compile-time target triple; unsupported platforms get a clear `cargo install` message.
- `chm diagnose` now prints a gentle best-effort "update available" hint to stderr (<1s timeout, never fails the command); opt out via `CHM_NO_UPDATE_CHECK=1`.

## Deps
Reuses the crate's existing `reqwest`/`serde`/`tokio`/`anyhow`; adds only `sha2` for checksum. No `self_update` crate.

## Tests
`cargo test -p ch-monitor-cli` — 24 pass, incl. semver parse/compare, newest-tag from a JSON fixture (drafts/prereleases skipped), and a known-vector checksum. `cargo fmt` + clippy clean.

## Docs
- `docs/content/guide/guides/diagnostics-cli.mdx` — new **Update** section (`chm update`, `--check`, `CHM_NO_UPDATE_CHECK`).
- `rust/ch-monitor-cli/README.md` — Update section.

https://claude.ai/code/session_016pN3dJ84hj6Qkv9qiZ2pzo