### PR TITLE
feat(cloud-hooks): DAU/MAU, weekly report, and new-issue Telegram alerts

### DIFF
--- a/apps/cloud-hooks/deploy.config.ts
+++ b/apps/cloud-hooks/deploy.config.ts
@@ -14,6 +14,10 @@ export default {
     'CHM_EXCEPTION_ISSUE_LABELS',
     'CHM_EXCEPTION_MAX_ISSUES_PER_RUN',
     'CHM_EXCEPTION_SCRIPTS',
+    // New-issue watch (see apps/cloud-hooks/wrangler.toml header). Both are
+    // optional — sensible defaults are baked in.
+    'CHM_ISSUE_WATCH_EXCLUDE_LABELS',
+    'CHM_ISSUE_WATCH_MAX_PER_RUN',
     // Optional GitHub App installation id (non-secret); unset → resolved from
     // the repo and cached in KV.
     'GH_APP_INSTALLATION_ID',

--- a/apps/cloud-hooks/src/clerk-metrics.ts
+++ b/apps/cloud-hooks/src/clerk-metrics.ts
@@ -32,15 +32,24 @@ async function countUsers(
   return typeof body.total_count === 'number' ? body.total_count : null
 }
 
+/** 24 hours — the daily digest's window, and the default here. */
+export const DAY_SECONDS = 24 * 60 * 60
+/** 7 days — the weekly report's window. */
+export const WEEK_SECONDS = 7 * DAY_SECONDS
+
 /**
- * Fetch `{ totalUsers, newUsers24h }` or null when unavailable. `now` is unix
- * seconds (injectable for tests); the 24h window is derived from it and passed
- * to Clerk as `created_at_after` in unix milliseconds.
+ * Fetch `{ totalUsers, newUsers, windowSeconds }` or null when unavailable.
+ * `now` is unix seconds (injectable for tests); `windowSeconds` sets how far
+ * back "new" reaches (24h for the daily digest, 7d for the weekly report) and
+ * is passed to Clerk as `created_at_after` in unix MILLIseconds. It is carried
+ * on the result so the formatter labels the number from the same value that
+ * produced it and the two can never drift.
  */
 export async function fetchClerkMetrics(
   secretKey: string | undefined,
   fetchImpl: typeof fetch = fetch,
-  now: number = Math.floor(Date.now() / 1000)
+  now: number = Math.floor(Date.now() / 1000),
+  windowSeconds: number = DAY_SECONDS
 ): Promise<ClerkMetrics | null> {
   if (!secretKey) {
     console.log(
@@ -52,13 +61,13 @@ export async function fetchClerkMetrics(
   try {
     const total = await countUsers(auth, fetchImpl)
     if (total === null) return null
-    const sinceMs = (now - 24 * 60 * 60) * 1000
+    const sinceMs = (now - windowSeconds) * 1000
     const recent = await countUsers(
       auth,
       fetchImpl,
       `?created_at_after=${sinceMs}`
     )
-    return { totalUsers: total, newUsers24h: recent ?? 0 }
+    return { totalUsers: total, newUsers: recent ?? 0, windowSeconds }
   } catch (err) {
     console.error('[cloud-hooks] Clerk metrics fetch failed', err)
     return null

--- a/apps/cloud-hooks/src/cron.test.ts
+++ b/apps/cloud-hooks/src/cron.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Cron wiring — guards the one coupling that fails silently.
+ *
+ * Cloudflare hands `scheduled()` the cron string exactly as configured in
+ * wrangler.toml, and index.ts routes on string equality. If someone edits a
+ * schedule in wrangler.toml (or merely reformats one), the report it was meant
+ * to trigger does not error — it quietly falls through to the ops-sweep branch
+ * and is never sent again. Nothing else in the suite would notice, so
+ * this test compares the two sources directly.
+ */
+
+import { DAILY_CRON, WEEKLY_CRON } from './index'
+import { describe, expect, test } from 'bun:test'
+
+/** The `crons = [...]` array from wrangler.toml, parsed without a TOML dep. */
+async function configuredCrons(): Promise<string[]> {
+  const toml = await Bun.file(
+    new URL('../wrangler.toml', import.meta.url)
+  ).text()
+  const match = toml.match(/^crons\s*=\s*\[(.*?)\]/ms)
+  if (!match) throw new Error('no `crons = [...]` found in wrangler.toml')
+  return [...match[1].matchAll(/"([^"]+)"/g)].map((m) => m[1])
+}
+
+describe('cron triggers', () => {
+  test('every schedule index.ts routes on is actually configured', async () => {
+    const crons = await configuredCrons()
+    expect(crons).toContain(DAILY_CRON)
+    expect(crons).toContain(WEEKLY_CRON)
+  })
+
+  test('the weekly schedule is distinct from the daily one', () => {
+    // Identical strings would make the first matching branch win and the other
+    // report would never run.
+    expect(WEEKLY_CRON).not.toBe(DAILY_CRON)
+  })
+
+  test('the ops sweep still has a schedule that falls through to it', async () => {
+    const crons = await configuredCrons()
+    const sweep = crons.filter((c) => c !== DAILY_CRON && c !== WEEKLY_CRON)
+    // Probes, the exception scan, and the issue watch all hang off this branch.
+    expect(sweep.length).toBeGreaterThan(0)
+  })
+})

--- a/apps/cloud-hooks/src/env.ts
+++ b/apps/cloud-hooks/src/env.ts
@@ -7,6 +7,12 @@
 export interface Env {
   /** Shared billing D1 (same `chm-cloud` database the dashboard reads). */
   CHM_CLOUD_D1?: D1Database
+  /**
+   * Telemetry D1 (the `chm_telemetry` database apps/telemetry writes), read for
+   * the DAU/WAU/MAU section of the digests. READ-ONLY here — this worker never
+   * writes telemetry. Unbound → the Usage section is omitted.
+   */
+  CHM_TELEMETRY_DB?: D1Database
   /** KV namespace storing last-known health-probe state (transitions only). */
   CHM_HOOKS_KV?: KVNamespace
 
@@ -68,6 +74,14 @@ export interface Env {
   CHM_EXCEPTION_MAX_ISSUES_PER_RUN?: string
   /** Comma-separated Worker script names to scan. Default `chmonitor-dash,chmonitor-hooks`. */
   CHM_EXCEPTION_SCRIPTS?: string
+  /**
+   * Labels whose new issues the watch stays quiet about, comma-separated.
+   * Default `cloudflare-exception` — the exception scan already announces the
+   * issues it files, so without this the operator is told twice.
+   */
+  CHM_ISSUE_WATCH_EXCLUDE_LABELS?: string
+  /** Max new issues announced per ops sweep. Default `10`; the rest defer to the next run. */
+  CHM_ISSUE_WATCH_MAX_PER_RUN?: string
 
   // Polar product ids per plan/period (CHM_POLAR_PRODUCT_<PLAN>_<PERIOD>). Same
   // names the dashboard uses so both Workers map products identically.

--- a/apps/cloud-hooks/src/index.ts
+++ b/apps/cloud-hooks/src/index.ts
@@ -7,23 +7,39 @@
  *   GET  /healthz         → 200 liveness shell (static, no deps)
  *
  * Scheduled (wrangler.toml [triggers] crons):
- *   "0 0 * * *"       → daily billing summary → Telegram
- *   every 15 minutes  → health probes (dash/docs/landing) → Telegram on changes
+ *   "0 0 * * *"       → daily digest (billing + users + DAU/MAU) → Telegram
+ *   "0 1 * * 1"       → weekly report (week-over-week trends) → Telegram
+ *   every 15 minutes  → ops sweep: health probes, Worker exceptions → GitHub
+ *                       issues, and new GitHub issues → Telegram
  *
  * OSS/self-host never deploys this — it is purely additive Cloud plumbing.
  */
 
 import type { Env } from './env'
+import type { GitHubRepo } from './exceptions'
+import type { GitHubAppAuth } from './github-app'
 
-import { fetchClerkMetrics } from './clerk-metrics'
+import { fetchClerkMetrics, WEEK_SECONDS } from './clerk-metrics'
 import { handleClerkWebhook } from './clerk-webhook'
 import { parseRepo, runExceptionScan } from './exceptions'
 import { resolveGitHubAuth } from './github-app'
+import { fetchIssueStats, runIssueWatch } from './issues'
 import { fetchWorkerExceptions } from './observability'
 import { readProbeSnapshot, runProbes } from './probes'
 import { collectSummary, formatDigest } from './summary'
 import { Notifier } from './telegram'
+import { collectUsage } from './usage'
 import { handlePolarWebhook } from './webhook'
+import { collectWeekly, formatWeekly, weekBounds } from './weekly'
+
+/**
+ * Cron expressions, which MUST match `[triggers] crons` in wrangler.toml
+ * character for character — Cloudflare hands `scheduled()` the raw string it
+ * was configured with, so a reformatted expression would silently fall through
+ * to the ops-sweep branch instead of running its report.
+ */
+export const DAILY_CRON = '0 0 * * *'
+export const WEEKLY_CRON = '0 1 * * 1' // Mondays 01:00 UTC
 
 function notifierFor(env: Env): Notifier {
   return new Notifier({
@@ -32,25 +48,147 @@ function notifierFor(env: Env): Notifier {
   })
 }
 
+/**
+ * Resolve a usable GitHub token once per job. Three capabilities now need one
+ * (exception scan, issue watch, weekly issue stats), so the credential checks,
+ * repo parsing, and token minting live here instead of being repeated.
+ *
+ * Returns null — after ONE explanatory log line — whenever GitHub is not
+ * configured, so a deploy without these secrets simply runs without the
+ * GitHub-backed features.
+ */
+async function resolveGitHub(
+  env: Env,
+  label: string
+): Promise<{
+  repo: GitHubRepo
+  token: string
+  auth: GitHubAppAuth | null
+} | null> {
+  const hasAuth = (env.GH_APP_ID && env.GH_APP_PRIVATE_KEY) || env.GITHUB_TOKEN
+  if (!hasAuth) {
+    console.log(`[cloud-hooks] ${label} disabled (no GitHub credentials)`)
+    return null
+  }
+  const repo = parseRepo(env.GITHUB_REPOSITORY || 'chmonitor/chmonitor')
+  if (!repo) {
+    console.log(`[cloud-hooks] ${label} disabled (bad GITHUB_REPOSITORY)`)
+    return null
+  }
+  const auth = resolveGitHubAuth(
+    env,
+    repo.owner,
+    repo.repo,
+    env.CHM_HOOKS_KV ?? null
+  )
+  if (auth.mode === 'disabled') {
+    console.log(`[cloud-hooks] ${label} disabled (no GitHub credentials)`)
+    return null
+  }
+  try {
+    const token =
+      auth.mode === 'app' ? await auth.app!.getToken() : (auth.token as string)
+    return {
+      repo,
+      token,
+      auth: auth.mode === 'app' ? (auth.app ?? null) : null,
+    }
+  } catch (err) {
+    console.error(
+      `[cloud-hooks] ${label}: GitHub token acquisition failed`,
+      err
+    )
+    return null
+  }
+}
+
 async function runDailySummary(env: Env, notifier: Notifier): Promise<void> {
   if (!env.CHM_CLOUD_D1) {
     console.error('[cloud-hooks] CHM_CLOUD_D1 unbound; skipping daily summary')
     return
   }
   try {
-    // Billing (D1) is the required core; Clerk metrics + probe snapshot are
-    // best-effort enrichments that degrade to omitted sections when absent.
-    const [data, clerk, probes] = await Promise.all([
+    // Billing (D1) is the required core; Clerk metrics, usage (DAU/WAU/MAU from
+    // the telemetry D1), and the probe snapshot are best-effort enrichments that
+    // degrade to omitted sections when absent.
+    const [data, clerk, usage, probes] = await Promise.all([
       collectSummary(env.CHM_CLOUD_D1),
       fetchClerkMetrics(env.CLERK_SECRET_KEY),
+      collectUsage(env.CHM_TELEMETRY_DB ?? null),
       readProbeSnapshot(env.CHM_HOOKS_KV ?? null),
     ])
     await notifier.notify(
       'daily_summary',
-      formatDigest(data, { clerk, probes })
+      formatDigest(data, { clerk, usage, probes })
     )
   } catch (err) {
     console.error('[cloud-hooks] daily summary failed', err)
+  }
+}
+
+/**
+ * Weekly report — the same surfaces as the daily digest but week-over-week, plus
+ * issue throughput. Billing (D1) is required; every other section degrades to
+ * omitted, so this still sends something useful on a partially-configured
+ * deployment.
+ */
+async function runWeeklyReport(env: Env, notifier: Notifier): Promise<void> {
+  if (!env.CHM_CLOUD_D1) {
+    console.error('[cloud-hooks] CHM_CLOUD_D1 unbound; skipping weekly report')
+    return
+  }
+  try {
+    const nowSeconds = Math.floor(Date.now() / 1000)
+    const { start } = weekBounds(nowSeconds)
+    const sinceDay = new Date(start * 1000).toISOString().slice(0, 10)
+
+    const [data, clerk, usage, probes, issues] = await Promise.all([
+      collectWeekly(env.CHM_CLOUD_D1, nowSeconds),
+      // A 7-day window here, so "new users" matches the reported period.
+      fetchClerkMetrics(env.CLERK_SECRET_KEY, fetch, nowSeconds, WEEK_SECONDS),
+      collectUsage(env.CHM_TELEMETRY_DB ?? null, nowSeconds),
+      readProbeSnapshot(env.CHM_HOOKS_KV ?? null),
+      resolveGitHub(env, 'weekly issue stats').then((gh) =>
+        gh ? fetchIssueStats(gh.repo, gh.token, sinceDay) : null
+      ),
+    ])
+    await notifier.notify(
+      'weekly_summary',
+      formatWeekly(data, { clerk, usage, probes, issues })
+    )
+  } catch (err) {
+    console.error('[cloud-hooks] weekly report failed', err)
+  }
+}
+
+/**
+ * Announce GitHub issues opened since the last sweep. Read-only — it files
+ * nothing, it just makes sure a community bug report reaches the operator.
+ */
+async function runIssues(env: Env, notifier: Notifier): Promise<void> {
+  const gh = await resolveGitHub(env, 'issue watch')
+  if (!gh) return
+
+  const maxPerRun = Number.parseInt(env.CHM_ISSUE_WATCH_MAX_PER_RUN || '10', 10)
+  const excludeLabels = (
+    env.CHM_ISSUE_WATCH_EXCLUDE_LABELS ?? 'cloudflare-exception'
+  )
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+
+  try {
+    await runIssueWatch({
+      repo: gh.repo,
+      githubToken: gh.token,
+      auth: gh.auth,
+      kv: env.CHM_HOOKS_KV ?? null,
+      excludeLabels,
+      maxPerRun: Number.isFinite(maxPerRun) ? maxPerRun : 10,
+      notify: (kind, text) => notifier.notify(kind, text),
+    })
+  } catch (err) {
+    console.error('[cloud-hooks] issue watch failed', err)
   }
 }
 
@@ -60,11 +198,9 @@ async function runDailySummary(env: Env, notifier: Notifier): Promise<void> {
  * (never a crash), so an OSS-style deploy without these secrets just skips it.
  */
 async function runExceptions(env: Env, notifier: Notifier): Promise<void> {
+  // Cloudflare-side credentials are specific to this job; the GitHub side is
+  // resolved by the shared helper.
   const missing: string[] = []
-  const hasGitHubAuth =
-    (env.GH_APP_ID && env.GH_APP_PRIVATE_KEY) || env.GITHUB_TOKEN
-  if (!hasGitHubAuth)
-    missing.push('GH_APP_ID+GH_APP_PRIVATE_KEY or GITHUB_TOKEN')
   if (!env.CF_OBSERVABILITY_API_TOKEN)
     missing.push('CF_OBSERVABILITY_API_TOKEN')
   if (!env.CF_ACCOUNT_ID) missing.push('CF_ACCOUNT_ID')
@@ -75,22 +211,9 @@ async function runExceptions(env: Env, notifier: Notifier): Promise<void> {
     return
   }
 
-  const repo = parseRepo(env.GITHUB_REPOSITORY || 'chmonitor/chmonitor')
-  if (!repo) {
-    console.log('[cloud-hooks] exception scan disabled (bad GITHUB_REPOSITORY)')
-    return
-  }
-
-  const auth = resolveGitHubAuth(
-    env,
-    repo.owner,
-    repo.repo,
-    env.CHM_HOOKS_KV ?? null
-  )
-  if (auth.mode === 'disabled') {
-    console.log('[cloud-hooks] exception scan disabled (no GitHub credentials)')
-    return
-  }
+  const gh = await resolveGitHub(env, 'exception scan')
+  if (!gh) return
+  const { repo, token: githubToken, auth } = gh
 
   const scripts = (
     env.CHM_EXCEPTION_SCRIPTS || 'chmonitor-dash,chmonitor-hooks'
@@ -107,20 +230,11 @@ async function runExceptions(env: Env, notifier: Notifier): Promise<void> {
     10
   )
 
-  let githubToken: string
-  try {
-    githubToken =
-      auth.mode === 'app' ? await auth.app!.getToken() : (auth.token as string)
-  } catch (err) {
-    console.error('[cloud-hooks] GitHub App token acquisition failed', err)
-    return
-  }
-
   try {
     await runExceptionScan({
       repo,
       githubToken,
-      auth: auth.mode === 'app' ? auth.app : null,
+      auth,
       fetchExceptions: () =>
         fetchWorkerExceptions({
           accountId: env.CF_ACCOUNT_ID as string,
@@ -178,12 +292,20 @@ export default {
     ctx: ExecutionContext
   ): Promise<void> {
     const notifier = notifierFor(env)
-    if (event.cron === '0 0 * * *') {
+
+    // Weekly first: `0 1 * * 1` is also matched by no other branch, but keeping
+    // the most specific schedule at the top makes the routing order obvious.
+    if (event.cron === WEEKLY_CRON) {
+      ctx.waitUntil(runWeeklyReport(env, notifier))
+      return
+    }
+    if (event.cron === DAILY_CRON) {
       ctx.waitUntil(runDailySummary(env, notifier))
       return
     }
     // Default the shorter cadence (and any other trigger) to the ops sweep:
-    // full-surface health probes + Cloudflare exception → GitHub issue scan.
+    // full-surface health probes, the Cloudflare exception → GitHub issue scan,
+    // and the new-issue watch.
     ctx.waitUntil(
       runProbes({
         kv: env.CHM_HOOKS_KV ?? null,
@@ -192,5 +314,6 @@ export default {
       })
     )
     ctx.waitUntil(runExceptions(env, notifier))
+    ctx.waitUntil(runIssues(env, notifier))
   },
 }

--- a/apps/cloud-hooks/src/issues.test.ts
+++ b/apps/cloud-hooks/src/issues.test.ts
@@ -1,0 +1,221 @@
+/**
+ * New-issue watch — seeding, the created_at re-filter, exclusion, and capping.
+ */
+
+import type { KVLike } from './github-app'
+import type { GitHubIssue } from './issues'
+
+import {
+  formatIssue,
+  ISSUE_CURSOR_KEY,
+  runIssueWatch,
+  selectNewIssues,
+} from './issues'
+import { describe, expect, mock, test } from 'bun:test'
+
+const REPO = { owner: 'chmonitor', repo: 'chmonitor' }
+const CURSOR = '2026-07-24T00:00:00.000Z'
+const NOW = Date.parse('2026-07-24T12:00:00.000Z')
+
+function issue(over: Partial<GitHubIssue> = {}): GitHubIssue {
+  return {
+    number: 1,
+    title: 'Something is broken',
+    html_url: 'https://github.com/chmonitor/chmonitor/issues/1',
+    created_at: '2026-07-24T06:00:00.000Z',
+    user: { login: 'someone' },
+    labels: [],
+    ...over,
+  }
+}
+
+/** In-memory KV with the two methods the watch uses. */
+function memKv(initial: Record<string, string> = {}) {
+  const store = new Map(Object.entries(initial))
+  return {
+    store,
+    async get(key: string) {
+      return store.get(key) ?? null
+    },
+    async put(key: string, value: string) {
+      store.set(key, value)
+    },
+  } satisfies KVLike & { store: Map<string, string> }
+}
+
+function jsonFetch(issues: GitHubIssue[]) {
+  return mock(async () => new Response(JSON.stringify(issues), { status: 200 }))
+}
+
+describe('selectNewIssues', () => {
+  test('drops pull requests — the issues API returns them too', () => {
+    const got = selectNewIssues(
+      [issue({ number: 2, pull_request: { url: 'x' } }), issue({ number: 3 })],
+      CURSOR
+    )
+    expect(got.map((i) => i.number)).toEqual([3])
+  })
+
+  test('drops issues merely UPDATED since the cursor, not created', () => {
+    // GitHub's `since` filters on updated_at, so a comment on an old issue
+    // comes back in the response. It is not a new issue.
+    const old = issue({ number: 4, created_at: '2024-01-01T00:00:00.000Z' })
+    expect(selectNewIssues([old], CURSOR)).toEqual([])
+  })
+
+  test('drops issues carrying an excluded label (already announced elsewhere)', () => {
+    const exc = issue({
+      number: 5,
+      labels: [{ name: 'bug' }, { name: 'cloudflare-exception' }],
+    })
+    expect(selectNewIssues([exc], CURSOR)).toEqual([])
+    // …and keeps it when the exclusion list is empty.
+    expect(selectNewIssues([exc], CURSOR, [])).toHaveLength(1)
+  })
+
+  test('accepts labels in GitHub’s string form as well as objects', () => {
+    const strLabels = issue({
+      number: 6,
+      labels: ['cloudflare-exception'],
+    }) as GitHubIssue
+    expect(selectNewIssues([strLabels], CURSOR)).toEqual([])
+  })
+
+  test('returns oldest first so the chat reads chronologically', () => {
+    const got = selectNewIssues(
+      [
+        issue({ number: 7, created_at: '2026-07-24T09:00:00.000Z' }),
+        issue({ number: 8, created_at: '2026-07-24T02:00:00.000Z' }),
+      ],
+      CURSOR
+    )
+    expect(got.map((i) => i.number)).toEqual([8, 7])
+  })
+})
+
+describe('runIssueWatch', () => {
+  test('first run seeds the cursor and announces nothing', async () => {
+    const kv = memKv()
+    const notify = mock(async () => true)
+    const fetchImpl = jsonFetch([issue()])
+
+    const res = await runIssueWatch({
+      repo: REPO,
+      githubToken: 't',
+      kv,
+      notify,
+      fetch: fetchImpl,
+      now: () => NOW,
+    })
+
+    expect(res.seeded).toBe(true)
+    expect(notify).not.toHaveBeenCalled()
+    // Enabling the watch on a repo with a long backlog must not flood the chat.
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(kv.store.get(ISSUE_CURSOR_KEY)).toBe(new Date(NOW).toISOString())
+  })
+
+  test('announces each new issue and advances the cursor to the newest', async () => {
+    const kv = memKv({ [ISSUE_CURSOR_KEY]: CURSOR })
+    const notify = mock(async () => true)
+    const sent: string[] = []
+
+    const res = await runIssueWatch({
+      repo: REPO,
+      githubToken: 't',
+      kv,
+      notify: async (_kind, text) => {
+        sent.push(text)
+        return notify()
+      },
+      fetch: jsonFetch([
+        issue({ number: 11, created_at: '2026-07-24T03:00:00.000Z' }),
+        issue({ number: 12, created_at: '2026-07-24T05:00:00.000Z' }),
+      ]),
+      now: () => NOW,
+    })
+
+    expect(res.notified).toEqual([11, 12])
+    expect(sent).toHaveLength(2)
+    expect(kv.store.get(ISSUE_CURSOR_KEY)).toBe('2026-07-24T05:00:00.000Z')
+  })
+
+  test('a capped run defers the rest instead of skipping them', async () => {
+    const kv = memKv({ [ISSUE_CURSOR_KEY]: CURSOR })
+    const res = await runIssueWatch({
+      repo: REPO,
+      githubToken: 't',
+      kv,
+      maxPerRun: 2,
+      notify: async () => true,
+      fetch: jsonFetch([
+        issue({ number: 21, created_at: '2026-07-24T01:00:00.000Z' }),
+        issue({ number: 22, created_at: '2026-07-24T02:00:00.000Z' }),
+        issue({ number: 23, created_at: '2026-07-24T03:00:00.000Z' }),
+      ]),
+      now: () => NOW,
+    })
+
+    expect(res.notified).toEqual([21, 22])
+    expect(res.deferred).toBe(1)
+    // The cursor stops at the last ANNOUNCED issue, so #23 is picked up next
+    // run rather than being lost forever.
+    expect(kv.store.get(ISSUE_CURSOR_KEY)).toBe('2026-07-24T02:00:00.000Z')
+  })
+
+  test('leaves the cursor untouched when the GitHub call fails', async () => {
+    const kv = memKv({ [ISSUE_CURSOR_KEY]: CURSOR })
+    const res = await runIssueWatch({
+      repo: REPO,
+      githubToken: 't',
+      kv,
+      notify: async () => true,
+      fetch: mock(async () => new Response('bad creds', { status: 401 })),
+      now: () => NOW,
+      logError: () => {},
+    })
+
+    expect(res.notified).toEqual([])
+    // Same window is retried next run — a transient failure loses nothing.
+    expect(kv.store.get(ISSUE_CURSOR_KEY)).toBe(CURSOR)
+  })
+
+  test('skips entirely without KV, since a watch with no memory repeats itself', async () => {
+    const notify = mock(async () => true)
+    const res = await runIssueWatch({
+      repo: REPO,
+      githubToken: 't',
+      kv: null,
+      notify,
+      fetch: jsonFetch([issue()]),
+      now: () => NOW,
+      logError: () => {},
+    })
+    expect(res).toEqual({ notified: [], seeded: false })
+    expect(notify).not.toHaveBeenCalled()
+  })
+})
+
+describe('formatIssue', () => {
+  test('includes number, title, author, labels and url', () => {
+    const text = formatIssue(
+      issue({ number: 42, labels: [{ name: 'bug' }] }),
+      REPO
+    )
+    expect(text).toContain('#42')
+    expect(text).toContain('Something is broken')
+    expect(text).toContain('@someone')
+    expect(text).toContain('bug')
+    expect(text).toContain('https://github.com/chmonitor/chmonitor/issues/1')
+  })
+
+  test('escapes HTML so a crafted title cannot break the message', () => {
+    // Telegram parses the message as HTML; an unescaped <b> in a title would
+    // corrupt the message or get it rejected outright.
+    const text = formatIssue(
+      issue({ title: 'crash in <Chart> & <b>bold' }),
+      REPO
+    )
+    expect(text).toContain('&lt;Chart&gt; &amp; &lt;b&gt;bold')
+  })
+})

--- a/apps/cloud-hooks/src/issues.ts
+++ b/apps/cloud-hooks/src/issues.ts
@@ -1,0 +1,324 @@
+/**
+ * New GitHub issues → Telegram.
+ *
+ * On the ops cron, `runIssueWatch` lists issues created since a KV cursor
+ * (`issue-watch:v1:last-created`) and announces each one. Unlike the exception
+ * scan this files nothing — it is a read-only watch so a community bug report
+ * reaches the operator without them polling the repo.
+ *
+ * Three details that matter:
+ *
+ * 1. **First run seeds, it does not flood.** With no cursor we record "now" and
+ *    announce nothing. Otherwise enabling the watch on a repo with hundreds of
+ *    open issues would dump all of them into the chat.
+ * 2. **The GitHub `since` filter is on `updated_at`, not `created_at`.** An old
+ *    issue that someone comments on comes back in the response, so we re-filter
+ *    on `created_at` locally. Without that, every comment on a 2024 issue would
+ *    read as "new issue".
+ * 3. **Capping is deferral, not loss.** When more issues arrive than the per-run
+ *    cap, we take the OLDEST ones and advance the cursor only past those, so the
+ *    remainder are announced on the next run instead of being skipped forever.
+ *
+ * Nothing throws: any failure logs and leaves the cursor untouched, so the next
+ * run retries the same window.
+ */
+
+import type { GitHubRepo } from './exceptions'
+import type { GitHubAppAuth, KVLike } from './github-app'
+import type { NotifyKind } from './telegram'
+
+import { withTokenRefresh } from './github-app'
+
+export const ISSUE_NOTIFY_KIND: NotifyKind = 'new_issue'
+export const ISSUE_CURSOR_KEY = 'issue-watch:v1:last-created'
+const DEFAULT_MAX_PER_RUN = 10
+/**
+ * Labels whose issues are announced elsewhere. The exception scan already sends
+ * its own Telegram message when it files an issue, so without this the operator
+ * gets two notifications for the same event.
+ */
+export const DEFAULT_EXCLUDE_LABELS = ['cloudflare-exception']
+
+export interface GitHubIssue {
+  number: number
+  title: string
+  html_url: string
+  created_at: string
+  state?: string
+  user?: { login?: string } | null
+  labels?: Array<{ name?: string } | string> | null
+  /** Present only on pull requests — the issues API returns PRs too. */
+  pull_request?: unknown
+}
+
+export interface FetchIssuesResult {
+  status: number
+  issues: GitHubIssue[]
+  error?: string
+}
+
+/** Normalize GitHub's label union (string | {name}) to plain names. */
+export function labelNames(issue: GitHubIssue): string[] {
+  return (issue.labels ?? [])
+    .map((l) => (typeof l === 'string' ? l : (l?.name ?? '')))
+    .filter(Boolean)
+}
+
+/** List issues updated since `sinceIso`. Never throws. */
+export async function fetchIssuesSince(
+  repo: GitHubRepo,
+  token: string,
+  sinceIso: string,
+  fetchImpl: typeof fetch = fetch,
+  apiBase = 'https://api.github.com',
+  perPage = 50
+): Promise<FetchIssuesResult> {
+  const url =
+    `${apiBase}/repos/${repo.owner}/${repo.repo}/issues` +
+    `?state=all&sort=created&direction=desc&per_page=${perPage}` +
+    `&since=${encodeURIComponent(sinceIso)}`
+  let res: Response
+  try {
+    res = await fetchImpl(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'chmonitor-hooks',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    })
+  } catch (err) {
+    return {
+      status: 0,
+      issues: [],
+      error: `fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+    }
+  }
+  if (!res.ok) {
+    let text = ''
+    try {
+      text = await res.text()
+    } catch {
+      /* ignore */
+    }
+    return { status: res.status, issues: [], error: text }
+  }
+  try {
+    const data = (await res.json()) as GitHubIssue[]
+    return { status: res.status, issues: Array.isArray(data) ? data : [] }
+  } catch (err) {
+    return {
+      status: res.status,
+      issues: [],
+      error: `bad json: ${err instanceof Error ? err.message : String(err)}`,
+    }
+  }
+}
+
+/** Issue counts for a period — the weekly report's Issues section. */
+export interface IssueStats {
+  opened: number
+  closed: number
+}
+
+/** Run one GitHub issue search and return its `total_count`, or null. */
+async function searchCount(
+  query: string,
+  token: string,
+  fetchImpl: typeof fetch,
+  apiBase: string
+): Promise<number | null> {
+  const url = `${apiBase}/search/issues?q=${encodeURIComponent(query)}&per_page=1`
+  try {
+    const res = await fetchImpl(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'chmonitor-hooks',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    })
+    if (!res.ok) return null
+    const data = (await res.json()) as { total_count?: number }
+    return typeof data.total_count === 'number' ? data.total_count : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Issues opened and closed since `sinceDay` ('YYYY-MM-DD'). Uses the search API
+ * so we pay two requests instead of paging the issue list. Best-effort: any
+ * failure returns null and the weekly report omits the Issues section.
+ *
+ * `is:issue` excludes pull requests, which GitHub otherwise counts as issues.
+ */
+export async function fetchIssueStats(
+  repo: GitHubRepo,
+  token: string,
+  sinceDay: string,
+  fetchImpl: typeof fetch = fetch,
+  apiBase = 'https://api.github.com'
+): Promise<IssueStats | null> {
+  const scope = `repo:${repo.owner}/${repo.repo} is:issue`
+  const [opened, closed] = await Promise.all([
+    searchCount(`${scope} created:>=${sinceDay}`, token, fetchImpl, apiBase),
+    searchCount(`${scope} closed:>=${sinceDay}`, token, fetchImpl, apiBase),
+  ])
+  if (opened === null && closed === null) return null
+  return { opened: opened ?? 0, closed: closed ?? 0 }
+}
+
+/**
+ * Keep only genuinely new, announceable issues, oldest first. Pure, so the
+ * filtering rules (see the module header) are testable without the network.
+ */
+export function selectNewIssues(
+  issues: GitHubIssue[],
+  cursorIso: string,
+  excludeLabels: string[] = DEFAULT_EXCLUDE_LABELS
+): GitHubIssue[] {
+  const cursorMs = Date.parse(cursorIso)
+  const excluded = new Set(excludeLabels.map((l) => l.toLowerCase()))
+  return issues
+    .filter((issue) => {
+      if (issue.pull_request) return false // the issues API includes PRs
+      const created = Date.parse(issue.created_at)
+      if (!Number.isFinite(created) || created <= cursorMs) return false
+      if (excluded.size === 0) return true
+      return !labelNames(issue).some((n) => excluded.has(n.toLowerCase()))
+    })
+    .sort((a, b) => Date.parse(a.created_at) - Date.parse(b.created_at))
+}
+
+/** Escape the HTML-significant characters in Telegram's HTML parse mode. */
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+/** The Telegram message for one new issue. */
+export function formatIssue(issue: GitHubIssue, repo: GitHubRepo): string {
+  const labels = labelNames(issue)
+  const parts = [
+    `\u{1F195} <b>New issue</b> #${issue.number} in <code>${repo.owner}/${repo.repo}</code>`,
+    escapeHtml(issue.title),
+  ]
+  const meta: string[] = []
+  if (issue.user?.login) meta.push(`by @${escapeHtml(issue.user.login)}`)
+  if (labels.length > 0) meta.push(labels.map(escapeHtml).join(', '))
+  if (meta.length > 0) parts.push(`<i>${meta.join(' · ')}</i>`)
+  parts.push(issue.html_url)
+  return parts.join('\n')
+}
+
+export interface RunIssueWatchDeps {
+  repo: GitHubRepo
+  githubToken: string
+  /** App auth, used to refresh the token once on a 401. Omit for PAT auth. */
+  auth?: GitHubAppAuth | null
+  kv?: KVLike | null
+  excludeLabels?: string[]
+  maxPerRun?: number
+  notify: (kind: NotifyKind, text: string) => Promise<boolean>
+  fetch?: typeof fetch
+  githubApiBase?: string
+  now?: () => number
+  logError?: (message: string, meta?: unknown) => void
+}
+
+export interface IssueWatchResult {
+  /** Issue numbers announced this run. */
+  notified: number[]
+  /** True when this run only recorded a starting cursor. */
+  seeded: boolean
+  /** Set when the per-run cap deferred issues to the next run. */
+  deferred?: number
+}
+
+/**
+ * Announce issues created since the stored cursor. Idempotent across runs via
+ * the KV cursor; without KV it can only seed (and logs why), because a watch
+ * with no memory would re-announce the same issues every 15 minutes.
+ */
+export async function runIssueWatch(
+  deps: RunIssueWatchDeps
+): Promise<IssueWatchResult> {
+  const fetchImpl = deps.fetch ?? fetch
+  const apiBase = deps.githubApiBase ?? 'https://api.github.com'
+  const cap = deps.maxPerRun ?? DEFAULT_MAX_PER_RUN
+  const now = deps.now ?? Date.now
+  const logError = deps.logError ?? ((m, meta) => console.error(m, meta))
+  const nowIso = new Date(now()).toISOString()
+
+  if (!deps.kv) {
+    logError(
+      '[cloud-hooks] issue watch needs CHM_HOOKS_KV for its cursor; skipping'
+    )
+    return { notified: [], seeded: false }
+  }
+
+  let cursor: string | null = null
+  try {
+    cursor = await deps.kv.get(ISSUE_CURSOR_KEY)
+  } catch (err) {
+    logError('[cloud-hooks] issue cursor read failed', err)
+    return { notified: [], seeded: false }
+  }
+
+  // First run: remember where we started, announce nothing (see header).
+  if (!cursor) {
+    try {
+      await deps.kv.put(ISSUE_CURSOR_KEY, nowIso)
+    } catch (err) {
+      logError('[cloud-hooks] issue cursor seed failed', err)
+    }
+    console.log(`[cloud-hooks] issue watch seeded at ${nowIso}`)
+    return { notified: [], seeded: true }
+  }
+
+  const result = await withTokenRefresh(
+    deps.auth ?? null,
+    (token) =>
+      fetchIssuesSince(deps.repo, token, cursor as string, fetchImpl, apiBase),
+    deps.githubToken
+  )
+  if (result.error || result.status === 0) {
+    logError('[cloud-hooks] issue list failed', {
+      status: result.status,
+      error: result.error,
+    })
+    return { notified: [], seeded: false }
+  }
+
+  const fresh = selectNewIssues(
+    result.issues,
+    cursor,
+    deps.excludeLabels ?? DEFAULT_EXCLUDE_LABELS
+  )
+  if (fresh.length === 0) return { notified: [], seeded: false }
+
+  // Oldest-first up to the cap; the cursor advances only past what we announce.
+  const batch = fresh.slice(0, cap)
+  const notified: number[] = []
+  for (const issue of batch) {
+    await deps.notify(ISSUE_NOTIFY_KIND, formatIssue(issue, deps.repo))
+    notified.push(issue.number)
+  }
+
+  const newest = batch[batch.length - 1]?.created_at
+  if (newest) {
+    try {
+      await deps.kv.put(ISSUE_CURSOR_KEY, newest)
+    } catch (err) {
+      // Leave the cursor alone — the next run re-announces at worst.
+      logError('[cloud-hooks] issue cursor write failed', err)
+    }
+  }
+
+  const deferred = fresh.length - batch.length
+  return {
+    notified,
+    seeded: false,
+    ...(deferred > 0 ? { deferred } : {}),
+  }
+}

--- a/apps/cloud-hooks/src/summary.test.ts
+++ b/apps/cloud-hooks/src/summary.test.ts
@@ -126,11 +126,34 @@ describe('formatDigest — sections degrade gracefully', () => {
 
   test('Clerk metrics add a Users section', () => {
     const msg = formatDigest(base, {
-      clerk: { totalUsers: 42, newUsers24h: 3 },
+      clerk: { totalUsers: 42, newUsers: 3, windowSeconds: 24 * 60 * 60 },
     })
     expect(msg).toContain('Users')
     expect(msg).toContain('42')
+    // The label is derived from windowSeconds, so it can never claim "24h"
+    // while reporting a differently-sized window.
     expect(msg).toContain('New in 24h: 3')
+  })
+
+  test('the Users label follows the window it was measured over', () => {
+    const msg = formatDigest(base, {
+      clerk: { totalUsers: 42, newUsers: 9, windowSeconds: 7 * 24 * 60 * 60 },
+    })
+    expect(msg).toContain('New in 7d: 9')
+  })
+
+  test('usage metrics add a Usage section reported as installs', () => {
+    const msg = formatDigest(base, {
+      usage: {
+        referenceDay: '2026-07-23',
+        dashboard: { dau: 10, wau: 40, mau: 120 },
+        cli: { dau: 2, wau: 5, mau: 11 },
+        cliInstalls24h: 3,
+      },
+    })
+    expect(msg).toContain('Usage')
+    expect(msg).toContain('DAU 10 · WAU 40 · MAU 120')
+    expect(msg).toContain('New CLI installs: 3')
   })
 
   test('a probe snapshot adds a Surfaces section flagging down surfaces', () => {

--- a/apps/cloud-hooks/src/summary.ts
+++ b/apps/cloud-hooks/src/summary.ts
@@ -8,6 +8,9 @@
  * never drift from the published prices.
  */
 
+import type { UsageMetrics } from './usage'
+
+import { usageLines } from './usage'
 import { BILLING_PLANS, type Plan, type PlanId } from '@chm/pricing'
 
 /** Minimal D1 subset used by the summary queries (adds `.all()`). */
@@ -44,7 +47,16 @@ export interface SummaryData {
 /** Optional Clerk user metrics (omitted from the digest when unavailable). */
 export interface ClerkMetrics {
   totalUsers: number
-  newUsers24h: number
+  /** Accounts created inside `windowSeconds` (24h for the daily digest, 7d for the weekly report). */
+  newUsers: number
+  /** Width of the "new users" window in seconds — the digest labels itself from this. */
+  windowSeconds: number
+}
+
+/** Render a window width as a compact label: 86400 → "24h", 604800 → "7d". */
+export function formatWindowLabel(seconds: number): string {
+  const hours = Math.round(seconds / 3600)
+  return hours < 48 ? `${hours}h` : `${Math.round(hours / 24)}d`
 }
 
 /** Optional per-surface probe snapshot (last-known up/down state). */
@@ -53,6 +65,8 @@ export type ProbeSnapshot = Record<string, 'up' | 'down'>
 export interface DigestExtras {
   clerk?: ClerkMetrics | null
   probes?: ProbeSnapshot | null
+  /** DAU/WAU/MAU from the telemetry D1 (see usage.ts). */
+  usage?: UsageMetrics | null
 }
 
 const ACTIVE_STATUSES = "('active','trialing')"
@@ -108,11 +122,14 @@ export function reduceSummary(
   }
 }
 
-/** Query D1 for the daily summary. `now` is unix seconds (injectable for tests). */
-export async function collectSummary(
-  db: D1SummaryDb,
-  now: number = Math.floor(Date.now() / 1000)
-): Promise<SummaryData> {
+/**
+ * Active subscriptions grouped by (plan, period) — the input to both the active
+ * counts and the MRR estimate. Shared with the weekly report so the two digests
+ * can never disagree about what "active" or "MRR" means.
+ */
+export async function queryPlanBreakdown(
+  db: D1SummaryDb
+): Promise<PlanBreakdownRow[]> {
   const breakdown = await db
     .prepare(
       `SELECT plan_id, billing_period, COUNT(*) AS n
@@ -122,6 +139,15 @@ export async function collectSummary(
     )
     .bind()
     .all<PlanBreakdownRow>()
+  return breakdown.results ?? []
+}
+
+/** Query D1 for the daily summary. `now` is unix seconds (injectable for tests). */
+export async function collectSummary(
+  db: D1SummaryDb,
+  now: number = Math.floor(Date.now() / 1000)
+): Promise<SummaryData> {
+  const breakdownRows = await queryPlanBreakdown(db)
 
   const since = now - 24 * 60 * 60
   const newRow = await db
@@ -155,7 +181,7 @@ export async function collectSummary(
     newByPlan[row.plan_id] = (newByPlan[row.plan_id] ?? 0) + row.n
   }
 
-  return reduceSummary(breakdown.results ?? [], newRow?.n ?? 0, {
+  return reduceSummary(breakdownRows, newRow?.n ?? 0, {
     newByPlan,
     cancellations24h: cancelRow?.n ?? 0,
   })
@@ -186,9 +212,12 @@ export function formatDigest(
       '',
       '\u{1F465} <b>Users</b>',
       `  • Total: ${extras.clerk.totalUsers}`,
-      `  • New in 24h: ${extras.clerk.newUsers24h}`
+      `  • New in ${formatWindowLabel(extras.clerk.windowSeconds)}: ${extras.clerk.newUsers}`
     )
   }
+
+  // ── Usage (telemetry D1) — DAU/WAU/MAU, omitted when unavailable ───────────
+  parts.push(...usageLines(extras.usage))
 
   // ── Subscriptions ───────────────────────────────────────────────────────────
   parts.push(

--- a/apps/cloud-hooks/src/telegram.ts
+++ b/apps/cloud-hooks/src/telegram.ts
@@ -19,8 +19,11 @@ export type NotifyKind =
   | 'payment_failure'
   | 'signature_failure'
   | 'daily_summary'
+  | 'weekly_summary'
   | 'probe'
   | 'error'
+  // A new GitHub issue opened on the repo (POST-less watch, ops cron).
+  | 'new_issue'
   // Clerk lifecycle events (POST /webhooks/clerk).
   | 'user_created'
   | 'session_created'
@@ -36,8 +39,15 @@ export const THROTTLE_MS: Record<NotifyKind, number> = {
   payment_failure: 5_000,
   // A misconfigured/spoofing source could hammer bad signatures — damp hard.
   signature_failure: 60_000,
-  // Scheduled once a day; the throttle is just a belt-and-braces dedupe.
+  // Scheduled once a day / once a week; the throttle is just a belt-and-braces
+  // dedupe against a double-fired cron.
   daily_summary: 60_000,
+  weekly_summary: 60_000,
+  // NOT throttled, deliberately. The issue watch already guarantees each issue
+  // is announced exactly once (its KV cursor only advances past what it sent),
+  // so a throttle here could not prevent a duplicate — it could only DROP the
+  // 2nd..Nth genuinely-distinct issue of a burst.
+  new_issue: 0,
   // Health transitions: avoid re-alerting on a flapping target within a window.
   probe: 30_000,
   error: 30_000,

--- a/apps/cloud-hooks/src/usage.test.ts
+++ b/apps/cloud-hooks/src/usage.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Usage metrics — window arithmetic, graceful degradation, and the digest block.
+ */
+
+import type { D1UsageDb } from './usage'
+
+import {
+  collectUsage,
+  formatActiveLine,
+  shiftDay,
+  stickiness,
+  usageLines,
+  utcDay,
+} from './usage'
+import { describe, expect, test } from 'bun:test'
+
+/** 2026-07-24T06:00:00Z — a mid-morning run, so "yesterday" is 2026-07-23. */
+const NOW = Math.floor(Date.parse('2026-07-24T06:00:00Z') / 1000)
+
+interface Call {
+  sql: string
+  binds: unknown[]
+}
+
+/**
+ * Fake D1 that dispatches on a substring of the SQL, so a test states only the
+ * rows it cares about and the assertions read against real query text.
+ */
+function fakeDb(
+  rows: Array<[match: string, row: unknown]>,
+  calls: Call[] = []
+): D1UsageDb & { calls: Call[] } {
+  return {
+    calls,
+    prepare(sql: string) {
+      return {
+        bind(...binds: unknown[]) {
+          return {
+            async first<T>() {
+              calls.push({ sql, binds })
+              const hit = rows.find(([match]) => sql.includes(match))
+              return (hit ? hit[1] : null) as T | null
+            },
+          }
+        },
+      }
+    },
+  }
+}
+
+describe('day arithmetic', () => {
+  test('utcDay formats a Date as the telemetry day key', () => {
+    expect(utcDay(new Date('2026-07-23T23:59:59Z'))).toBe('2026-07-23')
+  })
+
+  test('shiftDay walks backwards across a month boundary', () => {
+    expect(shiftDay('2026-07-01', -1)).toBe('2026-06-30')
+    expect(shiftDay('2026-03-01', -1)).toBe('2026-02-28')
+  })
+
+  test('a 7-day window is the reference day minus 6, inclusive', () => {
+    // Reference day INCLUDED in the window, so -6 gives 7 distinct days.
+    expect(shiftDay('2026-07-23', -6)).toBe('2026-07-17')
+    expect(shiftDay('2026-07-23', -29)).toBe('2026-06-24')
+  })
+})
+
+describe('stickiness', () => {
+  test('is DAU/MAU as a percentage with one decimal', () => {
+    expect(stickiness({ dau: 25, wau: 60, mau: 100 })).toBe(25)
+    expect(stickiness({ dau: 1, wau: 2, mau: 3 })).toBe(33.3)
+  })
+
+  test('is null (not 0%) when there is no monthly base to divide by', () => {
+    expect(stickiness({ dau: 0, wau: 0, mau: 0 })).toBeNull()
+  })
+})
+
+describe('collectUsage', () => {
+  test('measures every window back from YESTERDAY, not today', async () => {
+    const db = fakeDb([
+      ['ping_daily', { dau: 10, wau: 40, mau: 120 }],
+      ['cli_daily', { dau: 3, wau: 9, mau: 20 }],
+    ])
+    const usage = await collectUsage(db, NOW)
+
+    // The run is on the 24th; the last COMPLETE UTC day is the 23rd.
+    expect(usage?.referenceDay).toBe('2026-07-23')
+    const windowCall = db.calls.find((c) => c.sql.includes('ping_daily'))
+    expect(windowCall?.binds).toEqual([
+      '2026-07-23', // ?1 reference day
+      '2026-07-17', // ?2 week start
+      '2026-06-24', // ?3 month start
+    ])
+  })
+
+  test('reads dashboard and CLI streams into separate counts', async () => {
+    const db = fakeDb([
+      ['ping_daily', { dau: 10, wau: 40, mau: 120 }],
+      ["event = 'cli_install'", { n: 7 }],
+      ['cli_daily', { dau: 3, wau: 9, mau: 20 }],
+    ])
+    const usage = await collectUsage(db, NOW)
+
+    expect(usage?.dashboard).toEqual({ dau: 10, wau: 40, mau: 120 })
+    expect(usage?.cli).toEqual({ dau: 3, wau: 9, mau: 20 })
+    expect(usage?.cliInstalls24h).toBe(7)
+  })
+
+  test('excludes install-only rows from the CLI active count', async () => {
+    // cli_install rows can carry an ephemeral id, which would inflate DAU.
+    const db = fakeDb([['cli_daily', { dau: 3, wau: 9, mau: 20 }]])
+    await collectUsage(db, NOW)
+
+    const cliWindowCall = db.calls.find(
+      (c) => c.sql.includes('cli_daily') && c.sql.includes('COUNT(DISTINCT')
+    )
+    expect(cliWindowCall?.sql).toContain("event <> 'cli_install'")
+  })
+
+  test('returns null when the telemetry database is unbound', async () => {
+    expect(await collectUsage(null, NOW)).toBeNull()
+    expect(await collectUsage(undefined, NOW)).toBeNull()
+  })
+
+  test('returns null and logs when every query throws (never crashes the cron)', async () => {
+    const boom: D1UsageDb = {
+      prepare() {
+        return {
+          bind() {
+            return {
+              first<T>(): Promise<T | null> {
+                throw new Error('no such table: ping_daily')
+              },
+            }
+          },
+        }
+      },
+    }
+    const logged: string[] = []
+    expect(await collectUsage(boom, NOW, (m) => logged.push(m))).toBeNull()
+    // One line per failing stream — a silent null would hide a broken binding.
+    expect(logged.length).toBeGreaterThan(0)
+  })
+
+  test('still reports the stream that works when the other table is missing', async () => {
+    // cli_daily arrived in migration 0005; a database mid-migration must not
+    // take down the whole Usage section.
+    const partial: D1UsageDb = {
+      prepare(sql: string) {
+        return {
+          bind() {
+            return {
+              async first<T>(): Promise<T | null> {
+                if (sql.includes('cli_daily')) {
+                  throw new Error('no such table: cli_daily')
+                }
+                return { dau: 10, wau: 40, mau: 120 } as T
+              },
+            }
+          },
+        }
+      },
+    }
+    const usage = await collectUsage(partial, NOW, () => {})
+    expect(usage?.dashboard).toEqual({ dau: 10, wau: 40, mau: 120 })
+    expect(usage?.cli).toEqual({ dau: 0, wau: 0, mau: 0 })
+  })
+
+  test('treats missing rows as zero rather than failing', async () => {
+    const usage = await collectUsage(fakeDb([]), NOW)
+    expect(usage).toBeNull() // both streams absent → nothing to report
+  })
+})
+
+describe('digest block', () => {
+  test('labels the numbers as installs, with the measured day', () => {
+    const lines = usageLines({
+      referenceDay: '2026-07-23',
+      dashboard: { dau: 10, wau: 40, mau: 120 },
+      cli: { dau: 3, wau: 9, mau: 20 },
+      cliInstalls24h: 0,
+    })
+    const text = lines.join('\n')
+    // "installs" is not cosmetic: telemetry has no user identity, so calling
+    // these users would misreport the metric.
+    expect(text).toContain('installs, 2026-07-23')
+    expect(text).toContain('DAU 10 · WAU 40 · MAU 120')
+    expect(text).not.toContain('New CLI installs') // omitted at 0
+  })
+
+  test('is empty when usage is unavailable so the caller can spread it', () => {
+    expect(usageLines(null)).toEqual([])
+  })
+
+  test('omits stickiness when there is no monthly base', () => {
+    expect(formatActiveLine('CLI', { dau: 0, wau: 0, mau: 0 })).not.toContain(
+      'stickiness'
+    )
+  })
+})

--- a/apps/cloud-hooks/src/usage.ts
+++ b/apps/cloud-hooks/src/usage.ts
@@ -1,0 +1,217 @@
+/**
+ * Usage metrics (DAU / WAU / MAU) read from the telemetry D1 (`chm_telemetry`,
+ * bound as CHM_TELEMETRY_DB — the same database apps/telemetry writes).
+ *
+ * IMPORTANT — what these numbers mean. The telemetry store is deliberately
+ * anonymous: `ping_daily` holds one deduped row per (UTC day, opaque install
+ * hash) and `cli_daily` one per (day, install, event, command). There is no
+ * user identity in either table, so these are **active installs**, NOT active
+ * humans, and every label in the digest says "installs" for that reason. Clerk
+ * account counts (clerk-metrics.ts) remain the user-level figure.
+ *
+ * Windows end on the last COMPLETE UTC day. The daily digest fires at 00:00 UTC
+ * when "today" has barely started; counting it would report a near-zero DAU
+ * every morning. So `referenceDay` is yesterday and every window is measured
+ * back from it.
+ *
+ * Best-effort like the rest of the worker: an unbound database, a missing
+ * table, or a query error logs one line and returns null, and the digest simply
+ * omits the Usage section.
+ */
+
+/** Minimal D1 subset used here (mirrors `D1SummaryDb` in summary.ts). */
+export interface D1UsageDb {
+  prepare(sql: string): {
+    bind(...values: unknown[]): {
+      first<T = unknown>(): Promise<T | null>
+    }
+  }
+}
+
+/** DAU/WAU/MAU for one telemetry stream. */
+export interface ActiveCounts {
+  /** Distinct installs active on the reference day. */
+  dau: number
+  /** Distinct installs active in the 7 days ending on the reference day. */
+  wau: number
+  /** Distinct installs active in the 30 days ending on the reference day. */
+  mau: number
+}
+
+export interface UsageMetrics {
+  /** Last complete UTC day the windows are measured back from ('YYYY-MM-DD'). */
+  referenceDay: string
+  /** Dashboard installs (`ping_daily`). */
+  dashboard: ActiveCounts
+  /** CLI installs (`cli_daily`), excluding install-only rows. */
+  cli: ActiveCounts
+  /** New CLI installs recorded on the reference day (`event = 'cli_install'`). */
+  cliInstalls24h: number
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/** Format a Date as a UTC 'YYYY-MM-DD' day key, matching the telemetry schema. */
+export function utcDay(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
+
+/** Shift a 'YYYY-MM-DD' day key by `days` (negative = earlier). */
+export function shiftDay(day: string, days: number): string {
+  return utcDay(new Date(Date.parse(`${day}T00:00:00Z`) + days * DAY_MS))
+}
+
+/**
+ * Stickiness — DAU as a percentage of MAU, the standard "how many of this
+ * month's installs showed up today" ratio. Returns null when MAU is 0 so the
+ * digest can omit it rather than print a meaningless 0%.
+ */
+export function stickiness(counts: ActiveCounts): number | null {
+  if (counts.mau <= 0) return null
+  return Math.round((counts.dau / counts.mau) * 1000) / 10
+}
+
+interface WindowRow {
+  dau: number | null
+  wau: number | null
+  mau: number | null
+}
+
+/**
+ * One pass over a day-partitioned table yields all three windows: SQLite counts
+ * distinct ids per window with a CASE inside COUNT(DISTINCT …), so we scan the
+ * 30-day range once instead of issuing three separate queries.
+ *
+ * `idColumn` and `table` are interpolated, never user input — they are the two
+ * literals below. `extraWhere` is likewise a fixed fragment.
+ */
+async function countWindows(
+  db: D1UsageDb,
+  table: string,
+  idColumn: string,
+  referenceDay: string,
+  extraWhere = ''
+): Promise<ActiveCounts | null> {
+  const weekStart = shiftDay(referenceDay, -6)
+  const monthStart = shiftDay(referenceDay, -29)
+  const row = await db
+    .prepare(
+      `SELECT
+         COUNT(DISTINCT CASE WHEN day = ?1 THEN ${idColumn} END) AS dau,
+         COUNT(DISTINCT CASE WHEN day >= ?2 THEN ${idColumn} END) AS wau,
+         COUNT(DISTINCT ${idColumn}) AS mau
+       FROM ${table}
+      WHERE day >= ?3 AND day <= ?1${extraWhere}`
+    )
+    .bind(referenceDay, weekStart, monthStart)
+    .first<WindowRow>()
+  if (!row) return null
+  return { dau: row.dau ?? 0, wau: row.wau ?? 0, mau: row.mau ?? 0 }
+}
+
+/**
+ * Run one query, converting any failure into null. Each stream is isolated on
+ * purpose: `cli_daily` is a newer table than `ping_daily`, so a database that
+ * is mid-migration should still report the stream that does exist instead of
+ * dropping the whole Usage section. It also keeps a failure from surfacing as
+ * an unhandled rejection when several queries are in flight together.
+ */
+async function safeQuery<T>(
+  run: () => Promise<T | null>,
+  label: string,
+  logError: (message: string, meta?: unknown) => void
+): Promise<T | null> {
+  try {
+    return await run()
+  } catch (err) {
+    logError(`[cloud-hooks] usage query failed (${label})`, err)
+    return null
+  }
+}
+
+/**
+ * Collect DAU/WAU/MAU for both telemetry streams. `now` is unix seconds
+ * (injectable for tests). Returns null when the database is unbound or every
+ * stream query fails; a single failing stream degrades to zeroes.
+ */
+export async function collectUsage(
+  db: D1UsageDb | null | undefined,
+  now: number = Math.floor(Date.now() / 1000),
+  logError: (message: string, meta?: unknown) => void = (m, meta) =>
+    console.error(m, meta)
+): Promise<UsageMetrics | null> {
+  if (!db) {
+    console.log('[cloud-hooks] CHM_TELEMETRY_DB unbound; digest omits usage')
+    return null
+  }
+  // Yesterday — the last complete UTC day (see the module header).
+  const referenceDay = utcDay(new Date((now - 24 * 60 * 60) * 1000))
+
+  const [dashboard, cli, installRow] = await Promise.all([
+    safeQuery(
+      () => countWindows(db, 'ping_daily', 'instance_hash', referenceDay),
+      'ping_daily',
+      logError
+    ),
+    // `cli_install` rows can carry an ephemeral id (see migration 0005), so
+    // they would inflate a distinct-install count. Active CLI usage is the
+    // run/diagnose events only.
+    safeQuery(
+      () =>
+        countWindows(
+          db,
+          'cli_daily',
+          'install_id',
+          referenceDay,
+          " AND event <> 'cli_install'"
+        ),
+      'cli_daily',
+      logError
+    ),
+    safeQuery(
+      () =>
+        db
+          .prepare(
+            `SELECT COUNT(*) AS n FROM cli_daily
+              WHERE day = ?1 AND event = 'cli_install'`
+          )
+          .bind(referenceDay)
+          .first<{ n: number }>(),
+      'cli_installs',
+      logError
+    ),
+  ])
+
+  if (!dashboard && !cli) return null
+  return {
+    referenceDay,
+    dashboard: dashboard ?? { dau: 0, wau: 0, mau: 0 },
+    cli: cli ?? { dau: 0, wau: 0, mau: 0 },
+    cliInstalls24h: installRow?.n ?? 0,
+  }
+}
+
+/** One "DAU x · WAU y · MAU z (stickiness s%)" line for a stream. */
+export function formatActiveLine(label: string, counts: ActiveCounts): string {
+  const stick = stickiness(counts)
+  const tail = stick === null ? '' : ` · stickiness ${stick}%`
+  return `  • ${label}: DAU ${counts.dau} · WAU ${counts.wau} · MAU ${counts.mau}${tail}`
+}
+
+/**
+ * The Usage block of a digest. Returns [] when there is nothing to report so
+ * the caller can spread it into the message unconditionally.
+ */
+export function usageLines(usage: UsageMetrics | null | undefined): string[] {
+  if (!usage) return []
+  const lines = [
+    '',
+    `\u{1F4C8} <b>Usage</b> <i>(installs, ${usage.referenceDay})</i>`,
+    formatActiveLine('Dashboard', usage.dashboard),
+    formatActiveLine('CLI', usage.cli),
+  ]
+  if (usage.cliInstalls24h > 0) {
+    lines.push(`  • New CLI installs: ${usage.cliInstalls24h}`)
+  }
+  return lines
+}

--- a/apps/cloud-hooks/src/weekly.test.ts
+++ b/apps/cloud-hooks/src/weekly.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Weekly report — equal-length comparison windows, trend rendering, degradation.
+ */
+
+import type { D1SummaryDb } from './summary'
+
+import {
+  collectWeekly,
+  formatTrend,
+  formatWeekly,
+  startOfUtcDay,
+  WEEK,
+  weekBounds,
+} from './weekly'
+import { describe, expect, test } from 'bun:test'
+
+/** Monday 2026-07-27T01:00:00Z — when the weekly cron fires. */
+const NOW = Math.floor(Date.parse('2026-07-27T01:00:00Z') / 1000)
+
+interface Call {
+  sql: string
+  binds: unknown[]
+}
+
+function fakeDb(
+  counts: Record<string, number> = {},
+  planRows: unknown[] = [],
+  calls: Call[] = []
+): D1SummaryDb & { calls: Call[] } {
+  return {
+    calls,
+    prepare(sql: string) {
+      return {
+        bind(...binds: unknown[]) {
+          return {
+            async all<T>() {
+              calls.push({ sql, binds })
+              return { results: planRows as T[] }
+            },
+            async first<T>() {
+              calls.push({ sql, binds })
+              const kind = sql.includes('canceled') ? 'cancel' : 'new'
+              const key = `${kind}:${binds[0]}`
+              return { n: counts[key] ?? 0 } as T
+            },
+          }
+        },
+      }
+    },
+  }
+}
+
+describe('week bounds', () => {
+  test('anchors on start-of-today, not the moment the cron ran', () => {
+    // The 01:00 run time must not shift the window, or the two periods would
+    // be misaligned against the day-granular data.
+    expect(startOfUtcDay(NOW)).toBe(
+      Math.floor(Date.parse('2026-07-27T00:00:00Z') / 1000)
+    )
+  })
+
+  test('produces two adjacent windows of exactly equal length', () => {
+    const { prevStart, start, end } = weekBounds(NOW)
+    expect(end - start).toBe(WEEK)
+    expect(start - prevStart).toBe(WEEK)
+    // Adjacent, non-overlapping: last week ends exactly where this week starts.
+    expect(start).toBe(prevStart + WEEK)
+  })
+
+  test('reports the 7 complete days before the run', async () => {
+    const data = await collectWeekly(fakeDb(), NOW)
+    // Run on Monday the 27th → covers Mon 20th through Sun 26th.
+    expect(data.weekStart).toBe('2026-07-20')
+    expect(data.weekEnd).toBe('2026-07-26')
+  })
+})
+
+describe('collectWeekly', () => {
+  test('compares this week against the previous week on the same query', async () => {
+    const { prevStart, start } = weekBounds(NOW)
+    const db = fakeDb({
+      [`new:${start}`]: 5,
+      [`new:${prevStart}`]: 2,
+      [`cancel:${start}`]: 1,
+      [`cancel:${prevStart}`]: 3,
+    })
+    const data = await collectWeekly(db, NOW)
+
+    expect(data.newSubscriptions).toEqual({ current: 5, previous: 2 })
+    expect(data.cancellations).toEqual({ current: 1, previous: 3 })
+  })
+
+  test('derives active counts and MRR from the shared plan breakdown', async () => {
+    const db = fakeDb({}, [
+      { plan_id: 'pro', billing_period: 'monthly', n: 2 },
+      { plan_id: 'pro', billing_period: 'yearly', n: 1 },
+    ])
+    const data = await collectWeekly(db, NOW)
+
+    expect(data.billing.totalActive).toBe(3)
+    expect(data.billing.byPlan.pro).toBe(3)
+    // Non-zero MRR proves the shared pricing math ran (yearly ÷ 12 included).
+    expect(data.billing.mrrUsd).toBeGreaterThan(0)
+  })
+})
+
+describe('formatTrend', () => {
+  test('shows direction and delta against last week', () => {
+    expect(formatTrend({ current: 5, previous: 2 })).toBe('5 (▲ +3 vs 2)')
+    expect(formatTrend({ current: 1, previous: 3 })).toBe('1 (▼ -2 vs 3)')
+  })
+
+  test('says flat rather than "+0"', () => {
+    expect(formatTrend({ current: 4, previous: 4 })).toBe('4 (flat vs 4)')
+  })
+
+  test('omits a meaningless comparison against an empty previous week', () => {
+    expect(formatTrend({ current: 3, previous: 0 })).toBe('3')
+    expect(formatTrend({ current: 0, previous: 0 })).toBe('0')
+  })
+})
+
+describe('formatWeekly', () => {
+  const data = {
+    weekStart: '2026-07-20',
+    weekEnd: '2026-07-26',
+    billing: {
+      totalActive: 3,
+      byPlan: { pro: 3 },
+      newLast24h: 0,
+      newByPlan: {},
+      cancellations24h: 0,
+      mrrUsd: 87,
+    },
+    newSubscriptions: { current: 5, previous: 2 },
+    cancellations: { current: 1, previous: 3 },
+  }
+
+  test('always reports the period and the billing core', () => {
+    const text = formatWeekly(data)
+    expect(text).toContain('2026-07-20 → 2026-07-26')
+    expect(text).toContain('New this week: 5 (▲ +3 vs 2)')
+    expect(text).toContain('$87.00')
+  })
+
+  test('omits every optional section when its source is unavailable', () => {
+    const text = formatWeekly(data)
+    expect(text).not.toContain('Users')
+    expect(text).not.toContain('Usage')
+    expect(text).not.toContain('Issues')
+    expect(text).not.toContain('Surfaces')
+  })
+
+  test('includes optional sections when their sources answered', () => {
+    const text = formatWeekly(data, {
+      clerk: { totalUsers: 40, newUsers: 6, windowSeconds: 7 * 86400 },
+      usage: {
+        referenceDay: '2026-07-26',
+        dashboard: { dau: 10, wau: 40, mau: 120 },
+        cli: { dau: 2, wau: 5, mau: 11 },
+        cliInstalls24h: 0,
+      },
+      issues: { opened: 9, closed: 4 },
+      probes: { dashboard: 'up', docs: 'down' },
+    })
+
+    expect(text).toContain('New in 7d: 6') // window label follows the window
+    expect(text).toContain('DAU 10')
+    expect(text).toContain('Opened: 9')
+    expect(text).toContain('1 down')
+  })
+})

--- a/apps/cloud-hooks/src/weekly.ts
+++ b/apps/cloud-hooks/src/weekly.ts
@@ -1,0 +1,205 @@
+/**
+ * Weekly report — the Monday-morning counterpart to the daily digest.
+ *
+ * The daily digest answers "what happened yesterday". This answers "is the
+ * trend up or down", so every headline number is paired with the SAME number
+ * from the previous week. A bare "3 new subscriptions" tells the operator
+ * nothing; "3 (▲ +1 vs 2)" does.
+ *
+ * Window: the 7 complete UTC days before the run — i.e. `[start-of-today − 7d,
+ * start-of-today)`, with the comparison period the 7 days before that. Anchoring
+ * on start-of-today rather than "now" keeps the two periods exactly equal in
+ * length, which is what makes the comparison honest.
+ *
+ * Reuses `queryPlanBreakdown` + `reduceSummary` from summary.ts so the active
+ * counts and the MRR estimate are computed identically in both reports.
+ */
+
+import type { IssueStats } from './issues'
+import type {
+  ClerkMetrics,
+  D1SummaryDb,
+  ProbeSnapshot,
+  SummaryData,
+} from './summary'
+import type { UsageMetrics } from './usage'
+
+import { formatWindowLabel, queryPlanBreakdown, reduceSummary } from './summary'
+import { usageLines } from './usage'
+
+const DAY = 24 * 60 * 60
+export const WEEK = 7 * DAY
+
+/** A count this period alongside the same count last period. */
+export interface Trend {
+  current: number
+  previous: number
+}
+
+export interface WeeklyData {
+  /** Inclusive first day of the reported week ('YYYY-MM-DD', UTC). */
+  weekStart: string
+  /** Inclusive last day of the reported week ('YYYY-MM-DD', UTC). */
+  weekEnd: string
+  /** Active subscriptions, plan breakdown, and MRR as of now. */
+  billing: SummaryData
+  newSubscriptions: Trend
+  cancellations: Trend
+}
+
+export interface WeeklyExtras {
+  clerk?: ClerkMetrics | null
+  usage?: UsageMetrics | null
+  probes?: ProbeSnapshot | null
+  issues?: IssueStats | null
+}
+
+/** Start of the UTC day containing `now` (unix seconds), as unix seconds. */
+export function startOfUtcDay(now: number): number {
+  return Math.floor(now / DAY) * DAY
+}
+
+function utcDayString(unixSeconds: number): string {
+  return new Date(unixSeconds * 1000).toISOString().slice(0, 10)
+}
+
+/**
+ * The four boundaries the report needs, all unix seconds:
+ * `[prevStart, start)` is last week and `[start, end)` is this week.
+ */
+export function weekBounds(now: number): {
+  prevStart: number
+  start: number
+  end: number
+} {
+  const end = startOfUtcDay(now)
+  return { end, start: end - WEEK, prevStart: end - 2 * WEEK }
+}
+
+/**
+ * Render a trend as "current (▲ +delta vs previous)". Flat periods print "flat"
+ * rather than "+0", and a first-ever week (no previous data) prints the bare
+ * number instead of a meaningless "▲ +3 vs 0".
+ */
+export function formatTrend(trend: Trend): string {
+  const delta = trend.current - trend.previous
+  if (trend.previous === 0 && trend.current === 0) return '0'
+  if (trend.previous === 0) return `${trend.current}`
+  if (delta === 0) return `${trend.current} (flat vs ${trend.previous})`
+  const arrow = delta > 0 ? '\u{25B2}' : '\u{25BC}' // ▲ ▼
+  const sign = delta > 0 ? '+' : ''
+  return `${trend.current} (${arrow} ${sign}${delta} vs ${trend.previous})`
+}
+
+/** Count rows in a half-open window on one timestamp column. */
+async function countBetween(
+  db: D1SummaryDb,
+  sql: string,
+  from: number,
+  to: number
+): Promise<number> {
+  const row = await db.prepare(sql).bind(from, to).first<{ n: number }>()
+  return row?.n ?? 0
+}
+
+const NEW_SUBS_SQL = `SELECT COUNT(*) AS n FROM user_subscriptions
+   WHERE created_at >= ?1 AND created_at < ?2`
+const CANCELS_SQL = `SELECT COUNT(*) AS n FROM user_subscriptions
+   WHERE status IN ('canceled','revoked') AND updated_at >= ?1 AND updated_at < ?2`
+
+/** Query D1 for the weekly report. `now` is unix seconds (injectable). */
+export async function collectWeekly(
+  db: D1SummaryDb,
+  now: number = Math.floor(Date.now() / 1000)
+): Promise<WeeklyData> {
+  const { prevStart, start, end } = weekBounds(now)
+
+  const [rows, newCur, newPrev, cancelCur, cancelPrev] = await Promise.all([
+    queryPlanBreakdown(db),
+    countBetween(db, NEW_SUBS_SQL, start, end),
+    countBetween(db, NEW_SUBS_SQL, prevStart, start),
+    countBetween(db, CANCELS_SQL, start, end),
+    countBetween(db, CANCELS_SQL, prevStart, start),
+  ])
+
+  return {
+    weekStart: utcDayString(start),
+    // `end` is exclusive (start of today), so the last reported day is end-1s.
+    weekEnd: utcDayString(end - 1),
+    billing: reduceSummary(rows, newCur),
+    newSubscriptions: { current: newCur, previous: newPrev },
+    cancellations: { current: cancelCur, previous: cancelPrev },
+  }
+}
+
+function planLines(byPlan: Record<string, number>): string {
+  const lines = Object.entries(byPlan)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([plan, n]) => `  • ${plan}: ${n}`)
+    .join('\n')
+  return lines || '  (none)'
+}
+
+/**
+ * Compact Telegram-HTML weekly report. Every optional section degrades to
+ * omitted, exactly like the daily digest.
+ */
+export function formatWeekly(
+  data: WeeklyData,
+  extras: WeeklyExtras = {}
+): string {
+  const parts: string[] = [
+    '\u{1F5D3}\u{FE0F} <b>chmonitor weekly report</b>',
+    `<i>${data.weekStart} → ${data.weekEnd}</i>`,
+  ]
+
+  if (extras.clerk) {
+    parts.push(
+      '',
+      '\u{1F465} <b>Users</b>',
+      `  • Total: ${extras.clerk.totalUsers}`,
+      `  • New in ${formatWindowLabel(extras.clerk.windowSeconds)}: ${extras.clerk.newUsers}`
+    )
+  }
+
+  parts.push(...usageLines(extras.usage))
+
+  parts.push(
+    '',
+    '\u{1F4B3} <b>Subscriptions</b>',
+    `  • Active: ${data.billing.totalActive}`,
+    planLines(data.billing.byPlan),
+    `  • New this week: ${formatTrend(data.newSubscriptions)}`,
+    `  • Cancellations: ${formatTrend(data.cancellations)}`,
+    `  • Estimated MRR: <b>$${data.billing.mrrUsd.toFixed(2)}</b>`
+  )
+
+  if (extras.issues) {
+    parts.push(
+      '',
+      '\u{1F41E} <b>Issues</b>',
+      `  • Opened: ${extras.issues.opened}`,
+      `  • Closed: ${extras.issues.closed}`
+    )
+  }
+
+  if (extras.probes && Object.keys(extras.probes).length > 0) {
+    const entries = Object.entries(extras.probes).sort(([a], [b]) =>
+      a.localeCompare(b)
+    )
+    const down = entries.filter(([, s]) => s === 'down')
+    parts.push(
+      '',
+      `\u{1F310} <b>Surfaces</b> — ${
+        down.length === 0 ? '\u{2705} all up' : `\u{1F534} ${down.length} down`
+      }`,
+      entries
+        .map(
+          ([name, s]) => `  ${s === 'up' ? '\u{1F7E2}' : '\u{1F534}'} ${name}`
+        )
+        .join('\n')
+    )
+  }
+
+  return parts.join('\n')
+}

--- a/apps/cloud-hooks/wrangler.toml
+++ b/apps/cloud-hooks/wrangler.toml
@@ -42,6 +42,13 @@
 #   CHM_EXCEPTION_MAX_ISSUES_PER_RUN  rate cap, default 5
 #   CHM_EXCEPTION_SCRIPTS             default `chmonitor-dash,chmonitor-hooks`
 #
+# New-issue watch (non-secret, optional — reuses the GitHub auth above and the
+# KV cursor `issue-watch:v1:last-created`; no extra credentials needed):
+#   CHM_ISSUE_WATCH_EXCLUDE_LABELS    default `cloudflare-exception` (those
+#                                     issues are announced by the exception scan)
+#   CHM_ISSUE_WATCH_MAX_PER_RUN       per-sweep cap, default 10 (the remainder is
+#                                     announced on the next run, never dropped)
+#
 # No GitHub auth (neither App creds nor GITHUB_TOKEN), or CF_OBSERVABILITY_API_TOKEN
 # / CF_ACCOUNT_ID unset → the exception-scan capability logs one line and no-ops
 # (never crashes).
@@ -68,10 +75,15 @@ minify = true
 [observability]
 enabled = true
 
-# Cron triggers: daily billing summary + the 15-min ops sweep (full-surface
-# health probes AND the Cloudflare exception → GitHub issue scan).
+# Cron triggers. These strings are matched CHARACTER FOR CHARACTER in
+# src/index.ts (DAILY_CRON / WEEKLY_CRON) — reformatting one here without
+# updating it there silently downgrades that report to the ops sweep.
+#   "0 0 * * *"      daily digest — billing + Clerk users + DAU/WAU/MAU
+#   "0 1 * * 1"      weekly report — week-over-week trends + issue throughput
+#   "*/15 * * * *"   ops sweep — health probes, Worker exceptions → GitHub
+#                    issues, and new GitHub issues → Telegram
 [triggers]
-crons = ["0 0 * * *", "*/15 * * * *"]
+crons = ["0 0 * * *", "0 1 * * 1", "*/15 * * * *"]
 
 # Custom domain — auto-provisions the hooks.chmonitor.dev DNS record on the
 # managed zone (same pattern as the dashboard's dash.chmonitor.dev). The
@@ -87,6 +99,16 @@ custom_domain = true
 binding = "CHM_CLOUD_D1"
 database_name = "chm-cloud"
 database_id = "cca247b6-9b25-41bd-b9ca-727b35bc6039"
+
+# Telemetry D1 (the database apps/telemetry writes) — READ-ONLY here, for the
+# DAU/WAU/MAU section of the daily digest and weekly report. `ping_daily` and
+# `cli_daily` hold one deduped row per (UTC day, opaque install id), so those
+# are ACTIVE INSTALLS, not active users; the digests label them accordingly.
+# No migrations_dir: apps/telemetry owns the schema, this worker only reads it.
+[[d1_databases]]
+binding = "CHM_TELEMETRY_DB"
+database_name = "chm_telemetry"
+database_id = "4887176b-0181-45bf-970f-a506f514d5a9"
 
 # Ops-state KV. `runProbes` (src/probes.ts) stores the last-known up/down state
 # per surface so the */15min cron notifies ONLY on transitions; `runExceptions`
@@ -111,6 +133,11 @@ name = "preview-chmonitor-hooks"
 binding = "CHM_CLOUD_D1"
 database_name = "chm-cloud"
 database_id = "cca247b6-9b25-41bd-b9ca-727b35bc6039"
+
+[[env.preview.d1_databases]]
+binding = "CHM_TELEMETRY_DB"
+database_name = "chm_telemetry"
+database_id = "4887176b-0181-45bf-970f-a506f514d5a9"
 
 [[env.preview.kv_namespaces]]
 binding = "CHM_HOOKS_KV"

--- a/docs/knowledge/cloud-hooks-worker.md
+++ b/docs/knowledge/cloud-hooks-worker.md
@@ -2,8 +2,23 @@
 id: cloud-hooks-worker
 type: spec
 related: [billing-checkout-flow, cloud-saas-mode, bug-handler-email-worker, deployment]
-tags: [cloud-hooks, polar, clerk, webhook, telegram, cron, cloudflare, billing, d1]
-updated: 2026-07-12
+tags:
+  [
+    cloud-hooks,
+    polar,
+    clerk,
+    webhook,
+    telegram,
+    cron,
+    cloudflare,
+    billing,
+    d1,
+    dau,
+    mau,
+    telemetry,
+    issues,
+  ]
+updated: 2026-07-25
 ---
 
 # Cloud-hooks worker (Polar webhooks + ops notifications)
@@ -31,11 +46,20 @@ Clerk ──► POST hooks.chmonitor.dev/webhooks/clerk
        1/user/6h) · 🏢 organization.created.  Unknown events → 202, ignored.
 
 cron
-  ├─ "0 0 * * *"      → daily digest → Telegram (users + subs + surfaces)
+  ├─ "0 0 * * *"      → daily digest → Telegram
+  │                      (users + DAU/WAU/MAU + subs + surfaces)
+  ├─ "0 1 * * 1"      → weekly report → Telegram (Mon 01:00 UTC)
+  │                      (same sections week-over-week + issue throughput)
   └─ every 15 minutes → ops sweep:
         ├─ full-surface health probes → Telegram on transitions
-        └─ Cloudflare Worker exceptions → new GitHub issue + Telegram
+        ├─ Cloudflare Worker exceptions → new GitHub issue + Telegram
+        └─ new GitHub issues (KV cursor) → Telegram
 ```
+
+The cron strings are matched **character for character** in `index.ts`
+(`DAILY_CRON` / `WEEKLY_CRON`). Editing one in `wrangler.toml` without the other
+does not error — the report silently falls through to the ops-sweep branch and
+stops being sent. `src/cron.test.ts` compares the two sources to catch that.
 
 ## Shared core, not a copy
 
@@ -104,10 +128,44 @@ The same `chm-cloud` D1 is bound into both Workers; the monotonic
   plan, new signups in 24h **+ new subs by plan and cancellations/revokes in
   24h**) and computes an MRR estimate from `BILLING_PLANS` (`@chm/pricing`) —
   yearly normalized to price/12. `formatDigest(data, { clerk, probes })` renders
-  a compact Telegram-HTML digest with **Users** (from Clerk metrics),
-  **Subscriptions**, and **Surfaces** (probe snapshot) sections — each section
-  omitted when its optional source is unavailable. Pure `reduceSummary`/
-  `mrrForGroup`/`formatDigest` are unit-tested.
+  a compact Telegram-HTML digest with **Users** (from Clerk metrics), **Usage**
+  (DAU/WAU/MAU), **Subscriptions**, and **Surfaces** (probe snapshot) sections —
+  each section omitted when its optional source is unavailable. Pure
+  `reduceSummary`/`mrrForGroup`/`formatDigest` are unit-tested.
+  `queryPlanBreakdown` is shared with `weekly.ts` so the two reports can never
+  disagree about what "active" or "MRR" means.
+- `usage.ts` — `collectUsage`: **DAU / WAU / MAU** from the telemetry D1
+  (`CHM_TELEMETRY_DB` → `chm_telemetry`, read-only). One query per stream
+  computes all three windows via `COUNT(DISTINCT CASE WHEN day = … END)`, so the
+  30-day range is scanned once instead of three times. **These are active
+  INSTALLS, not users** — `ping_daily`/`cli_daily` hold one deduped row per (UTC
+  day, opaque install id) and carry no user identity, so every line is labelled
+  "installs"; Clerk remains the user-level figure. Windows end on the **last
+  complete UTC day** (yesterday), because the digest cron fires at 00:00 UTC and
+  counting the day that just started would report a near-zero DAU every morning.
+  `cli_install` rows are excluded from the CLI active count (they can carry an
+  ephemeral id, which would inflate it) and reported separately as new installs.
+  Each stream query is isolated, so a missing table degrades that stream to zero
+  instead of dropping the whole section.
+- `weekly.ts` — `collectWeekly` + `formatWeekly`: the Monday counterpart to the
+  daily digest. Every headline number is paired with the **same number from the
+  previous week** (`formatTrend` → `5 (▲ +3 vs 2)`; "flat" instead of "+0", and a
+  bare number when there is no previous data to compare against). `weekBounds`
+  anchors on **start-of-today**, not the run instant, so the two periods are
+  exactly equal in length and adjacent — the property the comparison depends on.
+  Adds an **Issues** section (opened/closed, via `fetchIssueStats`).
+- `issues.ts` — `runIssueWatch`: announces **new GitHub issues** on the ops
+  sweep. Read-only — it files nothing. Three rules carry the design: (1) the
+  first run **seeds** the KV cursor (`issue-watch:v1:last-created`) and announces
+  nothing, so enabling it on a repo with a backlog does not flood the chat;
+  (2) GitHub's `since` filters on `updated_at`, so results are **re-filtered on
+  `created_at`** — otherwise a comment on an old issue reads as a new issue;
+  (3) the per-run cap **defers rather than drops** — the cursor only advances
+  past what was actually announced, so the remainder arrives next sweep. PRs and
+  `cloudflare-exception`-labelled issues (already announced by the exception
+  scan) are filtered out. Titles are HTML-escaped for Telegram's parse mode.
+  `fetchIssueStats` counts issues opened/closed since a day via the search API
+  for the weekly report; failure → null → section omitted.
 - `clerk-webhook.ts` — `handleClerkWebhook` + `verifyClerkWebhook`: the Clerk
   lifecycle receiver. Verifies the **Svix** signature manually (HMAC-SHA256 over
   WebCrypto — the same wire scheme Clerk's `verifyWebhook` uses, without the
@@ -116,10 +174,13 @@ The same `chm-cloud` D1 is bound into both Workers; the monotonic
   `CHM_HOOKS_KV` (`clerk-signin:v1:<user>`, 6h TTL). 501 unset secret, 403 bad
   sig, 202 otherwise; unknown events acknowledged and ignored; Telegram errors
   never fail the ack.
-- `clerk-metrics.ts` — `fetchClerkMetrics`: best-effort total + new-in-24h user
-  counts via the Clerk Backend REST `GET /v1/users/count` (with
-  `created_at_after`) using `CLERK_SECRET_KEY`. Missing key / non-2xx / error →
-  `null` → the digest omits the Users section.
+- `clerk-metrics.ts` — `fetchClerkMetrics`: best-effort total + new-in-window
+  user counts via the Clerk Backend REST `GET /v1/users/count` (with
+  `created_at_after`) using `CLERK_SECRET_KEY`. `windowSeconds` (24h daily, 7d
+  weekly) is **carried on the result** so `formatWindowLabel` renders the label
+  from the same value that produced the number — the label cannot claim "24h"
+  while reporting a week. Missing key / non-2xx / error → `null` → the digest
+  omits the Users section.
 - `polar-notify.ts` — pure `classifyTransition` (prior plan + new plan + status
   → new/upgrade/downgrade/cancel/revoke/past-due) + `formatPolarNotify` (plan
   name, monthly value from `@chm/pricing`, period). The webhook reads the prior
@@ -132,22 +193,31 @@ The same `chm-cloud` D1 is bound into both Workers; the monotonic
 - `webhook.ts` — `handlePolarWebhook`: `validateEvent` (injectable for tests) →
   core → `notify`. 403 + `signature_failure` alert on a bad signature; 202 on a
   handled event; unhandled types are acknowledged silently.
-- `index.ts` — `fetch` router (`/webhooks/polar`, `/webhooks/clerk`, `/healthz`) + `scheduled`
-  (routes the daily cron to the summary; the 15-min cron to the ops sweep —
-  probes **and** `runExceptions`). `runExceptions` gates on
-  `GITHUB_TOKEN` + `CF_OBSERVABILITY_API_TOKEN` + `CF_ACCOUNT_ID`: any missing →
-  one log line, no-op (never a crash).
+- `index.ts` — `fetch` router (`/webhooks/polar`, `/webhooks/clerk`, `/healthz`) +
+  `scheduled` (daily cron → digest, weekly cron → weekly report, everything else
+  → the ops sweep: probes, `runExceptions`, `runIssues`). `resolveGitHub(env,
+  label)` centralizes credential checks, repo parsing, and token minting for the
+  three GitHub-backed capabilities (exception scan, issue watch, weekly issue
+  stats); it returns null after one explanatory log line when GitHub is not
+  configured. `runExceptions` additionally gates on `CF_OBSERVABILITY_API_TOKEN`
+  + `CF_ACCOUNT_ID`: any missing → one log line, no-op (never a crash).
 
 ## Config (`wrangler.toml`)
 
 - `name = chmonitor-hooks`, custom domain `hooks.chmonitor.dev` (auto-provisions
-  DNS on the managed zone), crons `["0 0 * * *", "*/15 * * * *"]`.
+  DNS on the managed zone), crons `["0 0 * * *", "0 1 * * 1", "*/15 * * * *"]`.
 - D1 binding `CHM_CLOUD_D1` → `chm-cloud` (`database_id`
   `cca247b6-9b25-41bd-b9ca-727b35bc6039`, same as the dashboard).
+- D1 binding `CHM_TELEMETRY_DB` → `chm_telemetry` (`database_id`
+  `4887176b-0181-45bf-970f-a506f514d5a9`, the database `apps/telemetry` writes) —
+  **read-only** here, for the Usage section. No `migrations_dir`: `apps/telemetry`
+  owns that schema. Unbound → the Usage section is omitted.
 - `CHM_HOOKS_KV` KV binding is **active** (id `a1d9bd2c4377493eac5b5d4ad04dcc34`) —
-  it stores both per-probe up/down state and exception fingerprints
-  (`exc-fp:v1:<fp>`). Absent → probes fall back to per-run state and the
-  exception scan leans on the GitHub search fallback alone. Follows the `CHM_`
+  it stores per-probe up/down state, exception fingerprints (`exc-fp:v1:<fp>`),
+  and the new-issue watch cursor (`issue-watch:v1:last-created`). Absent → probes
+  fall back to per-run state, the exception scan leans on the GitHub search
+  fallback alone, and the **issue watch skips entirely** (a watch with no memory
+  would re-announce the same issues every 15 minutes). Follows the `CHM_`
   binding-naming rule (like `CHM_CLOUD_D1`).
 - **No secrets, no product-id vars committed.** Secrets set via
   `wrangler secret put` (CI does this, skipping any that are unset):
@@ -168,6 +238,9 @@ The same `chm-cloud` D1 is bound into both Workers; the monotonic
   `CHM_EXCEPTION_ISSUE_LABELS` (`bug,cloudflare-exception`),
   `CHM_EXCEPTION_MAX_ISSUES_PER_RUN` (`5`), `CHM_EXCEPTION_SCRIPTS`
   (`chmonitor-dash,chmonitor-hooks`).
+- **New-issue watch config** (non-secret, optional — reuses the GitHub auth and
+  KV above, no extra credentials): `CHM_ISSUE_WATCH_EXCLUDE_LABELS`
+  (`cloudflare-exception`), `CHM_ISSUE_WATCH_MAX_PER_RUN` (`10`).
 
 ## GitHub App auth setup (issue creation)
 


### PR DESCRIPTION
Extends the cloud-hooks Telegram notifications so chmonitor can be monitored without polling anything. Subscription events already alerted (Polar webhook); this adds the usage, trend, and issue signals that were missing.

## What's new

| Signal | Cadence | Source |
|---|---|---|
| **DAU / WAU / MAU** | daily digest + weekly report | telemetry D1 (`chm_telemetry`), new read-only binding |
| **Weekly report** | Mondays 01:00 UTC (new cron) | billing D1 + Clerk + telemetry + GitHub |
| **New GitHub issues** | 15-min ops sweep | GitHub REST, KV cursor |

## Design notes

**Usage numbers are active _installs_, not users.** `ping_daily` / `cli_daily` hold one deduped row per (UTC day, opaque install id) and carry no user identity — so every line is labelled "installs" and Clerk stays the user-level count. Calling them users would misstate the metric.

**Windows end on the last complete UTC day.** The digest cron fires at 00:00 UTC; counting the day that just started would report a near-zero DAU every morning.

**One query per stream, not three.** `COUNT(DISTINCT CASE WHEN day = ?1 THEN id END)` computes DAU/WAU/MAU in a single scan of the 30-day range.

**Weekly comparisons use two adjacent, equal-length windows** anchored on start-of-today rather than the run instant — that equality is what makes `5 (▲ +3 vs 2)` honest. Flat weeks read "flat", and a first-ever week prints the bare number instead of a meaningless "▲ +3 vs 0".

**The issue watch has three rules that carry the design:**
1. First run **seeds** the KV cursor and announces nothing — enabling it on a repo with a backlog must not dump it into the chat.
2. GitHub's `since` filters on `updated_at`, so results are re-filtered on `created_at` — otherwise a comment on a 2024 issue reads as a new issue.
3. The per-run cap **defers, never drops** — the cursor only advances past what was actually announced.

`new_issue` is deliberately **not** throttled: the cursor already guarantees exactly-once, so a throttle could only drop the 2nd..Nth genuinely-distinct issue of a burst.

## Incidental cleanups

- `ClerkMetrics` now carries the window it was measured over, so the digest label can't claim "24h" while reporting a week.
- `queryPlanBreakdown` is shared by both reports — active counts and MRR can't diverge.
- GitHub credential resolution centralized in `resolveGitHub` now that three jobs need a token.

## Graceful degradation

Every new section omits itself when its source is unavailable (telemetry D1 unbound, no Clerk key, no GitHub creds, no KV). A partially-configured deploy still sends a useful digest; nothing throws into a cron.

## Verification

- `bun test src/ --isolate` — **146 pass, 0 fail** (13 files; 45 new tests)
- `tsc --noEmit` clean, `biome check` clean
- `wrangler deploy --minify --dry-run` builds and resolves both D1 bindings

New `src/cron.test.ts` guards the one coupling that fails silently: the cron strings are duplicated between `wrangler.toml` and the routing in `index.ts`, and a drift there doesn't error — it just quietly stops sending that report.

## Operator note

No new secrets. The telemetry D1 binding is in `wrangler.toml`; `CHM_ISSUE_WATCH_*` are optional with defaults baked in.