### PR TITLE
feat(telemetry): CLI telemetry stream + analytics dashboard

### DIFF
--- a/apps/telemetry/README.md
+++ b/apps/telemetry/README.md
@@ -33,6 +33,21 @@ against a closed shape; unknown fields are ignored.
 - `event` — one of the five names in `TELEMETRY_EVENTS` (else rejected).
 - `props` — only `deploy_target`, `ch_version`, `ch_flavor` are stored.
 
+### `POST /v1/cli`
+```json
+{ "install_id": "<64-char sha256 hex>", "event": "cli_run", "command": "diagnose", "cli_version": "0.1.0", "os": "linux", "arch": "x86_64" }
+```
+A **separate tracking stream** for the `chm` CLI
+([`rust/ch-monitor-cli`](../../rust/ch-monitor-cli)) and its `scripts/install.sh`
+installer — recorded to `cli_daily`, never mixed with the dashboard's
+`ping_daily` / `events`.
+- `install_id` — required, 64-char lowercase hex. Opaque per-install id
+  persisted under `~/.config/chmonitor/cli-id` (ephemeral for one-shot installs).
+- `event` — one of `cli_install | cli_run | cli_diagnose` (else rejected).
+- `command` — subcommand name, coerced to a known enum or `''`.
+- `cli_version` — semver-like or dropped.
+- `os` — `linux|macos|windows|…|unknown`; `arch` — `x86_64|aarch64|unknown`.
+
 ### `GET /` or `/health`
 Returns `200` — liveness only.
 
@@ -69,6 +84,22 @@ IGNORE`) — `/v1/event` carries no `instance_hash`, so repeated identical
 events within the same UTC day collapse to one row instead of growing
 unbounded. Counts stay directionally correct for the analytics-only
 `events` table; this is not exact per-occurrence counting.
+
+### `cli_daily` table (CLI stream)
+| column        | type    | description |
+|---------------|---------|-------------|
+| `day`         | TEXT    | `YYYY-MM-DD` (UTC) |
+| `install_id`  | TEXT    | opaque SHA-256 CLI install id |
+| `event`       | TEXT    | cli_install/cli_run/cli_diagnose |
+| `command`     | TEXT    | subcommand name or `''` |
+| `cli_version` | TEXT    | semver-like or NULL |
+| `os`          | TEXT    | linux/macos/windows/unknown |
+| `arch`        | TEXT    | x86_64/aarch64/unknown |
+
+Primary key `(day, install_id, event, command)` — one deduped row per install
+per day per event/command. `/v1/summary` surfaces an aggregate `cli` block
+(installs, active users, runs-by-command, version/os/arch splits, 30-day install
+trend) that powers the CLI section of the analytics page.
 
 ## Deploy
 

--- a/apps/telemetry/migrations/0005_cli_events.sql
+++ b/apps/telemetry/migrations/0005_cli_events.sql
@@ -1,0 +1,24 @@
+-- Separate tracking stream for the `chm` CLI (rust/ch-monitor-cli) and its
+-- install.sh installer. Kept in its own table so CLI telemetry never mixes with
+-- the dashboard's install ping (ping_daily) or aggregate events (events) —
+-- distinct source dimension, distinct analytics.
+--
+-- Privacy contract mirrors ping_daily: install_id is an opaque SHA-256 hex
+-- digest of a random local UUID persisted under ~/.config/chmonitor/. No IPs,
+-- hostnames, paths, or free-text. One deduped row per (install, day, event,
+-- command) so a chatty CLI collapses to at most a handful of rows per day.
+
+CREATE TABLE IF NOT EXISTS cli_daily (
+  day         TEXT NOT NULL,            -- 'YYYY-MM-DD' (UTC)
+  install_id  TEXT NOT NULL,            -- opaque SHA-256 install id (or ephemeral for installs)
+  event       TEXT NOT NULL,            -- cli_install | cli_run | cli_diagnose
+  command     TEXT NOT NULL DEFAULT '', -- subcommand name (hosts/chart/tui/diagnose/...) or ''
+  cli_version TEXT,                     -- semver-like CLI version or NULL
+  os          TEXT,                     -- linux/macos/windows/unknown
+  arch        TEXT,                     -- x86_64/aarch64/unknown
+  PRIMARY KEY (day, install_id, event, command)
+);
+
+CREATE INDEX IF NOT EXISTS idx_cli_daily_day ON cli_daily (day);
+CREATE INDEX IF NOT EXISTS idx_cli_daily_event ON cli_daily (event);
+CREATE INDEX IF NOT EXISTS idx_cli_daily_command ON cli_daily (command);

--- a/apps/telemetry/src/index.test.ts
+++ b/apps/telemetry/src/index.test.ts
@@ -292,3 +292,103 @@ describe('POST /v1/event — bounded, deduped insert (#2503)', () => {
     expect(countEvents()).toBe(2)
   })
 })
+
+describe('POST /v1/cli — separate CLI tracking stream', () => {
+  let db: Database
+
+  afterEach(() => {
+    db?.close()
+  })
+
+  // Mirrors migrations/0005_cli_events.sql.
+  function seed() {
+    db = new Database(':memory:')
+    db.run(`
+      CREATE TABLE cli_daily (
+        day         TEXT NOT NULL,
+        install_id  TEXT NOT NULL,
+        event       TEXT NOT NULL,
+        command     TEXT NOT NULL DEFAULT '',
+        cli_version TEXT,
+        os          TEXT,
+        arch        TEXT,
+        PRIMARY KEY (day, install_id, event, command)
+      )
+    `)
+  }
+
+  function post(body: unknown) {
+    const env: Env = { CHM_TELEMETRY_DB: makeMockD1(db) }
+    return worker.fetch(
+      new Request('https://telemetry.chmonitor.dev/v1/cli', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      }),
+      env,
+      makeCtx()
+    )
+  }
+
+  const countCli = () =>
+    (db.query('SELECT COUNT(*) AS n FROM cli_daily').get() as { n: number }).n
+
+  it('accepts a valid cli_run ping', async () => {
+    seed()
+    const res = await post({
+      install_id: hex64('a'),
+      event: 'cli_run',
+      command: 'diagnose',
+      cli_version: '0.1.0',
+      os: 'linux',
+      arch: 'x86_64',
+    })
+    expect(res.status).toBe(204)
+    expect(countCli()).toBe(1)
+  })
+
+  it('rejects a malformed install_id and inserts nothing', async () => {
+    seed()
+    const res = await post({ install_id: 'nope', event: 'cli_run' })
+    expect(res.status).toBe(400)
+    expect(countCli()).toBe(0)
+  })
+
+  it('rejects an unknown event name', async () => {
+    seed()
+    const res = await post({ install_id: hex64('b'), event: 'cli_hack' })
+    expect(res.status).toBe(400)
+    expect(countCli()).toBe(0)
+  })
+
+  it('coerces unknown command/os/arch to safe defaults', async () => {
+    seed()
+    await post({
+      install_id: hex64('c'),
+      event: 'cli_run',
+      command: 'rm-rf',
+      os: 'plan9',
+      arch: 'sparc',
+    })
+    const row = db.query('SELECT command, os, arch FROM cli_daily').get() as {
+      command: string
+      os: string
+      arch: string
+    }
+    expect(row.command).toBe('')
+    expect(row.os).toBe('unknown')
+    expect(row.arch).toBe('unknown')
+  })
+
+  it('dedupes an identical ping posted twice on the same day', async () => {
+    seed()
+    const payload = {
+      install_id: hex64('d'),
+      event: 'cli_run',
+      command: 'hosts',
+    }
+    await post(payload)
+    await post(payload)
+    expect(countCli()).toBe(1)
+  })
+})

--- a/apps/telemetry/src/index.ts
+++ b/apps/telemetry/src/index.ts
@@ -50,6 +50,23 @@ const EVENTS = new Set([
   'ai_query_sent',
 ])
 
+// ─── CLI telemetry (source=cli) — a SEPARATE tracking stream ─────────────────
+// Emitted by rust/ch-monitor-cli (`chm`) and scripts/install.sh. Recorded to the
+// cli_daily table, never mixed with the dashboard's ping_daily / events streams.
+// Mirror rust/ch-monitor-cli/src/telemetry.rs — keep these in sync.
+const CLI_EVENTS = new Set(['cli_install', 'cli_run', 'cli_diagnose'])
+const CLI_COMMANDS = new Set([
+  'hosts',
+  'chart',
+  'table',
+  'tui',
+  'diagnose',
+  'install',
+  'update',
+  '',
+])
+const ARCHES = new Set(['x86_64', 'aarch64', 'unknown'])
+
 const HEX64 = /^[0-9a-f]{64}$/
 const MAJOR_MINOR = /^\d{1,3}\.\d{1,3}$/
 // CHM product version (e.g. '0.3.1') — semver-like, 1-3 dot-separated numbers.
@@ -713,6 +730,40 @@ export default {
         <div id="ch-flavors" class="bar-chart"></div>
       </div>
 
+      <div class="section" id="cli-section" style="display: none;">
+        <h2>CLI (chm)</h2>
+        <p style="color: var(--fg-muted); font-size: 0.9rem; margin: -8px 0 24px;">
+          Anonymous usage of the standalone <code>chm</code> command-line tool —
+          tracked as a separate stream from the dashboard above.
+        </p>
+
+        <div class="stats-grid">
+          <div class="stat-card">
+            <div class="stat-label">CLI Installs</div>
+            <div class="stat-value" id="cli-installs">0</div>
+          </div>
+          <div class="stat-card environments">
+            <div class="stat-label">Active CLI Users</div>
+            <div class="stat-value" id="cli-active">0</div>
+          </div>
+        </div>
+
+        <h3 style="font-size:1.05rem;font-weight:700;margin:8px 0 16px;letter-spacing:-0.02em;">Installs Over Time (30d)</h3>
+        <div id="cli-installs-time" class="bar-chart"></div>
+
+        <h3 style="font-size:1.05rem;font-weight:700;margin:32px 0 16px;letter-spacing:-0.02em;">Runs by Command</h3>
+        <div id="cli-commands" class="bar-chart"></div>
+
+        <h3 style="font-size:1.05rem;font-weight:700;margin:32px 0 16px;letter-spacing:-0.02em;">CLI Versions</h3>
+        <div id="cli-versions" class="bar-chart"></div>
+
+        <h3 style="font-size:1.05rem;font-weight:700;margin:32px 0 16px;letter-spacing:-0.02em;">Operating System</h3>
+        <div id="cli-os" class="bar-chart"></div>
+
+        <h3 style="font-size:1.05rem;font-weight:700;margin:32px 0 16px;letter-spacing:-0.02em;">Architecture</h3>
+        <div id="cli-arch" class="bar-chart"></div>
+      </div>
+
       <div class="footer">
         <p>
           Data updates every hour • Powered by <a href="https://chmonitor.dev">chmonitor</a> •
@@ -777,6 +828,21 @@ export default {
           renderBarChart('ch-flavors', data.by_ch_flavor);
         }
 
+        // Render CLI stream (separate from dashboard telemetry)
+        const cli = data.cli;
+        const hasCli = cli && (cli.installs > 0 || cli.active_users > 0 ||
+          (cli.by_command && cli.by_command.length > 0));
+        if (hasCli) {
+          document.getElementById('cli-section').style.display = 'block';
+          document.getElementById('cli-installs').textContent = (cli.installs || 0).toLocaleString();
+          document.getElementById('cli-active').textContent = (cli.active_users || 0).toLocaleString();
+          renderBarChart('cli-installs-time', (cli.installs_over_time || []).map(d => ({ day: d.day, installs: d.installs })), false);
+          renderBarChart('cli-commands', (cli.by_command || []).map(c => ({ command: c.command, installs: c.runs })));
+          renderBarChart('cli-versions', cli.by_cli_version || []);
+          renderBarChart('cli-os', cli.by_os || []);
+          renderBarChart('cli-arch', cli.by_arch || []);
+        }
+
       } catch (err) {
         loading.style.display = 'none';
         error.style.display = 'block';
@@ -785,7 +851,7 @@ export default {
       }
     }
 
-    function renderBarChart(containerId, data) {
+    function renderBarChart(containerId, data, sortByValue = true) {
       const container = document.getElementById(containerId);
       if (!data || data.length === 0) {
         container.innerHTML = '<p style="color: #999;">No data available</p>';
@@ -793,9 +859,11 @@ export default {
       }
 
       const maxValue = Math.max(...data.map(item => item.installs));
+      const rows = sortByValue
+        ? [...data].sort((a, b) => b.installs - a.installs)
+        : data;
 
-      container.innerHTML = data
-        .sort((a, b) => b.installs - a.installs)
+      container.innerHTML = rows
         .map(item => {
           const percentage = (item.installs / maxValue) * 100;
           const key = Object.keys(item).find(k => k !== 'installs');
@@ -934,6 +1002,45 @@ export default {
       return noContent()
     }
 
+    if (pathname === '/v1/cli') {
+      // Separate CLI tracking stream (source=cli). Closed, validated shape;
+      // unknown fields ignored. install_id is an opaque SHA-256 hex of a random
+      // local UUID — for one-shot installs (install.sh) it may be ephemeral.
+      const installId = data.install_id
+      if (typeof installId !== 'string' || !HEX64.test(installId)) {
+        return bad(400, 'invalid install_id')
+      }
+      const event =
+        typeof data.event === 'string' && CLI_EVENTS.has(data.event)
+          ? data.event
+          : ''
+      if (!event) return bad(400, 'invalid event')
+      const command = asEnum(data.command, CLI_COMMANDS, '')
+      const cliVersion = asChmVersion(data.cli_version)
+      const os = asEnum(data.os, PLATFORMS, 'unknown')
+      const arch = asEnum(data.arch, ARCHES, 'unknown')
+
+      const day = new Date().toISOString().slice(0, 10)
+      ctx.waitUntil(
+        env.CHM_TELEMETRY_DB.prepare(
+          'INSERT OR IGNORE INTO cli_daily (day, install_id, event, command, cli_version, os, arch) VALUES (?, ?, ?, ?, ?, ?, ?)'
+        )
+          .bind(
+            day,
+            installId,
+            event,
+            command,
+            cliVersion || null,
+            os || null,
+            arch || null
+          )
+          .run()
+          .then(() => undefined)
+          .catch(() => undefined)
+      )
+      return noContent()
+    }
+
     return bad(404, 'not found')
   },
 }
@@ -1025,8 +1132,11 @@ async function handleSummary(env: Env, req: Request): Promise<Response> {
       byDeployTarget[r.deploy_target] = Number(r.n)
     }
 
+    const cli = await cliSummary(env)
+
     return json(
       summaryShape({
+        cli,
         total: Number(totalRow?.n ?? 0),
         totalPlaces: Number(totalPlaces?.n ?? 0),
         byDeployTarget,
@@ -1059,6 +1169,85 @@ async function handleSummary(env: Env, req: Request): Promise<Response> {
   }
 }
 
+interface CliSummary {
+  installs: number
+  active_users: number
+  by_command: { command: string; runs: number }[]
+  by_cli_version: { cli_version: string; installs: number }[]
+  by_os: { os: string; installs: number }[]
+  by_arch: { arch: string; installs: number }[]
+  installs_over_time: { day: string; installs: number }[]
+}
+
+const EMPTY_CLI: CliSummary = {
+  installs: 0,
+  active_users: 0,
+  by_command: [],
+  by_cli_version: [],
+  by_os: [],
+  by_arch: [],
+  installs_over_time: [],
+}
+
+// Aggregate-only CLI stats from cli_daily. Every number is a COUNT/COUNT
+// DISTINCT of the opaque install_id — no per-install rows, IPs, or free-text
+// are exposed. Best-effort: any query failure degrades to zeros.
+async function cliSummary(env: Env): Promise<CliSummary> {
+  try {
+    const [installs, active, byCommand, byVersion, byOs, byArch, overTime] =
+      await Promise.all([
+        env.CHM_TELEMETRY_DB.prepare(
+          "SELECT COUNT(*) AS n FROM cli_daily WHERE event = 'cli_install'"
+        ).first<{ n: number }>(),
+        env.CHM_TELEMETRY_DB.prepare(
+          "SELECT COUNT(DISTINCT install_id) AS n FROM cli_daily WHERE event != 'cli_install'"
+        ).first<{ n: number }>(),
+        env.CHM_TELEMETRY_DB.prepare(
+          "SELECT command AS v, COUNT(*) AS n FROM cli_daily WHERE event != 'cli_install' AND command != '' GROUP BY v ORDER BY n DESC"
+        ).all<{ v: string; n: number }>(),
+        env.CHM_TELEMETRY_DB.prepare(
+          "SELECT COALESCE(cli_version, 'unknown') AS v, COUNT(DISTINCT install_id) AS n FROM cli_daily GROUP BY v ORDER BY n DESC"
+        ).all<{ v: string; n: number }>(),
+        env.CHM_TELEMETRY_DB.prepare(
+          "SELECT COALESCE(os, 'unknown') AS v, COUNT(DISTINCT install_id) AS n FROM cli_daily GROUP BY v ORDER BY n DESC"
+        ).all<{ v: string; n: number }>(),
+        env.CHM_TELEMETRY_DB.prepare(
+          "SELECT COALESCE(arch, 'unknown') AS v, COUNT(DISTINCT install_id) AS n FROM cli_daily GROUP BY v ORDER BY n DESC"
+        ).all<{ v: string; n: number }>(),
+        env.CHM_TELEMETRY_DB.prepare(
+          "SELECT day, COUNT(*) AS n FROM cli_daily WHERE event = 'cli_install' AND day >= date('now', '-30 days') GROUP BY day ORDER BY day ASC"
+        ).all<{ day: string; n: number }>(),
+      ])
+
+    return {
+      installs: Number(installs?.n ?? 0),
+      active_users: Number(active?.n ?? 0),
+      by_command: (byCommand.results ?? []).map((r) => ({
+        command: r.v,
+        runs: Number(r.n),
+      })),
+      by_cli_version: (byVersion.results ?? []).map((r) => ({
+        cli_version: r.v,
+        installs: Number(r.n),
+      })),
+      by_os: (byOs.results ?? []).map((r) => ({
+        os: r.v,
+        installs: Number(r.n),
+      })),
+      by_arch: (byArch.results ?? []).map((r) => ({
+        arch: r.v,
+        installs: Number(r.n),
+      })),
+      installs_over_time: (overTime.results ?? []).map((r) => ({
+        day: r.day,
+        installs: Number(r.n),
+      })),
+    }
+  } catch {
+    return EMPTY_CLI
+  }
+}
+
 interface SummaryBody {
   summary: string
   anonymous: boolean
@@ -1072,6 +1261,7 @@ interface SummaryBody {
   by_country: { country: string; installs: number }[]
   by_platform: { platform: string; installs: number }[]
   by_chm_version: { chm_version: string; installs: number }[]
+  cli: CliSummary
   source: string
   generated_at: string
 }
@@ -1085,6 +1275,7 @@ function summaryShape(input: {
   byCountry: { country: string; installs: number }[]
   byPlatform: { platform: string; installs: number }[]
   byChmVersion?: { chm_version: string; installs: number }[]
+  cli?: CliSummary
   scopedToDeployTarget?: string | null
 }): SummaryBody {
   return {
@@ -1100,6 +1291,7 @@ function summaryShape(input: {
     by_country: input.byCountry,
     by_platform: input.byPlatform,
     by_chm_version: input.byChmVersion ?? [],
+    cli: input.cli ?? EMPTY_CLI,
     source: 'D1 ping_daily (COUNT DISTINCT of opaque SHA-256 instance id)',
     generated_at: new Date().toISOString(),
   }

--- a/docs/content/guide/guides/diagnostics-cli.mdx
+++ b/docs/content/guide/guides/diagnostics-cli.mdx
@@ -101,7 +101,17 @@ Deep dive, live charts, and the AI advisor: https://dash.chmonitor.dev (hosted) 
 
 For live charts, alerting, the AI advisor, and multi-host clusters, point the same ClickHouse credentials at the full dashboard — [self-host it](/operate/deploy) or use the hosted [dash.chmonitor.dev](https://dash.chmonitor.dev/?ref=docs).
 
+## Anonymous telemetry
+
+The CLI sends an anonymous, opt-out usage ping (CLI version, command name,
+OS/arch, and a random install id) — a separate stream from the dashboard's
+telemetry, with no ClickHouse host, query text, or arguments. Disable it with
+`CHM_TELEMETRY=off` or `DO_NOT_TRACK=1`. See
+[Product Telemetry](/operate/advanced/telemetry#cli-telemetry-a-separate-stream)
+for the full field list and every opt-out.
+
 <Cards>
+<Card title="Product Telemetry" href="/operate/advanced/telemetry" description="What the CLI and dashboard collect, and how to opt out." />
 <Card title="Troubleshooting" href="/guide/guides/troubleshooting" description="Diagnose connection, auth, performance, and Kubernetes probe failures." />
 <Card title="Self-host chmonitor" href="/operate/deploy" description="Docker, Kubernetes, or Cloudflare Workers." />
 </Cards>

--- a/docs/content/operate/advanced/telemetry.mdx
+++ b/docs/content/operate/advanced/telemetry.mdx
@@ -132,6 +132,48 @@ one deduped row per install per day forever. See the collector README.
 sink to the collector's `/v1/event` endpoint. The sink installs once per app load
 and is a hard no-op when telemetry is disabled or no endpoint resolves.
 
+## CLI telemetry (a separate stream)
+
+The standalone [`chm` CLI](/guide/guides/diagnostics-cli) and its `install.sh` installer emit their
+own anonymous telemetry — tracked as a **separate stream** (`source=cli`) from
+the dashboard telemetry above, in its own `cli_daily` table. Same privacy
+posture: anonymous, opt-out, no PII.
+
+It is best-effort and non-blocking: the CLI fires the ping on a background thread
+with a sub-second timeout and never delays a command's exit by more than ~300ms,
+and never fails a command if the network is down.
+
+### Opt out (any one disables it)
+
+The CLI honours the **same** switches as the dashboard:
+
+```bash
+CHM_TELEMETRY=off              # also 0 / false / no
+DO_NOT_TRACK=1                 # cross-tool standard, hard override
+CHM_TELEMETRY_ENDPOINT=""      # hard kill-switch — no network call
+```
+
+The `install.sh` install ping additionally **skips automatically when `CI=true`**.
+
+### What the CLI collects
+
+| Field | Values | Notes |
+|---|---|---|
+| `install_id` | 64-char opaque hex | Random id persisted at `$XDG_CONFIG_HOME/chmonitor/cli-id` (default `~/.config/chmonitor/cli-id`). Counts distinct installs only; maps to no identity. |
+| `event` | `cli_install`, `cli_run`, `cli_diagnose` | Install ping vs. a command run vs. a `diagnose` run. |
+| `command` | `hosts`, `chart`, `table`, `tui`, `diagnose`, `install` | The subcommand name. |
+| `cli_version` | semver (e.g. `0.1.0`) | The `chm` version. |
+| `os` | `linux`, `macos`, `windows`, `unknown` | |
+| `arch` | `x86_64`, `aarch64`, `unknown` | |
+
+It sends **nothing else** — no ClickHouse host, query text, command arguments,
+file paths, usernames, or IPs. The install-script ping uses an **ephemeral**
+random id (one-shot installs do not persist identity).
+
+The public analytics page shows a dedicated **CLI** section (installs over time,
+active CLI users, runs by command, version distribution, and OS/arch split),
+sourced from the collector's aggregate-only `/v1/summary` `cli` block.
+
 ## Activation metric
 
 The project tracks a single derived metric called "activation":

--- a/rust/ch-monitor-cli/README.md
+++ b/rust/ch-monitor-cli/README.md
@@ -33,6 +33,19 @@ CLICKHOUSE_HOST=http://localhost:8123 CLICKHOUSE_USER=default chm diagnose
 See [docs.chmonitor.dev/guide/guides/diagnostics-cli](https://docs.chmonitor.dev/guide/guides/diagnostics-cli)
 for the full CLI reference.
 
+## Anonymous telemetry
+
+The CLI sends a best-effort, anonymous usage ping (a random install id, CLI
+version, command name, and OS/arch) to `telemetry.chmonitor.dev` — a separate
+stream from the dashboard's telemetry, with **no** ClickHouse host, query text,
+arguments, paths, or IPs. It runs on a background thread with a sub-second
+timeout and never blocks or fails a command.
+
+Opt out with any of `CHM_TELEMETRY=off`, `DO_NOT_TRACK=1`, or
+`CHM_TELEMETRY_ENDPOINT=""`. See
+[the telemetry docs](https://docs.chmonitor.dev/operate/advanced/telemetry#cli-telemetry-a-separate-stream)
+and `src/telemetry.rs`.
+
 ## License
 
 MIT

--- a/rust/ch-monitor-cli/src/main.rs
+++ b/rust/ch-monitor-cli/src/main.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 mod diagnose;
+mod telemetry;
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 struct FileConfig {
@@ -346,6 +347,17 @@ async fn main() -> Result<()> {
     let cfg = resolve_config(&cli)?;
     let client = Client::builder().timeout(Duration::from_secs(20)).build()?;
 
+    // Anonymous, opt-out CLI telemetry (source=cli). Fires in the background and
+    // never blocks or fails the command; see src/telemetry.rs.
+    let (tel_event, tel_command): (&'static str, &'static str) = match &cli.command {
+        Commands::Diagnose { .. } => ("cli_diagnose", "diagnose"),
+        Commands::Hosts => ("cli_run", "hosts"),
+        Commands::Chart { .. } => ("cli_run", "chart"),
+        Commands::Table { .. } => ("cli_run", "table"),
+        Commands::Tui { .. } => ("cli_run", "tui"),
+    };
+    let tel_handle = telemetry::spawn(tel_event, tel_command);
+
     match cli.command {
         Commands::Hosts => {
             let url = format!("{}/api/v1/hosts", cfg.base_url);
@@ -428,10 +440,12 @@ async fn main() -> Result<()> {
                 .iter()
                 .any(|f| f.severity == diagnose::Severity::Critical)
             {
+                telemetry::finish(tel_handle).await;
                 std::process::exit(1);
             }
         }
     }
 
+    telemetry::finish(tel_handle).await;
     Ok(())
 }

--- a/rust/ch-monitor-cli/src/telemetry.rs
+++ b/rust/ch-monitor-cli/src/telemetry.rs
@@ -1,0 +1,195 @@
+//! Anonymous, opt-out CLI telemetry — a SEPARATE stream from the dashboard's
+//! product telemetry (source=cli). Best-effort and non-blocking: it never fails
+//! a command and never delays process exit by more than ~300ms.
+//!
+//! ## What is sent (and nothing else)
+//! A single JSON POST to the collector's `/v1/cli` endpoint:
+//! ```json
+//! {
+//!   "install_id":  "<64-hex opaque random id>",  // persisted, not tied to identity
+//!   "event":       "cli_run" | "cli_diagnose",
+//!   "command":     "diagnose" | "hosts" | "chart" | ...,
+//!   "cli_version": "0.1.0",
+//!   "os":          "linux" | "macos" | "windows" | "unknown",
+//!   "arch":        "x86_64" | "aarch64" | "unknown"
+//! }
+//! ```
+//! No ClickHouse host, query text, args, paths, IPs, or usernames are ever
+//! included. The install_id is 32 random bytes hex-encoded, generated once and
+//! stored at `$XDG_CONFIG_HOME/chmonitor/cli-id` (default `~/.config/...`); it
+//! exists only to count distinct installs — it maps to no identity.
+//!
+//! ## Opt out (any one disables it entirely)
+//!   CHM_TELEMETRY=off            (also 0 / false / no)
+//!   DO_NOT_TRACK=1               (cross-tool standard, hard override)
+//!   CHM_TELEMETRY_ENDPOINT=""    (empty endpoint = no network call at all)
+
+use std::{
+    fs,
+    path::PathBuf,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use reqwest::Client;
+use serde::Serialize;
+use tokio::task::JoinHandle;
+
+const DEFAULT_ENDPOINT: &str = "https://telemetry.chmonitor.dev/v1/cli";
+/// Hard cap on how long we let a ping delay process exit.
+const EXIT_BUDGET: Duration = Duration::from_millis(300);
+/// The network request's own timeout (sub-second, best-effort).
+const REQUEST_TIMEOUT: Duration = Duration::from_millis(800);
+
+#[derive(Serialize)]
+struct CliPing {
+    install_id: String,
+    event: &'static str,
+    command: &'static str,
+    cli_version: &'static str,
+    os: &'static str,
+    arch: &'static str,
+}
+
+/// True when the user has opted out via any supported mechanism.
+fn opted_out() -> bool {
+    // DO_NOT_TRACK is a hard override (any non-empty, non-"0" value).
+    if let Ok(v) = std::env::var("DO_NOT_TRACK") {
+        let v = v.trim();
+        if !v.is_empty() && v != "0" && !v.eq_ignore_ascii_case("false") {
+            return true;
+        }
+    }
+    if let Ok(v) = std::env::var("CHM_TELEMETRY") {
+        let v = v.trim().to_ascii_lowercase();
+        if matches!(v.as_str(), "off" | "0" | "false" | "no") {
+            return true;
+        }
+    }
+    false
+}
+
+/// Resolve the collector endpoint. Returns `None` when telemetry is disabled or
+/// the endpoint was explicitly emptied (hard kill-switch).
+fn endpoint() -> Option<String> {
+    match std::env::var("CHM_TELEMETRY_ENDPOINT") {
+        // Explicitly set to empty = hard kill-switch.
+        Ok(v) if v.trim().is_empty() => None,
+        Ok(v) => Some(v.trim().to_string()),
+        Err(_) => Some(DEFAULT_ENDPOINT.to_string()),
+    }
+}
+
+fn os() -> &'static str {
+    match std::env::consts::OS {
+        "linux" => "linux",
+        "macos" => "macos",
+        "windows" => "windows",
+        _ => "unknown",
+    }
+}
+
+fn arch() -> &'static str {
+    match std::env::consts::ARCH {
+        "x86_64" => "x86_64",
+        "aarch64" => "aarch64",
+        _ => "unknown",
+    }
+}
+
+/// `$XDG_CONFIG_HOME/chmonitor/cli-id`, falling back to `~/.config/...`.
+fn install_id_path() -> Option<PathBuf> {
+    let base = std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .filter(|p| !p.as_os_str().is_empty())
+        .or_else(|| dirs::home_dir().map(|h| h.join(".config")))?;
+    Some(base.join("chmonitor").join("cli-id"))
+}
+
+/// 32 random bytes, hex-encoded (64 lowercase hex chars) — matches the
+/// collector's HEX64 validation.
+fn random_hex64() -> String {
+    // Prefer the OS CSPRNG; this is the common path on the Linux/macOS binaries
+    // we ship. No extra crates (keeps Cargo.toml untouched).
+    if let Ok(bytes) = fs::read("/dev/urandom") {
+        if bytes.len() >= 32 {
+            return hex(&bytes[..32]);
+        }
+    }
+    // Fallback: mix time + pid through a small splitmix64 to fill 32 bytes.
+    let seed = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0)
+        ^ ((std::process::id() as u64) << 32);
+    let mut state = seed;
+    let mut out = Vec::with_capacity(32);
+    while out.len() < 32 {
+        state = state.wrapping_add(0x9E3779B97F4A7C15);
+        let mut z = state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+        z ^= z >> 31;
+        out.extend_from_slice(&z.to_le_bytes());
+    }
+    hex(&out[..32])
+}
+
+fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+/// Load the persisted install id, creating and storing one on first run.
+/// Best-effort: if the config dir is unwritable we still return an id (so the
+/// ping can go out) but simply don't persist it.
+fn install_id() -> String {
+    let Some(path) = install_id_path() else {
+        return random_hex64();
+    };
+    if let Ok(existing) = fs::read_to_string(&path) {
+        let trimmed = existing.trim();
+        if trimmed.len() == 64 && trimmed.bytes().all(|b| b.is_ascii_hexdigit()) {
+            return trimmed.to_ascii_lowercase();
+        }
+    }
+    let id = random_hex64();
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let _ = fs::write(&path, &id);
+    id
+}
+
+/// Spawn a background ping for the given event/command. Returns `None` when
+/// telemetry is disabled (opt-out or empty endpoint) so callers pay nothing.
+pub fn spawn(event: &'static str, command: &'static str) -> Option<JoinHandle<()>> {
+    if opted_out() {
+        return None;
+    }
+    let endpoint = endpoint()?;
+    Some(tokio::spawn(async move {
+        let ping = CliPing {
+            install_id: install_id(),
+            event,
+            command,
+            cli_version: env!("CARGO_PKG_VERSION"),
+            os: os(),
+            arch: arch(),
+        };
+        let Ok(client) = Client::builder().timeout(REQUEST_TIMEOUT).build() else {
+            return;
+        };
+        // Errors are intentionally ignored — telemetry must never surface.
+        let _ = client.post(&endpoint).json(&ping).send().await;
+    }))
+}
+
+/// Await the spawned ping, but never block exit longer than `EXIT_BUDGET`.
+pub async fn finish(handle: Option<JoinHandle<()>>) {
+    if let Some(handle) = handle {
+        let _ = tokio::time::timeout(EXIT_BUDGET, handle).await;
+    }
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -154,3 +154,63 @@ esac
 log ""
 log "Run a zero-signup health check against a ClickHouse host:"
 log "  CLICKHOUSE_HOST=http://localhost:8123 CLICKHOUSE_USER=default ${INSTALL_DIR}/${BIN_NAME} diagnose"
+
+# --- anonymous, opt-out install ping (best-effort, backgrounded) -----------
+# Records a single anonymous cli_install event (os/arch + version) to the same
+# collector the CLI and dashboard use. It is a hard no-op when telemetry is
+# opted out, running under CI, or the endpoint is emptied. Sends NO hostnames,
+# IPs, paths, or identity — only an ephemeral random id + os/arch + version.
+send_install_ping() {
+  # Opt-out: DO_NOT_TRACK (hard override), CHM_TELEMETRY=off/0/false/no, CI.
+  case "${DO_NOT_TRACK:-}" in
+    '' | 0 | false | False | FALSE) : ;;
+    *) return 0 ;;
+  esac
+  case "$(printf '%s' "${CHM_TELEMETRY:-}" | tr '[:upper:]' '[:lower:]')" in
+    off | 0 | false | no) return 0 ;;
+  esac
+  case "${CI:-}" in
+    '' | 0 | false | False | FALSE) : ;;
+    *) return 0 ;;
+  esac
+
+  # CHM_TELEMETRY_ENDPOINT explicitly set to empty = hard kill-switch.
+  if [ "${CHM_TELEMETRY_ENDPOINT+set}" = set ] && [ -z "${CHM_TELEMETRY_ENDPOINT}" ]; then
+    return 0
+  fi
+  endpoint="https://telemetry.chmonitor.dev/v1/cli"
+
+  # os/arch in the collector's enum vocabulary.
+  case "$(uname -s)" in
+    Linux) tel_os="linux" ;;
+    Darwin) tel_os="macos" ;;
+    *) tel_os="unknown" ;;
+  esac
+  case "$(uname -m)" in
+    x86_64 | amd64) tel_arch="x86_64" ;;
+    aarch64 | arm64) tel_arch="aarch64" ;;
+    *) tel_arch="unknown" ;;
+  esac
+
+  # Ephemeral 64-hex id — one-shot installs do not persist identity.
+  if command -v hexdump >/dev/null 2>&1; then
+    tel_id="$(head -c 32 /dev/urandom 2>/dev/null | hexdump -v -e '/1 "%02x"' 2>/dev/null)"
+  else
+    tel_id="$(head -c 32 /dev/urandom 2>/dev/null | od -An -tx1 2>/dev/null | tr -d ' \n')"
+  fi
+  [ "${#tel_id}" -eq 64 ] || return 0
+
+  # Version → semver-ish (collector drops anything that isn't MAJOR.MINOR[.PATCH]).
+  tel_ver="$(printf '%s' "$VERSION" | sed -E 's/^chm-v//')"
+
+  payload="$(printf '{"install_id":"%s","event":"cli_install","command":"install","cli_version":"%s","os":"%s","arch":"%s"}' \
+    "$tel_id" "$tel_ver" "$tel_os" "$tel_arch")"
+
+  # Fire-and-forget: short timeout, silent, never blocks or fails the install.
+  curl -fsS -m 2 -X POST -H "content-type: application/json" \
+    --data "$payload" "$endpoint" >/dev/null 2>&1 || true
+}
+
+# Backgrounded; the curl inside is self-bounded to 2s (-m 2), so this never
+# holds the installer open for long and never affects its exit status.
+send_install_ping &


### PR DESCRIPTION
## Summary

Adds an anonymous, opt-out telemetry stream for the standalone `chm` CLI and its `install.sh` installer, tracked as a **separate stream** (`source=cli`) from the dashboard's product telemetry. Same privacy posture: anonymous, opt-out, no PII.

## What's collected (CLI)

A single POST to the collector's new `/v1/cli` endpoint:

| Field | Values |
|---|---|
| `install_id` | 64-hex opaque random id, persisted at `$XDG_CONFIG_HOME/chmonitor/cli-id` (default `~/.config/chmonitor/cli-id`); ephemeral for one-shot installs |
| `event` | `cli_install` \| `cli_run` \| `cli_diagnose` |
| `command` | `hosts`/`chart`/`table`/`tui`/`diagnose`/`install` (coerced to enum or `''`) |
| `cli_version` | semver |
| `os` / `arch` | `linux/macos/windows/unknown` / `x86_64/aarch64/unknown` |

Nothing else — no ClickHouse host, query text, arguments, paths, usernames, or IPs.

## Opt-out (every path)

`CHM_TELEMETRY=off` (also `0/false/no`), `DO_NOT_TRACK=1` (hard override), `CHM_TELEMETRY_ENDPOINT=""` (kill-switch). The install ping additionally skips when `CI=true`.

## Changes

- **rust/ch-monitor-cli** — new `src/telemetry.rs` module (fires on a background tokio task, sub-second request timeout, never delays exit >300ms, never fails a command) + a minimal hook in `main.rs`. No new crate deps (keeps `Cargo.toml` untouched to avoid conflicting with the concurrent `chm update` work).
- **scripts/install.sh** — backgrounded best-effort `cli_install` ping; POSIX-bash, shellcheck clean.
- **apps/telemetry** — `/v1/cli` ingest with a closed/validated schema, `cli_daily` table (migration `0005_cli_events.sql`), an aggregate-only `cli` block in `/v1/summary`, and a CLI section on the analytics page (installs over time, active CLI users, runs by command, version/os/arch splits). Dashboard `ping_daily`/`events` streams are untouched. New tests for the CLI ingest + validation + dedupe.
- **docs** — `telemetry.mdx` CLI section + `diagnostics-cli.mdx` cross-link; `apps/telemetry` and CLI READMEs.

## Verification

- `cargo check` / `cargo test` (18 pass) / `cargo fmt --check` / `cargo clippy` — clean
- `bun test` telemetry worker — 13 pass; `tsc --noEmit` clean; Biome clean
- `shellcheck scripts/install.sh` — clean

https://claude.ai/code/session_016pN3dJ84hj6Qkv9qiZ2pzo