### PR TITLE
fix(cloud-hooks): break two import cycles on main

### DIFF
--- a/apps/cloud-hooks/src/activation.ts
+++ b/apps/cloud-hooks/src/activation.ts
@@ -13,7 +13,18 @@
  * stalled case below, which is flagged inline.
  */
 
-import type { D1SummaryDb } from './summary'
+/**
+ * Minimal D1 subset for the connection count. Declared locally rather than
+ * imported from summary.ts, which imports `activationLines` from here — a mutual
+ * import would be a cycle.
+ */
+export interface D1ActivationDb {
+  prepare(sql: string): {
+    bind(...values: unknown[]): {
+      first<T = unknown>(): Promise<T | null>
+    }
+  }
+}
 
 export interface ActivationData {
   /** Connections created in the window. */
@@ -53,7 +64,7 @@ export function isStalled(data: ActivationData): boolean {
  * Returns null on failure so the digest omits the section.
  */
 export async function collectActivation(
-  db: D1SummaryDb | null | undefined,
+  db: D1ActivationDb | null | undefined,
   since: number,
   signups: number | null,
   logError: (message: string, meta?: unknown) => void = (m, meta) =>

--- a/apps/cloud-hooks/src/outage.ts
+++ b/apps/cloud-hooks/src/outage.ts
@@ -17,7 +17,26 @@
  * its existing shape.
  */
 
-import type { KVLike, ProbeResult } from './probes'
+/**
+ * Minimal KV subset (matches probes' / github-app's `KVLike`). Declared locally
+ * rather than imported so this module has NO dependency on probes.ts — probes
+ * imports this one, and a mutual import would be a cycle.
+ */
+export interface KVLike {
+  get(key: string): Promise<string | null>
+  put(key: string, value: string): Promise<void>
+}
+
+/**
+ * The part of a probe result this module needs. Structural, so probes' richer
+ * `ProbeResult` satisfies it without either module depending on the other.
+ */
+export interface ProbeOutcome {
+  name: string
+  state: 'up' | 'down'
+  status?: number
+  error?: string
+}
 
 export const OUTAGE_KV_KEY = 'probe-outage:v1'
 
@@ -89,7 +108,7 @@ export function nextReminderAt(record: OutageRecord): number {
  */
 export function reconcileOutages(
   prev: OutageState,
-  results: ProbeResult[],
+  results: ProbeOutcome[],
   now: number
 ): { alerts: OutageAlert[]; next: OutageState } {
   const alerts: OutageAlert[] = []


### PR DESCRIPTION
`main` is currently failing `depcruise`. #2837 merged before this fix landed — `depcruise` is not a required check, so auto-merge went ahead while the fix was still in flight.

## The cycles

```
apps/cloud-hooks/src/outage.ts → probes.ts → outage.ts
apps/cloud-hooks/src/activation.ts → summary.ts → activation.ts
```

`outage.ts` imported `KVLike` / `ProbeResult` *from* `probes.ts`, while `probes.ts` imports the escalation functions *from* `outage.ts`. Same shape between `activation.ts` (importing `D1SummaryDb`) and `summary.ts` (importing `activationLines`).

Both are type-only imports, which is why `tsc` and the full test suite stayed green — types erase at build time, so nothing at runtime ever formed a loop. Only `depcruise` sees it.

## The fix

Each module now declares the minimal structural interface it consumes, which is already the convention in this worker — `KVLike` is deliberately defined **twice**, in `probes.ts` and `github-app.ts`, with a comment saying it matches the other. That looked like duplication until this failure explained the reason: it keeps dependency direction one-way.

- `outage.ts` gains its own `KVLike` and a `ProbeOutcome` (`{ name, state, status?, error? }`)
- `activation.ts` gains its own `D1ActivationDb`

Structural typing means the concrete `ProbeResult` / `D1SummaryDb` still satisfy them, so **no call sites changed** — the diff is 34 lines added, 4 removed, all type declarations.

## Verification

- `pnpm run depcruise` — **zero** `apps/cloud-hooks` violations (the two remaining are `routeTree.gen.ts`, a gitignored generated file that only exists locally)
- `tsc --noEmit` clean
- `bun test src/ --isolate` — **192 pass, 0 fail**

Please merge even though `depcruise` is not required — main is red on it until this lands.