### PR TITLE
feat(cloud-hooks): outage escalation, error spikes, DAU anomaly + fix dropped alerts

### DIFF
--- a/apps/cloud-hooks/src/activation.test.ts
+++ b/apps/cloud-hooks/src/activation.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Activation — the signup → connected-a-cluster conversion line.
+ */
+
+import type { D1SummaryDb } from './summary'
+
+import {
+  activationLines,
+  activationRate,
+  collectActivation,
+  isStalled,
+  STALL_MIN_SIGNUPS,
+} from './activation'
+import { describe, expect, test } from 'bun:test'
+
+const SINCE = Math.floor(Date.parse('2026-07-24T00:00:00Z') / 1000)
+
+function fakeDb(row: unknown): D1SummaryDb {
+  return {
+    prepare() {
+      return {
+        bind() {
+          return {
+            async all<T>() {
+              return { results: [] as T[] }
+            },
+            async first<T>() {
+              return row as T
+            },
+          }
+        },
+      }
+    },
+  }
+}
+
+describe('activationRate', () => {
+  test('is activated users over signups', () => {
+    expect(
+      activationRate({ newConnections: 5, activatedUsers: 3, signups: 8 })
+    ).toBe(37.5)
+  })
+
+  test('is null without a denominator, rather than a misleading 0%', () => {
+    expect(
+      activationRate({ newConnections: 0, activatedUsers: 0, signups: 0 })
+    ).toBeNull()
+    expect(
+      activationRate({ newConnections: 2, activatedUsers: 1, signups: null })
+    ).toBeNull()
+  })
+})
+
+describe('isStalled', () => {
+  test('flags signups with nobody connecting anything', () => {
+    expect(
+      isStalled({
+        newConnections: 0,
+        activatedUsers: 0,
+        signups: STALL_MIN_SIGNUPS,
+      })
+    ).toBe(true)
+  })
+
+  test('does not flag a quiet day with one or two signups', () => {
+    // At tiny volumes "nobody connected" is ordinary, not a broken funnel.
+    expect(
+      isStalled({ newConnections: 0, activatedUsers: 0, signups: 1 })
+    ).toBe(false)
+  })
+
+  test('does not flag when someone did connect', () => {
+    expect(
+      isStalled({ newConnections: 1, activatedUsers: 1, signups: 10 })
+    ).toBe(false)
+  })
+})
+
+describe('collectActivation', () => {
+  test('counts connections and the distinct users behind them', async () => {
+    const data = await collectActivation(fakeDb({ n: 5, users: 3 }), SINCE, 8)
+    expect(data).toEqual({
+      newConnections: 5,
+      activatedUsers: 3,
+      signups: 8,
+    })
+  })
+
+  test('returns null without a database', async () => {
+    expect(await collectActivation(null, SINCE, 8)).toBeNull()
+  })
+
+  test('returns null and logs on a query failure', async () => {
+    const boom: D1SummaryDb = {
+      prepare() {
+        return {
+          bind() {
+            return {
+              all<T>(): Promise<{ results: T[] }> {
+                throw new Error('nope')
+              },
+              first<T>(): Promise<T | null> {
+                throw new Error('no such table: user_connections')
+              },
+            }
+          },
+        }
+      },
+    }
+    const logged: string[] = []
+    expect(
+      await collectActivation(boom, SINCE, 8, (m) => logged.push(m))
+    ).toBeNull()
+    expect(logged).toHaveLength(1)
+  })
+})
+
+describe('activationLines', () => {
+  test('reports the rate against signups', () => {
+    const text = activationLines({
+      newConnections: 5,
+      activatedUsers: 3,
+      signups: 8,
+    }).join('\n')
+    expect(text).toContain('Activation')
+    expect(text).toContain('3 of 8 signups (37.5%)')
+  })
+
+  test('calls out a stalled funnel explicitly', () => {
+    const text = activationLines({
+      newConnections: 0,
+      activatedUsers: 0,
+      signups: 6,
+    }).join('\n')
+    expect(text).toContain('6 signups, zero connected')
+  })
+
+  test('is empty when unavailable so the caller can spread it', () => {
+    expect(activationLines(null)).toEqual([])
+  })
+})

--- a/apps/cloud-hooks/src/activation.ts
+++ b/apps/cloud-hooks/src/activation.ts
@@ -1,0 +1,107 @@
+/**
+ * Activation — do the people who sign up ever connect a cluster?
+ *
+ * A signup that never adds a connection got nothing from the product. That is
+ * the single most diagnostic number for a self-serve tool, and it is invisible
+ * in a digest that reports signups and subscriptions separately: signups can
+ * look healthy while every one of them bounces off a broken connection form.
+ *
+ * Measured from `user_connections` in the billing D1 (rows created in the
+ * window, and how many DISTINCT users they belong to) against the Clerk signup
+ * count the digest already fetches. Deliberately a digest line rather than its
+ * own alert — it is a trend to watch, not an incident — EXCEPT for the
+ * stalled case below, which is flagged inline.
+ */
+
+import type { D1SummaryDb } from './summary'
+
+export interface ActivationData {
+  /** Connections created in the window. */
+  newConnections: number
+  /** Distinct users who created at least one connection in the window. */
+  activatedUsers: number
+  /** Signups in the same window, when known (Clerk). */
+  signups: number | null
+}
+
+/**
+ * Activated users as a percentage of signups. Null when signups are unknown or
+ * zero — a rate needs a denominator, and "0%" of nothing is misleading.
+ */
+export function activationRate(data: ActivationData): number | null {
+  if (data.signups === null || data.signups <= 0) return null
+  return Math.round((data.activatedUsers / data.signups) * 1000) / 10
+}
+
+/**
+ * The case worth flagging: people signed up and NOT ONE of them connected
+ * anything. With a handful of signups that is ordinary noise, so it only counts
+ * as stalled once enough people have tried.
+ */
+export const STALL_MIN_SIGNUPS = 3
+
+export function isStalled(data: ActivationData): boolean {
+  return (
+    data.signups !== null &&
+    data.signups >= STALL_MIN_SIGNUPS &&
+    data.activatedUsers === 0
+  )
+}
+
+/**
+ * Count connections created in `[since, now)`. `since` is unix seconds.
+ * Returns null on failure so the digest omits the section.
+ */
+export async function collectActivation(
+  db: D1SummaryDb | null | undefined,
+  since: number,
+  signups: number | null,
+  logError: (message: string, meta?: unknown) => void = (m, meta) =>
+    console.error(m, meta)
+): Promise<ActivationData | null> {
+  if (!db) return null
+  try {
+    const row = await db
+      .prepare(
+        `SELECT COUNT(*) AS n, COUNT(DISTINCT user_id) AS users
+           FROM user_connections
+          WHERE created_at >= ?1`
+      )
+      .bind(since)
+      .first<{ n: number; users: number }>()
+    if (!row) return null
+    return {
+      newConnections: row.n ?? 0,
+      activatedUsers: row.users ?? 0,
+      signups,
+    }
+  } catch (err) {
+    logError('[cloud-hooks] activation query failed', err)
+    return null
+  }
+}
+
+/**
+ * The Activation block of a digest. Returns [] when unavailable so the caller
+ * can spread it unconditionally.
+ */
+export function activationLines(
+  data: ActivationData | null | undefined
+): string[] {
+  if (!data) return []
+  const rate = activationRate(data)
+  const lines = [
+    '',
+    `\u{1F331} <b>Activation</b>`,
+    `  • Connected a cluster: ${data.activatedUsers}${
+      rate === null ? '' : ` of ${data.signups} signups (${rate}%)`
+    }`,
+    `  • New connections: ${data.newConnections}`,
+  ]
+  if (isStalled(data)) {
+    lines.push(
+      `  \u{26A0}\u{FE0F} <b>${data.signups} signups, zero connected</b> — check the connection flow`
+    )
+  }
+  return lines
+}

--- a/apps/cloud-hooks/src/anomaly.test.ts
+++ b/apps/cloud-hooks/src/anomaly.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Usage anomaly detection — the guards that keep this from crying wolf.
+ */
+
+import {
+  DEFAULT_DROP_THRESHOLD,
+  detectAnomaly,
+  formatAnomaly,
+  MIN_BASELINE,
+  median,
+} from './anomaly'
+import { describe, expect, test } from 'bun:test'
+
+const REF = '2026-07-24'
+
+/** A flat baseline of `n` for the 7 days before REF, plus REF at `current`. */
+function series(baselineValue: number, current: number) {
+  const days = [
+    '2026-07-17',
+    '2026-07-18',
+    '2026-07-19',
+    '2026-07-20',
+    '2026-07-21',
+    '2026-07-22',
+    '2026-07-23',
+  ]
+  return [
+    ...days.map((day) => ({ day, n: baselineValue })),
+    { day: REF, n: current },
+  ]
+}
+
+describe('median', () => {
+  test('is the middle value, and averages the middle pair when even', () => {
+    expect(median([5, 1, 3])).toBe(3)
+    expect(median([1, 2, 3, 4])).toBe(2.5)
+  })
+
+  test('is 0 for an empty list', () => {
+    expect(median([])).toBe(0)
+  })
+})
+
+describe('detectAnomaly', () => {
+  test('flags a drop past the threshold', () => {
+    const anomaly = detectAnomaly(series(100, 50), REF)
+    expect(anomaly?.kind).toBe('drop')
+    expect(anomaly?.changePct).toBe(-50)
+    expect(anomaly?.baseline).toBe(100)
+  })
+
+  test('stays silent for ordinary day-to-day movement', () => {
+    // 15% down is a Tuesday, not an incident.
+    expect(detectAnomaly(series(100, 85), REF)).toBeNull()
+  })
+
+  test('uses the median so one viral day cannot poison the baseline', () => {
+    // A single 1000-install spike would drag a MEAN to ~230 and make a normal
+    // 100 look like a 57% collapse. The median ignores it.
+    const withSpike = [
+      { day: '2026-07-17', n: 100 },
+      { day: '2026-07-18', n: 100 },
+      { day: '2026-07-19', n: 1000 },
+      { day: '2026-07-20', n: 100 },
+      { day: '2026-07-21', n: 100 },
+      { day: REF, n: 100 },
+    ]
+    expect(detectAnomaly(withSpike, REF)).toBeNull()
+  })
+
+  test('ignores baselines too small for a percentage to mean anything', () => {
+    // 3 → 1 is "-67%" and is pure noise.
+    expect(detectAnomaly(series(3, 1), REF)).toBeNull()
+    // Right at the floor it starts reporting.
+    expect(detectAnomaly(series(MIN_BASELINE, 0), REF)?.kind).toBe('drop')
+  })
+
+  test('treats a missing reference day as zero — silence IS the signal', () => {
+    // No row for yesterday means nothing reported at all: telemetry is down.
+    const noToday = series(100, 0).filter((row) => row.day !== REF)
+    const anomaly = detectAnomaly(noToday, REF)
+    expect(anomaly?.kind).toBe('drop')
+    expect(anomaly?.current).toBe(0)
+  })
+
+  test('flags a large spike but needs a much bigger move than a drop', () => {
+    expect(detectAnomaly(series(100, 200), REF)).toBeNull() // 2x — not yet
+    expect(detectAnomaly(series(100, 300), REF)?.kind).toBe('spike')
+  })
+
+  test('returns null when there is no baseline to compare against', () => {
+    expect(detectAnomaly([{ day: REF, n: 5 }], REF)).toBeNull()
+    expect(detectAnomaly([], REF)).toBeNull()
+  })
+
+  test('honours a caller-supplied threshold', () => {
+    expect(
+      detectAnomaly(series(100, 85), REF, { dropThreshold: 0.1 })?.kind
+    ).toBe('drop')
+    expect(DEFAULT_DROP_THRESHOLD).toBe(0.3)
+  })
+})
+
+describe('formatAnomaly', () => {
+  test('a drop states the magnitude and what usually causes it', () => {
+    const text = formatAnomaly({
+      kind: 'drop',
+      current: 50,
+      baseline: 100,
+      changePct: -50,
+      referenceDay: REF,
+    })
+    expect(text).toContain('dropped 50%')
+    expect(text).toContain('baseline 100')
+    expect(text).toContain('broken release')
+  })
+
+  test('a spike is phrased as news, not an incident', () => {
+    const text = formatAnomaly({
+      kind: 'spike',
+      current: 300,
+      baseline: 100,
+      changePct: 200,
+      referenceDay: REF,
+    })
+    expect(text).toContain('up 200%')
+    expect(text).not.toContain('broken')
+  })
+})

--- a/apps/cloud-hooks/src/anomaly.ts
+++ b/apps/cloud-hooks/src/anomaly.ts
@@ -1,0 +1,161 @@
+/**
+ * Usage anomaly detection — alert when DAU moves far enough from its own recent
+ * behaviour to mean something broke.
+ *
+ * The daily digest reports DAU as a number, which is passive: it only helps if
+ * someone reads it and remembers what yesterday's number was. A collapse in
+ * active installs almost always means a broken release, a broken telemetry
+ * endpoint, or an outage nobody caught — all things worth interrupting someone
+ * for. So we compare yesterday against the days before it and alert on the
+ * deviation, not the value.
+ *
+ * Design choices that keep this from crying wolf:
+ *
+ * - **Median baseline, not mean.** One viral day (an HN front page) would drag a
+ *   mean up for a week and make every following day look like a 40% collapse.
+ *   The median ignores it.
+ * - **A minimum baseline.** Below `MIN_BASELINE` installs, normal jitter is a
+ *   huge percentage — 3 → 1 is "-67%" and means nothing. Small numbers stay
+ *   silent.
+ * - **Drops only, by default.** A spike is interesting but not urgent; a
+ *   collapse is. Spikes are surfaced with a lower-key message and a much higher
+ *   threshold, since a genuine 3× spike is usually good news worth knowing.
+ */
+
+import { shiftDay } from './usage'
+
+/**
+ * Minimal D1 subset for the day-series query. Declared here rather than reused
+ * from `usage.ts` because this query needs `.all()` (a row per day) where the
+ * usage queries need `.first()`.
+ */
+export interface D1SeriesDb {
+  prepare(sql: string): {
+    bind(...values: unknown[]): {
+      all<T = unknown>(): Promise<{ results: T[] }>
+    }
+  }
+}
+
+/** Fraction below baseline that counts as a drop (0.3 = 30% down). */
+export const DEFAULT_DROP_THRESHOLD = 0.3
+/** Multiple of baseline that counts as a spike. */
+export const DEFAULT_SPIKE_MULTIPLE = 3
+/** Baselines below this are too small for a percentage to be meaningful. */
+export const MIN_BASELINE = 10
+/** How many prior days form the baseline. */
+export const BASELINE_DAYS = 7
+
+export interface DailyCount {
+  day: string
+  n: number
+}
+
+export interface Anomaly {
+  kind: 'drop' | 'spike'
+  /** The value observed on the reference day. */
+  current: number
+  /** Median of the baseline window. */
+  baseline: number
+  /** Signed change vs baseline as a percentage, rounded to one decimal. */
+  changePct: number
+  referenceDay: string
+}
+
+/** Median of a numeric list. Returns 0 for an empty list. */
+export function median(values: number[]): number {
+  if (values.length === 0) return 0
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid]
+}
+
+export interface DetectOptions {
+  dropThreshold?: number
+  spikeMultiple?: number
+  minBaseline?: number
+}
+
+/**
+ * Compare the reference day against the median of the preceding days. Pure, so
+ * every threshold decision is testable without a database. Returns null when
+ * nothing is worth reporting — including when the baseline is too small to
+ * judge.
+ */
+export function detectAnomaly(
+  series: DailyCount[],
+  referenceDay: string,
+  opts: DetectOptions = {}
+): Anomaly | null {
+  const dropThreshold = opts.dropThreshold ?? DEFAULT_DROP_THRESHOLD
+  const spikeMultiple = opts.spikeMultiple ?? DEFAULT_SPIKE_MULTIPLE
+  const minBaseline = opts.minBaseline ?? MIN_BASELINE
+
+  const currentRow = series.find((row) => row.day === referenceDay)
+  // A missing reference day is itself a signal: zero installs reported.
+  const current = currentRow?.n ?? 0
+
+  const baselineDays = series.filter((row) => row.day !== referenceDay)
+  if (baselineDays.length === 0) return null
+
+  const baseline = median(baselineDays.map((row) => row.n))
+  if (baseline < minBaseline) return null
+
+  const changePct = Math.round(((current - baseline) / baseline) * 1000) / 10
+
+  if (current <= baseline * (1 - dropThreshold)) {
+    return { kind: 'drop', current, baseline, changePct, referenceDay }
+  }
+  if (current >= baseline * spikeMultiple) {
+    return { kind: 'spike', current, baseline, changePct, referenceDay }
+  }
+  return null
+}
+
+/**
+ * Daily distinct-install counts for the baseline window plus the reference day.
+ * Returns [] on any failure — the caller then simply skips detection rather
+ * than alerting on a database error.
+ */
+export async function fetchDailySeries(
+  db: D1SeriesDb,
+  referenceDay: string,
+  days: number = BASELINE_DAYS,
+  logError: (message: string, meta?: unknown) => void = (m, meta) =>
+    console.error(m, meta)
+): Promise<DailyCount[]> {
+  const from = shiftDay(referenceDay, -days)
+  try {
+    const rows = await db
+      .prepare(
+        `SELECT day, COUNT(DISTINCT instance_hash) AS n
+           FROM ping_daily
+          WHERE day >= ?1 AND day <= ?2
+          GROUP BY day
+          ORDER BY day`
+      )
+      .bind(from, referenceDay)
+      .all<DailyCount>()
+    return rows.results ?? []
+  } catch (err) {
+    logError('[cloud-hooks] daily series query failed', err)
+    return []
+  }
+}
+
+export function formatAnomaly(anomaly: Anomaly): string {
+  if (anomaly.kind === 'drop') {
+    return [
+      `\u{1F4C9} <b>Active installs dropped ${Math.abs(anomaly.changePct)}%</b>`,
+      `  • ${anomaly.referenceDay}: <b>${anomaly.current}</b> (baseline ${anomaly.baseline})`,
+      '',
+      '<i>Usually a broken release, a broken telemetry endpoint, or an outage.</i>',
+    ].join('\n')
+  }
+  return [
+    `\u{1F680} <b>Active installs up ${anomaly.changePct}%</b>`,
+    `  • ${anomaly.referenceDay}: <b>${anomaly.current}</b> (baseline ${anomaly.baseline})`,
+  ].join('\n')
+}

--- a/apps/cloud-hooks/src/exceptions.test.ts
+++ b/apps/cloud-hooks/src/exceptions.test.ts
@@ -7,9 +7,13 @@ import type { WorkerException } from './observability'
 
 import {
   buildExceptionIssue,
+  isSpike,
   type KVLike,
   parseRepo,
   runExceptionScan,
+  SPIKE_COOLDOWN_MS,
+  SPIKE_MIN_COUNT,
+  SPIKE_MULTIPLE,
 } from './exceptions'
 import { describe, expect, mock, test } from 'bun:test'
 
@@ -172,5 +176,97 @@ describe('runExceptionScan — rate cap', () => {
     })
     expect(res.filed).toHaveLength(2)
     expect(res.cappedAt).toBe(2)
+  })
+})
+
+describe('spike detection (a KNOWN error getting much louder)', () => {
+  const NOW = 1_800_000_000_000
+
+  test('ignores low counts however large the multiple', () => {
+    // 2 → 6 is a 3x jump and still means nothing.
+    expect(isSpike(6, { count: 2, alertedAt: 0 }, NOW)).toBe(false)
+  })
+
+  test('fires when a loud error multiplies against its last count', () => {
+    const previous = { count: SPIKE_MIN_COUNT, alertedAt: 0 }
+    expect(isSpike(SPIKE_MIN_COUNT * SPIKE_MULTIPLE, previous, NOW)).toBe(true)
+    expect(isSpike(SPIKE_MIN_COUNT * 2, previous, NOW)).toBe(false)
+  })
+
+  test('holds off while the cooldown is running', () => {
+    // One ongoing incident must not re-alert every 15 minutes.
+    const justAlerted = { count: 10, alertedAt: NOW - 60_000 }
+    expect(isSpike(1_000, justAlerted, NOW)).toBe(false)
+    const stale = { count: 10, alertedAt: NOW - SPIKE_COOLDOWN_MS - 1 }
+    expect(isSpike(1_000, stale, NOW)).toBe(true)
+  })
+
+  test('with no history, needs to be loud on its own to fire', () => {
+    expect(isSpike(SPIKE_MIN_COUNT, null, NOW)).toBe(false)
+    expect(isSpike(SPIKE_MIN_COUNT * SPIKE_MULTIPLE, null, NOW)).toBe(true)
+  })
+
+  test('a known fingerprint spikes without filing a duplicate issue', async () => {
+    // The whole point: the issue already exists, so the scan skips it — but the
+    // volume change is exactly the thing worth knowing about.
+    const store = new Map<string, string>([['exc-fp:v1:deadbeef', 'seen']])
+    const kv: KVLike = {
+      async get(k) {
+        return store.get(k) ?? null
+      },
+      async put(k, v) {
+        store.set(k, v)
+      },
+    }
+    const createIssue = mock(async () => new Response('{}', { status: 201 }))
+    const notified: string[] = []
+
+    const res = await runExceptionScan({
+      repo,
+      githubToken: 't',
+      fetchExceptions: async () => [exc({ count: 500 })],
+      kv,
+      notify: async (_kind, text) => {
+        notified.push(text)
+        return true
+      },
+      fetch: createIssue as unknown as typeof fetch,
+      now: () => NOW,
+    })
+
+    expect(res.filed).toEqual([])
+    expect(res.skipped).toEqual(['deadbeef'])
+    expect(createIssue).not.toHaveBeenCalled()
+    expect(notified.join('\n')).toContain('Known error spiking')
+    // The new count becomes the baseline for next time.
+    expect(JSON.parse(store.get('exc-rate:v1:deadbeef') as string).count).toBe(
+      500
+    )
+  })
+
+  test('a known fingerprint at normal volume stays silent', async () => {
+    const store = new Map<string, string>([['exc-fp:v1:deadbeef', 'seen']])
+    const kv: KVLike = {
+      async get(k) {
+        return store.get(k) ?? null
+      },
+      async put(k, v) {
+        store.set(k, v)
+      },
+    }
+    const notify = mock(async () => true)
+
+    await runExceptionScan({
+      repo,
+      githubToken: 't',
+      fetchExceptions: async () => [exc({ count: 3 })],
+      kv,
+      notify,
+      fetch: mock(
+        async () => new Response('{}', { status: 200 })
+      ) as unknown as typeof fetch,
+      now: () => NOW,
+    })
+    expect(notify).not.toHaveBeenCalled()
   })
 })

--- a/apps/cloud-hooks/src/exceptions.ts
+++ b/apps/cloud-hooks/src/exceptions.ts
@@ -25,6 +25,59 @@ const KV_PREFIX = 'exc-fp:v1:'
 const DEFAULT_MAX_ISSUES_PER_RUN = 5
 const MAX_TITLE_LEN = 256
 
+// ── Spike detection ─────────────────────────────────────────────────────────
+// Fingerprint dedup is permanent by design: an error is filed once and never
+// re-filed. The blind spot is that a KNOWN error which suddenly fires 100× more
+// often is completely silent — it was already filed, so it is skipped. That is
+// usually the more urgent event: a latent bug that just became everyone's
+// problem. So on every skip we also compare this window's occurrence count
+// against the last count we saw for that fingerprint.
+const RATE_PREFIX = 'exc-rate:v1:'
+/** Below this many occurrences, a multiple is just noise (2 → 6 is not news). */
+export const SPIKE_MIN_COUNT = 25
+/** How many times the previous count qualifies as a spike. */
+export const SPIKE_MULTIPLE = 3
+/** Do not re-alert about the same fingerprint spiking within this window. */
+export const SPIKE_COOLDOWN_MS = 6 * 60 * 60 * 1000
+
+/** Per-fingerprint spike memory. */
+export interface RateRecord {
+  count: number
+  alertedAt: number
+}
+
+/**
+ * Is this window's count a spike against the previous one? Pure, so the
+ * thresholds are testable without KV. Requires BOTH an absolute floor and a
+ * relative jump, and respects a cooldown so one ongoing incident does not
+ * re-alert every 15 minutes.
+ */
+export function isSpike(
+  current: number,
+  previous: RateRecord | null,
+  now: number
+): boolean {
+  if (current < SPIKE_MIN_COUNT) return false
+  // No history: only alert if it is already loud on its own.
+  if (!previous) return current >= SPIKE_MIN_COUNT * SPIKE_MULTIPLE
+  if (now - previous.alertedAt < SPIKE_COOLDOWN_MS) return false
+  if (previous.count <= 0) return current >= SPIKE_MIN_COUNT * SPIKE_MULTIPLE
+  return current >= previous.count * SPIKE_MULTIPLE
+}
+
+/** The Telegram message for a known error that is suddenly much louder. */
+export function formatSpike(
+  exc: WorkerException,
+  previous: RateRecord | null
+): string {
+  const was = previous ? ` (was ${previous.count})` : ''
+  return [
+    `\u{1F4C8} <b>Known error spiking</b> in <code>${exc.script}</code>`,
+    `${exc.count} occurrences this window${was}`,
+    exc.message,
+  ].join('\n')
+}
+
 export interface GitHubRepo {
   owner: string
   repo: string
@@ -209,6 +262,8 @@ export interface RunExceptionScanDeps {
   notify: (kind: NotifyKind, text: string) => Promise<boolean>
   fetch?: typeof fetch
   githubApiBase?: string
+  /** Epoch ms, injectable so the spike cooldown is testable. */
+  now?: () => number
   logError?: (message: string, meta?: unknown) => void
 }
 
@@ -219,6 +274,48 @@ export interface ExceptionScanResult {
   skipped: string[]
   /** Whether the run hit the per-run rate cap. */
   cappedAt?: number
+}
+
+/**
+ * Compare a known fingerprint's current occurrence count against the last one
+ * we recorded, alert if it spiked, and always store the new count so the
+ * baseline tracks reality. Never throws — spike detection is an enhancement,
+ * not a reason to fail a scan.
+ */
+async function checkSpike(
+  deps: RunExceptionScanDeps,
+  exc: WorkerException,
+  now: number,
+  logError: (message: string, meta?: unknown) => void
+): Promise<void> {
+  if (!deps.kv) return
+  const key = `${RATE_PREFIX}${exc.fingerprint}`
+  let previous: RateRecord | null = null
+  try {
+    const raw = await deps.kv.get(key)
+    if (raw) previous = JSON.parse(raw) as RateRecord
+  } catch (err) {
+    logError('[cloud-hooks] exception rate read failed', { err })
+  }
+
+  const spiking = isSpike(exc.count, previous, now)
+  if (spiking) {
+    await deps.notify(EXCEPTION_NOTIFY_KIND, formatSpike(exc, previous))
+  }
+
+  try {
+    await deps.kv.put(
+      key,
+      JSON.stringify({
+        count: exc.count,
+        // Only move the cooldown clock when we actually alerted, so a quiet
+        // update cannot postpone the next real alert.
+        alertedAt: spiking ? now : (previous?.alertedAt ?? 0),
+      } satisfies RateRecord)
+    )
+  } catch (err) {
+    logError('[cloud-hooks] exception rate write failed', { err })
+  }
 }
 
 /**
@@ -233,6 +330,7 @@ export async function runExceptionScan(
   const labels = deps.labels ?? ['bug', 'cloudflare-exception']
   const cap = deps.maxIssuesPerRun ?? DEFAULT_MAX_ISSUES_PER_RUN
   const logError = deps.logError ?? ((m, meta) => console.error(m, meta))
+  const now = (deps.now ?? Date.now)()
 
   const filed: string[] = []
   const skipped: string[] = []
@@ -257,6 +355,9 @@ export async function runExceptionScan(
       try {
         if (await deps.kv.get(kvKey)) {
           skipped.push(exc.fingerprint)
+          // Known error: no new issue, but check whether it just got much
+          // louder — that is the event this scan would otherwise miss entirely.
+          await checkSpike(deps, exc, now, logError)
           continue
         }
       } catch (err) {

--- a/apps/cloud-hooks/src/index.ts
+++ b/apps/cloud-hooks/src/index.ts
@@ -19,6 +19,8 @@ import type { Env } from './env'
 import type { GitHubRepo } from './exceptions'
 import type { GitHubAppAuth } from './github-app'
 
+import { collectActivation } from './activation'
+import { detectAnomaly, fetchDailySeries, formatAnomaly } from './anomaly'
 import { fetchClerkMetrics, WEEK_SECONDS } from './clerk-metrics'
 import { handleClerkWebhook } from './clerk-webhook'
 import { parseRepo, runExceptionScan } from './exceptions'
@@ -28,7 +30,7 @@ import { fetchWorkerExceptions } from './observability'
 import { readProbeSnapshot, runProbes } from './probes'
 import { collectSummary, formatDigest } from './summary'
 import { Notifier } from './telegram'
-import { collectUsage } from './usage'
+import { collectUsage, utcDay } from './usage'
 import { handlePolarWebhook } from './webhook'
 import { collectWeekly, formatWeekly, weekBounds } from './weekly'
 
@@ -102,27 +104,63 @@ async function resolveGitHub(
   }
 }
 
+/**
+ * Alert when yesterday's active installs diverge sharply from their own recent
+ * baseline. Sent as its OWN message rather than a digest line: a collapse in
+ * usage means something is broken right now, and a line inside a long digest is
+ * easy to miss. Silent when there is no telemetry binding or no anomaly.
+ */
+async function runUsageAnomaly(
+  env: Env,
+  notifier: Notifier,
+  nowSeconds: number
+): Promise<void> {
+  const db = env.CHM_TELEMETRY_DB
+  if (!db) return
+  const referenceDay = utcDay(new Date((nowSeconds - 24 * 60 * 60) * 1000))
+  const series = await fetchDailySeries(db, referenceDay)
+  if (series.length === 0) return
+  const anomaly = detectAnomaly(series, referenceDay)
+  if (!anomaly) return
+  await notifier.notify('usage_anomaly', formatAnomaly(anomaly))
+}
+
 async function runDailySummary(env: Env, notifier: Notifier): Promise<void> {
   if (!env.CHM_CLOUD_D1) {
     console.error('[cloud-hooks] CHM_CLOUD_D1 unbound; skipping daily summary')
     return
   }
+  const nowSeconds = Math.floor(Date.now() / 1000)
   try {
     // Billing (D1) is the required core; Clerk metrics, usage (DAU/WAU/MAU from
     // the telemetry D1), and the probe snapshot are best-effort enrichments that
     // degrade to omitted sections when absent.
     const [data, clerk, usage, probes] = await Promise.all([
-      collectSummary(env.CHM_CLOUD_D1),
-      fetchClerkMetrics(env.CLERK_SECRET_KEY),
-      collectUsage(env.CHM_TELEMETRY_DB ?? null),
+      collectSummary(env.CHM_CLOUD_D1, nowSeconds),
+      fetchClerkMetrics(env.CLERK_SECRET_KEY, fetch, nowSeconds),
+      collectUsage(env.CHM_TELEMETRY_DB ?? null, nowSeconds),
       readProbeSnapshot(env.CHM_HOOKS_KV ?? null),
     ])
+    // Activation needs the signup count, so it runs after Clerk answers.
+    const activation = await collectActivation(
+      env.CHM_CLOUD_D1,
+      nowSeconds - 24 * 60 * 60,
+      clerk?.newUsers ?? null
+    )
     await notifier.notify(
       'daily_summary',
-      formatDigest(data, { clerk, usage, probes })
+      formatDigest(data, { clerk, usage, activation, probes })
     )
   } catch (err) {
     console.error('[cloud-hooks] daily summary failed', err)
+  }
+
+  // Separate from the digest's try/catch: a failed digest must not swallow the
+  // anomaly alert, which is the more urgent of the two.
+  try {
+    await runUsageAnomaly(env, notifier, nowSeconds)
+  } catch (err) {
+    console.error('[cloud-hooks] usage anomaly check failed', err)
   }
 }
 

--- a/apps/cloud-hooks/src/outage.test.ts
+++ b/apps/cloud-hooks/src/outage.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Outage escalation — the reminder schedule, recovery accounting, and the
+ * guarantee that we never double-alert the initial "is DOWN".
+ */
+
+import type { OutageState } from './outage'
+import type { ProbeResult } from './probes'
+
+import {
+  ESCALATION_STEPS_MS,
+  formatDuration,
+  formatOutageAlert,
+  nextReminderAt,
+  reconcileOutages,
+} from './outage'
+import { describe, expect, test } from 'bun:test'
+
+const T0 = Date.parse('2026-07-25T02:00:00Z')
+const MINUTE = 60_000
+const HOUR = 60 * MINUTE
+
+const down = (name = 'dashboard'): ProbeResult => ({
+  name,
+  state: 'down',
+  status: 503,
+})
+const up = (name = 'dashboard'): ProbeResult => ({ name, state: 'up' })
+
+describe('formatDuration', () => {
+  test('reads naturally at each scale', () => {
+    expect(formatDuration(45 * MINUTE)).toBe('45m')
+    expect(formatDuration(2 * HOUR + 15 * MINUTE)).toBe('2h 15m')
+    expect(formatDuration(27 * HOUR)).toBe('1d 3h')
+  })
+})
+
+describe('escalation schedule', () => {
+  test('widens rather than repeating at a fixed interval', () => {
+    // The first hour matters most; an outage you have been told about four
+    // times does not need a fifth reminder every 15 minutes.
+    const gaps = ESCALATION_STEPS_MS.map((step, i) =>
+      i === 0 ? step : step - ESCALATION_STEPS_MS[i - 1]
+    )
+    for (let i = 1; i < gaps.length; i++) {
+      expect(gaps[i]).toBeGreaterThan(gaps[i - 1])
+    }
+  })
+
+  test('past the last step, reminders keep coming at the final interval', () => {
+    const last = ESCALATION_STEPS_MS.length
+    const at = nextReminderAt({
+      downSince: T0,
+      lastAlertAt: T0,
+      reminders: last,
+    })
+    expect(at).toBeGreaterThan(T0 + ESCALATION_STEPS_MS[last - 1])
+  })
+})
+
+describe('reconcileOutages', () => {
+  test('the first time down only starts the clock — diffStates owns that alert', () => {
+    // Alerting here too would send two messages for one event.
+    const { alerts, next } = reconcileOutages({}, [down()], T0)
+    expect(alerts).toEqual([])
+    expect(next.dashboard.downSince).toBe(T0)
+    expect(next.dashboard.reminders).toBe(0)
+  })
+
+  test('stays quiet until the first step elapses, then reminds', () => {
+    const prev: OutageState = {
+      dashboard: { downSince: T0, lastAlertAt: T0, reminders: 0 },
+    }
+    const tooSoon = reconcileOutages(prev, [down()], T0 + 15 * MINUTE)
+    expect(tooSoon.alerts).toEqual([])
+
+    const due = reconcileOutages(prev, [down()], T0 + ESCALATION_STEPS_MS[0])
+    expect(due.alerts).toHaveLength(1)
+    expect(due.alerts[0].kind).toBe('ongoing')
+    expect(due.next.dashboard.reminders).toBe(1)
+  })
+
+  test('an ongoing reminder carries how long it has been down', () => {
+    const prev: OutageState = {
+      dashboard: { downSince: T0, lastAlertAt: T0, reminders: 0 },
+    }
+    const { alerts } = reconcileOutages(prev, [down()], T0 + 2 * HOUR)
+    expect(alerts[0].downtimeMs).toBe(2 * HOUR)
+    expect(formatOutageAlert(alerts[0])).toContain('STILL DOWN — 2h 0m')
+  })
+
+  test('recovery reports total downtime exactly once, then forgets', () => {
+    const prev: OutageState = {
+      dashboard: { downSince: T0, lastAlertAt: T0, reminders: 2 },
+    }
+    const { alerts, next } = reconcileOutages(prev, [up()], T0 + 3 * HOUR)
+    expect(alerts).toHaveLength(1)
+    expect(formatOutageAlert(alerts[0])).toContain('RECOVERED — was down 3h 0m')
+    // Dropped from state, so a later run cannot report it again.
+    expect(next.dashboard).toBeUndefined()
+
+    const after = reconcileOutages(next, [up()], T0 + 4 * HOUR)
+    expect(after.alerts).toEqual([])
+  })
+
+  test('a healthy surface that was never down produces nothing', () => {
+    expect(reconcileOutages({}, [up()], T0).alerts).toEqual([])
+  })
+
+  test('tracks several simultaneous outages independently', () => {
+    // A multi-surface incident is exactly the case the old per-kind throttle
+    // collapsed into a single message.
+    const prev: OutageState = {
+      dashboard: { downSince: T0, lastAlertAt: T0, reminders: 0 },
+      docs: { downSince: T0 + HOUR, lastAlertAt: T0 + HOUR, reminders: 0 },
+    }
+    const { alerts } = reconcileOutages(
+      prev,
+      [down('dashboard'), down('docs')],
+      T0 + HOUR + ESCALATION_STEPS_MS[0]
+    )
+    // dashboard is well past its step; docs just reached its own first step.
+    expect(alerts.map((a) => a.name).sort()).toEqual(['dashboard', 'docs'])
+    expect(
+      alerts.find((a) => a.name === 'dashboard')?.downtimeMs
+    ).toBeGreaterThan(alerts.find((a) => a.name === 'docs')?.downtimeMs ?? 0)
+  })
+})

--- a/apps/cloud-hooks/src/outage.ts
+++ b/apps/cloud-hooks/src/outage.ts
@@ -1,0 +1,184 @@
+/**
+ * Outage escalation — keep reminding while a surface stays down.
+ *
+ * `diffStates` (probes.ts) notifies only when a surface CHANGES state, which is
+ * right for avoiding a 15-minute drumbeat but leaves a real hole: a surface that
+ * goes down at 02:00 produces exactly one message and then silence, however long
+ * it stays broken. Miss that one notification and nothing ever tells you again.
+ *
+ * This module tracks, per surface, when it went down and when it was last
+ * alerted about, and re-alerts on a WIDENING schedule (30m → 2h → 6h → daily).
+ * Widening is the point: the first hour matters most, and an outage you have
+ * already been told about four times does not need a fifth reminder every 15
+ * minutes. The recovery message carries the total downtime, which is the number
+ * you actually want afterwards.
+ *
+ * State lives in its own KV key so `probe-state:v1` (read by the digest) keeps
+ * its existing shape.
+ */
+
+import type { KVLike, ProbeResult } from './probes'
+
+export const OUTAGE_KV_KEY = 'probe-outage:v1'
+
+const MINUTE = 60_000
+const HOUR = 60 * MINUTE
+
+/**
+ * Elapsed-time thresholds at which an ongoing outage is re-announced, measured
+ * from when it started. After the last step, reminders repeat at that final
+ * interval (daily).
+ */
+export const ESCALATION_STEPS_MS = [30 * MINUTE, 2 * HOUR, 6 * HOUR, 24 * HOUR]
+
+/** Per-surface outage record. */
+export interface OutageRecord {
+  /** Epoch ms when the surface was first observed down. */
+  downSince: number
+  /** Epoch ms of the most recent alert (initial or reminder). */
+  lastAlertAt: number
+  /** How many reminders (excluding the initial alert) have been sent. */
+  reminders: number
+}
+
+export type OutageState = Record<string, OutageRecord>
+
+export interface OutageAlert {
+  name: string
+  kind: 'ongoing' | 'recovered'
+  /** How long the surface has been (or was) down, in ms. */
+  downtimeMs: number
+  status?: number
+  error?: string
+}
+
+/** Human-readable duration: "45m", "2h 15m", "1d 3h". */
+export function formatDuration(ms: number): string {
+  const totalMinutes = Math.max(0, Math.floor(ms / MINUTE))
+  const days = Math.floor(totalMinutes / (24 * 60))
+  const hours = Math.floor((totalMinutes % (24 * 60)) / 60)
+  const minutes = totalMinutes % 60
+  if (days > 0) return `${days}d ${hours}h`
+  if (hours > 0) return `${hours}h ${minutes}m`
+  return `${minutes}m`
+}
+
+/**
+ * When is the next reminder due for an outage that started `downSince` and has
+ * already sent `reminders` reminders? Returns the absolute epoch-ms deadline.
+ * Past the last step, reminders repeat at the final interval.
+ */
+export function nextReminderAt(record: OutageRecord): number {
+  const steps = ESCALATION_STEPS_MS
+  if (record.reminders < steps.length) {
+    return record.downSince + steps[record.reminders]
+  }
+  const overflow = record.reminders - steps.length + 1
+  return record.downSince + steps[steps.length - 1] * (overflow + 1)
+}
+
+/**
+ * Fold this run's probe results into the stored outage state.
+ *
+ * Pure: returns the alerts to send and the state to persist, so the escalation
+ * schedule is testable by advancing a clock rather than by waiting.
+ *
+ * A surface that is down and already tracked produces an `ongoing` alert only
+ * when its next reminder is due. A surface that recovered produces exactly one
+ * `recovered` alert carrying total downtime, and is dropped from the state.
+ */
+export function reconcileOutages(
+  prev: OutageState,
+  results: ProbeResult[],
+  now: number
+): { alerts: OutageAlert[]; next: OutageState } {
+  const alerts: OutageAlert[] = []
+  const next: OutageState = {}
+
+  for (const result of results) {
+    const record = prev[result.name]
+
+    if (result.state === 'down') {
+      if (!record) {
+        // First time down. `diffStates` already sends the initial alert, so we
+        // only start the clock here — alerting twice about the same event would
+        // be worse than not escalating at all.
+        next[result.name] = {
+          downSince: now,
+          lastAlertAt: now,
+          reminders: 0,
+        }
+        continue
+      }
+      if (now >= nextReminderAt(record)) {
+        alerts.push({
+          name: result.name,
+          kind: 'ongoing',
+          downtimeMs: now - record.downSince,
+          status: result.status,
+          error: result.error,
+        })
+        next[result.name] = {
+          ...record,
+          lastAlertAt: now,
+          reminders: record.reminders + 1,
+        }
+      } else {
+        next[result.name] = record
+      }
+      continue
+    }
+
+    // Back up: report total downtime once, then forget it.
+    if (record) {
+      alerts.push({
+        name: result.name,
+        kind: 'recovered',
+        downtimeMs: now - record.downSince,
+      })
+    }
+  }
+
+  return { alerts, next }
+}
+
+export function formatOutageAlert(alert: OutageAlert): string {
+  const duration = formatDuration(alert.downtimeMs)
+  if (alert.kind === 'recovered') {
+    return `\u{1F7E2} <b>${alert.name}</b> RECOVERED — was down ${duration}`
+  }
+  const detail = alert.status
+    ? ` (HTTP ${alert.status})`
+    : alert.error
+      ? ` (${alert.error})`
+      : ''
+  return `\u{1F534} <b>${alert.name}</b> STILL DOWN — ${duration}${detail}`
+}
+
+/** Read the stored outage state. Any problem → empty (we simply re-start clocks). */
+export async function readOutageState(
+  kv: KVLike | null | undefined
+): Promise<OutageState> {
+  if (!kv) return {}
+  try {
+    const raw = await kv.get(OUTAGE_KV_KEY)
+    return raw ? (JSON.parse(raw) as OutageState) : {}
+  } catch {
+    return {}
+  }
+}
+
+/** Persist the outage state. Never throws — a KV hiccup must not fail the cron. */
+export async function writeOutageState(
+  kv: KVLike | null | undefined,
+  state: OutageState,
+  logError: (message: string, meta?: unknown) => void = (m, meta) =>
+    console.error(m, meta)
+): Promise<void> {
+  if (!kv) return
+  try {
+    await kv.put(OUTAGE_KV_KEY, JSON.stringify(state))
+  } catch (err) {
+    logError('[cloud-hooks] failed to persist outage state to KV', err)
+  }
+}

--- a/apps/cloud-hooks/src/probes.test.ts
+++ b/apps/cloud-hooks/src/probes.test.ts
@@ -218,3 +218,103 @@ describe('runProbes — KV-backed, notify on transitions', () => {
     expect(notify).not.toHaveBeenCalled()
   })
 })
+
+describe('runProbes — outage escalation', () => {
+  function makeKV(initial?: Record<string, string>): KVLike & {
+    store: Map<string, string>
+  } {
+    const store = new Map<string, string>(Object.entries(initial ?? {}))
+    return {
+      store,
+      async get(key) {
+        return store.get(key) ?? null
+      },
+      async put(key, value) {
+        store.set(key, value)
+      },
+    }
+  }
+
+  const T0 = Date.parse('2026-07-25T02:00:00Z')
+  const downFetch = () => mock(async () => new Response('x', { status: 503 }))
+  const target = [{ name: 'solo', url: 'https://solo' }]
+
+  test('a surface still down hours later gets a reminder, not silence', async () => {
+    // Without this, a surface that broke overnight produces exactly one message
+    // at the moment it broke and nothing ever again.
+    const kv = makeKV({
+      'probe-state:v1': JSON.stringify({ solo: 'down' }),
+      'probe-outage:v1': JSON.stringify({
+        solo: { downSince: T0, lastAlertAt: T0, reminders: 0 },
+      }),
+    })
+    const sent: string[] = []
+
+    const transitions = await runProbes({
+      kv,
+      notify: async (_k, text) => {
+        sent.push(text)
+        return true
+      },
+      fetch: downFetch(),
+      targets: target,
+      now: () => T0 + 3 * 60 * 60 * 1000,
+    })
+
+    // No state CHANGE — down before, down now — so diffStates says nothing…
+    expect(transitions).toEqual([])
+    // …but escalation still speaks up, with the elapsed time.
+    expect(sent).toHaveLength(1)
+    expect(sent[0]).toContain('STILL DOWN')
+    expect(sent[0]).toContain('3h 0m')
+  })
+
+  test('recovery reports the total downtime and clears the record', async () => {
+    const kv = makeKV({
+      'probe-state:v1': JSON.stringify({ solo: 'down' }),
+      'probe-outage:v1': JSON.stringify({
+        solo: { downSince: T0, lastAlertAt: T0, reminders: 1 },
+      }),
+    })
+    const sent: string[] = []
+
+    await runProbes({
+      kv,
+      notify: async (_k, text) => {
+        sent.push(text)
+        return true
+      },
+      fetch: mock(async () => new Response('ok', { status: 200 })),
+      targets: target,
+      now: () => T0 + 90 * 60 * 1000,
+    })
+
+    // One up-transition message plus one recovery message with the duration.
+    expect(sent.join('\n')).toContain('is UP')
+    expect(sent.join('\n')).toContain('RECOVERED — was down 1h 30m')
+    expect(JSON.parse(kv.store.get('probe-outage:v1') as string)).toEqual({})
+  })
+
+  test('the first time down does not double-message', async () => {
+    const kv = makeKV()
+    const sent: string[] = []
+
+    await runProbes({
+      kv,
+      notify: async (_k, text) => {
+        sent.push(text)
+        return true
+      },
+      fetch: downFetch(),
+      targets: target,
+      now: () => T0,
+    })
+
+    // diffStates owns the initial alert; escalation only starts the clock.
+    expect(sent).toHaveLength(1)
+    expect(sent[0]).toContain('is DOWN')
+    expect(
+      JSON.parse(kv.store.get('probe-outage:v1') as string).solo.downSince
+    ).toBe(T0)
+  })
+})

--- a/apps/cloud-hooks/src/probes.ts
+++ b/apps/cloud-hooks/src/probes.ts
@@ -7,6 +7,13 @@
 
 import type { NotifyKind } from './telegram'
 
+import {
+  formatOutageAlert,
+  readOutageState,
+  reconcileOutages,
+  writeOutageState,
+} from './outage'
+
 export type ProbeState = 'up' | 'down'
 
 /**
@@ -226,6 +233,8 @@ export interface RunProbesDeps {
   /** Optional D1 binding — when present, a `SELECT 1` read probe is added. */
   d1?: D1ProbeDb | null
   notify: (kind: NotifyKind, text: string) => Promise<boolean>
+  /** Epoch ms, injectable so the escalation schedule is testable. */
+  now?: () => number
   logError?: (message: string, meta?: unknown) => void
 }
 
@@ -257,6 +266,20 @@ export async function runProbes(deps: RunProbesDeps): Promise<Transition[]> {
   for (const t of transitions) {
     await deps.notify(PROBE_NOTIFY_KIND, formatTransition(t))
   }
+
+  // Escalation: keep reminding while a surface stays down, and report total
+  // downtime on recovery. `diffStates` above owns the first "is DOWN" message;
+  // this only adds the reminders it cannot produce.
+  const now = (deps.now ?? Date.now)()
+  const { alerts, next } = reconcileOutages(
+    await readOutageState(deps.kv),
+    results,
+    now
+  )
+  for (const alert of alerts) {
+    await deps.notify(PROBE_NOTIFY_KIND, formatOutageAlert(alert))
+  }
+  await writeOutageState(deps.kv, next, (m, meta) => logError(m, meta))
 
   const nextState: Record<string, ProbeState> = {}
   for (const r of results) nextState[r.name] = r.state

--- a/apps/cloud-hooks/src/summary.ts
+++ b/apps/cloud-hooks/src/summary.ts
@@ -8,8 +8,10 @@
  * never drift from the published prices.
  */
 
+import type { ActivationData } from './activation'
 import type { UsageMetrics } from './usage'
 
+import { activationLines } from './activation'
 import { usageLines } from './usage'
 import { BILLING_PLANS, type Plan, type PlanId } from '@chm/pricing'
 
@@ -67,6 +69,8 @@ export interface DigestExtras {
   probes?: ProbeSnapshot | null
   /** DAU/WAU/MAU from the telemetry D1 (see usage.ts). */
   usage?: UsageMetrics | null
+  /** Signup → connected-a-cluster conversion (see activation.ts). */
+  activation?: ActivationData | null
 }
 
 const ACTIVE_STATUSES = "('active','trialing')"
@@ -218,6 +222,9 @@ export function formatDigest(
 
   // ── Usage (telemetry D1) — DAU/WAU/MAU, omitted when unavailable ───────────
   parts.push(...usageLines(extras.usage))
+
+  // ── Activation — did the signups actually connect anything? ────────────────
+  parts.push(...activationLines(extras.activation))
 
   // ── Subscriptions ───────────────────────────────────────────────────────────
   parts.push(

--- a/apps/cloud-hooks/src/telegram.test.ts
+++ b/apps/cloud-hooks/src/telegram.test.ts
@@ -47,10 +47,47 @@ describe('per-kind throttle', () => {
     let now = 1_000_000
     const n = new Notifier(cfg, { fetch: fetchImpl, now: () => now })
 
-    expect(await n.notify('probe', 'down')).toBe(true)
-    now += 31_000 // past the 30s probe window
-    expect(await n.notify('probe', 'up')).toBe(true)
+    expect(await n.notify('signature_failure', 'bad sig')).toBe(true)
+    now += 61_000 // past the 60s signature_failure window
+    expect(await n.notify('signature_failure', 'bad sig again')).toBe(true)
     expect(fetchImpl).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('kinds that must never be throttled', () => {
+  // These are deduped by durable state (probe transitions, KV fingerprints, the
+  // issue cursor), so a timer could not prevent a duplicate — it could only drop
+  // distinct information. Regression guard: a 30s window here used to mean a
+  // four-surface outage reported one surface.
+  test.each([
+    'probe',
+    'error',
+    'new_issue',
+    'usage_anomaly',
+  ] as const)('sends every %s message in a same-instant burst', async (kind) => {
+    const fetchImpl = okFetch()
+    const now = 1_000_000
+    const n = new Notifier(cfg, { fetch: fetchImpl, now: () => now })
+
+    expect(await n.notify(kind, 'first')).toBe(true)
+    expect(await n.notify(kind, 'second')).toBe(true)
+    expect(await n.notify(kind, 'third')).toBe(true)
+    expect(fetchImpl).toHaveBeenCalledTimes(3)
+  })
+
+  test('a four-surface outage reports all four surfaces', async () => {
+    const fetchImpl = okFetch()
+    const now = 1_000_000
+    const n = new Notifier(cfg, { fetch: fetchImpl, now: () => now })
+
+    for (const surface of ['dashboard', 'docs', 'landing', 'blog']) {
+      expect(await n.notify('probe', `${surface} is DOWN`)).toBe(true)
+    }
+    const sent = fetchImpl.mock.calls.map(
+      ([, init]) => JSON.parse((init as RequestInit).body as string).text
+    )
+    expect(sent).toHaveLength(4)
+    expect(sent.join('\n')).toContain('blog is DOWN')
   })
 })
 

--- a/apps/cloud-hooks/src/telegram.ts
+++ b/apps/cloud-hooks/src/telegram.ts
@@ -24,6 +24,9 @@ export type NotifyKind =
   | 'error'
   // A new GitHub issue opened on the repo (POST-less watch, ops cron).
   | 'new_issue'
+  // A tracked metric moved far enough from its own baseline to be worth waking
+  // someone for (e.g. DAU collapsing overnight).
+  | 'usage_anomaly'
   // Clerk lifecycle events (POST /webhooks/clerk).
   | 'user_created'
   | 'session_created'
@@ -48,9 +51,19 @@ export const THROTTLE_MS: Record<NotifyKind, number> = {
   // so a throttle here could not prevent a duplicate — it could only DROP the
   // 2nd..Nth genuinely-distinct issue of a burst.
   new_issue: 0,
-  // Health transitions: avoid re-alerting on a flapping target within a window.
-  probe: 30_000,
-  error: 30_000,
+  // NOT throttled, for the same reason as `new_issue` — and this one was an
+  // outright bug. Both producers run ONLY on the 15-minute ops cron, so a
+  // 30s in-memory window never spanned two runs and never damped a flapping
+  // target; all it could do was drop distinct messages inside ONE run. That
+  // made the alerting worst exactly when the incident was biggest: four
+  // surfaces failing together reported one, and a run that filed five GitHub
+  // issues announced one. Dedupe is state's job — probes only notify on a
+  // transition, exceptions only on an unseen KV fingerprint.
+  probe: 0,
+  error: 0,
+  // Usage anomalies are computed once per day from a completed day of data,
+  // so there is no burst to damp.
+  usage_anomaly: 0,
   // Signups/sign-ins are individually meaningful; light throttle only collapses
   // an at-least-once duplicate delivery burst (per-user sign-in throttling is
   // handled separately in KV over a 6h window).

--- a/docs/knowledge/cloud-hooks-worker.md
+++ b/docs/knowledge/cloud-hooks-worker.md
@@ -52,9 +52,27 @@ cron
   │                      (same sections week-over-week + issue throughput)
   └─ every 15 minutes → ops sweep:
         ├─ full-surface health probes → Telegram on transitions
+        │    └─ + outage escalation: reminders while still down (30m→2h→6h→daily)
+        │      and total downtime on recovery
         ├─ Cloudflare Worker exceptions → new GitHub issue + Telegram
+        │    └─ + spike alert when a KNOWN fingerprint gets much louder
         └─ new GitHub issues (KV cursor) → Telegram
 ```
+
+## Throttling rule (learned the hard way)
+
+`Notifier` throttles per KIND, in memory, per isolate. That is right for webhook
+bursts and wrong for anything a cron produces: **`probe` and `error` carried a
+30s window while their only producers run every 15 minutes**, so the window
+never spanned two runs and never damped a flapping target — all it could do was
+drop distinct messages inside ONE run. Four surfaces failing together reported
+one; a run that filed five GitHub issues announced one. Both are now `0`.
+
+The rule: **if a producer already dedupes on durable state, it must not also be
+throttled on a timer.** A timer cannot prevent a duplicate that state already
+prevents; it can only delete real information. Kinds deduped by state and
+therefore unthrottled: `probe` (only fires on a transition), `error` (KV
+fingerprint), `new_issue` (KV cursor), `usage_anomaly` (once a day).
 
 The cron strings are matched **character for character** in `index.ts`
 (`DAILY_CRON` / `WEEKLY_CRON`). Editing one in `wrangler.toml` without the other
@@ -104,6 +122,14 @@ The same `chm-cloud` D1 is bound into both Workers; the monotonic
   GitHub search fallback (`in:body "<fp>"`) so a KV miss/eviction never re-files;
   the fallback backfills KV. **Rate cap**: `maxIssuesPerRun` (default 5). Labels
   default `bug,cloudflare-exception`. Every step is injected + never throws.
+  **Spike detection** (`isSpike`) fills the blind spot that permanent dedup
+  creates: a known error firing 100× more often is skipped silently, even though
+  it is usually the more urgent event. On every skip the current window count is
+  compared against the last one recorded (`exc-rate:v1:<fp>`); an alert needs
+  BOTH an absolute floor (`SPIKE_MIN_COUNT`, since 2 → 6 is not news) and a
+  relative jump (`SPIKE_MULTIPLE`), and respects `SPIKE_COOLDOWN_MS` so one
+  incident does not re-alert every 15 minutes. The cooldown clock only moves when
+  an alert actually fired, so a quiet update cannot postpone the next real one.
   **Auth** is resolved by `github-app.ts`'s `resolveGitHubAuth`, order:
   GitHub App creds (`GH_APP_ID` + `GH_APP_PRIVATE_KEY`) → PAT (`GITHUB_TOKEN`) →
   disabled (one log line). App mode passes the installation token as
@@ -134,6 +160,32 @@ The same `chm-cloud` D1 is bound into both Workers; the monotonic
   `reduceSummary`/`mrrForGroup`/`formatDigest` are unit-tested.
   `queryPlanBreakdown` is shared with `weekly.ts` so the two reports can never
   disagree about what "active" or "MRR" means.
+- `outage.ts` — `reconcileOutages`: closes the hole left by transition-only
+  probing. A surface that goes down at 02:00 otherwise produces ONE message and
+  then silence for as long as it stays broken. Tracks `downSince` / `reminders`
+  per surface in its own KV key (`probe-outage:v1`, so `probe-state:v1` keeps its
+  shape) and re-alerts on a **widening** schedule (`ESCALATION_STEPS_MS` =
+  30m → 2h → 6h → daily, then daily). The first time down deliberately only
+  starts the clock — `diffStates` already owns that alert, and alerting twice for
+  one event is worse than not escalating. Recovery reports **total downtime** and
+  drops the record. Pure + clock-injected, so the schedule is tested by advancing
+  a number.
+- `anomaly.ts` — `detectAnomaly`: alerts when yesterday's DAU diverges from its
+  own recent baseline, because a digest *number* is passive — it only helps if
+  someone reads it and remembers yesterday's. Three guards keep it from crying
+  wolf: a **median** baseline (one HN-front-page day would drag a mean up for a
+  week and make every following day look like a collapse), a **minimum baseline**
+  (`MIN_BASELINE`, since 3 → 1 is "-67%" and means nothing), and **asymmetric
+  thresholds** (a 30% drop alerts; a spike needs 3×, and is phrased as news
+  rather than an incident). A missing reference day counts as zero — silence from
+  the telemetry endpoint IS the signal. Sent as its own message, not a digest
+  line.
+- `activation.ts` — `collectActivation`: signups vs users who actually connected
+  a cluster (`user_connections`), the most diagnostic number for a self-serve
+  product and invisible when signups and subscriptions are reported separately.
+  A digest line rather than an alert, except `isStalled` (≥`STALL_MIN_SIGNUPS`
+  signups and ZERO connections), which is flagged inline as a probable broken
+  connection flow.
 - `usage.ts` — `collectUsage`: **DAU / WAU / MAU** from the telemetry D1
   (`CHM_TELEMETRY_DB` → `chm_telemetry`, read-only). One query per stream
   computes all three windows via `COUNT(DISTINCT CASE WHEN day = … END)`, so the
@@ -213,8 +265,10 @@ The same `chm-cloud` D1 is bound into both Workers; the monotonic
   **read-only** here, for the Usage section. No `migrations_dir`: `apps/telemetry`
   owns that schema. Unbound → the Usage section is omitted.
 - `CHM_HOOKS_KV` KV binding is **active** (id `a1d9bd2c4377493eac5b5d4ad04dcc34`) —
-  it stores per-probe up/down state, exception fingerprints (`exc-fp:v1:<fp>`),
-  and the new-issue watch cursor (`issue-watch:v1:last-created`). Absent → probes
+  it stores per-probe up/down state (`probe-state:v1`), outage escalation records
+  (`probe-outage:v1`), exception fingerprints (`exc-fp:v1:<fp>`), exception rate
+  baselines (`exc-rate:v1:<fp>`), and the new-issue watch cursor
+  (`issue-watch:v1:last-created`). Absent → probes
   fall back to per-run state, the exception scan leans on the GitHub search
   fallback alone, and the **issue watch skips entirely** (a watch with no memory
   would re-announce the same issues every 15 minutes). Follows the `CHM_`


### PR DESCRIPTION
Follow-up to #2836. That PR added the *numbers*; this one makes them act. It also fixes a bug that made the existing alerting fail hardest exactly when an incident was biggest.

## The bug: alerts were being dropped

`Notifier` throttles per *kind*, in memory. `probe` and `error` carried a 30s window — but their only producers run on the **15-minute** ops cron. So the window never spanned two runs and never damped a flapping target (what the comment claimed). All it could do was drop distinct messages *inside one run*:

- four surfaces failing together → **one** reported
- a run that filed five GitHub issues → **one** announced

Both set to `0`. The rule now documented in the knowledge doc: **if a producer dedupes on durable state, it must not also be throttled on a timer.** A timer can't prevent a duplicate that state already prevents — it can only delete real information.

## Four new alerts

### 1. Outage escalation (`outage.ts`)
`diffStates` fires only on a state *change*, so a surface that went down at 02:00 produced one message and then silence for as long as it stayed broken. Miss it and nothing ever tells you again.

Now tracks `downSince` per surface and re-alerts on a **widening** schedule (30m → 2h → 6h → daily). Widening matters: the first hour is what counts, and an outage you've been told about four times doesn't need a fifth reminder every 15 minutes. Recovery reports **total downtime**.

The first time down deliberately only starts the clock — `diffStates` already owns that alert, and two messages for one event is worse than not escalating.

### 2. Error spikes (`exceptions.ts`)
Fingerprint dedup is permanent by design, which creates a blind spot: a **known** error firing 100× more often is skipped in silence. That's usually the *more* urgent event — a latent bug that just became everyone's problem.

An alert needs **both** an absolute floor (`SPIKE_MIN_COUNT` — 2 → 6 isn't news) **and** a relative jump (`SPIKE_MULTIPLE`), plus a cooldown. The cooldown clock only moves when an alert actually fired, so a quiet update can't postpone the next real one.

### 3. DAU anomaly (`anomaly.ts`)
A digest number is passive — it only helps if someone reads it *and* remembers yesterday's. This alerts on the deviation instead. Three guards against crying wolf:

- **Median baseline, not mean.** One HN-front-page day would drag a mean up for a week and make every following day read as a 40% collapse.
- **Minimum baseline.** 3 → 1 is "-67%" and means nothing.
- **Asymmetric thresholds.** 30% down is an incident; a spike needs 3× and is phrased as news.

A missing reference day counts as zero — silence from the telemetry endpoint *is* the signal.

### 4. Activation (`activation.ts`)
Signups vs users who actually connected a cluster — the most diagnostic number for a self-serve product, and invisible when signups and subscriptions are reported separately. A **digest line**, not an alert, except when several people signed up and *not one* connected anything, which is flagged inline as a probable broken connection flow.

## Routing

Per the chosen noise level — urgent interrupts, everything else in the digest:

| Alert | Delivery |
|---|---|
| Outage escalation / recovery | immediate |
| Error spike | immediate |
| DAU anomaly | immediate (own message, not a digest line) |
| Activation | daily digest line |

## Verification

- `bun test src/ --isolate` — **192 pass, 0 fail** (16 files; 46 new tests)
- `tsc --noEmit` clean, `biome check` clean
- `wrangler deploy --minify --dry-run` builds, all three bindings resolve

The escalation schedule and spike cooldown are clock-injected, so they're tested by advancing a number rather than waiting. `telegram.test.ts` gains a regression guard that a four-surface outage reports all four.

## Not built (deliberately)

You didn't select these, and I'd skip them anyway without a reason: star/fork notifications, per-deploy messages, latency percentiles — high volume, low action, and they train you to ignore the channel. Revenue-at-risk (`past_due` follow-up, trial-ending) and repo health (main CI red, Dependabot) remain available if you want them later; the `past_due` gap is real — today it alerts at the webhook moment and never follows up.

No new secrets or bindings.